### PR TITLE
ci: add GitHub Actions gate (pytest + ruff) and regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Oldest supported and newest — comfy-cli itself runs on 3.14, where
+        # asyncio/typing behavior has shifted, so both ends matter.
+        python-version: ['3.10', '3.14']
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install
+        run: pip install -e '.[dev]'
+      - name: Lint (ruff)
+        run: ruff check .
+      - name: Format check (ruff)
+        run: ruff format --check .
+      - name: Tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is a small, standalone codebase. Each tool shells out to the `comfy` command 
 `--where local --json`, parses comfy-cli's `envelope/1` output, and returns it. There is no HTTP
 client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engine.
 
-> **Status:** early POC. Four tools; the comfy-cli plumbing is smoke-tested, a full generation round-trip is pending a running ComfyUI.
+> **Status:** early POC. Four tools, validated end-to-end against a live local ComfyUI (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on 3.10 and 3.14.
 
 ## Prerequisites
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8"]
+dev = ["pytest>=8", "ruff>=0.8"]
 
 [project.scripts]
 comfy-local-mcp = "comfy_local_mcp.server:main"
@@ -22,3 +22,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.ruff]
+target-version = "py310"

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,0 +1,103 @@
+"""Regression tests for the comfy-cli invocation and output collection.
+
+These lock in the two behaviors that actually broke during development:
+1. comfy-cli's global flags (``--json``, ``--where``) MUST precede the
+   subcommand — a trailing ``--json`` errors with "No such option".
+2. ``fetch_outputs`` must handle BOTH output representations a local run
+   produces: bare on-disk paths (from ``comfy run --wait``) and ``/view``
+   HTTP URLs (from ``comfy jobs status``) — ``comfy download`` refuses the
+   path form, which is why the tool collects outputs itself.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+
+import pytest
+
+from comfy_local_mcp import server
+
+
+def _fake_run(envelope: dict):
+    """Return a subprocess.run stand-in that captures the call and emits an envelope."""
+    calls: list[dict] = []
+
+    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+        calls.append({"cmd": cmd, "env": env})
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout=json.dumps(envelope), stderr=""
+        )
+
+    return fake, calls
+
+
+def test_global_flags_precede_subcommand(monkeypatch):
+    """Regression: `comfy run … --json` errors; it must be `comfy --json … run`."""
+    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": {"x": 1}})
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    assert server._run_comfy("jobs", "status", "abc") == {"x": 1}
+
+    cmd = calls[0]["cmd"]
+    assert cmd[0] == server.COMFY_BIN
+    assert cmd[1:4] == ["--json", "--where", "local"]  # global flags first
+    assert cmd[4:] == ["jobs", "status", "abc"]  # subcommand strictly after
+    assert calls[0]["env"]["COMFY_WHERE"] == "local"  # belt-and-suspenders pin
+
+
+def test_error_envelope_raises_with_code(monkeypatch):
+    fake, _ = _fake_run(
+        {
+            "type": "envelope",
+            "ok": False,
+            "error": {"code": "server_not_running", "message": "ComfyUI not running"},
+        }
+    )
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    with pytest.raises(server.ComfyCliError, match="server_not_running"):
+        server._run_comfy("env")
+
+
+def test_missing_binary_raises(monkeypatch):
+    monkeypatch.setattr(server.shutil, "which", lambda _: None)
+    with pytest.raises(server.ComfyCliError, match="not found on PATH"):
+        server._run_comfy("env")
+
+
+def test_fetch_outputs_copies_on_disk_path(monkeypatch, tmp_path):
+    """Regression: local `comfy run` emits bare paths; we copy, never `comfy download`."""
+    src = tmp_path / "src" / "img.png"
+    src.parent.mkdir()
+    src.write_bytes(b"png-bytes")
+    out_dir = tmp_path / "out"
+
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: {"outputs": [str(src)]})
+    result = server.fetch_outputs("pid", str(out_dir))
+
+    assert result["saved"] == [str(out_dir / "img.png")]
+    assert (out_dir / "img.png").read_bytes() == b"png-bytes"
+
+
+def test_fetch_outputs_fetches_view_url(monkeypatch, tmp_path):
+    """Regression: `comfy jobs status` emits /view URLs; we fetch those."""
+    url = "http://127.0.0.1:8188/view?filename=gen.png&subfolder=&type=output"
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: {"outputs": [url]})
+
+    fetched: list[str] = []
+
+    def fake_urlopen(ref, timeout):  # noqa: ARG001
+        fetched.append(ref)
+        return io.BytesIO(b"view-bytes")
+
+    monkeypatch.setattr(server.urllib.request, "urlopen", fake_urlopen)
+    out_dir = tmp_path / "out"
+    result = server.fetch_outputs("pid", str(out_dir))
+
+    assert fetched == [url]
+    assert result["saved"] == [str(out_dir / "gen.png")]  # name from ?filename=
+    assert (out_dir / "gen.png").read_bytes() == b"view-bytes"


### PR DESCRIPTION
The repo had tests but nothing ran them. This adds the gate and locks in the two behaviors that actually broke during development.

## Changes
- **`.github/workflows/ci.yml`** — ruff check → ruff format --check → pytest, on Python **3.10 and 3.14** (SHA-pinned checkout/setup-python, concurrency-cancel, `contents: read`).
- **`tests/test_wrapper.py`** — 5 regression tests: global flags must precede the subcommand (`comfy --json --where local run …` — trailing `--json` is rejected by comfy-cli), `COMFY_WHERE=local` env pin, error-envelope → `ComfyCliError`, missing binary, and `fetch_outputs` handling **both** local output forms (bare on-disk path + `/view` URL).
- `pyproject.toml`: ruff in the dev extra, `target-version = py310`. README status refreshed.

## Testing
9/9 tests pass locally; ruff check + format both clean.