### PR TITLE
ci: harden workflow (persist-credentials, job name, timeout) and cap ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ permissions:
 
 jobs:
   test:
+    name: test (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -27,6 +29,8 @@ jobs:
         python-version: ['3.10', '3.14']
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8", "ruff>=0.8"]
+dev = ["pytest>=8", "ruff>=0.15,<0.16"]
 
 [project.scripts]
 comfy-local-mcp = "comfy_local_mcp.server:main"

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -20,24 +20,34 @@ import pytest
 from comfy_local_mcp import server
 
 
-def _fake_run(envelope: dict):
-    """Return a subprocess.run stand-in that captures the call and emits an envelope."""
-    calls: list[dict] = []
+@pytest.fixture
+def patched_run(monkeypatch):
+    """Patch away ``shutil.which`` + ``subprocess.run`` for ``_run_comfy``.
 
-    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
-        calls.append({"cmd": cmd, "env": env})
-        return subprocess.CompletedProcess(
-            cmd, 0, stdout=json.dumps(envelope), stderr=""
-        )
+    Returns a ``setup(envelope) -> calls`` helper: call it with the envelope
+    the fake comfy-cli should emit, and get back the list that captures each
+    invocation (``cmd`` + ``env``).
+    """
 
-    return fake, calls
+    def setup(envelope: dict) -> list[dict]:
+        calls: list[dict] = []
+
+        def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+            calls.append({"cmd": cmd, "env": env})
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=json.dumps(envelope), stderr=""
+            )
+
+        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+        monkeypatch.setattr(server.subprocess, "run", fake)
+        return calls
+
+    return setup
 
 
-def test_global_flags_precede_subcommand(monkeypatch):
+def test_global_flags_precede_subcommand(patched_run):
     """Regression: `comfy run … --json` errors; it must be `comfy --json … run`."""
-    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": {"x": 1}})
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"x": 1}})
 
     assert server._run_comfy("jobs", "status", "abc") == {"x": 1}
 
@@ -48,16 +58,14 @@ def test_global_flags_precede_subcommand(monkeypatch):
     assert calls[0]["env"]["COMFY_WHERE"] == "local"  # belt-and-suspenders pin
 
 
-def test_error_envelope_raises_with_code(monkeypatch):
-    fake, _ = _fake_run(
+def test_error_envelope_raises_with_code(patched_run):
+    patched_run(
         {
             "type": "envelope",
             "ok": False,
             "error": {"code": "server_not_running", "message": "ComfyUI not running"},
         }
     )
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
 
     with pytest.raises(server.ComfyCliError, match="server_not_running"):
         server._run_comfy("env")


### PR DESCRIPTION
## ELI-5

Our CI robot had a few small safety gaps. This tightens them:

- It used to keep a copy of the login key lying around in the checkout — now it doesn't.
- The test job was nameless and could run forever if it got stuck — now it has a name and a 10-minute stop-clock.
- Our linter (`ruff`) could quietly upgrade itself and start complaining about brand-new rules — now it's pinned to the version we know is happy.
- Some test code was copy-pasted twice — now it lives in one shared helper.

No product behavior changes; this is CI/test hardening only.

## What & why

Follow-ups from the CodeRabbit review of the CI PR:

1. **[security] `persist-credentials: false` on checkout.** `actions/checkout` persists the GitHub token into local git config by default, where the later `pip install -e '.[dev]'` step (which runs arbitrary build-backend code) could read it. The workflow never uses the token for any git operation, so disabling persistence is safe.
2. **Named `test` job + `timeout-minutes: 10`.** zizmor flags the anonymous job; without a timeout a hung `pytest` burns metered private-repo runner minutes indefinitely.
3. **Cap the ruff dev extra to `>=0.15,<0.16`.** `ruff>=0.8` was unbounded; ruff minors add default-enabled rules, so a future release could redden CI with no code change. `0.15.20` is what passes today.
4. **Dedupe test monkeypatching.** Extracted the repeated `shutil.which` + `subprocess.run` patch setup in `tests/test_wrapper.py` into a `patched_run` fixture that returns the captured `calls`. No behavior change.

## Testing

- `ruff check .` — pass
- `ruff format --check .` — pass
- `pytest -q` — 9/9 pass

Verified locally on Python 3.12 (ruff 0.15.20). CI exercises the 3.10 / 3.14 matrix; the changes are CI-config + test-refactor with no version-sensitive runtime code.
