### PR TITLE
feat: job management tools — cancel_job + get_queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is a small, standalone codebase. Each tool shells out to the `comfy` command 
 `--where local --json`, parses comfy-cli's `envelope/1` output, and returns it. There is no HTTP
 client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engine.
 
-> **Status:** early POC. Four tools, validated end-to-end against a live local ComfyUI (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on 3.10 and 3.14.
+> **Status:** early POC. Six tools, core loop validated end-to-end against a live local ComfyUI (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on 3.10 and 3.14.
 
 ## Prerequisites
 
@@ -24,6 +24,8 @@ client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engi
 | `server_info()` | `comfy env` | Is a local ComfyUI running, where, and which workspace. Call first. |
 | `run_workflow(workflow_path, wait=True, timeout_seconds=600)` | `comfy run --workflow <path> [--wait]` | Run a workflow JSON; `wait=False` submits async and returns a `prompt_id`. |
 | `job_status(prompt_id)` | `comfy jobs status <prompt_id>` | Poll a submitted job's status + outputs. |
+| `cancel_job(prompt_id)` | `comfy jobs cancel <prompt_id>` | Cancel a queued or running job. |
+| `get_queue()` | `comfy jobs ls` | List known jobs with status (pending/running/completed). |
 | `fetch_outputs(prompt_id, out_dir)` | `comfy download <prompt_id> --out-dir <dir>` | Download a finished job's outputs to disk. |
 
 Planned next, each a one-line passthrough: `discover` (`comfy discover`),

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -144,6 +144,29 @@ def job_status(prompt_id: str) -> Any:
 
 
 @mcp.tool()
+def cancel_job(prompt_id: str) -> Any:
+    """Cancel a queued or running LOCAL job.
+
+    Wraps ``comfy jobs cancel <prompt_id>``. Use this to stop a job you
+    submitted via ``run_workflow(wait=False)`` before it finishes; cancelling an
+    unknown or already-finished ``prompt_id`` surfaces comfy-cli's error envelope.
+    """
+    return _run_comfy("jobs", "cancel", prompt_id, timeout=60.0)
+
+
+@mcp.tool()
+def get_queue() -> Any:
+    """List known LOCAL jobs with their status (pending / running / completed).
+
+    Wraps ``comfy jobs ls``. comfy-cli merges its on-disk job state with the
+    running ComfyUI server's queue, so this returns both jobs still in the queue
+    and recently completed ones — call it to find a ``prompt_id`` to inspect with
+    ``job_status`` or cancel with ``cancel_job``.
+    """
+    return _run_comfy("jobs", "ls", timeout=60.0)
+
+
+@mcp.tool()
 def fetch_outputs(prompt_id: str, out_dir: str) -> Any:
     """Collect a completed job's output files into ``out_dir``; returns the paths.
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -69,6 +69,66 @@ def test_missing_binary_raises(monkeypatch):
         server._run_comfy("env")
 
 
+def test_cancel_job_maps_command_and_returns_data(monkeypatch):
+    """cancel_job wraps `comfy jobs cancel <id>` and returns the envelope data."""
+    fake, calls = _fake_run(
+        {"type": "envelope", "ok": True, "data": {"cancelled": "abc"}}
+    )
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    assert server.cancel_job("abc") == {"cancelled": "abc"}
+    assert calls[0]["cmd"][4:] == ["jobs", "cancel", "abc"]  # mapped subcommand
+
+
+def test_cancel_job_unknown_id_raises_error_envelope(monkeypatch):
+    """Cancelling an unknown prompt_id surfaces comfy-cli's error envelope."""
+    fake, _ = _fake_run(
+        {
+            "type": "envelope",
+            "ok": False,
+            "error": {"code": "not_found", "message": "no such job: nope"},
+        }
+    )
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    with pytest.raises(server.ComfyCliError, match="not_found"):
+        server.cancel_job("nope")
+
+
+def test_get_queue_maps_command_and_returns_data(monkeypatch):
+    """get_queue wraps `comfy jobs ls` and returns the merged job list."""
+    jobs = {
+        "jobs": [
+            {"prompt_id": "a", "status": "running"},
+            {"prompt_id": "b", "status": "completed"},
+        ]
+    }
+    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": jobs})
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    assert server.get_queue() == jobs
+    assert calls[0]["cmd"][4:] == ["jobs", "ls"]  # no positional args
+
+
+def test_get_queue_error_envelope_raises(monkeypatch):
+    """A failing `comfy jobs ls` (e.g. server unreachable) raises ComfyCliError."""
+    fake, _ = _fake_run(
+        {
+            "type": "envelope",
+            "ok": False,
+            "error": {"code": "server_not_running", "message": "ComfyUI not running"},
+        }
+    )
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    with pytest.raises(server.ComfyCliError, match="server_not_running"):
+        server.get_queue()
+
+
 def test_fetch_outputs_copies_on_disk_path(monkeypatch, tmp_path):
     """Regression: local `comfy run` emits bare paths; we copy, never `comfy download`."""
     src = tmp_path / "src" / "img.png"


### PR DESCRIPTION
## ELI-5

ComfyUI can have a line of jobs waiting to run. This adds two buttons to the local MCP: one to **cancel** a job you already sent, and one to **see the whole list** of jobs and whether each is waiting, running, or done. Both just ask `comfy-cli` to do the work and hand back its answer.

## What changed

Two new thin passthrough tools in `src/comfy_local_mcp/server.py`, following the existing `job_status` pattern (docstring names the wrapped command; `timeout=60.0`; return value is the unwrapped envelope `data` from `_run_comfy`):

| Tool | Wraps |
|---|---|
| `cancel_job(prompt_id)` | `comfy jobs cancel <prompt_id>` |
| `get_queue()` | `comfy jobs ls` |

`get_queue` lists known local jobs with status (pending/running/completed); comfy-cli already merges its on-disk job state with the running server's queue, so this is a single passthrough.

Architecture guard honored: both are pure comfy-cli passthroughs via the existing `_run_comfy()` helper — no HTTP client, no code ported from the cloud MCP (only the tool *names* are adopted for contract parity).

## Tests

Added to `tests/test_wrapper.py`, mocking `subprocess.run` exactly like the existing tests:

- `cancel_job` — happy path (asserts the mapped `jobs cancel <id>` command + returned data) and an unknown-`prompt_id` error envelope raising `ComfyCliError`.
- `get_queue` — happy path (mapped `jobs ls` command + returned merged job list) and an error envelope (server not running) raising `ComfyCliError`.

Full suite: **13 passed**; `ruff check .` and `ruff format --check .` clean. Verified locally on Python 3.14; the new code uses no version-specific syntax, so the 3.10 matrix leg is equivalent.

## Notes / judgment calls

- Updated the README tools table + tool count (4 → 6) so it stays in sync — small, in-scope doc hygiene rather than a leftover stale table.
- Left the `server.py` module docstring's "next tools to add" prose alone (already pre-existingly stale — it lists `job_status`, which exists) to keep the diff scoped.
