### PR TITLE
feat: add upload_file + validate_workflow passthroughs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engi
 | `run_workflow(workflow_path, wait=True, timeout_seconds=600)` | `comfy run --workflow <path> [--wait]` | Run a workflow JSON; `wait=False` submits async and returns a `prompt_id`. |
 | `job_status(prompt_id)` | `comfy jobs status <prompt_id>` | Poll a submitted job's status + outputs. |
 | `fetch_outputs(prompt_id, out_dir)` | `comfy download <prompt_id> --out-dir <dir>` | Download a finished job's outputs to disk. |
+| `upload_file(paths, overwrite=False)` | `comfy upload <files...> [--overwrite]` | Stage source images/masks into the local `input` dir (unlocks img2img / inpaint). |
+| `validate_workflow(workflow_path)` | `comfy validate --workflow <path>` | Pre-flight a workflow against the live `object_info` before a slow run; surfaces the structured error code on failure. |
 
 Planned next, each a one-line passthrough: `discover` (`comfy discover`),
 `launch`/`stop` (`comfy launch --background` / `comfy stop`) — plus a real

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -172,6 +172,37 @@ def fetch_outputs(prompt_id: str, out_dir: str) -> Any:
     return {"saved": saved, "source_outputs": outputs}
 
 
+@mcp.tool()
+def upload_file(paths: list[str], overwrite: bool = False) -> Any:
+    """Upload local files into the LOCAL ComfyUI ``input`` directory.
+
+    Wraps ``comfy upload <files...> [--overwrite]``. Use this to stage source
+    images/masks a workflow references by filename before running it — it is
+    what unlocks img2img / inpaint workflows on a local ComfyUI. Pass
+    ``overwrite=True`` to replace files that already exist in the input dir
+    (otherwise comfy-cli skips or errors on collisions).
+    """
+    args = ["upload", *paths]
+    if overwrite:
+        args.append("--overwrite")
+    return _run_comfy(*args, timeout=300.0)
+
+
+@mcp.tool()
+def validate_workflow(workflow_path: str) -> Any:
+    """Pre-flight a workflow against the live local ComfyUI before running it.
+
+    Wraps ``comfy validate --workflow <path>``. Checks the workflow's
+    class_types, input shapes, enum values and wiring against the running
+    ComfyUI's ``object_info`` and returns the validation result — cheap
+    insurance before a slow ``run_workflow``. On an invalid workflow this
+    raises :class:`ComfyCliError` carrying comfy-cli's structured error code
+    (e.g. ``workflow_unknown_nodes``) and message, so a missing-node or
+    missing-model problem stays actionable instead of failing deep inside a run.
+    """
+    return _run_comfy("validate", "--workflow", workflow_path, timeout=60.0)
+
+
 def main() -> None:
     """Entry point: serve the MCP over stdio."""
     mcp.run()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -69,6 +69,62 @@ def test_missing_binary_raises(monkeypatch):
         server._run_comfy("env")
 
 
+def test_upload_file_passes_paths_and_overwrite(monkeypatch):
+    """upload_file forwards every path and appends --overwrite when asked."""
+    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": {"uploaded": 2}})
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    assert server.upload_file(["a.png", "b.png"], overwrite=True) == {"uploaded": 2}
+
+    cmd = calls[0]["cmd"]
+    assert cmd[1:4] == ["--json", "--where", "local"]  # global flags first
+    assert cmd[4:] == ["upload", "a.png", "b.png", "--overwrite"]
+
+
+def test_upload_file_omits_overwrite_by_default(monkeypatch):
+    """Without overwrite the flag must be absent, not passed as False."""
+    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": {"uploaded": 1}})
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    server.upload_file(["only.png"])
+
+    assert calls[0]["cmd"][4:] == ["upload", "only.png"]
+    assert "--overwrite" not in calls[0]["cmd"]
+
+
+def test_validate_workflow_returns_results_for_valid(monkeypatch):
+    """A valid workflow returns comfy-cli's validation data unwrapped."""
+    fake, calls = _fake_run(
+        {"type": "envelope", "ok": True, "data": {"valid": True, "nodes": 7}}
+    )
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    assert server.validate_workflow("wf.json") == {"valid": True, "nodes": 7}
+    assert calls[0]["cmd"][4:] == ["validate", "--workflow", "wf.json"]
+
+
+def test_validate_workflow_raises_with_error_code(monkeypatch):
+    """An invalid workflow surfaces comfy-cli's structured error code, not a swallow."""
+    fake, _ = _fake_run(
+        {
+            "type": "envelope",
+            "ok": False,
+            "error": {
+                "code": "workflow_unknown_nodes",
+                "message": "Unknown node type: FooSampler",
+            },
+        }
+    )
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    with pytest.raises(server.ComfyCliError, match="workflow_unknown_nodes"):
+        server.validate_workflow("broken.json")
+
+
 def test_fetch_outputs_copies_on_disk_path(monkeypatch, tmp_path):
     """Regression: local `comfy run` emits bare paths; we copy, never `comfy download`."""
     src = tmp_path / "src" / "img.png"


### PR DESCRIPTION
## ELI-5

The local Comfy MCP could already *run* a workflow, but it couldn't hand ComfyUI
the pictures a workflow needs, and it had no way to catch a broken workflow
before spending minutes running it. This adds two small tools:

- **`upload_file`** copies your source images/masks into ComfyUI's `input`
  folder — that's what img2img and inpaint workflows read from. Now they work.
- **`validate_workflow`** checks a workflow against your running ComfyUI *first*
  (do all its nodes exist? are the inputs wired right?) and, if something's
  wrong, tells you exactly what — e.g. a missing node — instead of failing deep
  inside a slow run.

## What

Two new tools in `src/comfy_local_mcp/server.py`, both thin passthroughs over
the existing `_run_comfy()` helper (no HTTP client, no code borrowed from the
cloud MCP — comfy-cli stays the engine):

| Tool | Wraps |
|---|---|
| `upload_file(paths, overwrite=False)` | `comfy upload <files...> [--overwrite]` |
| `validate_workflow(workflow_path)` | `comfy validate --workflow <path>` |

`validate_workflow` relies on `_run_comfy`'s existing error handling, which
formats an error envelope as `ComfyCliError` with the structured code embedded
(`comfy validate failed [workflow_unknown_nodes]: ...`) — the missing-node /
missing-model message stays actionable rather than being swallowed.

## Tests

- `upload_file`: asserts the composed argv forwards multiple paths and appends
  `--overwrite` only when requested.
- `validate_workflow`: returns the validation data for a valid workflow; raises
  `ComfyCliError` carrying the error code for an invalid one.
- Full suite green locally (`pytest -q` → 13 passed), `ruff check .` and
  `ruff format --check .` clean. CI runs the same on the 3.10 / 3.14 matrix.

## Judgment calls

- **Error code surfacing**: kept the repo's established convention of embedding
  the comfy-cli error code in the `ComfyCliError` *message* (matched by the
  existing `test_error_envelope_raises_with_code`) rather than adding a new
  `.code` attribute to the shared exception class — consistent, no blast radius.
- **`--overwrite` placement** (after the file args) matches the spec'd
  invocation; an empty `paths` list degrades to comfy-cli's own error, surfaced
  as `ComfyCliError` (thin-passthrough behavior, not re-validated here).
- The exact `comfy upload` / `comfy validate` invocations still want a smoke
  test against a live comfy-cli + local ComfyUI, same caveat the module header
  already carries for the other tools.
