### PR TITLE
feat: discovery tools — search_nodes / get_node / search_models

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engi
 | `run_workflow(workflow_path, wait=True, timeout_seconds=600)` | `comfy run --workflow <path> [--wait]` | Run a workflow JSON; `wait=False` submits async and returns a `prompt_id`. |
 | `job_status(prompt_id)` | `comfy jobs status <prompt_id>` | Poll a submitted job's status + outputs. |
 | `fetch_outputs(prompt_id, out_dir)` | `comfy download <prompt_id> --out-dir <dir>` | Download a finished job's outputs to disk. |
+| `search_nodes(query)` | `comfy nodes search <query>` | Find node classes in the **live local** `object_info` (includes installed custom nodes). |
+| `get_node(name)` | `comfy nodes show <ClassName>` | Full input/output schema for one node class — what you need to author/repair a graph. |
+| `search_models(query="", folder="")` | `comfy models search` / `models list-folder <folder>` / `models list-folders` | List/search model files on disk. **Local:** filenames only, no cloud enrichment. |
+
+Discovery reads the **user's live install** (custom nodes included), not a static
+catalog — that's the local differentiator from the cloud MCP's equivalents.
 
 Planned next, each a one-line passthrough: `discover` (`comfy discover`),
 `launch`/`stop` (`comfy launch --background` / `comfy stop`) — plus a real

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -172,6 +172,55 @@ def fetch_outputs(prompt_id: str, out_dir: str) -> Any:
     return {"saved": saved, "source_outputs": outputs}
 
 
+@mcp.tool()
+def search_nodes(query: str) -> Any:
+    """Search node classes in the LOCAL ComfyUI's live ``object_info``.
+
+    Wraps ``comfy nodes search <query>``. Because the catalog is read from the
+    user's running install, results include their INSTALLED custom nodes — not a
+    static/bundled catalog. Use this to find the class name of a node (e.g.
+    "KSampler", "load image") before authoring or repairing a workflow graph;
+    pass the returned name to ``get_node`` for its full schema.
+    """
+    return _run_comfy("nodes", "search", query, timeout=60.0)
+
+
+@mcp.tool()
+def get_node(name: str) -> Any:
+    """Return one node class's full input/output schema from the live local catalog.
+
+    Wraps ``comfy nodes show <ClassName>``. ``name`` is the node's class name
+    (as returned by ``search_nodes``). The schema — required/optional inputs,
+    their types and defaults, and outputs — is what an agent needs to author or
+    repair a workflow graph. Reflects the user's live install, so it resolves
+    custom-node classes too (not just built-ins).
+    """
+    return _run_comfy("nodes", "show", name, timeout=60.0)
+
+
+@mcp.tool()
+def search_models(query: str = "", folder: str = "") -> Any:
+    """Search / list model files available to the LOCAL ComfyUI install.
+
+    Thin passthrough with three modes, in precedence order:
+
+    - ``query`` given → ``comfy models search <query>`` (match model filenames).
+    - else ``folder`` given → ``comfy models list-folder <folder>`` (list one
+      model folder, e.g. ``checkpoints``, ``loras``).
+    - else (both empty) → ``comfy models list-folders`` (list the folder names).
+
+    LOCAL DEGRADATION: unlike the cloud catalog, this returns only what is on
+    disk — filenames, with no enrichment (no base-model / hash / description /
+    download metadata). Agents should set expectations accordingly: it answers
+    "which model files does this install have?", not "tell me about this model".
+    """
+    if query:
+        return _run_comfy("models", "search", query, timeout=60.0)
+    if folder:
+        return _run_comfy("models", "list-folder", folder, timeout=60.0)
+    return _run_comfy("models", "list-folders", timeout=60.0)
+
+
 def main() -> None:
     """Entry point: serve the MCP over stdio."""
     mcp.run()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,96 @@
+"""Mocked tests for the discovery tools (search_nodes / get_node / search_models).
+
+These assert the exact ``comfy`` argv each tool composes (the thin-passthrough
+contract) against a stubbed ``subprocess.run``, plus one error-envelope path
+(local server not running) that must surface as ``ComfyCliError``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from comfy_local_mcp import server
+
+
+def _stub_comfy(monkeypatch, envelope: dict):
+    """Stub shutil.which + subprocess.run; return the list that records each argv."""
+    calls: list[list[str]] = []
+
+    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+        calls.append(cmd)
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout=json.dumps(envelope), stderr=""
+        )
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+    return calls
+
+
+def _ok(data):
+    return {"type": "envelope", "ok": True, "data": data}
+
+
+def test_search_nodes_argv(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok([{"name": "KSampler"}]))
+    assert server.search_nodes("sampler") == [{"name": "KSampler"}]
+    # global flags first, then the subcommand + query verbatim
+    assert calls[0] == [
+        server.COMFY_BIN,
+        "--json",
+        "--where",
+        "local",
+        "nodes",
+        "search",
+        "sampler",
+    ]
+
+
+def test_get_node_argv(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok({"name": "KSampler", "inputs": {}}))
+    assert server.get_node("KSampler") == {"name": "KSampler", "inputs": {}}
+    assert calls[0][4:] == ["nodes", "show", "KSampler"]
+
+
+def test_search_models_query_uses_search(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok(["sd_xl_base.safetensors"]))
+    assert server.search_models(query="xl") == ["sd_xl_base.safetensors"]
+    assert calls[0][4:] == ["models", "search", "xl"]
+
+
+def test_search_models_folder_uses_list_folder(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok(["model.ckpt"]))
+    assert server.search_models(folder="checkpoints") == ["model.ckpt"]
+    assert calls[0][4:] == ["models", "list-folder", "checkpoints"]
+
+
+def test_search_models_empty_lists_folders(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok(["checkpoints", "loras"]))
+    assert server.search_models() == ["checkpoints", "loras"]
+    assert calls[0][4:] == ["models", "list-folders"]
+
+
+def test_search_models_query_takes_precedence_over_folder(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok([]))
+    server.search_models(query="xl", folder="checkpoints")
+    assert calls[0][4:] == ["models", "search", "xl"]
+
+
+def test_discovery_surfaces_error_envelope(monkeypatch):
+    """A local server-not-running envelope must raise, not return silently."""
+    _stub_comfy(
+        monkeypatch,
+        {
+            "type": "envelope",
+            "ok": False,
+            "error": {
+                "code": "server_not_running",
+                "message": "local ComfyUI not running",
+            },
+        },
+    )
+    with pytest.raises(server.ComfyCliError, match="server_not_running"):
+        server.search_nodes("sampler")


### PR DESCRIPTION
## ELI-5

If you want to build or fix a ComfyUI workflow, you first need to know **what nodes exist** and **what each node's inputs/outputs are** — and **which model files** you actually have. This adds three tools that answer exactly those questions by asking your **live, running local ComfyUI** (so it sees your installed custom nodes too), not a frozen catalog.

## What

Three read-only discovery tools in `server.py`, each a thin `_run_comfy()` passthrough:

| Tool | Wraps |
|---|---|
| `search_nodes(query)` | `comfy nodes search <query>` |
| `get_node(name)` | `comfy nodes show <ClassName>` |
| `search_models(query="", folder="")` | `comfy models search <query>` / `comfy models list-folder <folder>` / `comfy models list-folders` |

`search_models` picks its subcommand by precedence: `query` → search; else `folder` → list-folder; else → list-folders.

## Why

The cloud tool names (`search_nodes` / `get_node` / `search_models`) are adopted for contract parity. The **local differentiator**: results come from the user's live install (custom nodes included), not a static/bundled catalog. `search_models` degrades locally to filename listing with no cloud enrichment — this is called out in its docstring so agents set expectations.

## Tests

`tests/test_discovery.py` — mocked `subprocess.run`; asserts the exact argv each tool composes (thin-passthrough contract), the `search_models` mode/precedence matrix (including query-beats-folder), and one error-envelope path (server not running → `ComfyCliError`). Full suite: 16 passed; `ruff check` + `ruff format --check` clean locally.

## Notes / judgment calls

- **comfy-cli subcommand names unverified against a live install.** The verbs (`nodes search/show`, `models search/list-folder/list-folders`) come from the ticket; they are not yet smoke-tested against a real comfy-cli — consistent with the repo's existing documented posture (the module docstring already flags that the exact `comfy` invocation needs a smoke test). What the tests lock in is argv composition + envelope handling, not the CLI verbs themselves.
- **`search_models` when both `query` and `folder` are given:** `query` takes precedence (documented + tested). The ticket enumerated the three commands but not the combination; this seemed the least-surprising rule (a text query is the more specific intent).
- Architecture guard respected: pure `_run_comfy` passthroughs, no code/index/bundled data from the cloud MCP.