### PR TITLE
feat: template tools — search_templates / get_template / fetch_template

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -172,6 +172,84 @@ def fetch_outputs(prompt_id: str, out_dir: str) -> Any:
     return {"saved": saved, "source_outputs": outputs}
 
 
+def _template_matches(item: Any, query_lower: str) -> bool:
+    """True if ``query_lower`` (already lowercased) is a substring of a template entry.
+
+    Handles both shapes comfy-cli might emit for a template: a bare name string,
+    or a dict of fields (name / title / description / …) — we match against every
+    string value so the query hits any of them.
+    """
+    if isinstance(item, str):
+        return query_lower in item.lower()
+    if isinstance(item, dict):
+        return any(
+            isinstance(v, str) and query_lower in v.lower() for v in item.values()
+        )
+    return False
+
+
+@mcp.tool()
+def search_templates(query: str = "") -> Any:
+    """Search the built-in ComfyUI workflow templates by name/description.
+
+    Wraps ``comfy templates ls``. When ``query`` is non-empty the listing is
+    filtered client-side (case-insensitive substring match against each
+    template's name and any text fields) — comfy-cli's ``ls`` has no server-side
+    filter argument, so the narrowing happens here; an empty ``query`` returns
+    the full list.
+
+    Step 1 of the template on-ramp: pick a ``name`` from the results, inspect it
+    with ``get_template(name)``, then ``fetch_template(name, out_path)`` to write
+    a runnable workflow JSON and pass that path straight to ``run_workflow`` — a
+    working generation without hand-authoring workflow JSON.
+    """
+    data = _run_comfy("templates", "ls", timeout=60.0)
+    if not query:
+        return data
+    q = query.lower()
+    if isinstance(data, list):
+        return [item for item in data if _template_matches(item, q)]
+    if isinstance(data, dict) and isinstance(data.get("templates"), list):
+        return {
+            **data,
+            "templates": [t for t in data["templates"] if _template_matches(t, q)],
+        }
+    # Unknown shape — return it unfiltered rather than silently dropping data.
+    return data
+
+
+@mcp.tool()
+def get_template(name: str) -> Any:
+    """Show one template's details/schema (inputs, description, node graph).
+
+    Wraps ``comfy templates show <name>``, using a ``name`` from
+    ``search_templates``. Step 2 of the on-ramp: inspect a template before
+    fetching it, then ``fetch_template(name, out_path)`` writes the runnable JSON
+    for ``run_workflow``.
+    """
+    return _run_comfy("templates", "show", name, timeout=60.0)
+
+
+@mcp.tool()
+def fetch_template(name: str, out_path: str) -> str:
+    """Write a template's runnable workflow JSON to ``out_path``; return its absolute path.
+
+    Wraps ``comfy templates fetch <name> --out <path>``, which materializes the
+    template as a workflow JSON file on disk. Returns the ABSOLUTE path so it can
+    be passed straight to ``run_workflow(workflow_path=...)``, completing the
+    template on-ramp::
+
+        search_templates("flux")               # find a template
+        get_template("flux_dev")               # inspect it
+        path = fetch_template("flux_dev", "/tmp/flux.json")
+        run_workflow(path)                      # generate — no hand-authored JSON
+
+    so an agent reaches a working generation without hand-authoring workflow JSON.
+    """
+    _run_comfy("templates", "fetch", name, "--out", out_path, timeout=60.0)
+    return os.path.abspath(out_path)
+
+
 def main() -> None:
     """Entry point: serve the MCP over stdio."""
     mcp.run()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,112 @@
+"""Tests for the template tools — the search -> fetch -> run_workflow on-ramp.
+
+These lock in the passthrough argv (global flags before the subcommand, same
+rule the wrapper enforces) and the two behaviors the tools own on top of the
+passthrough:
+1. ``search_templates`` filters ``comfy templates ls`` client-side, since the
+   CLI has no server-side filter arg.
+2. ``fetch_template`` returns the ABSOLUTE output path so it can be handed
+   straight to ``run_workflow``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+
+from comfy_local_mcp import server
+
+
+def _fake_run(envelope: dict):
+    """Return a subprocess.run stand-in that captures the call and emits an envelope."""
+    calls: list[dict] = []
+
+    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+        calls.append({"cmd": cmd, "env": env})
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout=json.dumps(envelope), stderr=""
+        )
+
+    return fake, calls
+
+
+def test_search_templates_argv(monkeypatch):
+    """Passthrough: `comfy --json --where local templates ls`, empty query = full list."""
+    data = ["flux_dev", "sd15_basic"]
+    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": data})
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    assert server.search_templates() == data
+
+    cmd = calls[0]["cmd"]
+    assert cmd[1:4] == ["--json", "--where", "local"]  # global flags first
+    assert cmd[4:] == ["templates", "ls"]  # subcommand strictly after
+
+
+def test_search_templates_filters_list_client_side(monkeypatch):
+    """Non-empty query narrows the `ls` output (CLI has no filter arg)."""
+    data = ["flux_dev", "flux_schnell", "sd15_basic"]
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: data)
+
+    assert server.search_templates("flux") == ["flux_dev", "flux_schnell"]
+    assert server.search_templates("FLUX") == [
+        "flux_dev",
+        "flux_schnell",
+    ]  # case-insensitive
+    assert server.search_templates("nope") == []
+
+
+def test_search_templates_filters_dict_entries(monkeypatch):
+    """Matches across any text field of a dict-shaped template entry."""
+    data = [
+        {"name": "flux_dev", "description": "Flux dev text-to-image"},
+        {"name": "sd15_basic", "description": "Stable Diffusion 1.5"},
+    ]
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: data)
+
+    # Hit on description text, not just the name.
+    assert server.search_templates("stable diffusion") == [data[1]]
+    assert server.search_templates("text-to-image") == [data[0]]
+
+
+def test_search_templates_unknown_shape_returned_unfiltered(monkeypatch):
+    """An unexpected data shape is returned as-is rather than silently dropped."""
+    data = {"count": 2}
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: data)
+    assert server.search_templates("flux") == data
+
+
+def test_get_template_argv(monkeypatch):
+    """Passthrough: `comfy --json --where local templates show <name>`."""
+    fake, calls = _fake_run(
+        {"type": "envelope", "ok": True, "data": {"name": "flux_dev", "nodes": 12}}
+    )
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    assert server.get_template("flux_dev") == {"name": "flux_dev", "nodes": 12}
+    assert calls[0]["cmd"][4:] == ["templates", "show", "flux_dev"]
+
+
+def test_fetch_template_argv_and_returns_abspath(monkeypatch, tmp_path):
+    """Passthrough argv is `templates fetch <name> --out <path>`; returns the abs path."""
+    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": None})
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    out = tmp_path / "flux.json"
+    result = server.fetch_template("flux_dev", str(out))
+
+    assert calls[0]["cmd"][4:] == ["templates", "fetch", "flux_dev", "--out", str(out)]
+    assert result == str(out)  # tmp_path is already absolute
+    assert os.path.isabs(result)
+
+
+def test_fetch_template_resolves_relative_path(monkeypatch):
+    """A relative out_path is returned as an absolute path (ready for run_workflow)."""
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: None)
+    result = server.fetch_template("flux_dev", "flux.json")
+    assert result == os.path.abspath("flux.json")
+    assert os.path.isabs(result)


### PR DESCRIPTION
## ELI-5

ComfyUI ships a pile of ready-made workflow "templates." Today an agent using this MCP has to hand-write workflow JSON before it can run anything. These three tools let it instead: **list templates → look one up → save it to a file → run that file** — a working image generation with zero JSON authoring.

## What

Adds three thin `comfy-cli` passthroughs to `server.py`, all going through the existing `_run_comfy()` helper (no HTTP, no code borrowed from the cloud MCP):

| Tool | Wraps | Notes |
|---|---|---|
| `search_templates(query="")` | `comfy templates ls` | Filters the listing **client-side** by `query` (case-insensitive substring over each template's text fields) — the CLI has no server-side filter arg. Empty query = full list. |
| `get_template(name)` | `comfy templates show <name>` | Template details / schema. |
| `fetch_template(name, out_path)` | `comfy templates fetch <name> --out <path>` | Writes the runnable workflow JSON and returns the **absolute** path, so it drops straight into `run_workflow`. |

The tool names `search_templates` / `get_template` match the Comfy Cloud MCP for contract parity.

## The on-ramp

```
search_templates("flux")               # find a template
get_template("flux_dev")               # inspect it
path = fetch_template("flux_dev", "/tmp/flux.json")
run_workflow(path)                      # generate — no hand-authored JSON
```

Each docstring spells this chain out so an agent discovers it.

## Tests

New `tests/test_templates.py` (mocked, no live comfy-cli needed): passthrough argv for all three (global flags before subcommand), client-side filtering (list + dict entry shapes, case-insensitivity, unknown-shape passthrough), and that `fetch_template` returns an absolute path. Full suite green (`ruff check`, `ruff format --check`, `pytest` — 16 passed).

## Judgment calls

- **comfy-cli is not installed on the build host**, so the exact `templates` subcommand data shape couldn't be smoke-tested — same caveat the module already documents for its other verbs. Mitigations: `search_templates` with an empty query is a pure passthrough, and a non-empty query against an unexpected shape returns the data **unfiltered** rather than dropping it (graceful degradation, never a crash).
- `fetch_template` is kept a **thin passthrough** — it returns `abspath(out_path)` and trusts comfy-cli to have written there (consistent with the architecture guard); `run_workflow` surfaces a clear error if the file is absent.
