### PR TITLE
feat: lifecycle tools — launch_comfyui + stop_comfyui

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is a small, standalone codebase. Each tool shells out to the `comfy` command 
 `--where local --json`, parses comfy-cli's `envelope/1` output, and returns it. There is no HTTP
 client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engine.
 
-> **Status:** early POC. Six tools, core loop validated end-to-end against a live local ComfyUI (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on 3.10 and 3.14.
+> **Status:** early POC. Eight tools, core loop validated end-to-end against a live local ComfyUI (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on 3.10 and 3.14.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engi
 | `cancel_job(prompt_id)` | `comfy jobs cancel <prompt_id>` | Cancel a queued or running job. |
 | `get_queue()` | `comfy jobs ls` | List known jobs with status (pending/running/completed). |
 | `fetch_outputs(prompt_id, out_dir)` | `comfy download <prompt_id> --out-dir <dir>` | Download a finished job's outputs to disk. |
+| `launch_comfyui(extra_args=None)` | `comfy launch --background [-- <extras>]` | Start the local ComfyUI detached; forwards `extra_args` to ComfyUI. |
+| `stop_comfyui()` | `comfy stop` | Stop the ComfyUI that comfy-cli launched (only its own recorded pid). |
 
-Planned next, each a one-line passthrough: `discover` (`comfy discover`),
-`launch`/`stop` (`comfy launch --background` / `comfy stop`) — plus a real
-generation round-trip test.
+Planned next, each a one-line passthrough: `discover` (`comfy discover`) — plus
+a real generation round-trip test.
 
 ## Run
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -5,10 +5,10 @@ target, asks for JSON, parses comfy-cli's versioned ``envelope/1`` result, and
 returns its ``data``. There is deliberately no HTTP client and no code shared
 with the Comfy Cloud MCP — comfy-cli is the engine.
 
-Tools so far: the run -> get-output core loop plus ``job_status`` and the
-``launch_comfyui`` / ``stop_comfyui`` lifecycle pair (``comfy launch
---background`` / ``comfy stop``). Next passthrough to add: ``discover``
-(``comfy discover`` / ``comfy which``).
+Tools so far: the run -> get-output core loop plus job management
+(``job_status`` / ``cancel_job`` / ``get_queue``) and the ``launch_comfyui`` /
+``stop_comfyui`` lifecycle pair (``comfy launch --background`` / ``comfy stop``).
+Next passthrough to add: ``discover`` (``comfy discover`` / ``comfy which``).
 
 NOTE: the exact ``comfy`` invocation + envelope shape still need a smoke test
 against a real comfy-cli install and a running local ComfyUI.

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -5,10 +5,10 @@ target, asks for JSON, parses comfy-cli's versioned ``envelope/1`` result, and
 returns its ``data``. There is deliberately no HTTP client and no code shared
 with the Comfy Cloud MCP — comfy-cli is the engine.
 
-First cut: the run -> get-output core loop (2 tools). Next tools to add, each a
-one-line passthrough: ``job_status`` (``comfy jobs status``), ``discover``
-(``comfy discover`` / ``comfy which``), ``launch``/``stop``
-(``comfy launch --background`` / ``comfy stop``).
+Tools so far: the run -> get-output core loop plus ``job_status`` and the
+``launch_comfyui`` / ``stop_comfyui`` lifecycle pair (``comfy launch
+--background`` / ``comfy stop``). Next passthrough to add: ``discover``
+(``comfy discover`` / ``comfy which``).
 
 NOTE: the exact ``comfy`` invocation + envelope shape still need a smoke test
 against a real comfy-cli install and a running local ComfyUI.
@@ -193,6 +193,46 @@ def fetch_outputs(prompt_id: str, out_dir: str) -> Any:
             shutil.copy2(ref, dst)
             saved.append(dst)
     return {"saved": saved, "source_outputs": outputs}
+
+
+@mcp.tool()
+def launch_comfyui(extra_args: list[str] | None = None) -> Any:
+    """Start the LOCAL ComfyUI server, detached, and return once it is up.
+
+    Wraps ``comfy launch --background``, which boots ComfyUI as a background
+    process and records its pid so ``stop_comfyui`` can later shut it down. Any
+    ``extra_args`` are forwarded to ComfyUI itself after a ``--`` separator
+    (e.g. ``["--port", "8189"]`` -> ``comfy launch --background -- --port 8189``).
+    The timeout is generous because the first boot loads torch and can take a
+    while.
+
+    Call ``server_info`` first if you only want to check whether a server is
+    already running — launching a second one will fail on the port.
+
+    NOTE (temporary upstream caveat): ``comfy launch --background`` currently
+    crashes on Python 3.14 (comfy-cli asyncio ``get_event_loop`` issue; a fix is
+    in review upstream). On affected comfy-cli versions the crash surfaces here
+    as a clean :class:`ComfyCliError` from the error envelope. Remove this note
+    once the upstream fix ships.
+    """
+    args = ["launch", "--background"]
+    if extra_args:
+        args += ["--", *extra_args]
+    return _run_comfy(*args, timeout=180.0)
+
+
+@mcp.tool()
+def stop_comfyui() -> Any:
+    """Stop the LOCAL ComfyUI server that comfy-cli launched.
+
+    Wraps ``comfy stop``. Ownership semantics: comfy-cli only kills the pid it
+    recorded when IT launched the server via ``launch_comfyui`` /
+    ``comfy launch --background``. It therefore cannot stop a ComfyUI started by
+    the desktop app or by hand — in that case comfy-cli reports it has no
+    recorded server and this tool raises a :class:`ComfyCliError` carrying that
+    message, rather than killing an unrelated process.
+    """
+    return _run_comfy("stop", timeout=60.0)
 
 
 def main() -> None:

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -77,35 +77,29 @@ def test_missing_binary_raises(monkeypatch):
         server._run_comfy("env")
 
 
-def test_cancel_job_maps_command_and_returns_data(monkeypatch):
+def test_cancel_job_maps_command_and_returns_data(patched_run):
     """cancel_job wraps `comfy jobs cancel <id>` and returns the envelope data."""
-    fake, calls = _fake_run(
-        {"type": "envelope", "ok": True, "data": {"cancelled": "abc"}}
-    )
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"cancelled": "abc"}})
 
     assert server.cancel_job("abc") == {"cancelled": "abc"}
     assert calls[0]["cmd"][4:] == ["jobs", "cancel", "abc"]  # mapped subcommand
 
 
-def test_cancel_job_unknown_id_raises_error_envelope(monkeypatch):
+def test_cancel_job_unknown_id_raises_error_envelope(patched_run):
     """Cancelling an unknown prompt_id surfaces comfy-cli's error envelope."""
-    fake, _ = _fake_run(
+    patched_run(
         {
             "type": "envelope",
             "ok": False,
             "error": {"code": "not_found", "message": "no such job: nope"},
         }
     )
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
 
     with pytest.raises(server.ComfyCliError, match="not_found"):
         server.cancel_job("nope")
 
 
-def test_get_queue_maps_command_and_returns_data(monkeypatch):
+def test_get_queue_maps_command_and_returns_data(patched_run):
     """get_queue wraps `comfy jobs ls` and returns the merged job list."""
     jobs = {
         "jobs": [
@@ -113,35 +107,29 @@ def test_get_queue_maps_command_and_returns_data(monkeypatch):
             {"prompt_id": "b", "status": "completed"},
         ]
     }
-    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": jobs})
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run({"type": "envelope", "ok": True, "data": jobs})
 
     assert server.get_queue() == jobs
     assert calls[0]["cmd"][4:] == ["jobs", "ls"]  # no positional args
 
 
-def test_get_queue_error_envelope_raises(monkeypatch):
+def test_get_queue_error_envelope_raises(patched_run):
     """A failing `comfy jobs ls` (e.g. server unreachable) raises ComfyCliError."""
-    fake, _ = _fake_run(
+    patched_run(
         {
             "type": "envelope",
             "ok": False,
             "error": {"code": "server_not_running", "message": "ComfyUI not running"},
         }
     )
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
 
     with pytest.raises(server.ComfyCliError, match="server_not_running"):
         server.get_queue()
 
 
-def test_launch_comfyui_passes_background_flag(monkeypatch):
+def test_launch_comfyui_passes_background_flag(patched_run):
     """launch_comfyui must run `comfy … launch --background` (detached start)."""
-    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": {"pid": 42}})
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"pid": 42}})
 
     assert server.launch_comfyui() == {"pid": 42}
 
@@ -150,20 +138,18 @@ def test_launch_comfyui_passes_background_flag(monkeypatch):
     assert cmd[4:] == ["launch", "--background"]  # no extras -> no `--` separator
 
 
-def test_launch_comfyui_forwards_extra_args_after_separator(monkeypatch):
+def test_launch_comfyui_forwards_extra_args_after_separator(patched_run):
     """Extra args are forwarded to ComfyUI after a `--` separator."""
-    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": {}})
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
 
     server.launch_comfyui(["--port", "8189"])
 
     assert calls[0]["cmd"][4:] == ["launch", "--background", "--", "--port", "8189"]
 
 
-def test_stop_comfyui_surfaces_no_recorded_server_error(monkeypatch):
+def test_stop_comfyui_surfaces_no_recorded_server_error(patched_run):
     """stop only targets comfy-cli's own pid; no recorded server -> clean error."""
-    fake, calls = _fake_run(
+    calls = patched_run(
         {
             "type": "envelope",
             "ok": False,
@@ -173,8 +159,6 @@ def test_stop_comfyui_surfaces_no_recorded_server_error(monkeypatch):
             },
         }
     )
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
 
     with pytest.raises(server.ComfyCliError, match="no_recorded_server"):
         server.stop_comfyui()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -137,6 +137,51 @@ def test_get_queue_error_envelope_raises(monkeypatch):
         server.get_queue()
 
 
+def test_launch_comfyui_passes_background_flag(monkeypatch):
+    """launch_comfyui must run `comfy … launch --background` (detached start)."""
+    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": {"pid": 42}})
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    assert server.launch_comfyui() == {"pid": 42}
+
+    cmd = calls[0]["cmd"]
+    assert cmd[1:4] == ["--json", "--where", "local"]  # global flags still first
+    assert cmd[4:] == ["launch", "--background"]  # no extras -> no `--` separator
+
+
+def test_launch_comfyui_forwards_extra_args_after_separator(monkeypatch):
+    """Extra args are forwarded to ComfyUI after a `--` separator."""
+    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": {}})
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    server.launch_comfyui(["--port", "8189"])
+
+    assert calls[0]["cmd"][4:] == ["launch", "--background", "--", "--port", "8189"]
+
+
+def test_stop_comfyui_surfaces_no_recorded_server_error(monkeypatch):
+    """stop only targets comfy-cli's own pid; no recorded server -> clean error."""
+    fake, calls = _fake_run(
+        {
+            "type": "envelope",
+            "ok": False,
+            "error": {
+                "code": "no_recorded_server",
+                "message": "no ComfyUI server was launched by comfy-cli",
+            },
+        }
+    )
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    with pytest.raises(server.ComfyCliError, match="no_recorded_server"):
+        server.stop_comfyui()
+
+    assert calls[0]["cmd"][4:] == ["stop"]
+
+
 def test_fetch_outputs_copies_on_disk_path(monkeypatch, tmp_path):
     """Regression: local `comfy run` emits bare paths; we copy, never `comfy download`."""
     src = tmp_path / "src" / "img.png"


### PR DESCRIPTION
## ELI-5

You can already ask this MCP to *run* a workflow, but only if a local ComfyUI is
already up. These two new tools let an agent turn the local ComfyUI **on** and
**off** by itself:

- `launch_comfyui()` — starts ComfyUI in the background (like flipping the power
  switch) and waits for it to boot.
- `stop_comfyui()` — turns off the ComfyUI *that this tool started*. It can't
  accidentally kill a ComfyUI you opened via the desktop app or by hand — if it
  wasn't started by the CLI, it just says so instead of shutting anything down.

## What

Adds two lifecycle passthrough tools to `server.py`, both thin `_run_comfy()`
wrappers (no HTTP, no shared cloud code):

| Tool | Wraps |
|---|---|
| `launch_comfyui(extra_args=None)` | `comfy launch --background [-- <extras>]` |
| `stop_comfyui()` | `comfy stop` |

- `launch_comfyui` starts the local ComfyUI detached with a generous 180s
  timeout (first boot loads torch). Optional `extra_args` are forwarded to
  ComfyUI after a `--` separator.
- `stop_comfyui` is structurally safe: the CLI only kills the pid it recorded at
  launch, so it can never take down a desktop-app or manually-started server —
  it surfaces the "no recorded server" error as a clean `ComfyCliError`.

## Docstrings

- `stop_comfyui` documents the ownership semantics (stop only affects
  CLI-launched servers).
- `launch_comfyui` documents the temporary upstream caveat that
  `comfy launch --background` currently crashes on Python 3.14 (the fix is in
  review upstream); the error propagates as a clean `ComfyCliError`. The
  docstring carries a "remove once the fix ships" note.

## Tests

Three new mocked regression tests (argv assertions, no real subprocess):
- `launch --background` argv, with and without the `--` extras separator.
- `stop` surfaces the "no recorded server" error as a `ComfyCliError`.

Local run (Python 3.14): `ruff check` + `ruff format --check` clean, 12 tests
pass.

## Judgment calls

- Timeout set to 180s (ticket asked for ≥120s) to give torch's first boot
  headroom.
- README + module docstring tool tables updated to list the new pair and drop
  them from the "planned next" line.
