### PR TITLE
feat: wait_for_job tool + MCP server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is a small, standalone codebase. Each tool shells out to the `comfy` command 
 `--where local --json`, parses comfy-cli's `envelope/1` output, and returns it. There is no HTTP
 client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engine.
 
-> **Status:** early POC. Six tools, core loop validated end-to-end against a live local ComfyUI (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on 3.10 and 3.14.
+> **Status:** early POC. Twelve tools, core loop validated end-to-end against a live local ComfyUI (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on 3.10 and 3.14.
 
 ## Prerequisites
 
@@ -24,6 +24,7 @@ client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engi
 | `server_info()` | `comfy env` | Is a local ComfyUI running, where, and which workspace. Call first. |
 | `run_workflow(workflow_path, wait=True, timeout_seconds=600)` | `comfy run --workflow <path> [--wait]` | Run a workflow JSON; `wait=False` submits async and returns a `prompt_id`. |
 | `job_status(prompt_id)` | `comfy jobs status <prompt_id>` | Poll a submitted job's status + outputs. |
+| `wait_for_job(prompt_id, timeout_seconds=25)` | `comfy jobs status <prompt_id>` (polled) | Bounded wait until a job reaches a terminal status; returns a timed-out payload on expiry. |
 | `cancel_job(prompt_id)` | `comfy jobs cancel <prompt_id>` | Cancel a queued or running job. |
 | `get_queue()` | `comfy jobs ls` | List known jobs with status (pending/running/completed). |
 | `fetch_outputs(prompt_id, out_dir)` | `comfy download <prompt_id> --out-dir <dir>` | Download a finished job's outputs to disk. |

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -20,13 +20,34 @@ import json
 import os
 import shutil
 import subprocess
+import time
 import urllib.request
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 from mcp.server.fastmcp import FastMCP
 
-mcp = FastMCP("comfy-local-mcp")
+# Rides every client handshake — teach an agent the canonical flows up front so
+# it does not have to rediscover them tool-by-tool. Keep this short.
+INSTRUCTIONS = """\
+This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
+
+- Call `server_info` FIRST to confirm a local ComfyUI is running before anything
+  else.
+- Long generations: submit non-blocking with `run_workflow(wait=False)` to get a
+  `prompt_id`, poll `wait_for_job` (a short bounded wait — chain several) or
+  `job_status` until it finishes, then collect files with `fetch_outputs`.
+  Prefer this over `run_workflow(wait=True)` for slow runs so nothing blocks.
+- Start from a template: `search_templates` to find one, `fetch_template` to save
+  its workflow JSON, then `run_workflow` on that file.
+- When custom nodes or models may be missing, pre-flight with `validate_workflow`
+  before running.
+- Manage in-flight work with `get_queue` (list jobs) and `cancel_job`.
+
+Everything targets the LOCAL server only — there is no cloud access here.
+"""
+
+mcp = FastMCP("comfy-local-mcp", instructions=INSTRUCTIONS)
 
 # Allow overriding the binary (e.g. a venv path) without touching code.
 COMFY_BIN = os.environ.get("COMFY_BIN", "comfy")
@@ -141,6 +162,58 @@ def job_status(prompt_id: str) -> Any:
     finished, its output references. Poll this after ``run_workflow(wait=False)``.
     """
     return _run_comfy("jobs", "status", prompt_id, timeout=60.0)
+
+
+# Statuses that mean a job is finished (no point polling further). comfy-cli
+# surfaces ComfyUI's own states plus its wrapper's, so match generously and
+# case-insensitively; anything else (queued / pending / running) keeps polling.
+_TERMINAL_STATUSES = frozenset(
+    {
+        "completed",
+        "complete",
+        "success",
+        "succeeded",
+        "done",
+        "error",
+        "failed",
+        "cancelled",
+        "canceled",
+    }
+)
+
+
+def _is_terminal(status: Any) -> bool:
+    """True if a ``jobs status`` payload reports a finished state."""
+    if isinstance(status, dict):
+        value = status.get("status")
+        if isinstance(value, str):
+            return value.lower() in _TERMINAL_STATUSES
+    return False
+
+
+@mcp.tool()
+def wait_for_job(prompt_id: str, timeout_seconds: float = 25.0) -> Any:
+    """Wait (bounded) for a submitted LOCAL job to reach a terminal status.
+
+    Polls ``comfy jobs status <prompt_id>`` with a short sleep between polls
+    until the job finishes (completed / error / cancelled) or
+    ``timeout_seconds`` elapses. Returns the final status payload on completion,
+    or ``{"timed_out": True, "status": <last payload>}`` on expiry. The wait is
+    bounded by design — chain several short ``wait_for_job`` calls (checking
+    ``job_status`` in between) rather than issuing one long block. Use after
+    ``run_workflow(wait=False)``.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    poll_interval = 2.0
+    last: Any = None
+    while True:
+        last = _run_comfy("jobs", "status", prompt_id, timeout=60.0)
+        if _is_terminal(last):
+            return last
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return {"timed_out": True, "status": last}
+        time.sleep(min(poll_interval, remaining))
 
 
 @mcp.tool()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -77,35 +77,29 @@ def test_missing_binary_raises(monkeypatch):
         server._run_comfy("env")
 
 
-def test_cancel_job_maps_command_and_returns_data(monkeypatch):
+def test_cancel_job_maps_command_and_returns_data(patched_run):
     """cancel_job wraps `comfy jobs cancel <id>` and returns the envelope data."""
-    fake, calls = _fake_run(
-        {"type": "envelope", "ok": True, "data": {"cancelled": "abc"}}
-    )
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"cancelled": "abc"}})
 
     assert server.cancel_job("abc") == {"cancelled": "abc"}
     assert calls[0]["cmd"][4:] == ["jobs", "cancel", "abc"]  # mapped subcommand
 
 
-def test_cancel_job_unknown_id_raises_error_envelope(monkeypatch):
+def test_cancel_job_unknown_id_raises_error_envelope(patched_run):
     """Cancelling an unknown prompt_id surfaces comfy-cli's error envelope."""
-    fake, _ = _fake_run(
+    patched_run(
         {
             "type": "envelope",
             "ok": False,
             "error": {"code": "not_found", "message": "no such job: nope"},
         }
     )
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
 
     with pytest.raises(server.ComfyCliError, match="not_found"):
         server.cancel_job("nope")
 
 
-def test_get_queue_maps_command_and_returns_data(monkeypatch):
+def test_get_queue_maps_command_and_returns_data(patched_run):
     """get_queue wraps `comfy jobs ls` and returns the merged job list."""
     jobs = {
         "jobs": [
@@ -113,35 +107,29 @@ def test_get_queue_maps_command_and_returns_data(monkeypatch):
             {"prompt_id": "b", "status": "completed"},
         ]
     }
-    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": jobs})
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run({"type": "envelope", "ok": True, "data": jobs})
 
     assert server.get_queue() == jobs
     assert calls[0]["cmd"][4:] == ["jobs", "ls"]  # no positional args
 
 
-def test_get_queue_error_envelope_raises(monkeypatch):
+def test_get_queue_error_envelope_raises(patched_run):
     """A failing `comfy jobs ls` (e.g. server unreachable) raises ComfyCliError."""
-    fake, _ = _fake_run(
+    patched_run(
         {
             "type": "envelope",
             "ok": False,
             "error": {"code": "server_not_running", "message": "ComfyUI not running"},
         }
     )
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
 
     with pytest.raises(server.ComfyCliError, match="server_not_running"):
         server.get_queue()
 
 
-def test_upload_file_passes_paths_and_overwrite(monkeypatch):
+def test_upload_file_passes_paths_and_overwrite(patched_run):
     """upload_file forwards every path and appends --overwrite when asked."""
-    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": {"uploaded": 2}})
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"uploaded": 2}})
 
     assert server.upload_file(["a.png", "b.png"], overwrite=True) == {"uploaded": 2}
 
@@ -150,11 +138,9 @@ def test_upload_file_passes_paths_and_overwrite(monkeypatch):
     assert cmd[4:] == ["upload", "a.png", "b.png", "--overwrite"]
 
 
-def test_upload_file_omits_overwrite_by_default(monkeypatch):
+def test_upload_file_omits_overwrite_by_default(patched_run):
     """Without overwrite the flag must be absent, not passed as False."""
-    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": {"uploaded": 1}})
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"uploaded": 1}})
 
     server.upload_file(["only.png"])
 
@@ -162,21 +148,19 @@ def test_upload_file_omits_overwrite_by_default(monkeypatch):
     assert "--overwrite" not in calls[0]["cmd"]
 
 
-def test_validate_workflow_returns_results_for_valid(monkeypatch):
+def test_validate_workflow_returns_results_for_valid(patched_run):
     """A valid workflow returns comfy-cli's validation data unwrapped."""
-    fake, calls = _fake_run(
+    calls = patched_run(
         {"type": "envelope", "ok": True, "data": {"valid": True, "nodes": 7}}
     )
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
 
     assert server.validate_workflow("wf.json") == {"valid": True, "nodes": 7}
     assert calls[0]["cmd"][4:] == ["validate", "--workflow", "wf.json"]
 
 
-def test_validate_workflow_raises_with_error_code(monkeypatch):
+def test_validate_workflow_raises_with_error_code(patched_run):
     """An invalid workflow surfaces comfy-cli's structured error code, not a swallow."""
-    fake, _ = _fake_run(
+    patched_run(
         {
             "type": "envelope",
             "ok": False,
@@ -186,11 +170,54 @@ def test_validate_workflow_raises_with_error_code(monkeypatch):
             },
         }
     )
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
 
     with pytest.raises(server.ComfyCliError, match="workflow_unknown_nodes"):
         server.validate_workflow("broken.json")
+
+
+def test_wait_for_job_returns_terminal_status(monkeypatch):
+    """wait_for_job polls until a terminal status and returns that final payload."""
+    statuses = iter(
+        [
+            {"status": "running"},
+            {"status": "running"},
+            {"status": "completed", "outputs": ["/tmp/gen.png"]},
+        ]
+    )
+    calls: list[tuple] = []
+
+    def fake_run(*args, **kwargs):
+        calls.append(args)
+        return next(statuses)
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run)
+    monkeypatch.setattr(server.time, "sleep", lambda _s: None)
+
+    result = server.wait_for_job("pid", timeout_seconds=25.0)
+
+    assert result == {"status": "completed", "outputs": ["/tmp/gen.png"]}
+    assert calls[0] == ("jobs", "status", "pid")  # polls `comfy jobs status <id>`
+    assert len(calls) == 3  # kept polling past the two `running` responses
+
+
+def test_wait_for_job_times_out_cleanly(monkeypatch):
+    """A job that never finishes within the bound returns a clean timed-out payload."""
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: {"status": "running"})
+    monkeypatch.setattr(server.time, "sleep", lambda _s: None)
+
+    # Fake a monotonic clock that jumps 10s each read, so the 25s bound expires.
+    clock = {"t": 0.0}
+
+    def fake_monotonic():
+        now = clock["t"]
+        clock["t"] += 10.0
+        return now
+
+    monkeypatch.setattr(server.time, "monotonic", fake_monotonic)
+
+    result = server.wait_for_job("pid", timeout_seconds=25.0)
+
+    assert result == {"timed_out": True, "status": {"status": "running"}}
 
 
 def test_fetch_outputs_copies_on_disk_path(monkeypatch, tmp_path):
@@ -225,3 +252,17 @@ def test_fetch_outputs_fetches_view_url(monkeypatch, tmp_path):
     assert fetched == [url]
     assert result["saved"] == [str(out_dir / "gen.png")]  # name from ?filename=
     assert (out_dir / "gen.png").read_bytes() == b"view-bytes"
+
+
+def test_server_instructions_cover_canonical_flows():
+    """Instructions ride the handshake and teach submit->poll->fetch + templates."""
+    instructions = server.mcp.instructions
+    assert instructions  # present on the FastMCP instance
+
+    # Call-server-info-first + the async submit -> poll -> fetch generation loop.
+    for tool in ("server_info", "run_workflow", "wait_for_job", "fetch_outputs"):
+        assert tool in instructions
+
+    # The template on-ramp.
+    for tool in ("search_templates", "fetch_template"):
+        assert tool in instructions


### PR DESCRIPTION
## ELI-5

Agents that kick off a long image generation need two things this PR adds:

1. A **`wait_for_job`** button they can press to say "wait a bit for my job to
   finish" — but only a *short* bit, so they never get stuck holding forever. If
   it finishes, they get the result; if the timer runs out, they get a tidy
   "not done yet" note and can press again.
2. A short **"how to use me"** note that the server hands every client the moment
   it connects, so an agent knows the right order of operations without guessing.

## What changed

- **`wait_for_job(prompt_id, timeout_seconds=25.0)`** — a bounded wait that polls
  `comfy jobs status <id>` (2s between polls) until the job reaches a terminal
  status, then returns the final status payload; on expiry it returns
  `{"timed_out": true, "status": <last payload>}`. Bounded by design — agents
  chain several short waits rather than one long block. Terminal states are
  matched generously and case-insensitively (completed/success/done/error/
  failed/cancelled/…); anything else keeps polling.
- **Server instructions** — an `instructions` string on the `FastMCP(...)`
  constructor teaching the canonical flows (check `server_info` first; async
  `run_workflow(wait=False)` → poll `wait_for_job`/`job_status` → `fetch_outputs`
  for long runs; the template on-ramp; `validate_workflow` pre-flight). ~16
  lines; rides every client handshake.
- **README** — new tool row + bumped the tool-count status line (6 → 7).
- **Tests** — a completes-within-bound case and a clean-timeout case for
  `wait_for_job` (both mock `_run_comfy`), plus an assertion that the server
  instructions are present and cover submit→poll→fetch + the template on-ramp.

## Judgment calls (please sanity-check)

- **Collateral test fix (why cancel_job/get_queue tests are touched).** The base
  branch's suite was already **red**: its `cancel_job`/`get_queue` tests
  referenced a `_fake_run` helper that had been removed in favor of the
  `patched_run` fixture but never updated at the call sites (`NameError`, 4
  failures). Green CI is a required acceptance criterion, so this PR converts
  those four call sites to `patched_run` — no behavior change, just repairs the
  dangling references.
- **Instructions name a few not-yet-landed tools.** The instructions reference
  `search_templates`, `fetch_template`, and `validate_workflow`, which land via
  sibling in-flight branches and aren't on the default branch yet. They're
  included deliberately: the template on-ramp is an explicit acceptance
  criterion, and these are the adopted canonical tool names — the instructions
  describe the intended server contract as the toolset converges.
- **Poll errors propagate.** If a `comfy jobs status` poll itself errors
  (unknown/errored `prompt_id`), the `ComfyCliError` propagates rather than being
  swallowed — consistent with `job_status`/`cancel_job`. The bound only governs
  the *not-yet-terminal* case.

## Verification

- `pytest -q` → 16 passed
- `ruff check .` and `ruff format --check .` → clean
- Confirmed all 7 tools register and `mcp.instructions` is populated (16 lines).

No secrets / internal hostnames / cross-service code — thin passthrough via
`_run_comfy()` only.
