### PR TITLE
test: e2e smoke harness for the no-model round-trip

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engi
 Discovery reads the **user's live install** (custom nodes included), not a static
 catalog — that's the local differentiator from the cloud MCP's equivalents.
 
-Planned next: `discover` (`comfy discover`), progress streaming for long runs,
-and a real generation round-trip test.
+Planned next: `discover` (`comfy discover`) and progress streaming for long runs.
 
 ## Run
 
@@ -50,6 +49,22 @@ comfy-local-mcp   # serves over stdio
 ```
 
 Point your MCP client at the `comfy-local-mcp` command.
+
+## Smoke test
+
+Turn the manual validation ritual into one command. The e2e smoke test drives the
+real tools end-to-end (no mocks): `server_info` → `run_workflow` on a checkpoint-free
+`EmptyImage` → `SaveImage` graph → `fetch_outputs`, and asserts a valid PNG lands in
+a temp out_dir.
+
+```bash
+./scripts/smoke.sh            # or: python -m pytest tests/e2e -m e2e
+```
+
+It needs a running local ComfyUI (`COMFYUI_URL`, default `http://127.0.0.1:8188`)
+**and** the `comfy` binary on `PATH` (or `COMFY_BIN`). Without both it **skips**
+rather than fails, so it's safe to run anywhere — and the plain `pytest` gate stays
+green on CI runners that have neither.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,5 +23,10 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.pytest.ini_options]
+markers = [
+    "e2e: live end-to-end smoke test; needs a running local ComfyUI + comfy-cli (skips otherwise)",
+]
+
 [tool.ruff]
 target-version = "py310"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# One-command e2e smoke: a real no-model round-trip against a LIVE local ComfyUI.
+#
+#   server_info -> run_workflow (EmptyImage -> SaveImage) -> fetch_outputs -> PNG.
+#
+# Requires a running local ComfyUI (COMFYUI_URL, default 127.0.0.1:8188) AND the
+# comfy binary on PATH (or COMFY_BIN). Without both, the test SKIPS rather than
+# fails — so this is safe to run anywhere; it just reports "skipped" if you're
+# not set up. Answers "does it really work on this machine?" in one shot.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+exec python -m pytest tests/e2e -m e2e "$@"

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1,0 +1,109 @@
+"""End-to-end smoke test: a real no-model round-trip against a LIVE local ComfyUI.
+
+This is the manual validation ritual turned into a command. It drives the actual
+tools (no mocks): ``server_info`` -> ``run_workflow`` on a checkpoint-free
+``EmptyImage`` -> ``SaveImage`` graph (both ComfyUI core nodes) -> ``fetch_outputs``,
+then asserts a real PNG landed in a temp out_dir.
+
+**Gated.** It requires BOTH a live local ComfyUI answering on ``COMFYUI_URL`` (or
+``http://127.0.0.1:8188``) AND the ``comfy`` binary on ``PATH`` (or ``COMFY_BIN``).
+CI runners have neither, so it SKIPS cleanly there — CI stays green via skip, not
+failure. Run it on a machine that has both with::
+
+    python -m pytest tests/e2e -m e2e      # or: scripts/smoke.sh
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from comfy_local_mcp import server
+
+# PNG signature — the 8 magic bytes every PNG starts with. Enough to prove a real
+# image landed without pulling in an image library (Pillow etc.).
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+_WORKFLOW = Path(__file__).parent / "workflow_smoke.json"
+
+
+def _comfyui_url() -> str:
+    """Base URL of the local ComfyUI to probe (env override, else the default)."""
+    return os.environ.get("COMFYUI_URL", "http://127.0.0.1:8188").rstrip("/")
+
+
+def _server_responds() -> bool:
+    """True iff a ComfyUI HTTP server answers 200 on ``/system_stats``."""
+    url = _comfyui_url() + "/system_stats"
+    try:
+        with urllib.request.urlopen(url, timeout=3) as resp:
+            return resp.status == 200
+    except (urllib.error.URLError, OSError):
+        return False
+
+
+def _skip_reason() -> str | None:
+    """Return why the smoke test can't run here, or None if the prereqs are met."""
+    if shutil.which(server.COMFY_BIN) is None:
+        return f"`{server.COMFY_BIN}` not on PATH — install comfy-cli or set COMFY_BIN"
+    if not _server_responds():
+        return f"no live ComfyUI at {_comfyui_url()} — launch one or set COMFYUI_URL"
+    return None
+
+
+_SKIP_REASON = _skip_reason()
+
+# Marked `e2e` (run in isolation via `-m e2e`) and skipped unless the live
+# prerequisites are present, so a plain `pytest` in CI collects it and skips.
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        _SKIP_REASON is not None, reason=_SKIP_REASON or "prereqs present"
+    ),
+]
+
+
+def _extract_prompt_id(result: object) -> str | None:
+    """Best-effort pull of a ``prompt_id`` out of ``run_workflow``'s return.
+
+    The exact envelope shape from ``comfy run --wait`` isn't pinned down, so look
+    for the common spellings at the top level and one nesting level down.
+    """
+    if isinstance(result, str):
+        return result or None
+    if isinstance(result, dict):
+        for key in ("prompt_id", "promptId", "id"):
+            value = result.get(key)
+            if value:
+                return str(value)
+        for container in ("data", "job", "result"):
+            nested = _extract_prompt_id(result.get(container))
+            if nested:
+                return nested
+    return None
+
+
+def test_no_model_round_trip(tmp_path):
+    """server_info -> run_workflow -> fetch_outputs leaves a valid PNG on disk."""
+    # 1. Confirm the wrapper can talk to the local environment at all.
+    info = server.server_info()
+    assert info, f"server_info() returned nothing usable: {info!r}"
+
+    # 2. Run the checkpoint-free EmptyImage -> SaveImage workflow to completion.
+    result = server.run_workflow(str(_WORKFLOW), wait=True, timeout_seconds=180.0)
+    prompt_id = _extract_prompt_id(result)
+    assert prompt_id, f"no prompt_id in run_workflow result: {result!r}"
+
+    # 3. Collect the outputs into a temp dir and prove a real PNG landed.
+    out_dir = tmp_path / "smoke_out"
+    collected = server.fetch_outputs(prompt_id, str(out_dir))
+    saved = collected.get("saved") or []
+    assert saved, f"fetch_outputs wrote no files: {collected!r}"
+
+    pngs = [p for p in saved if Path(p).read_bytes()[:8] == _PNG_MAGIC]
+    assert pngs, f"no valid PNG among collected outputs: {saved}"

--- a/tests/e2e/workflow_smoke.json
+++ b/tests/e2e/workflow_smoke.json
@@ -1,0 +1,20 @@
+{
+  "1": {
+    "class_type": "EmptyImage",
+    "inputs": {
+      "width": 512,
+      "height": 512,
+      "batch_size": 1,
+      "color": 0
+    },
+    "_meta": { "title": "EmptyImage (no model)" }
+  },
+  "2": {
+    "class_type": "SaveImage",
+    "inputs": {
+      "images": ["1", 0],
+      "filename_prefix": "comfy_local_mcp_smoke"
+    },
+    "_meta": { "title": "SaveImage" }
+  }
+}


### PR DESCRIPTION
## ELI-5

We had a "does it really work?" ritual: start a local ComfyUI, run a tiny
image workflow, and check a PNG comes out. This turns that ritual into **one
command**. It runs the real tools end-to-end (no fakes) —
`server_info` → `run_workflow` (a checkpoint-free `EmptyImage` → `SaveImage`
graph, so no model download) → `fetch_outputs` — and checks a genuine PNG
landed on disk. If you don't have a ComfyUI running, it just **skips** instead
of failing, so CI stays green.

## What's in here

- `tests/e2e/workflow_smoke.json` — the no-model workflow: `EmptyImage(512×512)`
  → `SaveImage(filename_prefix="comfy_local_mcp_smoke")`, both ComfyUI core
  nodes (no checkpoint needed), in API format.
- `tests/e2e/test_smoke.py` — a pytest that calls the real tools with **no
  mocks** and asserts: the run completes, `fetch_outputs` writes ≥1 file, and a
  file is a valid PNG (verified by the 8 magic bytes — no image-library
  dependency).
- **Gating**: the test is marked `e2e` and skips unless BOTH a live local
  ComfyUI answers on `COMFYUI_URL` (default `http://127.0.0.1:8188`) AND the
  `comfy` binary is on `PATH` (or `COMFY_BIN`). The prereq probe is a cheap
  `/system_stats` GET plus a `shutil.which` check, evaluated at collection time.
- `scripts/smoke.sh` — the one-command entry (`./scripts/smoke.sh`, equivalently
  `python -m pytest tests/e2e -m e2e`), documented in the README.
- Registers the `e2e` pytest marker in `pyproject.toml`.

## Verification

- `pytest -q` → **31 passed, 1 skipped** (the e2e test skips here — no local
  ComfyUI / comfy binary), so CI stays green.
- `ruff check .` and `ruff format --check .` → clean.
- `./scripts/smoke.sh` → skips cleanly with a clear reason on a machine without
  the prereqs.

## Judgment calls / things a reviewer should know

- **The full pass (acceptance #1) could not be exercised on the build machine**
  — it has no `comfy` binary and no live ComfyUI, so the round-trip itself has
  not been run green here; only the skip path is verified. On a set-up machine
  the one command runs it for real.
- The exact envelope shape returned by `comfy run --wait` isn't pinned down yet
  (the wrapper's own docstring flags this), so `run_workflow`'s result is mined
  for a `prompt_id` best-effort (`prompt_id` / `promptId` / `id`, top level or
  one level down). If the real shape differs, the test fails with a clear
  diagnostic (`no prompt_id in run_workflow result: …`) — which is exactly the
  signal this harness exists to surface. Worth confirming against a real run.
- The server probe requires HTTP 200 on `/system_stats`; the binary check runs
  first and short-circuits, so CI does no network call.
