### PR TITLE
feat: stream run_workflow progress via MCP progress notifications

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -16,6 +16,7 @@ against a real comfy-cli install and a running local ComfyUI.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import shutil
@@ -25,7 +26,7 @@ import urllib.request
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
 
 # Rides every client handshake — teach an agent the canonical flows up front so
 # it does not have to rediscover them tool-by-tool. Keep this short.
@@ -88,18 +89,31 @@ def _run_comfy(*args: str, timeout: float | None = None) -> Any:
             f"comfy-cli timed out after {timeout}s: {' '.join(cmd)}"
         ) from exc
 
-    envelope = _last_json_object(proc.stdout)
+    return _unwrap_envelope(
+        _last_json_object(proc.stdout), args, proc.returncode, proc.stderr
+    )
+
+
+def _unwrap_envelope(
+    envelope: dict | None, args: tuple[str, ...], returncode: int, stderr: str
+) -> Any:
+    """Unwrap comfy-cli's ``envelope/1`` result, raising on error/absence.
+
+    Shared by the plain (`--json`) and streaming (`--json-stream`) paths so both
+    have identical terminal behavior: return ``data`` on success, and raise a
+    :class:`ComfyCliError` carrying the envelope's ``error.code`` on failure.
+    """
     if envelope is None:
         raise ComfyCliError(
-            f"comfy-cli returned no JSON (exit {proc.returncode}). "
-            f"stderr: {proc.stderr.strip()[:500]}"
+            f"comfy-cli returned no JSON (exit {returncode}). "
+            f"stderr: {stderr.strip()[:500]}"
         )
     if not envelope.get("ok", False):
         err = envelope.get("error") or {}
         raise ComfyCliError(
             f"comfy {' '.join(args)} failed "
             f"[{err.get('code', 'unknown')}]: "
-            f"{err.get('message') or proc.stderr.strip()[:500]}"
+            f"{err.get('message') or stderr.strip()[:500]}"
         )
     return envelope.get("data")
 
@@ -124,6 +138,139 @@ def _last_json_object(stdout: str) -> dict | None:
     return best
 
 
+def _parse_event(line: str) -> dict | None:
+    """Parse one NDJSON stream line into a dict, or None if it isn't JSON."""
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+class _StreamProgress:
+    """Maps comfy-cli's ``--json-stream`` run events to MCP progress values.
+
+    comfy-cli's run dialect (see comfy-cli ``execution.py``) emits, per line:
+    a ``queued`` event carrying the workflow's node manifest, then per node an
+    ``executing`` event, throttled ``progress`` events (per-node step counts,
+    ~10Hz), and an ``executed`` / ``execution_cached`` event. We turn those into
+    a single overall bar: ``total`` = node count from the manifest, and
+    ``progress`` = fully-finished nodes plus the current node's step fraction, so
+    the value climbs monotonically 0..total across the run.
+    """
+
+    def __init__(self) -> None:
+        self.total: float | None = None  # node count (from the queued manifest)
+        self.done = 0  # nodes fully executed or served from cache
+        self._last = -1.0  # last value reported (kept non-decreasing)
+
+    async def report(self, ctx: Context, event: dict) -> None:
+        """Forward one stream event as an MCP progress notification, if relevant."""
+        etype = event.get("type")
+        if etype == "queued":
+            nodes = event.get("nodes")
+            if isinstance(nodes, list) and nodes:
+                self.total = float(len(nodes))
+            progress, message = 0.0, "queued"
+        elif etype == "executing":
+            progress = float(self.done)
+            message = f"executing {event.get('title') or event.get('node')}"
+        elif etype in ("executed", "execution_cached"):
+            self.done += 1
+            progress = float(self.done)
+            message = f"finished {event.get('title') or event.get('node')}"
+        elif etype == "progress":
+            completed = event.get("completed") or 0
+            node_total = event.get("total") or 0
+            frac = (completed / node_total) if node_total else 0.0
+            progress = self.done + frac
+            message = f"node {event.get('node')}: {completed}/{node_total}"
+        else:
+            return  # output / execution_error / unknown -> not a progress tick
+        # MCP guidance: progress should not go backwards, even as nodes reset.
+        progress = max(progress, self._last)
+        self._last = progress
+        await ctx.report_progress(progress=progress, total=self.total, message=message)
+
+
+async def _run_comfy_streaming(
+    *args: str, ctx: Context | None = None, timeout: float | None = None
+) -> Any:
+    """Run ``comfy --json-stream --where local <args>`` and stream progress.
+
+    Spawns comfy-cli with :class:`subprocess.Popen`, reads its NDJSON stdout
+    line-by-line (each ``readline`` off-loaded to a thread so the event loop
+    stays free), and forwards run events as MCP progress notifications via
+    ``ctx.report_progress``. The final ``envelope/1`` line is unwrapped exactly
+    as :func:`_run_comfy` does, so an error envelope raises
+    :class:`ComfyCliError` with the same code — terminal behavior is unchanged.
+    """
+    if shutil.which(COMFY_BIN) is None:
+        raise ComfyCliError(
+            f"`{COMFY_BIN}` not found on PATH. Install comfy-cli "
+            "(`pip install comfy-cli`) or set the COMFY_BIN env var."
+        )
+    # --json-stream is a global flag and, like --json/--where, MUST precede the
+    # subcommand; a trailing form errors with "No such option".
+    cmd = [COMFY_BIN, "--json-stream", "--where", "local", *args]
+    env = {**os.environ, "COMFY_WHERE": "local"}
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    lines: list[str] = []
+    tracker = _StreamProgress()
+
+    async def _pump() -> None:
+        assert proc.stdout is not None
+        while True:
+            line = await asyncio.to_thread(proc.stdout.readline)
+            if not line:  # EOF: comfy-cli closed stdout
+                break
+            lines.append(line)
+            if ctx is not None:
+                event = _parse_event(line)
+                if event is not None:
+                    await tracker.report(ctx, event)
+
+    # Drain stderr concurrently so a chatty child can't deadlock on a full pipe.
+    stderr_future = (
+        asyncio.ensure_future(asyncio.to_thread(proc.stderr.read))
+        if proc.stderr is not None
+        else None
+    )
+    try:
+        try:
+            if timeout is not None:
+                await asyncio.wait_for(_pump(), timeout=timeout)
+            else:
+                await _pump()
+        except (asyncio.TimeoutError, TimeoutError) as exc:
+            raise ComfyCliError(
+                f"comfy-cli timed out after {timeout}s: {' '.join(cmd)}"
+            ) from exc
+
+        returncode = await asyncio.to_thread(proc.wait)
+        stderr = (await stderr_future) if stderr_future is not None else ""
+        return _unwrap_envelope(
+            _last_json_object("".join(lines)), args, returncode, stderr
+        )
+    finally:
+        # Never leave a stray child or a dangling stderr reader on any exit path
+        # (timeout, a report_progress error, or normal completion).
+        if proc.poll() is None:
+            proc.kill()
+            await asyncio.to_thread(proc.wait)
+        if stderr_future is not None and not stderr_future.done():
+            stderr_future.cancel()
+
+
 @mcp.tool()
 def server_info() -> Any:
     """Report the local ComfyUI / comfy-cli environment.
@@ -136,22 +283,32 @@ def server_info() -> Any:
 
 
 @mcp.tool()
-def run_workflow(
-    workflow_path: str, wait: bool = True, timeout_seconds: float = 600.0
+async def run_workflow(
+    workflow_path: str,
+    wait: bool = True,
+    timeout_seconds: float = 600.0,
+    ctx: Context | None = None,
 ) -> Any:
     """Run a ComfyUI workflow JSON on the LOCAL ComfyUI.
 
     Accepts an API-format or UI-export workflow file. Wraps
-    ``comfy run --workflow <path>``. With ``wait=True`` (default) this blocks
-    until the run finishes and returns the full result; with ``wait=False`` it
-    submits and returns immediately with a ``prompt_id`` to poll via
-    ``job_status`` — use that for minutes-long generations so the call does not
-    block.
+    ``comfy run --workflow <path>``. With ``wait=True`` (default) this waits
+    until the run finishes and returns the full result, streaming live progress
+    as MCP progress notifications (per-node execution + sampler step counts) so
+    a long generation is not a silent block; with ``wait=False`` it submits and
+    returns immediately with a ``prompt_id`` to poll via ``job_status``.
     """
-    args = ["run", "--workflow", workflow_path]
-    if wait:
-        args.append("--wait")
-    return _run_comfy(*args, timeout=timeout_seconds if wait else 60.0)
+    if not wait:
+        # Fire-and-return: no stream to follow, so keep the plain --json path.
+        return _run_comfy("run", "--workflow", workflow_path, timeout=60.0)
+    return await _run_comfy_streaming(
+        "run",
+        "--workflow",
+        workflow_path,
+        "--wait",
+        ctx=ctx,
+        timeout=timeout_seconds,
+    )
 
 
 @mcp.tool()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -7,10 +7,15 @@ These lock in the two behaviors that actually broke during development:
    produces: bare on-disk paths (from ``comfy run --wait``) and ``/view``
    HTTP URLs (from ``comfy jobs status``) — ``comfy download`` refuses the
    path form, which is why the tool collects outputs itself.
+
+Plus the streaming ``run_workflow(wait=True)`` path: it drives
+``comfy --json-stream … run --wait`` via Popen, forwards NDJSON run events as
+MCP progress notifications, and still returns the final envelope's data.
 """
 
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import subprocess
@@ -315,3 +320,171 @@ def test_stop_comfyui_surfaces_no_recorded_server_error(patched_run):
         server.stop_comfyui()
 
     assert calls[0]["cmd"][4:] == ["stop"]
+
+
+# --- streaming run_workflow(wait=True) -------------------------------------
+
+
+class _FakeProc:
+    """A minimal stand-in for ``subprocess.Popen`` over a canned NDJSON stream."""
+
+    def __init__(self, cmd, stdout_text, stderr_text=""):
+        self.cmd = cmd
+        self.stdout = io.StringIO(stdout_text)
+        self.stderr = io.StringIO(stderr_text)
+        self.returncode = 0
+        self.killed = False
+
+    def poll(self):
+        return self.returncode  # already "finished" once the stream is drained
+
+    def wait(self):
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+
+
+class _RecordingCtx:
+    """A fake FastMCP Context that records each ``report_progress`` call."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def report_progress(self, progress, total=None, message=None):
+        self.calls.append({"progress": progress, "total": total, "message": message})
+
+
+@pytest.fixture
+def patched_stream(monkeypatch):
+    """Patch ``shutil.which`` + ``subprocess.Popen`` for the streaming path.
+
+    Returns ``setup(stdout_text) -> procs`` — the list capturing each spawned
+    ``_FakeProc`` (so the test can assert the command line that was run).
+    """
+
+    def setup(stdout_text: str) -> list[_FakeProc]:
+        procs: list[_FakeProc] = []
+
+        def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
+            proc = _FakeProc(cmd, stdout_text)
+            procs.append(proc)
+            return proc
+
+        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+        monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+        return procs
+
+    return setup
+
+
+# A queued event (2-node manifest), a per-node step progress event, two
+# node-completion events, then the success envelope on the last line.
+_OK_STREAM = (
+    "\n".join(
+        json.dumps(evt)
+        for evt in [
+            {
+                "schema": "event/1",
+                "type": "queued",
+                "nodes": [{"node_id": "1"}, {"node_id": "2"}],
+            },
+            {"schema": "event/1", "type": "executing", "node": "1", "title": "Load"},
+            {
+                "schema": "event/1",
+                "type": "progress",
+                "node": "1",
+                "completed": 5,
+                "total": 10,
+            },
+            {"schema": "event/1", "type": "executed", "node": "1", "title": "Load"},
+            {"schema": "event/1", "type": "executed", "node": "2", "title": "Save"},
+            {
+                "schema": "envelope/1",
+                "type": "envelope",
+                "ok": True,
+                "data": {"outputs": ["/x.png"]},
+            },
+        ]
+    )
+    + "\n"
+)
+
+
+def test_run_workflow_streams_progress_and_returns_data(patched_stream):
+    """wait=True drives --json-stream, emits progress, returns the envelope data."""
+    procs = patched_stream(_OK_STREAM)
+    ctx = _RecordingCtx()
+
+    result = asyncio.run(server.run_workflow("wf.json", wait=True, ctx=ctx))
+
+    assert result == {"outputs": ["/x.png"]}  # final envelope's data
+    assert len(ctx.calls) >= 1  # acceptance: >=1 progress notification
+
+    cmd = procs[0].cmd
+    assert cmd[0] == server.COMFY_BIN
+    assert cmd[1:4] == ["--json-stream", "--where", "local"]  # global flags first
+    assert cmd[4:] == ["run", "--workflow", "wf.json", "--wait"]
+
+    # The 2-node manifest becomes the progress total, and the value never drops.
+    assert all(c["total"] == 2.0 for c in ctx.calls if c["total"] is not None)
+    values = [c["progress"] for c in ctx.calls]
+    assert values == sorted(values)  # monotonically non-decreasing
+    assert values[-1] == 2.0  # both nodes finished
+
+
+def test_run_workflow_stream_error_envelope_raises_with_code(patched_stream):
+    """An error envelope on the final line raises ComfyCliError with its code."""
+    stream = (
+        "\n".join(
+            json.dumps(evt)
+            for evt in [
+                {"type": "queued", "nodes": [{"node_id": "1"}]},
+                {"type": "progress", "node": "1", "completed": 1, "total": 4},
+                {
+                    "schema": "envelope/1",
+                    "type": "envelope",
+                    "ok": False,
+                    "error": {"code": "execution_error", "message": "boom"},
+                },
+            ]
+        )
+        + "\n"
+    )
+    patched_stream(stream)
+    ctx = _RecordingCtx()
+
+    with pytest.raises(server.ComfyCliError, match="execution_error"):
+        asyncio.run(server.run_workflow("wf.json", wait=True, ctx=ctx))
+
+
+def test_run_workflow_stream_works_without_ctx(patched_stream):
+    """A direct wait=True call with no Context still returns the final data."""
+    patched_stream(_OK_STREAM)
+
+    result = asyncio.run(server.run_workflow("wf.json", wait=True))
+
+    assert result == {"outputs": ["/x.png"]}
+
+
+def test_run_workflow_wait_false_uses_plain_json_no_stream(monkeypatch):
+    """wait=False keeps the plain --json _run_comfy path (no streaming, no --wait)."""
+    seen: dict = {}
+
+    def fake_run_comfy(*args, timeout=None):
+        seen["args"] = args
+        seen["timeout"] = timeout
+        return {"prompt_id": "p1"}
+
+    # If streaming were (wrongly) taken, this would blow up instead of returning.
+    def boom(*a, **k):
+        raise AssertionError("wait=False must not stream")
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run_comfy)
+    monkeypatch.setattr(server, "_run_comfy_streaming", boom)
+
+    result = asyncio.run(server.run_workflow("wf.json", wait=False))
+
+    assert result == {"prompt_id": "p1"}
+    assert seen["args"] == ("run", "--workflow", "wf.json")  # no --wait
+    assert seen["timeout"] == 60.0


### PR DESCRIPTION
## ELI-5

Running a workflow with `wait=True` used to just… sit there silently for the
whole generation — sometimes minutes for a big model — with no sign of life.
comfy-cli can already narrate what it's doing: with the global `--json-stream`
flag it prints one JSON line per event (queued → per-node progress → done),
ending with the same result envelope we already parse. This PR makes
`run_workflow(wait=True)` follow that stream and relay each event to the MCP
client as a **progress notification**, so the caller sees a live bar instead of
a black box. The answer it returns at the end is exactly the same as before.

## What changed

- `run_workflow` is now `async` and takes the `ctx: Context` that FastMCP
  injects. For `wait=True` it calls a new `_run_comfy_streaming` helper that
  spawns `comfy --json-stream --where local run --workflow <path> --wait` with
  `subprocess.Popen`, reads stdout line-by-line (each blocking `readline`
  off-loaded to a thread so the event loop stays free), and forwards run events
  via `ctx.report_progress`.
- Progress mapping: the `queued` event's node manifest sets the **total**;
  `executed`/`execution_cached` advance the finished-node count; throttled
  `progress` events add the current node's step fraction. The reported value is
  clamped monotonically non-decreasing (per MCP guidance) and climbs `0..total`.
- Terminal behavior is unchanged: the final `envelope/1` line is unwrapped by a
  new shared `_unwrap_envelope` helper (extracted from `_run_comfy`), so an
  error envelope still raises `ComfyCliError` carrying the error `code`.
- `wait=False` and every other tool keep the existing synchronous `--json`
  `_run_comfy` path untouched.
- Still a thin comfy-cli wrapper — the stream comes from comfy-cli; no HTTP or
  websocket client was added.

## Acceptance criteria

1. ✅ Mocked `Popen` over a canned NDJSON stream: `run_workflow(wait=True)`
   emits ≥1 progress notification and returns the final envelope's `data`; the
   error-stream case raises `ComfyCliError` matching the error code.
   (`test_run_workflow_streams_progress_and_returns_data`,
   `test_run_workflow_stream_error_envelope_raises_with_code`)
2. ✅ `wait=False` and all other tools behaviorally unchanged — the pre-existing
   suite stays green, plus a test asserting `wait=False` never streams.
3. ✅ Local `ruff check` / `ruff format --check` / `pytest` all green; async
   tests run under `asyncio.run`, so no new test dependency (the CI 3.10/3.14
   matrix needs nothing extra).

## Testing

`ruff check .` clean, `ruff format --check .` clean, `pytest -q` → 35 passed.

## Judgment calls / notes

- **Progress shape.** MCP has no canonical "workflow progress" schema, so I map
  to an overall node bar (`done + current-node-fraction` out of the manifest
  node count) rather than surfacing raw per-node sampler counts that reset each
  node — it stays monotonic and reads as one bar. Reasonable people could pick a
  different mapping; the events forwarded are documented on `_StreamProgress`.
- **stderr drained concurrently** (via a thread) alongside stdout so a chatty
  child can't deadlock on a full pipe; cleaned up on every exit path (timeout /
  error / normal) along with a guaranteed child kill.
- comfy-cli's `progress` events are already server-throttled to ~10Hz per node,
  so no extra client-side throttle was needed.
- The README status line ("Six tools …") is already stale on the base branch
  vs. the current tool set and is unrelated to this change — left untouched to
  keep the diff scoped (README is also CI-path-ignored).
