### PR TITLE
docs: install & client-configuration guide (Claude Code / Desktop / Cursor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,176 @@
 # comfy-local-mcp
 
 A local [MCP](https://modelcontextprotocol.io) server for **ComfyUI** — a thin wrapper over
-[`comfy-cli`](https://github.com/Comfy-Org/comfy-cli) that lets AI agents (Claude, Cursor, …)
-drive your **local** ComfyUI.
+[`comfy-cli`](https://github.com/Comfy-Org/comfy-cli) that lets AI agents (Claude Code, Claude
+Desktop, Cursor, …) drive your **local** ComfyUI: run workflows, wait on jobs, collect the
+resulting images, and inspect the nodes/models/templates your install actually has.
 
 It is a small, standalone codebase. Each tool shells out to the `comfy` command with
 `--where local --json`, parses comfy-cli's `envelope/1` output, and returns it. There is no HTTP
 client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engine.
 
-> **Status:** early POC. Twelve tools, core loop validated end-to-end against a live local ComfyUI (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on 3.10 and 3.14.
+> **Status:** early POC. Seventeen tools, core loop validated end-to-end against a live local
+> ComfyUI (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on
+> Python 3.10 and 3.14.
 
 ## Prerequisites
 
-- Python ≥ 3.10
-- [`comfy-cli`](https://github.com/Comfy-Org/comfy-cli) on your `PATH` (`pip install comfy-cli`),
-  pointed at a local ComfyUI workspace. (Override the binary with the `COMFY_BIN` env var.)
-- A local ComfyUI you can run (`comfy launch`).
+- **Python ≥ 3.10.**
+- **comfy-cli** on your `PATH`: `pip install comfy-cli`. This is the engine every tool wraps.
+- **A ComfyUI workspace.** If you don't have one, `comfy-cli` can create it: `comfy install`
+  sets up a ComfyUI workspace it will point at. (An existing ComfyUI checkout works too — see
+  `comfy set-default <path>`.)
+- **A running ComfyUI.** ComfyUI must be **started before you use the tools** — launch it with
+  `comfy launch` (or, from an agent, the `launch_comfyui` tool), and confirm it is up with
+  `server_info`. Nothing here starts ComfyUI implicitly.
+- **`COMFY_BIN` override (optional).** By default the server calls `comfy` from `PATH`. MCP
+  clients launch the server with their own environment, which often does **not** include your
+  shell's `PATH` — so if `comfy` lives in a virtualenv or a non-standard location, set
+  `COMFY_BIN` to its absolute path (e.g. `/path/to/venv/bin/comfy`). Every client example below
+  shows where it goes.
 
-## Tools (first cut)
+## Install
+
+From a checkout of this repo:
+
+```bash
+pip install .          # or `pip install -e .` for a working copy
+comfy-local-mcp        # serves the MCP over stdio
+```
+
+`pip install` puts a `comfy-local-mcp` console script on your `PATH`; that command is what you
+point your AI client at below. (Installing into a dedicated venv is fine — just remember MCP
+clients may not see that venv's `PATH`, which is exactly what `COMFY_BIN` is for.)
+
+## Configure your AI client
+
+All three clients speak the same MCP stdio contract: run the `comfy-local-mcp` command as a
+server. Pick your client.
+
+> The `COMFY_BIN` env entry is shown in every example. Drop it if `comfy` is already on the
+> environment your client launches the server with; keep it (pointing at the absolute path) if
+> it isn't.
+
+### Claude Code
+
+One command registers the server:
+
+```bash
+claude mcp add comfy-local -e COMFY_BIN=/path/to/venv/bin/comfy -- comfy-local-mcp
+```
+
+Or, to check it into a project, add a `.mcp.json` at the repo root:
+
+```json
+{
+  "mcpServers": {
+    "comfy-local": {
+      "command": "comfy-local-mcp",
+      "env": { "COMFY_BIN": "/path/to/venv/bin/comfy" }
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Edit `claude_desktop_config.json` (Settings → Developer → Edit Config; on macOS it lives at
+`~/Library/Application Support/Claude/claude_desktop_config.json`) and add the server, then
+restart Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "comfy-local": {
+      "command": "comfy-local-mcp",
+      "env": { "COMFY_BIN": "/path/to/venv/bin/comfy" }
+    }
+  }
+}
+```
+
+### Cursor
+
+Add the server to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` in a project:
+
+```json
+{
+  "mcpServers": {
+    "comfy-local": {
+      "command": "comfy-local-mcp",
+      "env": { "COMFY_BIN": "/path/to/venv/bin/comfy" }
+    }
+  }
+}
+```
+
+## Quickstart
+
+Zero to a generated image:
+
+1. **Install the pieces.**
+
+   ```bash
+   pip install comfy-cli          # the engine
+   comfy install                  # create a ComfyUI workspace (skip if you have one)
+   pip install .                  # this MCP server → the `comfy-local-mcp` command
+   ```
+
+2. **Launch ComfyUI** and leave it running:
+
+   ```bash
+   comfy launch
+   ```
+
+3. **Add the server to your client** using the snippet for your client above, then restart /
+   reload it so the tools appear.
+
+4. **Ask your agent to run a workflow.** For example:
+
+   > "Confirm my local ComfyUI is running, then run the workflow at
+   > `~/workflows/txt2img.json` and show me the image."
+
+   Under the hood the agent calls `server_info` to confirm ComfyUI is up, `run_workflow` to
+   execute your workflow JSON (API-format or a UI export), and `fetch_outputs` to collect the
+   result. No hand-authored workflow? Ask it to start from a template instead — it can
+   `search_templates`, `fetch_template` to write a runnable JSON, and run that.
+
+**Where the images land.** ComfyUI writes generated files into your ComfyUI **workspace's
+`output/` directory** (part of the workspace `comfy install` created). On top of that,
+`fetch_outputs(prompt_id, out_dir)` **copies** a finished job's outputs into any directory you
+name — so telling the agent "save them to `./outputs`" puts a copy right where you asked while
+the originals stay in the ComfyUI workspace.
+
+## Tools
+
+Seventeen tools. Every tool runs `comfy` with the global `--json --where local` flags, unwraps
+comfy-cli's `envelope/1`, and returns its `data`.
 
 | Tool | Wraps | Purpose |
 |---|---|---|
-| `server_info()` | `comfy env` | Is a local ComfyUI running, where, and which workspace. Call first. |
-| `run_workflow(workflow_path, wait=True, timeout_seconds=600)` | `comfy run --workflow <path> [--wait]` | Run a workflow JSON; `wait=False` submits async and returns a `prompt_id`. |
+| `server_info()` | `comfy env` | Is a local ComfyUI running, where, and which workspace. **Call first.** |
+| `run_workflow(workflow_path, wait=True, timeout_seconds=600.0)` | `comfy run --workflow <path> [--wait]` | Run a workflow JSON; `wait=False` submits async and returns a `prompt_id`. |
 | `job_status(prompt_id)` | `comfy jobs status <prompt_id>` | Poll a submitted job's status + outputs. |
-| `wait_for_job(prompt_id, timeout_seconds=25)` | `comfy jobs status <prompt_id>` (polled) | Bounded wait until a job reaches a terminal status; returns a timed-out payload on expiry. |
+| `wait_for_job(prompt_id, timeout_seconds=25.0)` | `comfy jobs status <prompt_id>` (polled) | Bounded wait until a job reaches a terminal status; returns a `{"timed_out": True, …}` payload on expiry. Chain several. |
 | `cancel_job(prompt_id)` | `comfy jobs cancel <prompt_id>` | Cancel a queued or running job. |
 | `get_queue()` | `comfy jobs ls` | List known jobs with status (pending/running/completed). |
-| `fetch_outputs(prompt_id, out_dir)` | `comfy download <prompt_id> --out-dir <dir>` | Download a finished job's outputs to disk. |
-| `upload_file(paths, overwrite=False)` | `comfy upload <files...> [--overwrite]` | Stage source images/masks into the local `input` dir (unlocks img2img / inpaint). |
-| `validate_workflow(workflow_path)` | `comfy validate --workflow <path>` | Pre-flight a workflow against the live `object_info` before a slow run; surfaces the structured error code on failure. |
+| `fetch_outputs(prompt_id, out_dir)` | `comfy jobs status <prompt_id>` → copy/`/view` fetch | Collect a finished job's output files into `out_dir` (local outputs are on disk, so this copies them — not a cloud download). |
+| `launch_comfyui(extra_args=None)` | `comfy launch --background [-- <extras>]` | Start the local ComfyUI detached; forwards `extra_args` to ComfyUI. |
+| `stop_comfyui()` | `comfy stop` | Stop the ComfyUI that comfy-cli launched (only its own recorded pid). |
+| `search_templates(query="")` | `comfy templates ls` (filtered client-side) | Find a built-in workflow template by name/description; empty `query` lists all. |
+| `get_template(name)` | `comfy templates show <name>` | Show one template's details/schema before fetching it. |
+| `fetch_template(name, out_path)` | `comfy templates fetch <name> --out <path>` | Write a template's runnable workflow JSON to `out_path`; returns the absolute path for `run_workflow`. |
 | `search_nodes(query)` | `comfy nodes search <query>` | Find node classes in the **live local** `object_info` (includes installed custom nodes). |
 | `get_node(name)` | `comfy nodes show <ClassName>` | Full input/output schema for one node class — what you need to author/repair a graph. |
 | `search_models(query="", folder="")` | `comfy models search` / `models list-folder <folder>` / `models list-folders` | List/search model files on disk. **Local:** filenames only, no cloud enrichment. |
-| `launch_comfyui(extra_args=None)` | `comfy launch --background [-- <extras>]` | Start the local ComfyUI detached; forwards `extra_args` to ComfyUI. |
-| `stop_comfyui()` | `comfy stop` | Stop the ComfyUI that comfy-cli launched (only its own recorded pid). |
+| `upload_file(paths, overwrite=False)` | `comfy upload <files...> [--overwrite]` | Stage source images/masks into the local `input` dir (unlocks img2img / inpaint). |
+| `validate_workflow(workflow_path)` | `comfy validate --workflow <path>` | Pre-flight a workflow against the live `object_info` before a slow run; surfaces the structured error code on failure. |
 
-Discovery reads the **user's live install** (custom nodes included), not a static
-catalog — that's the local differentiator from the cloud MCP's equivalents.
+Discovery (`search_nodes` / `get_node` / `search_models`) reads the **user's live install**
+(custom nodes included), not a static catalog — that's the local differentiator from the cloud
+MCP's equivalents.
 
-Planned next: `discover` (`comfy discover`), progress streaming for long runs,
-and a real generation round-trip test.
-
-## Run
-
-```bash
-pip install -e .
-comfy-local-mcp   # serves over stdio
-```
-
-Point your MCP client at the `comfy-local-mcp` command.
+Planned next: `discover` (`comfy discover`), progress streaming for long runs.
 
 ## License
 


### PR DESCRIPTION
## ELI-5

If you want your AI assistant to make pictures with the ComfyUI running on
your own computer, you first have to tell the assistant how to reach it. This
PR rewrites the README so that's a copy-paste job: install a couple of things,
start ComfyUI, paste one config block for your app (Claude Code, Claude
Desktop, or Cursor), and ask "run this workflow and show me the image." It also
fixes the tool list, which had drifted out of date.

## What changed

README rework — no code changes:

- **Prerequisites**: Python ≥3.10, `pip install comfy-cli` (+ creating a ComfyUI
  workspace), the "start ComfyUI before use" note (`comfy launch`), and the
  optional `COMFY_BIN` override for `comfy` installs the client's environment
  can't see on `PATH`.
- **Install**: `pip install .` → the `comfy-local-mcp` console script.
- **Configure your AI client**: copy-paste blocks for **Claude Code**
  (`claude mcp add …` and the `.mcp.json` stanza), **Claude Desktop**
  (`claude_desktop_config.json`), and **Cursor** (`~/.cursor/mcp.json`) — each
  with the `COMFY_BIN` env entry.
- **Quickstart**: install → `comfy launch` → add to client → a natural-language
  "run this workflow and show me the image" example, plus where the images land
  (ComfyUI's workspace `output/` dir, and the copy `fetch_outputs` drops in a
  dir you name).
- **Tool reference table**: regenerated from `server.py`. It's now **17 tools**
  (the old table said "Twelve" and listed 14, missing the template tools), and
  the `fetch_outputs` row is corrected — it resolves via `comfy jobs status` and
  copies local files / fetches the `/view` URL, it is **not** a `comfy download`.

## Verification

- Console-script entry point verified from a **clean venv install**
  (`python -m venv` → `pip install .`): the `console_scripts` entry point
  resolves to `comfy_local_mcp.server:main` and `comfy-local-mcp` runs and exits
  cleanly. `pyproject.toml` was already correct — no change needed.
- `pytest` → 37 passed; `ruff check .` clean; `ruff format --check .` clean.
- Tool-table row count asserted equal to the `@mcp.tool()` count in `server.py` (17 == 17).

## Notes / judgment calls

- Left `server.py`'s module docstring (mildly stale "next: discover" prose)
  untouched to keep this a docs-only diff — the ticket's table scope is the
  README, and the docstring change would be an unrelated drive-by.
- `COMFY_BIN` example paths are illustrative placeholders
  (`/path/to/venv/bin/comfy`); the client config shapes are standard MCP stdio
  server stanzas, not invented.
