### PR TITLE
chore: add day-one governance files (SECURITY, dependabot, PR template, secret-scanning, AGENTS)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- Briefly describe what this PR does. -->
+
+## Changes
+
+<!-- List the key changes made in this PR. -->
+
+-
+
+## Motivation
+
+<!-- Why is this change needed? Link to a related issue if applicable (e.g. Closes #123). -->
+
+## Testing
+
+<!-- How did you verify these changes? -->
+
+- [ ] Existing tests pass (`pytest`)
+- [ ] Lint passes (`ruff check .`)
+- [ ] Format check passes (`ruff format --check .`)
+- [ ] Tested manually (describe below)
+
+## Additional Notes
+
+<!-- Anything reviewers should know — breaking changes, follow-up work, etc. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+#
+# Two ecosystems for this small Python repo: the pip dependencies declared in
+# pyproject.toml, and the SHA-pinned GitHub Actions in the workflows. No Docker
+# image ships from this repo, so there is no docker ecosystem.
+version: 2
+
+updates:
+  # pip — runtime + dev dependencies (pyproject.toml)
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    groups:
+      pip-dependencies:
+        patterns: ['*']
+    labels: ['dependencies']
+    open-pull-requests-limit: 5
+
+  # GitHub Actions — the SHA-pinned actions across all workflows
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    groups:
+      github-actions:
+        patterns: ['*']
+    labels: ['dependencies']
+    open-pull-requests-limit: 3

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,0 +1,27 @@
+name: Secret Scanning
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: TruffleHog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - uses: trufflesecurity/trufflehog@f446421baf832d6356c42c1743d99abff52ff334 # v3.95.7
+        with:
+          extra_args: --only-verified

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# Agent Guidelines — comfy-local-mcp
+
+A short guide for AI agents (and humans) contributing to this repo. **Keep it in
+sync:** if a PR changes the architecture rule, the toolchain, or the tool set,
+update the relevant section in the same PR.
+
+## What this repo is
+
+`comfy-local-mcp` is a small, standalone [MCP](https://modelcontextprotocol.io)
+server that lets an agent drive a user's **local** ComfyUI. It is a **thin
+wrapper over [`comfy-cli`](https://github.com/Comfy-Org/comfy-cli)** — comfy-cli
+is the engine; this repo is just the MCP surface over it.
+
+## The architecture rule — thin wrapper only (read this first)
+
+Every tool is a passthrough to the `comfy` binary. There is exactly one way to
+reach comfy-cli: the `_run_comfy(*args)` helper in `src/comfy_local_mcp/server.py`,
+which shells out to `comfy --json --where local <args>` (global flags **before**
+the subcommand), parses comfy-cli's versioned `envelope/1` result, and returns
+its `data`. Do not bypass it.
+
+Hard guardrails — a PR that breaks any of these should be rejected:
+
+- **Every tool is a `comfy --json --where local` passthrough.** New functionality
+  belongs in comfy-cli; expose it here as a thin tool that calls `_run_comfy`.
+  If a feature can't be expressed as a `comfy` subcommand, the fix is a comfy-cli
+  change, not a workaround in this repo.
+- **No HTTP client.** This server never talks to ComfyUI (or anything else) over
+  HTTP directly — no `httpx`, `requests`, `aiohttp`, `urllib` calls to a server.
+  comfy-cli owns all I/O with ComfyUI. (Reaching a *local* process is done by
+  shelling out to `comfy`, never by opening a socket.)
+- **No code from the cloud MCP.** Do not copy code, patterns, or dependencies
+  from `Comfy-Org/comfy-cloud-mcp-server`. That server is a multi-tenant HTTP
+  service with per-session state, signed URLs, analytics, and a cloud API client
+  — none of which apply here. This repo is local-only, single-process, and has no
+  filesystem/multi-tenancy concerns to design around.
+
+The local differentiator: discovery tools (`search_nodes`, `get_node`,
+`search_models`) read the **user's live install** — custom nodes included — via
+comfy-cli, not a bundled static catalog.
+
+## Toolchain
+
+Python ≥ 3.10. Everything runs through pip + setuptools (there is no `uv.lock`
+in this repo — comfy-cli bundles `uv` and may write a stray `uv.lock` into the
+working directory; it is gitignored and is not ours).
+
+```bash
+pip install -e '.[dev]'   # install with dev extras (pytest, ruff)
+
+pytest -q                 # run the tests
+ruff check .              # lint
+ruff format --check .     # format check (run `ruff format .` to fix)
+```
+
+CI (`.github/workflows/ci.yml`) runs all three on Python 3.10 and 3.14 for every
+PR. Get them green locally before pushing.
+
+## Tests
+
+Tests live in `tests/` and mock comfy-cli — they never require a real ComfyUI or
+the `comfy` binary. `_run_comfy` and the envelope parser are exercised directly
+(`test_wrapper.py`, `test_parser.py`); each tool group has its own file
+(`test_discovery.py`, `test_templates.py`). When you add or change a tool, add or
+update its test in the same PR.
+
+## Destined-public hygiene
+
+This repository is **private but destined to go public.** Treat everything you
+write as if it were already public:
+
+- **No secrets** — API keys, tokens, or credentials in code, commits, tests,
+  fixtures, or PR text.
+- **No internal hostnames, IPs, or internal-only URLs** in code, comments, or
+  commit messages.
+- **No internal-tracker references** in commits or PR titles/bodies — describe
+  the change on its own terms.
+- Prefer environment variables and documented config over anything hardcoded.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, **please report it responsibly**. Do **not** open a public GitHub issue.
+
+### How to report
+
+1. **GitHub Private Vulnerability Reporting (preferred)**
+   Navigate to the [Security Advisories page](https://github.com/Comfy-Org/comfy-local-mcp/security/advisories/new) and submit a new advisory. This keeps the report confidential until a fix is available.
+
+2. **Email**
+   Send a detailed report to **support@comfy.org**. Include:
+   - A description of the vulnerability and its potential impact
+   - Steps to reproduce or a proof-of-concept
+   - Affected versions (if known)
+   - Any suggested fix or mitigation
+
+### What to expect
+
+| Step                                   | Timeline                                      |
+| :------------------------------------- | :-------------------------------------------- |
+| Acknowledgement of your report         | Within **3 business days**                    |
+| Initial assessment and severity triage | Within **7 business days**                    |
+| Patch or mitigation plan communicated  | Within **30 days** for critical/high severity |
+
+We will keep you informed of our progress throughout the process. If the issue is accepted, we will coordinate disclosure with you and credit you in the advisory (unless you prefer to remain anonymous).
+
+### What counts as a vulnerability
+
+This server is a thin wrapper that shells out to the local [`comfy-cli`](https://github.com/Comfy-Org/comfy-cli) binary. The most relevant classes here are:
+
+- Command injection or argument injection into the `comfy` invocation
+- Path traversal or unsafe filesystem access via tool inputs (e.g. workflow paths, output directories, uploaded files)
+- Exposure of secrets, credentials, or API keys
+- Unsafe handling or parsing of comfy-cli's output that leads to code execution
+- Denial-of-service against the MCP server
+
+### Out of scope
+
+- Defects within third-party software itself (comfy-cli, ComfyUI, MCP clients) — please report those to the respective maintainers. Vulnerabilities in **this repository's integration logic** — e.g. how tool inputs are turned into `comfy` arguments, or how comfy-cli's responses are validated and handled — are in scope and should be reported here.
+- Social engineering or phishing
+- Reports from automated scanners without a demonstrated exploit
+
+## Supported Versions
+
+Security fixes are applied to the **latest release** on the `main` branch. We do not maintain patch branches for older versions.
+
+## Disclosure Policy
+
+We follow [coordinated disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure). We ask that you:
+
+- Allow us reasonable time to investigate and address the issue before public disclosure.
+- Act in good faith — do not access or modify other users' data.
+- Do not exploit the vulnerability beyond what is necessary to demonstrate it.
+
+We appreciate your help keeping this project and its users safe.


### PR DESCRIPTION
## ELI-5

Standard "day-one" paperwork so this repo is ready to go public: how to report a
security bug, a bot that keeps dependencies fresh, a checklist for pull requests,
an automated secret scanner, and a short rulebook for AI agents contributing here.

## Summary

Adds the standard Comfy-Org day-one repo-hygiene files, adapted for this small
Python repo (pytest + ruff). No product code changes.

## Changes

- **`SECURITY.md`** — org vulnerability-reporting policy: GitHub Private
  Vulnerability Reporting (preferred) / support@comfy.org, SLA table, disclosure
  policy. Scope adapted to this repo's surface (command/argument injection into
  the `comfy` invocation, path traversal, unsafe envelope handling) rather than
  the cloud API.
- **`.github/dependabot.yml`** — two ecosystems: `pip` (weekly) and
  `github-actions` (monthly). No docker (nothing ships a container here).
- **`.github/PULL_REQUEST_TEMPLATE.md`** — org shape (Summary / Changes /
  Motivation / Testing / Additional Notes); the Testing checklist is pytest +
  `ruff check` + `ruff format --check`.
- **`.github/workflows/secret-scanning.yml`** — SHA-pinned TruffleHog caller,
  copied verbatim from the org template.
- **`AGENTS.md`** — short agent-contributor guide. States the **thin-wrapper
  architecture guard** explicitly (every tool is a `comfy --json --where local`
  passthrough via `_run_comfy`; no HTTP client; no code copied from the cloud
  MCP), plus the toolchain commands and the destined-public hygiene rules.

## Motivation

Pre-public checklist: standard governance files every Comfy-Org repo carries,
sized down for a small Python thin-wrapper.

## Testing

- [x] Existing tests pass (`pytest` — 37 passed)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] `dependabot.yml` + both workflows parse as valid YAML

## Additional Notes

Judgment calls:
- **Deliberately omitted** (per scope): CODEOWNERS, Docker, release workflows,
  and a `detect-unreviewed-merge` workflow.
- Dropped the reference repo's `cooldown` keys and the docker ecosystem from
  `dependabot.yml` — the former is optional tuning, the latter doesn't apply.
- The only mention of the cloud MCP is in `AGENTS.md`, where the guard rule names
  it as the thing **not** to copy code from — intentional, not a stray reference.
