### PR TITLE
feat: node graph-introspection tools (ls / upstream / downstream / path / types / categories)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,21 @@ comfy-cli's `envelope/1`, and returns its `data`.
 | `fetch_template(name, out_path)` | `comfy templates fetch <name> --out <path>` | Write a template's runnable workflow JSON to `out_path`; returns the absolute path for `run_workflow`. |
 | `search_nodes(query)` | `comfy nodes search <query>` | Find node classes in the **live local** `object_info` (includes installed custom nodes). |
 | `get_node(name)` | `comfy nodes show <ClassName>` | Full input/output schema for one node class — what you need to author/repair a graph. |
+| `list_nodes(produces="", accepts="", category="", pack="", label="")` | `comfy nodes ls [--produces/--accepts/--category/--pack/--label …]` | List node classes, filtered by output/input type, category, pack, or label; bare call lists all. Reads the **live install**. |
+| `nodes_upstream(name, limit=None)` | `comfy nodes upstream <name> [--limit N]` | Nodes whose outputs can feed `<name>`'s inputs ("what wires INTO this?"). Reads the **live install**. |
+| `nodes_downstream(name, limit=None)` | `comfy nodes downstream <name> [--limit N]` | Nodes that accept `<name>`'s output types ("what does this wire INTO?"). Reads the **live install**. |
+| `nodes_path(from_type, to_type, max_depth=6, max_paths=10)` | `comfy nodes path <FROM> <TO> --max-depth N --max-paths N` | Node chains routing a value between two connection types (e.g. `MODEL` → `IMAGE`). Reads the **live install**. |
+| `nodes_types()` | `comfy nodes types` | All connection types (`MODEL`, `IMAGE`, …) ranked by connectivity. Reads the **live install**. |
+| `nodes_categories()` | `comfy nodes categories` | The node category tree. Reads the **live install**. |
 | `search_models(query="", folder="")` | `comfy models search` / `models list-folder <folder>` / `models list-folders` | List/search model files on disk. **Local:** filenames only, no cloud enrichment. |
 | `upload_file(paths, overwrite=False)` | `comfy upload <files...> [--overwrite]` | Stage source images/masks into the local `input` dir (unlocks img2img / inpaint). |
 | `validate_workflow(workflow_path)` | `comfy validate --workflow <path>` | Pre-flight a workflow against the live `object_info` before a slow run; surfaces the structured error code on failure. |
 
-Discovery (`search_nodes` / `get_node` / `search_models`) reads the **user's live install**
-(custom nodes included), not a static catalog — that's the local differentiator from the cloud
-MCP's equivalents.
+Node introspection (`search_nodes` / `get_node` / `list_nodes` / `nodes_upstream` /
+`nodes_downstream` / `nodes_path` / `nodes_types` / `nodes_categories`) and `search_models`
+read the **user's live install** (custom nodes included), not a static catalog — that's the
+local differentiator from the cloud MCP's equivalents. The graph-wiring verbs (`upstream` /
+`downstream` / `path`) are what an agent authoring a workflow uses to find compatible nodes.
 
 Planned next: `discover` (`comfy discover`).
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -570,6 +570,123 @@ def get_node(name: str) -> Any:
 
 
 @mcp.tool()
+def list_nodes(
+    produces: str = "",
+    accepts: str = "",
+    category: str = "",
+    pack: str = "",
+    label: str = "",
+) -> Any:
+    """List node classes from the live local ``object_info``, with optional filters.
+
+    Wraps ``comfy nodes ls``. Each argument, when non-empty, adds the matching
+    filter flag (empty ones are omitted, so a bare call lists everything):
+
+    - ``produces`` → ``--produces <TYPE>``: nodes whose outputs include ``<TYPE>``
+      (e.g. ``IMAGE``, ``MODEL``).
+    - ``accepts`` → ``--accepts <TYPE>``: nodes with an input of ``<TYPE>``.
+    - ``category`` → ``--category <path>``: nodes under a menu category
+      (e.g. ``loaders``).
+    - ``pack`` → ``--pack <name>``: nodes from a given custom-node pack.
+    - ``label`` → ``--label <text>``: nodes matching a display-label substring.
+
+    Reads the user's live install, so results include installed custom nodes —
+    the broad "what nodes can do X?" companion to ``search_nodes``' name search.
+    """
+    args = ["nodes", "ls"]
+    for flag, value in (
+        ("--produces", produces),
+        ("--accepts", accepts),
+        ("--category", category),
+        ("--pack", pack),
+        ("--label", label),
+    ):
+        if value:
+            args += [flag, value]
+    return _run_comfy(*args, timeout=60.0)
+
+
+@mcp.tool()
+def nodes_upstream(name: str, limit: int | None = None) -> Any:
+    """List node classes whose outputs can feed ``name``'s inputs.
+
+    Wraps ``comfy nodes upstream <name> [--limit N]``. Answers "what can I wire
+    INTO this node?" — the candidates that produce the types ``name`` accepts,
+    computed against the live local ``object_info`` (custom nodes included). Pass
+    ``limit`` to cap the number of results; omit it for the full set.
+    """
+    args = ["nodes", "upstream", name]
+    if limit is not None:
+        args += ["--limit", str(limit)]
+    return _run_comfy(*args, timeout=60.0)
+
+
+@mcp.tool()
+def nodes_downstream(name: str, limit: int | None = None) -> Any:
+    """List node classes that accept ``name``'s output types.
+
+    Wraps ``comfy nodes downstream <name> [--limit N]``. Answers "what can I wire
+    this node INTO?" — the candidates whose inputs accept the types ``name``
+    produces, computed against the live local ``object_info`` (custom nodes
+    included). Pass ``limit`` to cap the number of results; omit it for the full
+    set.
+    """
+    args = ["nodes", "downstream", name]
+    if limit is not None:
+        args += ["--limit", str(limit)]
+    return _run_comfy(*args, timeout=60.0)
+
+
+@mcp.tool()
+def nodes_path(
+    from_type: str, to_type: str, max_depth: int = 6, max_paths: int = 10
+) -> Any:
+    """Find node chains that route a value from ``from_type`` to ``to_type``.
+
+    Wraps ``comfy nodes path <FROM> <TO> --max-depth N --max-paths N``. Given two
+    connection types (e.g. ``MODEL`` → ``IMAGE``), returns sequences of nodes
+    whose wiring carries a value from ``from_type`` to ``to_type`` over the live
+    local ``object_info`` graph. ``max_depth`` bounds the chain length and
+    ``max_paths`` caps how many routes are returned.
+    """
+    return _run_comfy(
+        "nodes",
+        "path",
+        from_type,
+        to_type,
+        "--max-depth",
+        str(max_depth),
+        "--max-paths",
+        str(max_paths),
+        timeout=60.0,
+    )
+
+
+@mcp.tool()
+def nodes_types() -> Any:
+    """List every connection type in the live local graph, ranked by connectivity.
+
+    Wraps ``comfy nodes types``. Returns the set of edge types (``MODEL``,
+    ``IMAGE``, ``LATENT``, ``CONDITIONING``, …) present across the user's
+    installed nodes, ordered by how connective each is — the vocabulary you wire
+    with. Reflects custom nodes, so install-specific types show up too.
+    """
+    return _run_comfy("nodes", "types", timeout=60.0)
+
+
+@mcp.tool()
+def nodes_categories() -> Any:
+    """Return the node category tree from the live local ``object_info``.
+
+    Wraps ``comfy nodes categories``. Gives the menu-category hierarchy the
+    user's installed nodes fall under — a map for browsing what is available by
+    area (loaders, sampling, image, …) rather than by name. Reflects the live
+    install, so custom-node categories appear too.
+    """
+    return _run_comfy("nodes", "categories", timeout=60.0)
+
+
+@mcp.tool()
 def search_models(query: str = "", folder: str = "") -> Any:
     """Search / list model files available to the LOCAL ComfyUI install.
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -55,6 +55,119 @@ def test_get_node_argv(monkeypatch):
     assert calls[0][4:] == ["nodes", "show", "KSampler"]
 
 
+def test_list_nodes_no_filters_bare_ls(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok([{"name": "KSampler"}]))
+    assert server.list_nodes() == [{"name": "KSampler"}]
+    # no filters -> a bare `nodes ls`, no stray flags
+    assert calls[0][4:] == ["nodes", "ls"]
+
+
+def test_list_nodes_all_filters_in_order(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok([]))
+    server.list_nodes(
+        produces="IMAGE",
+        accepts="MODEL",
+        category="loaders",
+        pack="was-suite",
+        label="Load",
+    )
+    assert calls[0][4:] == [
+        "nodes",
+        "ls",
+        "--produces",
+        "IMAGE",
+        "--accepts",
+        "MODEL",
+        "--category",
+        "loaders",
+        "--pack",
+        "was-suite",
+        "--label",
+        "Load",
+    ]
+
+
+def test_list_nodes_omits_empty_filters(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok([]))
+    server.list_nodes(produces="IMAGE", category="sampling")
+    # only the two non-empty filters are passed, in declared order
+    assert calls[0][4:] == [
+        "nodes",
+        "ls",
+        "--produces",
+        "IMAGE",
+        "--category",
+        "sampling",
+    ]
+
+
+def test_nodes_upstream_without_limit(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok([{"name": "CheckpointLoaderSimple"}]))
+    assert server.nodes_upstream("KSampler") == [{"name": "CheckpointLoaderSimple"}]
+    assert calls[0][4:] == ["nodes", "upstream", "KSampler"]
+
+
+def test_nodes_upstream_with_limit(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok([]))
+    server.nodes_upstream("KSampler", limit=5)
+    assert calls[0][4:] == ["nodes", "upstream", "KSampler", "--limit", "5"]
+
+
+def test_nodes_downstream_without_limit(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok([{"name": "VAEDecode"}]))
+    assert server.nodes_downstream("KSampler") == [{"name": "VAEDecode"}]
+    assert calls[0][4:] == ["nodes", "downstream", "KSampler"]
+
+
+def test_nodes_downstream_with_limit(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok([]))
+    server.nodes_downstream("KSampler", limit=3)
+    assert calls[0][4:] == ["nodes", "downstream", "KSampler", "--limit", "3"]
+
+
+def test_nodes_path_defaults(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok([]))
+    server.nodes_path("MODEL", "IMAGE")
+    # concrete int defaults are always passed, so the argv is deterministic
+    assert calls[0][4:] == [
+        "nodes",
+        "path",
+        "MODEL",
+        "IMAGE",
+        "--max-depth",
+        "6",
+        "--max-paths",
+        "10",
+    ]
+
+
+def test_nodes_path_overrides(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok([]))
+    server.nodes_path("LATENT", "IMAGE", max_depth=3, max_paths=2)
+    assert calls[0][4:] == [
+        "nodes",
+        "path",
+        "LATENT",
+        "IMAGE",
+        "--max-depth",
+        "3",
+        "--max-paths",
+        "2",
+    ]
+
+
+def test_nodes_types_argv(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok(["MODEL", "IMAGE", "LATENT"]))
+    assert server.nodes_types() == ["MODEL", "IMAGE", "LATENT"]
+    assert calls[0][4:] == ["nodes", "types"]
+
+
+def test_nodes_categories_argv(monkeypatch):
+    calls = _stub_comfy(monkeypatch, _ok({"loaders": {}}))
+    assert server.nodes_categories() == {"loaders": {}}
+    assert calls[0][4:] == ["nodes", "categories"]
+
+
 def test_search_models_query_uses_search(monkeypatch):
     calls = _stub_comfy(monkeypatch, _ok(["sd_xl_base.safetensors"]))
     assert server.search_models(query="xl") == ["sd_xl_base.safetensors"]


### PR DESCRIPTION
## Summary

Completes node introspection by wrapping the six remaining `comfy nodes` graph-wiring verbs. Previously only `search_nodes` (name search) and `get_node` (one node's schema) were exposed; the verbs an agent needs to actually *wire a graph* — find nodes by type, walk upstream/downstream, route between connection types — were missing. Like the existing node tools, every new tool reads the user's **live install** (`object_info`), so results include their installed custom nodes.

## Changes

- `list_nodes(produces="", accepts="", category="", pack="", label="")` → `comfy nodes ls`, adding each `--produces/--accepts/--category/--pack/--label` filter only when non-empty (bare call lists all).
- `nodes_upstream(name, limit=None)` → `comfy nodes upstream <name> [--limit N]` — nodes whose outputs can feed `<name>`'s inputs.
- `nodes_downstream(name, limit=None)` → `comfy nodes downstream <name> [--limit N]` — nodes that accept `<name>`'s output types.
- `nodes_path(from_type, to_type, max_depth=6, max_paths=10)` → `comfy nodes path <FROM> <TO> --max-depth N --max-paths N` — routed type paths (e.g. `MODEL` → `IMAGE`).
- `nodes_types()` → `comfy nodes types` — connection types ranked by connectivity.
- `nodes_categories()` → `comfy nodes categories` — the category tree.
- New tests in `tests/test_discovery.py` asserting exact argv for each, including the optional-filter/limit branches.
- New rows in the README tool table plus a note that these read the live install.

All are thin passthroughs via `_run_comfy` (which pins `--where local`); no HTTP client, no new dependencies. `nodes refresh` is intentionally skipped — `object_info` is fetched live per call, so there is nothing to refresh.

## Motivation

The live-install node introspection is the local differentiator, but only 2 of the ~8 `comfy nodes` verbs were wrapped. The graph-wiring verbs are exactly what an agent authoring a workflow needs to find compatible nodes.

## Testing

- [x] Existing tests pass (`pytest`) — 52 passed, 1 skipped (e2e)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually — argv-level only (mocked); not smoke-tested against a live ComfyUI install (same posture as the other `nodes` tools, whose real-invocation smoke test is still pending).

## Additional Notes

Judgment call: `nodes_path` has concrete int defaults (`max_depth=6`, `max_paths=10`) rather than `None`, so it **always** passes `--max-depth`/`--max-paths` — making the argv deterministic and honoring the tool's declared defaults regardless of the CLI's internal defaults. By contrast `upstream`/`downstream` take `limit=None` and omit `--limit` when unset, matching the `[--limit N]` optional form. No unmet acceptance criteria.
