### PR TITLE
feat: workflow slot-editing tools — list_workflow_slots / set_workflow_slot / vary_workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It is a small, standalone codebase. Each tool shells out to the `comfy` command 
 `--where local --json`, parses comfy-cli's `envelope/1` output, and returns it. There is no HTTP
 client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engine.
 
-> **Status:** early POC. Seventeen tools, core loop validated end-to-end against a live local
+> **Status:** early POC. Twenty tools, core loop validated end-to-end against a live local
 > ComfyUI (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on
 > Python 3.10 and 3.14.
 
@@ -143,7 +143,7 @@ the originals stay in the ComfyUI workspace.
 
 ## Tools
 
-Seventeen tools. Every tool runs `comfy` with the global `--json --where local` flags, unwraps
+Twenty tools. Every tool runs `comfy` with the global `--json --where local` flags, unwraps
 comfy-cli's `envelope/1`, and returns its `data`.
 
 | Tool | Wraps | Purpose |
@@ -165,6 +165,9 @@ comfy-cli's `envelope/1`, and returns its `data`.
 | `search_models(query="", folder="")` | `comfy models search` / `models list-folder <folder>` / `models list-folders` | List/search model files on disk. **Local:** filenames only, no cloud enrichment. |
 | `upload_file(paths, overwrite=False)` | `comfy upload <files...> [--overwrite]` | Stage source images/masks into the local `input` dir (unlocks img2img / inpaint). |
 | `validate_workflow(workflow_path)` | `comfy validate --workflow <path>` | Pre-flight a workflow against the live `object_info` before a slow run; surfaces the structured error code on failure. |
+| `list_workflow_slots(workflow_path)` | `comfy workflow slots <path>` | List the agent-tweakable slots (addresses + current values) a frontend-format workflow exposes. |
+| `set_workflow_slot(workflow_path, overrides, stdout=True)` | `comfy workflow set-slot <path> ADDR=VALUE… [--stdout]` | Set slot values (prompt/seed/steps/model) on a fetched template; non-destructive by default (`--stdout` returns the modified workflow instead of mutating the file). |
+| `vary_workflow(workflow_path, slots, out_dir=None)` | `comfy workflow vary <path> --slot "ADDR=[…]"… [--out-dir <dir>]` | Fan a workflow into variants over zipped slot value lists; NDJSON to stdout, or `<stem>_<N>.json` files when `out_dir` is set. |
 
 Discovery (`search_nodes` / `get_node` / `search_models`) reads the **user's live install**
 (custom nodes included), not a static catalog — that's the local differentiator from the cloud

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -40,7 +40,10 @@ This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
   `job_status` until it finishes, then collect files with `fetch_outputs`.
   Prefer this over `run_workflow(wait=True)` for slow runs so nothing blocks.
 - Start from a template: `search_templates` to find one, `fetch_template` to save
-  its workflow JSON, then `run_workflow` on that file.
+  its workflow JSON, then `run_workflow` on that file. To change the prompt / seed
+  / steps / model of a fetched template before running, inspect its tweakable slots
+  with `list_workflow_slots` and edit them with `set_workflow_slot` (non-destructive
+  by default) — the loop is `fetch_template` -> `set_workflow_slot` -> `run_workflow`.
 - When custom nodes or models may be missing, pre-flight with `validate_workflow`
   before running.
 - Manage in-flight work with `get_queue` (list jobs) and `cancel_job`.
@@ -621,6 +624,74 @@ def validate_workflow(workflow_path: str) -> Any:
     missing-model problem stays actionable instead of failing deep inside a run.
     """
     return _run_comfy("validate", "--workflow", workflow_path, timeout=60.0)
+
+
+@mcp.tool()
+def list_workflow_slots(workflow_path: str) -> Any:
+    """List the agent-tweakable slots a frontend-format workflow exposes.
+
+    Wraps ``comfy workflow slots <path>``. A "slot" is a parameter comfy-cli
+    surfaces as a stable ``ADDR`` (e.g. the positive prompt text, a seed, step
+    count, or model name) together with its current value, so an agent can see
+    what a template exposes without hand-reading the raw workflow JSON. Operates
+    on the frontend-format (UI export) workflow that ``fetch_template`` writes and
+    ``run_workflow`` accepts. Pass a slot's ``ADDR`` back to ``set_workflow_slot``
+    (or ``vary_workflow``) to change it.
+    """
+    return _run_comfy("workflow", "slots", workflow_path, timeout=60.0)
+
+
+@mcp.tool()
+def set_workflow_slot(
+    workflow_path: str, overrides: list[str], stdout: bool = True
+) -> Any:
+    """Set one or more slot values on a frontend-format workflow.
+
+    Wraps ``comfy workflow set-slot <path> ADDR=VALUE [ADDR=VALUE ...]``, where
+    ``overrides`` is a list of ``"ADDR=VALUE"`` strings (the ``ADDR``s come from
+    ``list_workflow_slots``). This is the parameterize step of the template
+    on-ramp — change the prompt / seed / steps / model of a fetched template
+    without hand-editing its JSON.
+
+    ``stdout`` defaults to ``True`` (``--stdout``), so the tool is
+    NON-DESTRUCTIVE: comfy-cli returns the modified workflow instead of mutating
+    ``workflow_path`` in place. Set ``stdout=False`` to write the change back to
+    the file. Canonical loop::
+
+        path = fetch_template("flux_dev", "/tmp/flux.json")
+        modified = set_workflow_slot(path, ["6.text=a red bicycle", "3.seed=42"])
+        # write `modified` to disk (or call with stdout=False), then run_workflow
+    """
+    args = ["workflow", "set-slot", workflow_path, *overrides]
+    if stdout:
+        args.append("--stdout")
+    return _run_comfy(*args, timeout=60.0)
+
+
+@mcp.tool()
+def vary_workflow(
+    workflow_path: str, slots: list[str], out_dir: str | None = None
+) -> Any:
+    """Fan a frontend-format workflow out into variants over slot value lists.
+
+    Wraps ``comfy workflow vary <path> --slot "ADDR=[v1,v2,...]" [--slot ...]``.
+    ``slots`` is a list of ``"ADDR=[v1,v2,...]"`` strings, one per address (the
+    ``ADDR``s come from ``list_workflow_slots``); comfy-cli ZIPS the value lists,
+    so every list MUST be the same length — e.g. ``["3.seed=[1,2,3]",
+    "6.text=[cat,dog,fish]"]`` yields three variants pairing seed 1/cat, 2/dog,
+    3/fish.
+
+    With ``out_dir`` unset (default) comfy-cli emits the variants as NDJSON to
+    stdout; set ``out_dir`` to instead write ``<stem>_<N>.json`` files there (and
+    forward ``--out-dir``). Run each variant with ``run_workflow`` to sweep a
+    parameter grid.
+    """
+    args = ["workflow", "vary", workflow_path]
+    for slot in slots:
+        args += ["--slot", slot]
+    if out_dir:
+        args += ["--out-dir", out_dir]
+    return _run_comfy(*args, timeout=120.0)
 
 
 def main() -> None:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,126 @@
+"""Tests for the workflow slot-editing tools — list / set-slot / vary.
+
+These lock in the passthrough argv (global flags before the subcommand, same
+rule the wrapper enforces) for the three tools that let an agent parameterize a
+fetched template — the ``fetch_template`` -> ``set_workflow_slot`` ->
+``run_workflow`` loop — without hand-editing raw workflow JSON. The behaviors
+they own on top of the passthrough:
+1. ``set_workflow_slot`` passes each override as a positional ``ADDR=VALUE`` and
+   defaults to ``--stdout`` (non-destructive), togglable off.
+2. ``vary_workflow`` repeats ``--slot`` per address and forwards ``--out-dir``
+   only when given.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+from comfy_local_mcp import server
+
+
+def _fake_run(envelope: dict):
+    """Return a subprocess.run stand-in that captures the call and emits an envelope."""
+    calls: list[dict] = []
+
+    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+        calls.append({"cmd": cmd, "env": env})
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout=json.dumps(envelope), stderr=""
+        )
+
+    return fake, calls
+
+
+def test_list_workflow_slots_argv(monkeypatch):
+    """Passthrough: `comfy --json --where local workflow slots <path>`."""
+    data = [{"addr": "6.text", "value": "a cat"}, {"addr": "3.seed", "value": 42}]
+    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": data})
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    assert server.list_workflow_slots("/tmp/flux.json") == data
+
+    cmd = calls[0]["cmd"]
+    assert cmd[1:4] == ["--json", "--where", "local"]  # global flags first
+    assert cmd[4:] == ["workflow", "slots", "/tmp/flux.json"]  # subcommand after
+
+
+def test_set_workflow_slot_argv_default_stdout(monkeypatch):
+    """Default: positional ADDR=VALUE overrides + trailing --stdout (non-destructive)."""
+    fake, calls = _fake_run(
+        {"type": "envelope", "ok": True, "data": {"modified": True}}
+    )
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    result = server.set_workflow_slot(
+        "/tmp/flux.json", ["6.text=a red bicycle", "3.seed=42"]
+    )
+    assert result == {"modified": True}
+
+    assert calls[0]["cmd"][4:] == [
+        "workflow",
+        "set-slot",
+        "/tmp/flux.json",
+        "6.text=a red bicycle",  # each override passed as a positional ADDR=VALUE
+        "3.seed=42",
+        "--stdout",  # default: return the workflow, don't mutate the file
+    ]
+
+
+def test_set_workflow_slot_stdout_false_writes_in_place(monkeypatch):
+    """stdout=False drops --stdout so comfy-cli writes the change back to the file."""
+    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": None})
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    server.set_workflow_slot("/tmp/flux.json", ["3.seed=7"], stdout=False)
+
+    cmd = calls[0]["cmd"]
+    assert cmd[4:] == ["workflow", "set-slot", "/tmp/flux.json", "3.seed=7"]
+    assert "--stdout" not in cmd
+
+
+def test_vary_workflow_argv_repeats_slot_flag(monkeypatch):
+    """Each address becomes its own `--slot "ADDR=[...]"`; no --out-dir when unset."""
+    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": {"variants": 3}})
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    result = server.vary_workflow(
+        "/tmp/flux.json", ["3.seed=[1,2,3]", "6.text=[cat,dog,fish]"]
+    )
+    assert result == {"variants": 3}
+
+    cmd = calls[0]["cmd"]
+    assert cmd[4:] == [
+        "workflow",
+        "vary",
+        "/tmp/flux.json",
+        "--slot",
+        "3.seed=[1,2,3]",
+        "--slot",
+        "6.text=[cat,dog,fish]",
+    ]
+    assert "--out-dir" not in cmd  # stdout NDJSON mode when out_dir is unset
+
+
+def test_vary_workflow_forwards_out_dir(monkeypatch, tmp_path):
+    """out_dir appends `--out-dir <dir>` so variants are written to files."""
+    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": None})
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    out = tmp_path / "variants"
+    server.vary_workflow("/tmp/flux.json", ["3.seed=[1,2]"], out_dir=str(out))
+
+    assert calls[0]["cmd"][4:] == [
+        "workflow",
+        "vary",
+        "/tmp/flux.json",
+        "--slot",
+        "3.seed=[1,2]",
+        "--out-dir",
+        str(out),
+    ]


### PR DESCRIPTION
## ELI-5

Templates are great, but until now you could only run one exactly as shipped — changing the prompt, seed, step count, or model meant hand-editing raw workflow JSON. comfy-cli already has a `workflow` command group built for this: it exposes the tweakable knobs of a workflow as named "slots" you can list and set. This PR wraps three of those verbs as MCP tools, so an agent can fetch a template, tweak its slots, and run it — no JSON surgery.

## Summary

Adds three thin `comfy-cli` `workflow` passthroughs (all via `_run_comfy`, no HTTP client) that let an agent parameterize a frontend-format workflow — the same UI-export format `fetch_template` writes and `run_workflow` accepts. New canonical loop: **`fetch_template` → `set_workflow_slot` → `run_workflow`.**

## Changes

- **`list_workflow_slots(workflow_path)`** → `comfy workflow slots <path>` — lists the tweakable slots (addresses + current values) a workflow exposes.
- **`set_workflow_slot(workflow_path, overrides, stdout=True)`** → `comfy workflow set-slot <path> ADDR=VALUE …` — `overrides` is a list of `"ADDR=VALUE"` strings passed as positionals. Defaults to `--stdout` so it is **non-destructive**: comfy-cli returns the modified workflow instead of mutating the file. Pass `stdout=False` to write back in place.
- **`vary_workflow(workflow_path, slots, out_dir=None)`** → `comfy workflow vary <path> --slot "ADDR=[v1,v2,…]" …` — repeats `--slot` per address (lists are zipped, so equal length). NDJSON to stdout, or `<stem>_<N>.json` files when `out_dir` is set.
- Extends `INSTRUCTIONS` with the parameterize-before-run loop.
- New `tests/test_workflow.py` (5 tests) asserting the exact argv for each tool — global flags before subcommand, multiple positional overrides, `--stdout` default on/off, multiple `--slot` flags, and `--out-dir` on/off.
- Adds the three rows to the README tool table (and bumps the tool count 17 → 20).

The cloud-only `workflow list/get/save/delete` verbs are intentionally skipped — they hit Comfy Cloud and are out of scope for a local MCP.

## Motivation

The template on-ramp could only run a template as authored; changing any parameter required editing raw workflow JSON. This closes the single biggest coverage gap by wrapping comfy-cli's purpose-built slot-editing group.

## Testing

- [x] Existing + new tests pass (`pytest` — 46 passed, 1 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Not smoke-tested against a live comfy-cli + running ComfyUI (see note)

## Additional Notes

- **Argv is verified by unit tests but the exact comfy-cli `workflow` subcommand contract is not yet smoke-tested against a real install** — same posture as the rest of this POC (the module header already flags this). The tools encode the CLI syntax exactly as specified; if a signature differs, it surfaces as a clean `ComfyCliError` from the error envelope rather than a crash.
- **Judgment call:** `vary_workflow` guards `--out-dir` with a truthiness check (`if out_dir:`) rather than `is not None`, matching the repo's existing idiom for optional-string args (`search_models`'s `if folder:`), so a stray empty string doesn't forward `--out-dir ""`.
- **Judgment call:** bumped the README's "Seventeen tools" count to "Twenty" in both places so the doc stays self-consistent after adding three rows (a touch beyond the ticket's "add three rows", but leaving it stale would be a visible inconsistency).
