### PR TITLE
feat: add discover + which introspection tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It is a small, standalone codebase. Each tool shells out to the `comfy` command 
 `--where local --json`, parses comfy-cli's `envelope/1` output, and returns it. There is no HTTP
 client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engine.
 
-> **Status:** early POC. Twenty tools, core loop validated end-to-end against a live local
+> **Status:** early POC. Twenty-two tools, core loop validated end-to-end against a live local
 > ComfyUI (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on
 > Python 3.10 and 3.14.
 
@@ -143,7 +143,7 @@ the originals stay in the ComfyUI workspace.
 
 ## Tools
 
-Twenty tools. Every tool runs `comfy` with the global `--json --where local` flags, unwraps
+Twenty-two tools. Every tool runs `comfy` with the global `--json --where local` flags, unwraps
 comfy-cli's `envelope/1`, and returns its `data`.
 
 | Tool | Wraps | Purpose |
@@ -158,6 +158,8 @@ comfy-cli's `envelope/1`, and returns its `data`.
 | `fetch_outputs(prompt_id, out_dir, url_only=False)` | `comfy download <prompt_id> --where local -o <out_dir> [--url-only]` | Wraps `comfy download --where local` to write a finished local job's outputs into `out_dir`; `url_only=True` emits the output URLs without copying bytes. |
 | `launch_comfyui(extra_args=None)` | `comfy launch --background [-- <extras>]` | Start the local ComfyUI detached; forwards `extra_args` to ComfyUI. |
 | `stop_comfyui()` | `comfy stop` | Stop the ComfyUI that comfy-cli launched (only its own recorded pid). |
+| `discover()` | `comfy discover` | comfy-cli's self-describing surface (commands, arg schemas, error codes) — learn the CLI's own contract at runtime. |
+| `which()` | `comfy which` | Which ComfyUI install/workspace comfy-cli currently targets (a lighter answer than `server_info`). |
 | `search_templates(query="")` | `comfy templates ls` (filtered client-side) | Find a built-in workflow template by name/description; empty `query` lists all. |
 | `get_template(name)` | `comfy templates show <name>` | Show one template's details/schema before fetching it. |
 | `fetch_template(name, out_path)` | `comfy templates fetch <name> --out <path>` | Write a template's runnable workflow JSON to `out_path`; returns the absolute path for `run_workflow`. |
@@ -181,8 +183,6 @@ Node introspection (`search_nodes` / `get_node` / `list_nodes` / `nodes_upstream
 read the **user's live install** (custom nodes included), not a static catalog — that's the
 local differentiator from the cloud MCP's equivalents. The graph-wiring verbs (`upstream` /
 `downstream` / `path`) are what an agent authoring a workflow uses to find compatible nodes.
-
-Planned next: `discover` (`comfy discover`).
 
 ## Smoke test
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -25,6 +25,7 @@ import shutil
 import subprocess
 import time
 from typing import Any
+from urllib.parse import urlparse
 
 from mcp.server.fastmcp import Context, FastMCP
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -7,9 +7,10 @@ with the Comfy Cloud MCP — comfy-cli is the engine.
 
 Tools so far: the run -> get-output core loop plus job management
 (``job_status`` / ``wait_for_job`` / ``watch_job`` / ``cancel_job`` /
-``get_queue``) and the ``launch_comfyui`` / ``stop_comfyui`` lifecycle pair
-(``comfy launch --background`` / ``comfy stop``).
-Next passthrough to add: ``discover`` (``comfy discover`` / ``comfy which``).
+``get_queue``), the ``launch_comfyui`` / ``stop_comfyui`` lifecycle pair
+(``comfy launch --background`` / ``comfy stop``), and the ``discover`` /
+``which`` introspection pair (``comfy discover`` / ``comfy which``) that lets
+an agent learn the CLI's own contract and selection.
 
 NOTE: the exact ``comfy`` invocation + envelope shape still need a smoke test
 against a real comfy-cli install and a running local ComfyUI.
@@ -535,6 +536,30 @@ def stop_comfyui() -> Any:
     message, rather than killing an unrelated process.
     """
     return _run_comfy("stop", timeout=60.0)
+
+
+@mcp.tool()
+def discover() -> Any:
+    """Return comfy-cli's self-describing command surface (its own contract).
+
+    Wraps ``comfy discover``. comfy-cli emits a machine-readable description of
+    itself — the available commands, their argument schemas, and the error codes
+    they can return — so an agent can learn the CLI's contract at runtime instead
+    of hard-coding it. Returns that description verbatim.
+    """
+    return _run_comfy("discover", timeout=60.0)
+
+
+@mcp.tool()
+def which() -> Any:
+    """Report which ComfyUI install/workspace comfy-cli currently targets.
+
+    Wraps ``comfy which``. A lightweight "which one is selected?" answer; note
+    that ``server_info`` (``comfy env``) already reports the same selected
+    workspace alongside the running-server and Python details, so reach for this
+    only when the bare selection is all you want.
+    """
+    return _run_comfy("which", timeout=60.0)
 
 
 def _template_matches(item: Any, query_lower: str) -> bool:

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -455,6 +455,27 @@ def test_stop_comfyui_surfaces_no_recorded_server_error(patched_run):
     assert calls[0]["cmd"][4:] == ["stop"]
 
 
+def test_discover_maps_command_and_returns_data(patched_run):
+    """discover wraps `comfy discover` and returns the envelope data verbatim."""
+    surface = {"commands": ["run", "env"], "error_codes": ["server_not_running"]}
+    calls = patched_run({"type": "envelope", "ok": True, "data": surface})
+
+    assert server.discover() == surface
+    cmd = calls[0]["cmd"]
+    assert cmd[1:4] == ["--json", "--where", "local"]  # global flags first
+    assert cmd[4:] == ["discover"]  # bare subcommand, no positional args
+
+
+def test_which_maps_command_and_returns_data(patched_run):
+    """which wraps `comfy which` and returns the selected-workspace data."""
+    calls = patched_run(
+        {"type": "envelope", "ok": True, "data": {"workspace": "/home/me/ComfyUI"}}
+    )
+
+    assert server.which() == {"workspace": "/home/me/ComfyUI"}
+    assert calls[0]["cmd"][4:] == ["which"]  # no positional args
+
+
 # --- streaming run_workflow(wait=True) -------------------------------------
 
 


### PR DESCRIPTION
## ELI-5

The `comfy` CLI can describe *itself* — list its commands, their arguments, and
the error codes it can raise (`comfy discover`) — and tell you which ComfyUI
install it's pointed at (`comfy which`). This PR exposes both to agents as MCP
tools, so an agent can learn the CLI's own contract at runtime instead of us
hard-coding it.

## Summary

Adds two thin introspection passthroughs to the local MCP server:

- `discover()` → `comfy discover`: returns comfy-cli's self-describing command
  surface (commands, arg schemas, error codes) verbatim.
- `which()` → `comfy which`: reports which ComfyUI install/workspace is selected
  — a lighter answer than `server_info` (`comfy env`), which already reports the
  selected workspace alongside more detail.

Both go through the existing `_run_comfy()` helper (global `--json --where local`
flags, `envelope/1` unwrap), so there is no new HTTP client, no new dependency,
and no code shared with the Cloud MCP — comfy-cli stays the engine.

## Changes

- `server.py`: `discover()` and `which()` tools; module docstring updated (they
  were previously listed as the next passthrough to add).
- `README.md`: two new tool rows, tool count 17 → 19, and the
  "Planned next: `discover`" line removed.
- `tests/test_wrapper.py`: mocked tests asserting each tool's argv and unwrapped
  return.

## Testing

- [x] Existing tests pass (`pytest`) — 43 passed, 1 skipped (e2e smoke, no live ComfyUI)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)

## Additional Notes

- **Judgment call:** the ticket marked `which()` optional ("include only if
  trivial"). It's a one-line passthrough identical in shape to `discover()`, so
  it's included.
- Error handling (missing binary, error envelope) is inherited uniformly from
  `_run_comfy` and already covered by existing generic tests, so no per-tool
  error tests were added.
- `discover`/`which` are deliberately left out of the server `INSTRUCTIONS`
  handshake, which documents the core generation loop rather than meta
  introspection.
