### PR TITLE
ci: add cursor-review caller (wire into shared reusable workflow)

### DIFF
--- a/.github/workflows/ci-cursor-review.yml
+++ b/.github/workflows/ci-cursor-review.yml
@@ -1,0 +1,52 @@
+name: CI - Cursor Review
+
+# Thin caller for the shared reusable cursor-review workflow in
+# Comfy-Org/github-workflows — the review logic (panel matrix, judge
+# consolidation, prompts, extract/post/notify scripts) lives there as the
+# single source of truth. This repo carries only its own diff excludes.
+#
+# Triggered by adding the `cursor-review` label to a PR (apply `skip-cursor-review`
+# to opt a PR out). Requires two repo secrets to actually post a review:
+# CURSOR_API_KEY (required) and SLACK_BOT_TOKEN (optional — start/complete DMs
+# are skipped if absent). Without CURSOR_API_KEY the run degrades to a job
+# summary instead of a posted review.
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+# Cancel an earlier in-flight review for the same PR when the label is removed
+# or re-applied. Scoping by label name means removing an unrelated label does
+# not kill a running cursor review.
+concurrency:
+  group: cursor-review-pr-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
+  cancel-in-progress: true
+
+jobs:
+  cursor-review:
+    # Scope the GITHUB_TOKEN to this job; the reusable workflow further
+    # restricts per-job — only its consolidate job uses pull-requests: write
+    # to post the review.
+    permissions:
+      contents: read
+      pull-requests: write
+    # SHA-pinned. Bump this SHA to pick up upstream changes; keep workflows_ref
+    # matching so prompts/scripts load from the same commit. The
+    # bump-cursor-review-callers workflow updates this automatically.
+    uses: Comfy-Org/github-workflows/.github/workflows/cursor-review.yml@2836b64e0a6993efaa96d5334aa52288ec229fc6 # github-workflows#16
+    with:
+      workflows_ref: 2836b64e0a6993efaa96d5334aa52288ec229fc6
+      # Lockfiles, venvs, caches, egg-info, and the GPL license text carry no
+      # review signal and would only eat into the diff size cap.
+      diff_excludes: >-
+        :!**/uv.lock
+        :!**/*.lock
+        :!**/.venv/**
+        :!**/__pycache__/**
+        :!**/*.egg-info/**
+        :!**/dist/**
+        :!**/.claude/**
+        :!LICENSE
+    secrets:
+      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## ELI-5

Every other main Comfy repo gets an automatic multi-model code review on its PRs (add a `cursor-review` label, a robot posts a review). This repo was left out. This adds the little "caller" file that plugs it into that shared review system. One catch: the robot needs two keys to actually talk — a Cursor API key and a Slack token — and this repo doesn't have them yet, so they need to be added before reviews will post.

## What this does

Adds a thin `ci-cursor-review.yml` that calls the shared reusable `cursor-review.yml` in `Comfy-Org/github-workflows` (single source of truth for the panel/judge/prompts). Fires when the `cursor-review` label is added to a PR; `skip-cursor-review` opts a PR out. Repo-appropriate `diff_excludes` (lockfiles, venv, caches, egg-info, the GPL license) keep noise out of the size budget.

The fan-out side (auto-bumping this caller's pinned SHA when the reusable workflow changes) is registered in `Comfy-Org/github-workflows#20`.

## Required before reviews run

Two repo secrets must be added (values live in 1Password):

1. `CURSOR_API_KEY` — **required**; without it the run degrades to a job summary instead of a posted review.
2. `SLACK_BOT_TOKEN` — optional; only for start/complete DM notifications.

The `cursor-review` label already exists in this repo, so once the secrets are set a review triggers on label.
