### PR TITLE
feat: add watch_job tool to stream live progress for async-submitted jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ comfy-cli's `envelope/1`, and returns its `data`.
 | `run_workflow(workflow_path, wait=True, timeout_seconds=600.0)` | `comfy run --workflow <path> [--wait]` | Run a workflow JSON; `wait=False` submits async and returns a `prompt_id`. |
 | `job_status(prompt_id)` | `comfy jobs status <prompt_id>` | Poll a submitted job's status + outputs. |
 | `wait_for_job(prompt_id, timeout_seconds=25.0)` | `comfy jobs status <prompt_id>` (polled) | Bounded wait until a job reaches a terminal status; returns a `{"timed_out": True, …}` payload on expiry. Chain several. |
+| `watch_job(prompt_id, timeout_seconds=600.0)` | `comfy jobs watch <prompt_id>` (streamed) | Tail an async-submitted job's live execution, streaming progress notifications; bounded, returns a `{"timed_out": True, …}` payload on expiry. Streaming counterpart to `wait_for_job`. |
 | `cancel_job(prompt_id)` | `comfy jobs cancel <prompt_id>` | Cancel a queued or running job. |
 | `get_queue()` | `comfy jobs ls` | List known jobs with status (pending/running/completed). |
 | `fetch_outputs(prompt_id, out_dir)` | `comfy jobs status <prompt_id>` → copy/`/view` fetch | Collect a finished job's output files into `out_dir` (local outputs are on disk, so this copies them — not a cloud download). |

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -56,6 +56,10 @@ mcp = FastMCP("comfy-local-mcp", instructions=INSTRUCTIONS)
 # Allow overriding the binary (e.g. a venv path) without touching code.
 COMFY_BIN = os.environ.get("COMFY_BIN", "comfy")
 
+# Hard ceiling for a single bounded watch so `float('inf')` / an absurd value
+# can't hold a `comfy jobs watch` child open effectively forever (1 hour).
+_MAX_WATCH_TIMEOUT = 3600.0
+
 
 class ComfyCliError(RuntimeError):
     """comfy-cli was missing, timed out, or returned an error envelope."""
@@ -182,8 +186,13 @@ class _StreamProgress:
             "nodes_done": self.done,
         }
 
-    async def report(self, ctx: Context, event: dict) -> None:
-        """Forward one stream event as an MCP progress notification, if relevant."""
+    async def report(self, ctx: Context | None, event: dict) -> None:
+        """Advance tracker state from one stream event; notify via ``ctx`` if set.
+
+        State (``total`` / ``done`` / ``_last``) is updated unconditionally so a
+        bounded, ctx-less watch still reports real progress in its timed-out
+        :meth:`snapshot`; the MCP notification is the only ctx-gated part.
+        """
         etype = event.get("type")
         if etype == "queued":
             nodes = event.get("nodes")
@@ -208,7 +217,10 @@ class _StreamProgress:
         # MCP guidance: progress should not go backwards, even as nodes reset.
         progress = max(progress, self._last)
         self._last = progress
-        await ctx.report_progress(progress=progress, total=self.total, message=message)
+        if ctx is not None:
+            await ctx.report_progress(
+                progress=progress, total=self.total, message=message
+            )
 
 
 async def _run_comfy_streaming(
@@ -258,10 +270,11 @@ async def _run_comfy_streaming(
             if not line:  # EOF: comfy-cli closed stdout
                 break
             lines.append(line)
-            if ctx is not None:
-                event = _parse_event(line)
-                if event is not None:
-                    await tracker.report(ctx, event)
+            # Advance the tracker even without a ctx so a timed-out ctx-less
+            # watch still returns real progress; report() no-ops the notify.
+            event = _parse_event(line)
+            if event is not None:
+                await tracker.report(ctx, event)
 
     # Drain stderr concurrently so a chatty child can't deadlock on a full pipe.
     stderr_future = (
@@ -269,12 +282,23 @@ async def _run_comfy_streaming(
         if proc.stderr is not None
         else None
     )
+
+    async def _drain() -> Any:
+        # Read the whole stream, then reap the child and its stderr. Bounding
+        # this entire coroutine (not just _pump) means a child that closes
+        # stdout without exiting can't wedge the unbounded proc.wait/stderr read.
+        await _pump()
+        returncode = await asyncio.to_thread(proc.wait)
+        stderr = (await stderr_future) if stderr_future is not None else ""
+        return _unwrap_envelope(
+            _last_json_object("".join(lines)), args, returncode, stderr
+        )
+
     try:
         try:
             if timeout is not None:
-                await asyncio.wait_for(_pump(), timeout=timeout)
-            else:
-                await _pump()
+                return await asyncio.wait_for(_drain(), timeout=timeout)
+            return await _drain()
         except (asyncio.TimeoutError, TimeoutError) as exc:
             if not raise_on_timeout:
                 # Bounded tail: report how far the run got instead of erroring
@@ -283,12 +307,6 @@ async def _run_comfy_streaming(
             raise ComfyCliError(
                 f"comfy-cli timed out after {timeout}s: {' '.join(cmd)}"
             ) from exc
-
-        returncode = await asyncio.to_thread(proc.wait)
-        stderr = (await stderr_future) if stderr_future is not None else ""
-        return _unwrap_envelope(
-            _last_json_object("".join(lines)), args, returncode, stderr
-        )
     finally:
         # Never leave a stray child or a dangling stderr reader on any exit path
         # (timeout, a report_progress error, or normal completion).
@@ -417,10 +435,17 @@ async def watch_job(
 
     Use this to get LIVE progress on a job already submitted with
     ``run_workflow(wait=False)`` — the streaming counterpart to the polled
-    ``wait_for_job``. The wait is bounded by ``timeout_seconds`` so it can never
-    block forever; on expiry it returns ``{"timed_out": True, "status": <last
-    known progress>}`` (consistent with ``wait_for_job``) instead of raising.
+    ``wait_for_job``. The wait is bounded by ``timeout_seconds`` (clamped to a
+    sane maximum) so it can never block forever; on expiry it returns the same
+    ``{"timed_out": True, "status": ...}`` envelope shape as ``wait_for_job``,
+    except ``status`` here carries a live progress snapshot
+    (``{progress, total, nodes_done}``) rather than a raw ``jobs status`` dict.
     """
+    if prompt_id.startswith("-"):
+        # comfy-cli parses a leading-dash positional as an option/flag; reject
+        # it rather than let `jobs watch` misread the id (argument injection).
+        raise ComfyCliError(f"invalid prompt_id: {prompt_id!r} (leading '-')")
+    timeout_seconds = min(max(timeout_seconds, 0.0), _MAX_WATCH_TIMEOUT)
     return await _run_comfy_streaming(
         "jobs",
         "watch",

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -6,8 +6,9 @@ returns its ``data``. There is deliberately no HTTP client and no code shared
 with the Comfy Cloud MCP — comfy-cli is the engine.
 
 Tools so far: the run -> get-output core loop plus job management
-(``job_status`` / ``cancel_job`` / ``get_queue``) and the ``launch_comfyui`` /
-``stop_comfyui`` lifecycle pair (``comfy launch --background`` / ``comfy stop``).
+(``job_status`` / ``wait_for_job`` / ``watch_job`` / ``cancel_job`` /
+``get_queue``) and the ``launch_comfyui`` / ``stop_comfyui`` lifecycle pair
+(``comfy launch --background`` / ``comfy stop``).
 Next passthrough to add: ``discover`` (``comfy discover`` / ``comfy which``).
 
 NOTE: the exact ``comfy`` invocation + envelope shape still need a smoke test
@@ -39,6 +40,8 @@ This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
   `prompt_id`, poll `wait_for_job` (a short bounded wait — chain several) or
   `job_status` until it finishes, then collect files with `fetch_outputs`.
   Prefer this over `run_workflow(wait=True)` for slow runs so nothing blocks.
+  For LIVE progress on an already-submitted job, `watch_job(prompt_id)` tails
+  its execution events (bounded, like `wait_for_job`).
 - Start from a template: `search_templates` to find one, `fetch_template` to save
   its workflow JSON, then `run_workflow` on that file.
 - When custom nodes or models may be missing, pre-flight with `validate_workflow`
@@ -167,6 +170,18 @@ class _StreamProgress:
         self.done = 0  # nodes fully executed or served from cache
         self._last = -1.0  # last value reported (kept non-decreasing)
 
+    def snapshot(self) -> dict:
+        """Last-known progress, for a bounded watch that timed out mid-run.
+
+        ``progress`` is None until the first tick is reported (``_last`` starts
+        below zero), so a timed-out payload never claims phantom progress.
+        """
+        return {
+            "progress": self._last if self._last >= 0 else None,
+            "total": self.total,
+            "nodes_done": self.done,
+        }
+
     async def report(self, ctx: Context, event: dict) -> None:
         """Forward one stream event as an MCP progress notification, if relevant."""
         etype = event.get("type")
@@ -197,7 +212,10 @@ class _StreamProgress:
 
 
 async def _run_comfy_streaming(
-    *args: str, ctx: Context | None = None, timeout: float | None = None
+    *args: str,
+    ctx: Context | None = None,
+    timeout: float | None = None,
+    raise_on_timeout: bool = True,
 ) -> Any:
     """Run ``comfy --json-stream --where local <args>`` and stream progress.
 
@@ -207,6 +225,12 @@ async def _run_comfy_streaming(
     ``ctx.report_progress``. The final ``envelope/1`` line is unwrapped exactly
     as :func:`_run_comfy` does, so an error envelope raises
     :class:`ComfyCliError` with the same code — terminal behavior is unchanged.
+
+    ``timeout`` bounds the whole stream. By default an expiry raises
+    :class:`ComfyCliError` (the run-workflow contract); pass
+    ``raise_on_timeout=False`` for a bounded *tail* that should instead return a
+    ``{"timed_out": True, "status": <progress snapshot>}`` payload (mirroring
+    :func:`wait_for_job`) rather than surface the deadline as an error.
     """
     if shutil.which(COMFY_BIN) is None:
         raise ComfyCliError(
@@ -252,6 +276,10 @@ async def _run_comfy_streaming(
             else:
                 await _pump()
         except (asyncio.TimeoutError, TimeoutError) as exc:
+            if not raise_on_timeout:
+                # Bounded tail: report how far the run got instead of erroring
+                # (the finally below still kills the child).
+                return {"timed_out": True, "status": tracker.snapshot()}
             raise ComfyCliError(
                 f"comfy-cli timed out after {timeout}s: {' '.join(cmd)}"
             ) from exc
@@ -371,6 +399,36 @@ def wait_for_job(prompt_id: str, timeout_seconds: float = 25.0) -> Any:
         if remaining <= 0:
             return {"timed_out": True, "status": last}
         time.sleep(min(poll_interval, remaining))
+
+
+@mcp.tool()
+async def watch_job(
+    prompt_id: str,
+    timeout_seconds: float = 600.0,
+    ctx: Context | None = None,
+) -> Any:
+    """Tail a submitted LOCAL job's live execution, streaming progress.
+
+    Wraps ``comfy jobs watch <prompt_id>``, which follows a job's execution
+    events (per-node execution + sampler step counts) and ends on the terminal
+    envelope. Runs through the same streaming machinery as
+    ``run_workflow(wait=True)``, forwarding those events as MCP progress
+    notifications, and returns the final result ``data`` on completion.
+
+    Use this to get LIVE progress on a job already submitted with
+    ``run_workflow(wait=False)`` — the streaming counterpart to the polled
+    ``wait_for_job``. The wait is bounded by ``timeout_seconds`` so it can never
+    block forever; on expiry it returns ``{"timed_out": True, "status": <last
+    known progress>}`` (consistent with ``wait_for_job``) instead of raising.
+    """
+    return await _run_comfy_streaming(
+        "jobs",
+        "watch",
+        prompt_id,
+        ctx=ctx,
+        timeout=timeout_seconds,
+        raise_on_timeout=False,
+    )
 
 
 @mcp.tool()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -570,6 +570,53 @@ def test_watch_job_times_out_returns_payload(monkeypatch):
     assert procs[0].killed  # the child was cleaned up on timeout
 
 
+def test_watch_job_times_out_reports_progress_without_ctx(monkeypatch):
+    """A ctx-less watch still advances the tracker, so its timed-out snapshot is real."""
+    queued = json.dumps(
+        {"type": "queued", "nodes": [{"node_id": "1"}, {"node_id": "2"}]}
+    )
+    executed = json.dumps({"type": "executed", "node": "1"})
+    procs: list[_BlockingProc] = []
+
+    def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
+        proc = _BlockingProc(cmd, [queued + "\n", executed + "\n"])
+        procs.append(proc)
+        return proc
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+
+    # No ctx: the notification is a no-op, but tracker state must still advance
+    # so the snapshot reports the node that actually finished (not all zeros).
+    result = asyncio.run(server.watch_job("pid", timeout_seconds=0.25))
+
+    assert result["timed_out"] is True
+    assert result["status"]["total"] == 2.0
+    assert result["status"]["nodes_done"] == 1  # the `executed` event was tracked
+    assert result["status"]["progress"] == 1.0  # not None / not zero
+    assert procs[0].killed
+
+
+def test_watch_job_rejects_option_like_prompt_id():
+    """A leading-dash prompt_id is refused so comfy-cli can't parse it as a flag."""
+    with pytest.raises(server.ComfyCliError, match="invalid prompt_id"):
+        asyncio.run(server.watch_job("--help"))
+
+
+def test_watch_job_clamps_oversized_timeout(monkeypatch):
+    """timeout_seconds is clamped to the module ceiling, not passed through raw."""
+    seen: dict = {}
+
+    async def fake_stream(*args, ctx=None, timeout=None, raise_on_timeout=True):
+        seen["timeout"] = timeout
+        return {"outputs": []}
+
+    monkeypatch.setattr(server, "_run_comfy_streaming", fake_stream)
+    asyncio.run(server.watch_job("pid", timeout_seconds=float("inf")))
+
+    assert seen["timeout"] == server._MAX_WATCH_TIMEOUT
+
+
 def test_run_workflow_wait_false_uses_plain_json_no_stream(monkeypatch):
     """wait=False keeps the plain --json _run_comfy path (no streaming, no --wait)."""
     seen: dict = {}

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -19,6 +19,7 @@ import asyncio
 import io
 import json
 import subprocess
+import time
 
 import pytest
 
@@ -465,6 +466,108 @@ def test_run_workflow_stream_works_without_ctx(patched_stream):
     result = asyncio.run(server.run_workflow("wf.json", wait=True))
 
     assert result == {"outputs": ["/x.png"]}
+
+
+def test_watch_job_streams_progress_and_returns_data(patched_stream):
+    """watch_job tails `comfy jobs watch <id>`, emits progress, returns the data."""
+    procs = patched_stream(_OK_STREAM)
+    ctx = _RecordingCtx()
+
+    result = asyncio.run(server.watch_job("pid", ctx=ctx))
+
+    assert result == {"outputs": ["/x.png"]}  # final envelope's data unwrapped
+    assert len(ctx.calls) >= 1  # progress ticks forwarded
+
+    cmd = procs[0].cmd
+    assert cmd[0] == server.COMFY_BIN
+    assert cmd[1:4] == ["--json-stream", "--where", "local"]  # global flags first
+    assert cmd[4:] == ["jobs", "watch", "pid"]  # subcommand strictly after
+
+    # Same overall bar as run_workflow: 2-node manifest -> total, never drops.
+    assert all(c["total"] == 2.0 for c in ctx.calls if c["total"] is not None)
+    values = [c["progress"] for c in ctx.calls]
+    assert values == sorted(values)  # monotonically non-decreasing
+    assert values[-1] == 2.0  # both nodes finished
+
+
+def test_watch_job_stream_error_envelope_raises_with_code(patched_stream):
+    """A watch that ends on an error envelope raises ComfyCliError with its code."""
+    stream = (
+        "\n".join(
+            json.dumps(evt)
+            for evt in [
+                {"type": "queued", "nodes": [{"node_id": "1"}]},
+                {
+                    "schema": "envelope/1",
+                    "type": "envelope",
+                    "ok": False,
+                    "error": {"code": "execution_error", "message": "boom"},
+                },
+            ]
+        )
+        + "\n"
+    )
+    patched_stream(stream)
+
+    with pytest.raises(server.ComfyCliError, match="execution_error"):
+        asyncio.run(server.watch_job("pid"))
+
+
+class _BlockingProc:
+    """A fake Popen whose stdout yields ``first_lines`` then blocks (forces a timeout)."""
+
+    def __init__(self, cmd, first_lines):
+        self.cmd = cmd
+        self._lines = list(first_lines)
+        self.stdout = self  # readline lives on the proc itself
+        self.stderr = io.StringIO("")
+        self.returncode = 0
+        self.killed = False
+        self._alive = True
+
+    def readline(self):
+        if self._lines:
+            return self._lines.pop(0)
+        time.sleep(1.0)  # outlives the test's tiny timeout, never yields the envelope
+        return ""
+
+    def poll(self):
+        return None if self._alive else self.returncode
+
+    def wait(self):
+        self._alive = False
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+        self._alive = False
+
+
+def test_watch_job_times_out_returns_payload(monkeypatch):
+    """A watch bounded by timeout_seconds returns a timed-out payload, not an error."""
+    queued = json.dumps(
+        {"type": "queued", "nodes": [{"node_id": "1"}, {"node_id": "2"}]}
+    )
+    procs: list[_BlockingProc] = []
+
+    def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
+        proc = _BlockingProc(cmd, [queued + "\n"])
+        procs.append(proc)
+        return proc
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+
+    # MCP always injects a ctx, so the tracker has advanced by the time we expire.
+    result = asyncio.run(
+        server.watch_job("pid", timeout_seconds=0.25, ctx=_RecordingCtx())
+    )
+
+    # Consistent with wait_for_job: a {"timed_out": True, ...} marker, no raise.
+    assert result["timed_out"] is True
+    assert result["status"]["total"] == 2.0  # queued manifest was seen first
+    assert result["status"]["nodes_done"] == 0  # never reached a completion
+    assert procs[0].killed  # the child was cleaned up on timeout
 
 
 def test_run_workflow_wait_false_uses_plain_json_no_stream(monkeypatch):


### PR DESCRIPTION
## ELI-5

When you kick off a long image generation without waiting (`run_workflow(wait=False)`), you get a job id back and then you're flying blind — you can only *poll* for status. This adds `watch_job(prompt_id)`, which **tails that already-running job and streams live progress** (per-node execution + sampler step counts) the same way `run_workflow(wait=True)` does. It's the streaming counterpart to the polling `wait_for_job`.

## Summary

Adds a `watch_job` MCP tool that wraps `comfy jobs watch <prompt_id>` and streams its execution events as MCP progress notifications, returning the terminal envelope `data` on completion. It reuses the existing streaming machinery (`_run_comfy_streaming` + `_StreamProgress`) — no new HTTP/WS client and no second progress implementation.

## Changes

- **`watch_job(prompt_id, timeout_seconds=600.0)`** — a new `@mcp.tool()` that streams `comfy jobs watch <prompt_id>` through `_run_comfy_streaming`, reusing `_StreamProgress` for the progress bar and returning the final result `data`.
- **Bounded, never blocks forever.** Added an opt-in `raise_on_timeout=False` to the shared `_run_comfy_streaming`: on expiry `watch_job` returns a `{"timed_out": True, "status": <progress snapshot>}` payload (the same `{"timed_out": True, ...}` marker `wait_for_job` returns) instead of raising. The child process is still killed on the timeout path.
- **`_StreamProgress.snapshot()`** — a small helper returning the last-known progress for that timed-out payload (`progress` is `None` until the first tick, so it never claims phantom progress).
- Docs: new README tool row; server instructions + module docstring mention the tool.

## Motivation

`run_workflow(wait=True)` already streams progress, but a job submitted with `wait=False` could previously only be polled (`wait_for_job`). `comfy jobs watch` tails live execution events, so wrapping it gives an agent live progress on an already-submitted job.

## Testing

- [x] Existing tests pass (`pytest`) — 44 passed, 1 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] New mocked streaming tests (mirroring the `run_workflow` streaming test):
  - happy path — feed NDJSON, assert command line (`jobs watch <id>`), terminal `data` unwrap, and monotonic progress ticks;
  - error envelope on the final line raises `ComfyCliError` with its code;
  - timeout returns the `{"timed_out": True, ...}` payload (with the last progress snapshot) and cleans up the child.

## Additional Notes

- **Judgment call — timed-out payload shape.** The `{"timed_out": True, "status": ...}` *marker* matches `wait_for_job`, but the inner `status` differs: `wait_for_job` returns the last raw `comfy jobs status` payload, whereas a watch has no polled status, so `watch_job` returns a progress snapshot (`progress` / `total` / `nodes_done`). Keeping the snapshot in the generic streaming helper avoids an extra `jobs status` call and a second failure surface.
- **Event-schema assumption.** `_StreamProgress` maps comfy-cli's `run` event dialect (`queued` / `executing` / `progress` / `executed`); this assumes `comfy jobs watch --json-stream` emits the same execution events (the ticket directs reusing `_StreamProgress`). If it emits a different schema, non-matching events are simply ignored and the terminal envelope still unwraps — progress would be sparse, not broken. This is the same "needs a smoke test against a real comfy-cli" caveat the module docstring already carries for the whole wrapper.
