### PR TITLE
feat: add download_model tool wrapping `comfy model download`

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -593,6 +593,43 @@ def search_models(query: str = "", folder: str = "") -> Any:
 
 
 @mcp.tool()
+def download_model(
+    url: str, relative_path: str | None = None, filename: str | None = None
+) -> Any:
+    """Download a model file into the LOCAL ComfyUI models dir, by URL.
+
+    Wraps ``comfy model download --url <url> [--relative-path <path>]
+    [--filename <name>]`` (note the SINGULAR ``model`` verb group — the download
+    engine — distinct from the plural ``models`` catalog that ``search_models``
+    reads). comfy-cli understands HuggingFace and CivitAI URLs; any access
+    tokens are configured out-of-band via comfy-cli / environment variables and
+    are NOT passed through this tool. The file lands in the workspace models
+    directory, optionally under ``relative_path`` (e.g. ``models/loras`` to place
+    a LoRA in the right folder) and optionally renamed via ``filename``.
+
+    DOWNLOAD-BY-URL ONLY: this is a fetch of a known URL, not a hub search —
+    there is no HuggingFace/CivitAI browse or discovery here (comfy-cli has no
+    such search), so the caller must already have the direct model URL. Returns
+    comfy-cli's envelope ``data`` (the saved path / download metadata).
+    """
+    # comfy-cli parses a leading-dash value as an option/flag; reject any so a
+    # crafted argument can't be smuggled in as a CLI flag (argument injection).
+    if url.startswith("-"):
+        raise ComfyCliError(f"invalid url: {url!r} (leading '-')")
+    if relative_path is not None and relative_path.startswith("-"):
+        raise ComfyCliError(f"invalid relative_path: {relative_path!r} (leading '-')")
+    if filename is not None and filename.startswith("-"):
+        raise ComfyCliError(f"invalid filename: {filename!r} (leading '-')")
+    args = ["model", "download", "--url", url]
+    if relative_path is not None:
+        args += ["--relative-path", relative_path]
+    if filename is not None:
+        args += ["--filename", filename]
+    # Generous timeout: multi-GB checkpoints can take a long time to fetch.
+    return _run_comfy(*args, timeout=1800.0)
+
+
+@mcp.tool()
 def upload_file(paths: list[str], overwrite: bool = False) -> Any:
     """Upload local files into the LOCAL ComfyUI ``input`` directory.
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -616,14 +616,38 @@ def download_model(
     # crafted argument can't be smuggled in as a CLI flag (argument injection).
     if url.startswith("-"):
         raise ComfyCliError(f"invalid url: {url!r} (leading '-')")
-    if relative_path is not None and relative_path.startswith("-"):
-        raise ComfyCliError(f"invalid relative_path: {relative_path!r} (leading '-')")
-    if filename is not None and filename.startswith("-"):
-        raise ComfyCliError(f"invalid filename: {filename!r} (leading '-')")
+    # Restrict to http(s): this is a remote fetch of a known model URL, so a
+    # `file://` path or other scheme — an SSRF / local-file-read primitive whose
+    # body would be written straight into the models dir — is never legitimate.
+    if urlparse(url).scheme.lower() not in ("http", "https"):
+        raise ComfyCliError(f"invalid url: {url!r} (scheme must be http/https)")
+    # Optional args are treated as unset when falsy (None or ""), so an explicit
+    # empty string is omitted rather than forwarded as `--relative-path ""`.
+    if relative_path:
+        if relative_path.startswith("-"):
+            raise ComfyCliError(
+                f"invalid relative_path: {relative_path!r} (leading '-')"
+            )
+        # relative_path is a models-dir SUBFOLDER (e.g. `models/loras`); keep the
+        # write inside the models dir by rejecting absolute paths and `..`.
+        parts = relative_path.replace("\\", "/").split("/")
+        if os.path.isabs(relative_path) or ".." in parts:
+            raise ComfyCliError(
+                f"invalid relative_path: {relative_path!r} (path traversal)"
+            )
+    if filename:
+        if filename.startswith("-"):
+            raise ComfyCliError(f"invalid filename: {filename!r} (leading '-')")
+        # filename is a single output name, not a path; reject separators and `..`
+        # so it can't redirect the write out of the target directory.
+        if filename in (".", "..") or "/" in filename or "\\" in filename:
+            raise ComfyCliError(
+                f"invalid filename: {filename!r} (must be a bare filename)"
+            )
     args = ["model", "download", "--url", url]
-    if relative_path is not None:
+    if relative_path:
         args += ["--relative-path", relative_path]
-    if filename is not None:
+    if filename:
         args += ["--filename", filename]
     # Generous timeout: multi-GB checkpoints can take a long time to fetch.
     return _run_comfy(*args, timeout=1800.0)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -163,6 +163,105 @@ def test_upload_file_omits_overwrite_by_default(patched_run):
     assert "--overwrite" not in calls[0]["cmd"]
 
 
+def test_download_model_url_only(patched_run):
+    """download_model wraps the SINGULAR `model download --url` and returns data."""
+    calls = patched_run(
+        {"type": "envelope", "ok": True, "data": {"saved": "/models/x.safetensors"}}
+    )
+
+    assert server.download_model("https://hf.co/x.safetensors") == {
+        "saved": "/models/x.safetensors"
+    }
+
+    cmd = calls[0]["cmd"]
+    assert cmd[1:4] == ["--json", "--where", "local"]  # global flags first
+    # SINGULAR `model` verb group (download engine), not the plural catalog.
+    assert cmd[4:] == ["model", "download", "--url", "https://hf.co/x.safetensors"]
+
+
+def test_download_model_threads_relative_path(patched_run):
+    """--relative-path is appended only when provided."""
+    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+
+    server.download_model("https://hf.co/l.safetensors", relative_path="models/loras")
+
+    assert calls[0]["cmd"][4:] == [
+        "model",
+        "download",
+        "--url",
+        "https://hf.co/l.safetensors",
+        "--relative-path",
+        "models/loras",
+    ]
+
+
+def test_download_model_threads_filename(patched_run):
+    """--filename is appended only when provided."""
+    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+
+    server.download_model("https://hf.co/c.safetensors", filename="renamed.safetensors")
+
+    assert calls[0]["cmd"][4:] == [
+        "model",
+        "download",
+        "--url",
+        "https://hf.co/c.safetensors",
+        "--filename",
+        "renamed.safetensors",
+    ]
+
+
+def test_download_model_threads_all_optionals(patched_run):
+    """Both optional args thread through together, in order, only when set."""
+    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+
+    server.download_model(
+        "https://civitai.com/api/download/models/42",
+        relative_path="models/checkpoints",
+        filename="sd.safetensors",
+    )
+
+    assert calls[0]["cmd"][4:] == [
+        "model",
+        "download",
+        "--url",
+        "https://civitai.com/api/download/models/42",
+        "--relative-path",
+        "models/checkpoints",
+        "--filename",
+        "sd.safetensors",
+    ]
+
+
+def test_download_model_omits_absent_optionals(patched_run):
+    """Neither optional flag is emitted when the argument is left unset."""
+    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+
+    server.download_model("https://hf.co/x.safetensors")
+
+    cmd = calls[0]["cmd"]
+    assert "--relative-path" not in cmd
+    assert "--filename" not in cmd
+
+
+def test_download_model_rejects_option_like_url():
+    """A leading-dash url is refused so comfy-cli can't parse it as a flag."""
+    with pytest.raises(server.ComfyCliError, match="invalid url"):
+        server.download_model("--config")
+
+
+def test_download_model_rejects_option_like_relative_path():
+    """A leading-dash relative_path is refused (argument injection guard)."""
+    with pytest.raises(server.ComfyCliError, match="invalid relative_path"):
+        server.download_model("https://hf.co/x.safetensors", relative_path="-rf")
+
+
+def test_download_model_rejects_option_like_filename():
+    """A leading-dash filename is refused (argument injection guard)."""
+    with pytest.raises(server.ComfyCliError, match="invalid filename"):
+        server.download_model("https://hf.co/x.safetensors", filename="--evil")
+
+
 def test_validate_workflow_returns_results_for_valid(patched_run):
     """A valid workflow returns comfy-cli's validation data unwrapped."""
     calls = patched_run(

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -262,6 +262,42 @@ def test_download_model_rejects_option_like_filename():
         server.download_model("https://hf.co/x.safetensors", filename="--evil")
 
 
+@pytest.mark.parametrize(
+    "bad_url", ["file:///etc/passwd", "ftp://host/x", "/etc/passwd"]
+)
+def test_download_model_rejects_non_http_scheme(bad_url):
+    """Only http(s) URLs are allowed; file://, ftp:// and bare paths are refused."""
+    with pytest.raises(server.ComfyCliError, match="invalid url"):
+        server.download_model(bad_url)
+
+
+@pytest.mark.parametrize(
+    "bad_path", ["../../etc", "models/../../etc", "/abs/models", "..\\..\\etc"]
+)
+def test_download_model_rejects_traversal_relative_path(bad_path):
+    """relative_path must stay within the models dir: no `..` or absolute paths."""
+    with pytest.raises(server.ComfyCliError, match="invalid relative_path"):
+        server.download_model("https://hf.co/x.safetensors", relative_path=bad_path)
+
+
+@pytest.mark.parametrize("bad_name", ["../evil", "sub/dir.safetensors", "..", "a\\b"])
+def test_download_model_rejects_pathy_filename(bad_name):
+    """filename must be a bare name: no separators or `..` to escape the dir."""
+    with pytest.raises(server.ComfyCliError, match="invalid filename"):
+        server.download_model("https://hf.co/x.safetensors", filename=bad_name)
+
+
+def test_download_model_omits_empty_string_optionals(patched_run):
+    """Explicit empty-string optionals are treated as unset, not forwarded as ``""``."""
+    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+
+    server.download_model("https://hf.co/x.safetensors", relative_path="", filename="")
+
+    cmd = calls[0]["cmd"]
+    assert "--relative-path" not in cmd
+    assert "--filename" not in cmd
+
+
 def test_validate_workflow_returns_results_for_valid(patched_run):
     """A valid workflow returns comfy-cli's validation data unwrapped."""
     calls = patched_run(


### PR DESCRIPTION
## ELI-5

The MCP already lets an agent *see* which models a local ComfyUI has (`search_models`), but if a model was missing the agent had to ask a human to go download it. This adds a `download_model` tool so the agent can fetch a checkpoint/LoRA itself, given its URL — a thin wrapper over comfy-cli's existing `comfy model download`.

## Summary

Adds an `@mcp.tool()` `download_model(url, relative_path=None, filename=None)` next to `search_models` in `src/comfy_local_mcp/server.py`. It shells out to `comfy model download --url <url> [--relative-path <path>] [--filename <name>]` and returns comfy-cli's envelope `data` (saved path / metadata).

Note the verb group is the **singular** `model` (the download engine), distinct from the **plural** `models` catalog that `search_models` reads.

## Changes

- New `download_model` tool wrapping `comfy model download`:
  - Builds argv `["model", "download", "--url", url]`, appending `--relative-path` / `--filename` **only when provided**.
  - Argument-injection guard consistent with the other wrappers: a leading-dash `url`, `relative_path`, or `filename` is rejected with `ComfyCliError` (so a crafted value can't be smuggled in as a CLI flag).
  - Generous `timeout=1800.0` — multi-GB checkpoints can take a while (vs `upload_file`'s 300s).
  - Docstring: HuggingFace/CivitAI URLs supported; tokens are configured out-of-band (not passed here); download-by-URL only — there is no hub search/browse (comfy-cli has none), so callers must already have the URL.
- Tests in `tests/test_wrapper.py` (monkeypatch at the `subprocess.run` layer via the existing `patched_run` fixture): assert exact argv for url-only, each optional alone, both together, both omitted, and that a leading-dash url/relative_path/filename raises `ComfyCliError`.

## Motivation

Closes the model-fetch gap: inventory was covered by `search_models`, but there was no way for an agent to pull a missing model into the models dir. comfy-cli already ships the engine, so this is a thin CLI wrapper — HuggingFace hub *search/browse* is intentionally out of scope (comfy-cli has no HF search; a browse tool would break the CLI-wrapper architecture).

## Testing

- [x] Existing tests pass (`pytest`) — 49 passed, 1 skipped (the live e2e smoke, skipped without a running ComfyUI)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)

## Additional Notes

- **Judgment call:** the PR title omits a `(BE-…)` ticket suffix to match this repo's existing PR convention and the public-destined-repo caution; the Linear ticket autolinks via the branch name (`matt/be-2385-download-model`).