### PR TITLE
feat: add get_execution_error diagnostics tool (BE-2384)

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -6,7 +6,8 @@ returns its ``data``. There is deliberately no HTTP client and no code shared
 with the Comfy Cloud MCP — comfy-cli is the engine.
 
 Tools so far: the run -> get-output core loop plus job management
-(``job_status`` / ``cancel_job`` / ``get_queue``) and the ``launch_comfyui`` /
+(``job_status`` / ``get_execution_error`` / ``cancel_job`` / ``get_queue``) and
+the ``launch_comfyui`` /
 ``stop_comfyui`` lifecycle pair (``comfy launch --background`` / ``comfy stop``).
 Next passthrough to add: ``discover`` (``comfy discover`` / ``comfy which``).
 
@@ -319,6 +320,100 @@ def job_status(prompt_id: str) -> Any:
     finished, its output references. Poll this after ``run_workflow(wait=False)``.
     """
     return _run_comfy("jobs", "status", prompt_id, timeout=60.0)
+
+
+# How many trailing traceback frames survive into a get_execution_error verdict.
+# A full ComfyUI traceback can run hundreds of frames; the tail carries the
+# actual failure site. Mirrors comfy-cli's execution_errors._TRACEBACK_TAIL_FRAMES
+# (a smaller tail there — this tool is the deliberate deep-dive companion).
+_TRACEBACK_TAIL_FRAMES = 20
+
+# Byte cap on the joined traceback tail, so a pathological (megabyte) traceback
+# can't dump into an agent's context. Content is a Python traceback — no secret
+# redaction is required, only a size bound.
+_TRACEBACK_TAIL_MAX_CHARS = 8000
+
+
+def _cap_traceback_tail(frames: list[str]) -> list[str]:
+    """Bound the joined traceback tail to ``_TRACEBACK_TAIL_MAX_CHARS`` chars.
+
+    Drops leading (oldest) frames until the remainder fits, prepending a
+    ``"...(truncated)"`` marker so the caller knows frames were dropped. If a
+    single frame alone exceeds the cap, its characters are hard-truncated (keep
+    the tail — that's the failure site). Returns the frames unchanged, with no
+    marker, when already under the cap.
+    """
+
+    def joined_len(items: list[str]) -> int:
+        # Newline-joined length: chars plus one separator between frames.
+        return sum(len(f) for f in items) + max(0, len(items) - 1)
+
+    frames = list(frames)
+    if joined_len(frames) <= _TRACEBACK_TAIL_MAX_CHARS:
+        return frames
+    while len(frames) > 1 and joined_len(frames) > _TRACEBACK_TAIL_MAX_CHARS:
+        frames.pop(0)
+    if frames and joined_len(frames) > _TRACEBACK_TAIL_MAX_CHARS:
+        # One oversized frame remains; hard-cap its characters.
+        frames = [frames[0][-_TRACEBACK_TAIL_MAX_CHARS:]]
+    return ["...(truncated)", *frames]
+
+
+@mcp.tool()
+def get_execution_error(prompt_id: str) -> Any:
+    """Diagnostics companion to ``job_status``: the failure verdict for a run.
+
+    Call this after a run reports failure (``job_status`` returning
+    ``status: error``) to get the compact cause an agent needs to self-repair
+    the workflow — the failing ``node_type``/``node_id``, the
+    ``exception_type``/``exception_message``, and a bounded tail of the Python
+    traceback — without digging it out of the large raw status blob. Wraps
+    ``comfy jobs status <prompt_id>`` (the same source comfy-cli points at for
+    the full traceback) and normalizes ComfyUI's raw ``execution_error`` payload
+    from that snapshot's ``error`` field.
+
+    On a healthy prompt (completed / queued / running — no ``error``) it returns
+    ``{"prompt_id", "status", "error": None}`` rather than raising, so it is safe
+    to call speculatively.
+    """
+    if prompt_id.startswith("-"):
+        # comfy-cli parses a leading-dash positional as an option/flag; reject
+        # it rather than let `jobs status` misread the id (argument injection).
+        raise ComfyCliError(f"invalid prompt_id: {prompt_id!r} (leading '-')")
+
+    status = _run_comfy("jobs", "status", prompt_id, timeout=60.0)
+
+    error = status.get("error") if isinstance(status, dict) else None
+    if not error:
+        # No execution error — job completed, still queued/running, or an
+        # unexpected payload shape. Report an explicit no-error result.
+        reported = status.get("status") if isinstance(status, dict) else None
+        return {"prompt_id": prompt_id, "status": reported, "error": None}
+
+    # `error` is normally ComfyUI's execution_error dict, but tolerate a bare
+    # string (some failure paths surface just a message) so the tool never
+    # crashes on an unexpected shape — mirrors comfy-cli's parse_error_message.
+    if not isinstance(error, dict):
+        error = {"exception_message": str(error)}
+
+    # Mirror comfy-cli's parse_error_message shape (execution_errors.py): flat
+    # fields plus a tail of the traceback frames, with node_id coerced to str.
+    node_id = error.get("node_id")
+    traceback = error.get("traceback") or []
+    if isinstance(traceback, str):
+        traceback = [traceback]
+    traceback_tail = [str(frame) for frame in traceback[-_TRACEBACK_TAIL_FRAMES:]]
+    traceback_tail = _cap_traceback_tail(traceback_tail)
+
+    return {
+        "prompt_id": prompt_id,
+        "status": "error",
+        "exception_message": error.get("exception_message"),
+        "exception_type": error.get("exception_type"),
+        "node_id": str(node_id) if node_id is not None else None,
+        "node_type": error.get("node_type"),
+        "traceback_tail": traceback_tail,
+    }
 
 
 # Statuses that mean a job is finished (no point polling further). comfy-cli

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -328,10 +328,24 @@ def job_status(prompt_id: str) -> Any:
 # (a smaller tail there — this tool is the deliberate deep-dive companion).
 _TRACEBACK_TAIL_FRAMES = 20
 
-# Byte cap on the joined traceback tail, so a pathological (megabyte) traceback
-# can't dump into an agent's context. Content is a Python traceback — no secret
-# redaction is required, only a size bound.
+# Character cap on the joined traceback tail, so a pathological (megabyte)
+# traceback can't dump into an agent's context. ``len()`` counts Unicode code
+# points, not bytes; that's close enough for a context-size guard. Content is a
+# Python traceback — no secret redaction is required, only a size bound.
 _TRACEBACK_TAIL_MAX_CHARS = 8000
+
+# Marker prepended to a truncated tail so the caller knows frames were dropped.
+_TRACEBACK_TRUNCATION_MARKER = "...(truncated)"
+
+# Character cap on free-text failure fields (``exception_message`` etc.). A
+# hostile or buggy custom node can raise with a multi-megabyte message; bound it
+# for the same context-bloat reason the traceback tail is capped.
+_EXCEPTION_TEXT_MAX_CHARS = 8000
+
+# Reported statuses that mean the run failed. Used to tell a genuinely healthy
+# run apart from a failure that carried a falsy/empty `error` field, so the
+# latter is not reported as `error: None`. Compared case-insensitively.
+_ERROR_STATUSES = frozenset({"error", "failed", "failure"})
 
 
 def _cap_traceback_tail(frames: list[str]) -> list[str]:
@@ -340,8 +354,9 @@ def _cap_traceback_tail(frames: list[str]) -> list[str]:
     Drops leading (oldest) frames until the remainder fits, prepending a
     ``"...(truncated)"`` marker so the caller knows frames were dropped. If a
     single frame alone exceeds the cap, its characters are hard-truncated (keep
-    the tail — that's the failure site). Returns the frames unchanged, with no
-    marker, when already under the cap.
+    the tail — that's the failure site). The marker and its separator are
+    charged to the budget, so the joined result stays within the cap. Returns
+    the frames unchanged, with no marker, when already under the cap.
     """
 
     def joined_len(items: list[str]) -> int:
@@ -351,12 +366,27 @@ def _cap_traceback_tail(frames: list[str]) -> list[str]:
     frames = list(frames)
     if joined_len(frames) <= _TRACEBACK_TAIL_MAX_CHARS:
         return frames
-    while len(frames) > 1 and joined_len(frames) > _TRACEBACK_TAIL_MAX_CHARS:
+    # Reserve room for the marker plus its trailing separator so the final
+    # joined tail (marker + frames) never exceeds the documented cap.
+    budget = max(0, _TRACEBACK_TAIL_MAX_CHARS - (len(_TRACEBACK_TRUNCATION_MARKER) + 1))
+    while len(frames) > 1 and joined_len(frames) > budget:
         frames.pop(0)
-    if frames and joined_len(frames) > _TRACEBACK_TAIL_MAX_CHARS:
+    if frames and joined_len(frames) > budget:
         # One oversized frame remains; hard-cap its characters.
-        frames = [frames[0][-_TRACEBACK_TAIL_MAX_CHARS:]]
-    return ["...(truncated)", *frames]
+        frames = [frames[0][-budget:]] if budget else [""]
+    return [_TRACEBACK_TRUNCATION_MARKER, *frames]
+
+
+def _cap_text(value: Any, limit: int = _EXCEPTION_TEXT_MAX_CHARS) -> Any:
+    """Bound a free-text failure field to ``limit`` chars.
+
+    Non-strings (including ``None``) pass through untouched so the field's shape
+    is preserved for callers that key off it; only oversized strings are cut and
+    marked truncated.
+    """
+    if isinstance(value, str) and len(value) > limit:
+        return value[:limit] + _TRACEBACK_TRUNCATION_MARKER
+    return value
 
 
 @mcp.tool()
@@ -384,10 +414,24 @@ def get_execution_error(prompt_id: str) -> Any:
     status = _run_comfy("jobs", "status", prompt_id, timeout=60.0)
 
     error = status.get("error") if isinstance(status, dict) else None
+    reported = status.get("status") if isinstance(status, dict) else None
     if not error:
-        # No execution error — job completed, still queued/running, or an
-        # unexpected payload shape. Report an explicit no-error result.
-        reported = status.get("status") if isinstance(status, dict) else None
+        # No error payload. Distinguish a genuinely healthy run from a failed
+        # one that reported an error status but a falsy/empty `error` field
+        # ({}, "", 0): the latter must not masquerade as `error: None` and let a
+        # caller treat the failure as healthy.
+        reported_l = reported.strip().lower() if isinstance(reported, str) else None
+        if reported_l in _ERROR_STATUSES:
+            return {
+                "prompt_id": prompt_id,
+                "status": "error",
+                "exception_message": None,
+                "exception_type": None,
+                "node_id": None,
+                "node_type": None,
+                "traceback_tail": [],
+            }
+        # Job completed, still queued/running, or an unexpected payload shape.
         return {"prompt_id": prompt_id, "status": reported, "error": None}
 
     # `error` is normally ComfyUI's execution_error dict, but tolerate a bare
@@ -402,16 +446,21 @@ def get_execution_error(prompt_id: str) -> Any:
     traceback = error.get("traceback") or []
     if isinstance(traceback, str):
         traceback = [traceback]
+    elif not isinstance(traceback, (list, tuple)):
+        # Malformed payload (dict / int / etc.): a non-sequence would raise on
+        # the slice below. Drop it rather than crash — the "never crashes on an
+        # unexpected shape" contract wins over salvaging a garbage traceback.
+        traceback = []
     traceback_tail = [str(frame) for frame in traceback[-_TRACEBACK_TAIL_FRAMES:]]
     traceback_tail = _cap_traceback_tail(traceback_tail)
 
     return {
         "prompt_id": prompt_id,
         "status": "error",
-        "exception_message": error.get("exception_message"),
-        "exception_type": error.get("exception_type"),
+        "exception_message": _cap_text(error.get("exception_message")),
+        "exception_type": _cap_text(error.get("exception_type")),
         "node_id": str(node_id) if node_id is not None else None,
-        "node_type": error.get("node_type"),
+        "node_type": _cap_text(error.get("node_type")),
         "traceback_tail": traceback_tail,
     }
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,135 @@
+"""Tests for ``get_execution_error`` — the failure-diagnostics companion tool.
+
+It wraps ``comfy jobs status <id>`` and normalizes ComfyUI's raw
+``execution_error`` payload (carried under the snapshot's ``error`` field) into a
+compact verdict: the failing node + exception + a bounded traceback tail. These
+lock in the three shapes the tool must handle: a failed status with a multi-frame
+traceback (fields extracted, tail bounded), a healthy status (explicit
+``error: None``, no raise), and a leading-dash prompt_id (rejected).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from comfy_local_mcp import server
+
+
+def test_get_execution_error_extracts_fields_and_caps_traceback(monkeypatch):
+    """A failed status → flat fields extracted and the traceback tailed + capped."""
+    # 50 frames, each padded to ~500 chars, so the joined tail blows the byte cap
+    # and forces both the frame-count tail (last 20) and the char cap to bite.
+    frames = [f"frame {i}: " + "x" * 500 for i in range(50)]
+    status = {
+        "status": "error",
+        "error": {
+            "exception_message": "Tensor size mismatch",
+            "exception_type": "RuntimeError",
+            "node_id": 7,  # server may send an int; contract coerces to str
+            "node_type": "KSampler",
+            "traceback": frames,
+        },
+    }
+    calls: list[tuple] = []
+
+    def fake_run(*args, **kwargs):
+        calls.append(args)
+        return status
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run)
+
+    result = server.get_execution_error("pid-123")
+
+    assert calls[0] == ("jobs", "status", "pid-123")  # wraps `comfy jobs status <id>`
+    assert result["prompt_id"] == "pid-123"
+    assert result["status"] == "error"
+    assert result["exception_message"] == "Tensor size mismatch"
+    assert result["exception_type"] == "RuntimeError"
+    assert result["node_id"] == "7"  # coerced to str
+    assert result["node_type"] == "KSampler"
+
+    tail = result["traceback_tail"]
+    # Frame-count tail keeps only the newest frames (well under all 50)...
+    assert len(tail) <= server._TRACEBACK_TAIL_FRAMES + 1  # +1 for the marker
+    # ...and the char cap dropped leading frames, leaving a truncation marker.
+    assert tail[0] == "...(truncated)"
+    joined = "\n".join(tail[1:])
+    assert len(joined) <= server._TRACEBACK_TAIL_MAX_CHARS
+    # The newest frame (the actual failure site) survives.
+    assert tail[-1] == frames[-1]
+
+
+def test_get_execution_error_small_traceback_is_not_marked(monkeypatch):
+    """A short traceback passes through untouched — no cap marker, str-coerced."""
+    status = {
+        "status": "error",
+        "error": {
+            "exception_message": "boom",
+            "exception_type": "ValueError",
+            "node_id": None,
+            "node_type": "LoadImage",
+            "traceback": "single frame string",  # str, not a list
+        },
+    }
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: status)
+
+    result = server.get_execution_error("pid")
+
+    assert result["node_id"] is None
+    assert result["traceback_tail"] == ["single frame string"]  # wrapped, not marked
+
+
+def test_get_execution_error_tolerates_non_dict_error(monkeypatch):
+    """A bare-string ``error`` is normalized, not crashed on (safe speculative call)."""
+    monkeypatch.setattr(
+        server,
+        "_run_comfy",
+        lambda *a, **k: {"status": "error", "error": "raw failure text"},
+    )
+
+    result = server.get_execution_error("pid")
+
+    assert result["status"] == "error"
+    assert result["exception_message"] == "raw failure text"
+    assert result["node_id"] is None
+    assert result["traceback_tail"] == []
+
+
+def test_get_execution_error_no_error_returns_explicit_none(monkeypatch):
+    """A completed status (no ``error``) returns ``error: None`` instead of raising."""
+    monkeypatch.setattr(
+        server,
+        "_run_comfy",
+        lambda *a, **k: {"status": "completed", "outputs": ["/tmp/gen.png"]},
+    )
+
+    result = server.get_execution_error("pid")
+
+    assert result == {"prompt_id": "pid", "status": "completed", "error": None}
+
+
+def test_get_execution_error_rejects_leading_dash(monkeypatch):
+    """A leading-dash prompt_id is rejected before any comfy-cli call."""
+    called = False
+
+    def fake_run(*args, **kwargs):
+        nonlocal called
+        called = True
+        return {}
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run)
+
+    with pytest.raises(server.ComfyCliError, match="leading '-'"):
+        server.get_execution_error("-rf")
+    assert not called  # guarded before shelling out
+
+
+def test_cap_traceback_tail_hard_truncates_single_oversized_frame():
+    """One frame longer than the cap is character-truncated, keeping its tail."""
+    frame = "y" * (server._TRACEBACK_TAIL_MAX_CHARS + 500)
+    capped = server._cap_traceback_tail([frame])
+
+    assert capped[0] == "...(truncated)"
+    assert len(capped) == 2
+    assert len(capped[1]) == server._TRACEBACK_TAIL_MAX_CHARS
+    assert capped[1] == frame[-server._TRACEBACK_TAIL_MAX_CHARS :]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -108,6 +108,61 @@ def test_get_execution_error_no_error_returns_explicit_none(monkeypatch):
     assert result == {"prompt_id": "pid", "status": "completed", "error": None}
 
 
+def test_get_execution_error_error_status_with_empty_payload_is_not_healthy(
+    monkeypatch,
+):
+    """``status: error`` with a falsy ``error`` field must not masquerade as healthy."""
+    monkeypatch.setattr(
+        server,
+        "_run_comfy",
+        lambda *a, **k: {"status": "error", "error": {}},  # failed but no details
+    )
+
+    result = server.get_execution_error("pid")
+
+    # Distinguished from the no-error branch: status stays "error", not error=None.
+    assert result["status"] == "error"
+    assert "error" not in result  # flat failure shape, not the healthy shape
+    assert result["exception_message"] is None
+    assert result["traceback_tail"] == []
+
+
+def test_get_execution_error_tolerates_non_sequence_traceback(monkeypatch):
+    """A malformed non-sequence ``traceback`` (dict/int) is dropped, not crashed on."""
+    monkeypatch.setattr(
+        server,
+        "_run_comfy",
+        lambda *a, **k: {
+            "status": "error",
+            "error": {
+                "exception_message": "boom",
+                "traceback": {"unexpected": "shape"},
+            },
+        },
+    )
+
+    result = server.get_execution_error("pid")
+
+    assert result["exception_message"] == "boom"
+    assert result["traceback_tail"] == []  # garbage traceback dropped, no TypeError
+
+
+def test_get_execution_error_caps_oversized_exception_message(monkeypatch):
+    """A multi-megabyte ``exception_message`` is bounded, not dumped whole."""
+    huge = "z" * (server._EXCEPTION_TEXT_MAX_CHARS + 10_000)
+    monkeypatch.setattr(
+        server,
+        "_run_comfy",
+        lambda *a, **k: {"status": "error", "error": {"exception_message": huge}},
+    )
+
+    result = server.get_execution_error("pid")
+
+    msg = result["exception_message"]
+    assert len(msg) <= server._EXCEPTION_TEXT_MAX_CHARS + len("...(truncated)")
+    assert msg.endswith("...(truncated)")
+
+
 def test_get_execution_error_rejects_leading_dash(monkeypatch):
     """A leading-dash prompt_id is rejected before any comfy-cli call."""
     called = False
@@ -131,5 +186,9 @@ def test_cap_traceback_tail_hard_truncates_single_oversized_frame():
 
     assert capped[0] == "...(truncated)"
     assert len(capped) == 2
-    assert len(capped[1]) == server._TRACEBACK_TAIL_MAX_CHARS
-    assert capped[1] == frame[-server._TRACEBACK_TAIL_MAX_CHARS :]
+    # The marker + separator are charged to the budget, so the *joined* result
+    # (marker + frame) stays within the documented cap — not just the frame.
+    joined = "\n".join(capped)
+    assert len(joined) <= server._TRACEBACK_TAIL_MAX_CHARS
+    # The tail of the oversized frame (the failure site) is what survives.
+    assert capped[1] == frame[-len(capped[1]) :]


### PR DESCRIPTION
## ELI-5

When a local ComfyUI run fails, the only thing an agent gets back is `job_status: error` — and the *actual* reason (which node blew up, the exception, the Python traceback) is buried inside a big status blob that the docstring never even mentions. This adds a small, focused tool, `get_execution_error(prompt_id)`, that digs out just the useful bits: the failing node, the exception, and the tail of the traceback — so an agent can read the failure and fix the workflow itself. It's a thin wrapper over data comfy-cli already produces, not new plumbing.

## Summary

Adds an `@mcp.tool()` `get_execution_error(prompt_id)` — the diagnostics companion to `job_status`. It wraps `comfy jobs status <prompt_id>` (the same source comfy-cli points at for the full traceback), reads ComfyUI's raw `execution_error` payload from the snapshot's `error` field, and returns a compact, bounded failure verdict instead of a raw blob.

## Changes

- New `get_execution_error(prompt_id)` tool in `src/comfy_local_mcp/server.py` (after `job_status`):
  - Leading-dash guard (rejects `prompt_id` starting with `-` as `ComfyCliError`, same argument-injection guard `watch_job` uses).
  - On a failed status (truthy `error`), normalizes to `{prompt_id, status: "error", exception_message, exception_type, node_id (coerced to str|None), node_type, traceback_tail}`, mirroring comfy-cli's `execution_errors.parse_error_message` shape.
  - `traceback_tail` = last `_TRACEBACK_TAIL_FRAMES` (20) frames, then byte-capped by `_cap_traceback_tail` to `_TRACEBACK_TAIL_MAX_CHARS` (~8000): drops leading frames until under cap and prepends `"...(truncated)"`; a single oversized frame is hard-truncated so the failure site always survives.
  - On a healthy status (no `error` — completed/queued/running) returns `{prompt_id, status, error: None}` rather than raising, so it is safe to call speculatively.
- New `tests/test_diagnostics.py` (6 cases): field extraction + traceback cap, small-traceback passthrough, explicit `error: None`, leading-dash rejection, single-oversized-frame truncation, and non-dict `error` tolerance.

## Motivation

BE-2384. Agents get `job_status: error` with no pointer to the cause, and the streaming `watch_job` path *raises* on failure rather than returning structured detail. This gives a single focused, speculatively-safe tool for the failure verdict.

## Testing

- [x] Existing tests pass (`pytest` — 47 passed)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)

## Additional Notes

- **Judgment call (beyond the ticket plan):** the plan assumes `error` is always a dict. I added a guard so a bare-string `error` is normalized into `{"exception_message": str(error)}` instead of raising `AttributeError` — otherwise the "safe to call speculatively" contract breaks on an unexpected payload shape. Covered by `test_get_execution_error_tolerates_non_dict_error`.
- Branched off `origin/main`, which predates the in-flight `watch_job` PR, so the leading-dash guard is written inline here rather than sharing a helper; if both land, that guard is a natural small dedup follow-up.
- No live smoke test against a real comfy-cli / running ComfyUI was run (same standing caveat noted atop `server.py`); behavior is locked by monkeypatched unit tests mirroring comfy-cli's documented `execution_error` shape.
