### PR TITLE
feat: add restart_comfyui and inline image return from fetch_outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,10 @@ comfy-cli's `envelope/1`, and returns its `data`.
 | `watch_job(prompt_id, timeout_seconds=600.0)` | `comfy jobs watch <prompt_id>` (streamed) | Tail an async-submitted job's live execution, streaming progress notifications; bounded, returns a `{"timed_out": True, …}` payload on expiry. Streaming counterpart to `wait_for_job`. |
 | `cancel_job(prompt_id)` | `comfy jobs cancel <prompt_id>` | Cancel a queued or running job. |
 | `get_queue()` | `comfy jobs ls` | List known jobs with status (pending/running/completed). |
-| `fetch_outputs(prompt_id, out_dir, url_only=False)` | `comfy download <prompt_id> --where local -o <out_dir> [--url-only]` | Wraps `comfy download --where local` to write a finished local job's outputs into `out_dir`; `url_only=True` emits the output URLs without copying bytes. |
+| `fetch_outputs(prompt_id, out_dir, url_only=False, inline_images=False)` | `comfy download <prompt_id> --where local -o <out_dir> [--url-only]` | Wraps `comfy download --where local` to write a finished local job's outputs into `out_dir`; `url_only=True` emits the output URLs without copying bytes; `inline_images=True` also returns the copied images as inline MCP image content so the agent can see them without a second read. |
 | `launch_comfyui(extra_args=None)` | `comfy launch --background [-- <extras>]` | Start the local ComfyUI detached; forwards `extra_args` to ComfyUI. |
 | `stop_comfyui()` | `comfy stop` | Stop the ComfyUI that comfy-cli launched (only its own recorded pid). |
+| `restart_comfyui(extra_args=None)` | `comfy stop` then `comfy launch --background [-- <extras>]` | Stop-then-launch the local ComfyUI (best-effort stop); forwards `extra_args` to the fresh server. Handy for relaunching with different flags. |
 | `discover()` | `comfy discover` | comfy-cli's self-describing surface (commands, arg schemas, error codes) — learn the CLI's own contract at runtime. |
 | `which()` | `comfy which` | Which ComfyUI install/workspace comfy-cli currently targets (a lighter answer than `server_info`). |
 | `search_templates(query="")` | `comfy templates ls` (filtered client-side) | Find a built-in workflow template by name/description; empty `query` lists all. |

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -7,8 +7,9 @@ with the Comfy Cloud MCP — comfy-cli is the engine.
 
 Tools so far: the run -> get-output core loop plus job management
 (``job_status`` / ``wait_for_job`` / ``watch_job`` / ``get_execution_error`` /
-``cancel_job`` / ``get_queue``), the ``launch_comfyui`` / ``stop_comfyui``
-lifecycle pair (``comfy launch --background`` / ``comfy stop``), and the
+``cancel_job`` / ``get_queue``), the ``launch_comfyui`` / ``stop_comfyui`` /
+``restart_comfyui`` lifecycle trio (``comfy launch --background`` /
+``comfy stop`` / stop-then-launch), and the
 ``discover`` / ``which`` introspection pair (``comfy discover`` /
 ``comfy which``) that lets an agent learn the CLI's own contract and selection.
 
@@ -27,7 +28,7 @@ import time
 from typing import Any
 from urllib.parse import urlparse
 
-from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.fastmcp import Context, FastMCP, Image
 
 # Rides every client handshake — teach an agent the canonical flows up front so
 # it does not have to rediscover them tool-by-tool. Keep this short.
@@ -625,8 +626,58 @@ def get_queue() -> Any:
     return _run_comfy("jobs", "ls", timeout=60.0)
 
 
+# Image suffixes we return inline from ``fetch_outputs`` — kept to the formats
+# ``mcp.server.fastmcp.Image`` maps to a real ``image/*`` MIME type (an unknown
+# suffix would fall back to ``application/octet-stream`` and not render).
+_INLINE_IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg", ".gif", ".webp")
+
+
+def _iter_strings(obj: Any) -> Any:
+    """Yield every string value nested anywhere inside ``obj`` (dicts/lists/scalars)."""
+    if isinstance(obj, str):
+        yield obj
+    elif isinstance(obj, dict):
+        for value in obj.values():
+            yield from _iter_strings(value)
+    elif isinstance(obj, (list, tuple)):
+        for value in obj:
+            yield from _iter_strings(value)
+
+
+def _collect_output_images(data: Any, out_dir: str) -> list[str]:
+    """Resolve image files referenced by ``comfy download``'s data to on-disk paths.
+
+    Walks every string in the envelope ``data``, keeps those with an image
+    suffix, resolves each against ``out_dir`` when it is not already an existing
+    absolute/relative path, and returns the files that actually exist on disk
+    (deduped, order-preserving). Anything that does not resolve to a real file is
+    skipped — inline return is best-effort and never masks the on-disk copy.
+    """
+    resolved: dict[str, None] = {}
+    for value in _iter_strings(data):
+        if not value.lower().endswith(_INLINE_IMAGE_SUFFIXES):
+            continue
+        # Try the path as given, then relative to out_dir, then just its
+        # basename inside out_dir — comfy-cli may report absolute paths, paths
+        # relative to out_dir, or bare filenames depending on the invocation.
+        for candidate in (
+            value,
+            os.path.join(out_dir, value),
+            os.path.join(out_dir, os.path.basename(value)),
+        ):
+            if os.path.isfile(candidate):
+                resolved.setdefault(os.path.abspath(candidate), None)
+                break
+    return list(resolved)
+
+
 @mcp.tool()
-def fetch_outputs(prompt_id: str, out_dir: str, url_only: bool = False) -> Any:
+def fetch_outputs(
+    prompt_id: str,
+    out_dir: str,
+    url_only: bool = False,
+    inline_images: bool = False,
+) -> Any:
     """Download a completed LOCAL job's output files into ``out_dir``.
 
     Thin passthrough to ``comfy download <prompt_id> --where local -o <out_dir>``:
@@ -635,11 +686,23 @@ def fetch_outputs(prompt_id: str, out_dir: str, url_only: bool = False) -> Any:
     supplied by :func:`_run_comfy` as a global flag.) Pass ``url_only=True`` to
     add ``--url-only`` — comfy-cli then emits the output URLs without downloading,
     handy for handing URLs to other tools instead of copying bytes.
+
+    Pass ``inline_images=True`` to ALSO return the copied images as inline MCP
+    image content (base64) so the calling agent can see the result without a
+    second read — the on-disk copy into ``out_dir`` is unchanged either way. In
+    that mode the return is a list whose first element is comfy-cli's usual
+    metadata and whose remaining elements are the image files just written; a
+    non-image output (or ``url_only=True``, which downloads no bytes) simply
+    yields no inline images.
     """
     args = ["download", prompt_id, "-o", out_dir]
     if url_only:
         args.append("--url-only")
-    return _run_comfy(*args, timeout=300.0)
+    data = _run_comfy(*args, timeout=300.0)
+    if not inline_images:
+        return data
+    images = [Image(path=path) for path in _collect_output_images(data, out_dir)]
+    return [data, *images]
 
 
 @mcp.tool()
@@ -680,6 +743,30 @@ def stop_comfyui() -> Any:
     message, rather than killing an unrelated process.
     """
     return _run_comfy("stop", timeout=60.0)
+
+
+@mcp.tool()
+def restart_comfyui(extra_args: list[str] | None = None) -> Any:
+    """Restart the LOCAL ComfyUI server: stop the running one, then launch a fresh one.
+
+    Composes the existing :func:`stop_comfyui` and :func:`launch_comfyui` — there
+    is no ``comfy restart`` subcommand, so this is a thin stop-then-launch over
+    comfy-cli, not a new engine feature. ``extra_args`` are forwarded to the new
+    ComfyUI exactly as :func:`launch_comfyui` forwards them (after a ``--``
+    separator), so a restart is also how you relaunch with different flags.
+    Returns the new server's status (``launch_comfyui``'s envelope data).
+
+    The stop step is best-effort: if comfy-cli has no recorded server to stop
+    (e.g. nothing is running, or ComfyUI was started outside comfy-cli), that
+    ``ComfyCliError`` is swallowed and the launch proceeds — a restart should
+    still bring the server up. Any genuine problem the failed stop would cause
+    (such as the old process still holding the port) surfaces from the launch.
+    """
+    try:
+        stop_comfyui()
+    except ComfyCliError:
+        pass
+    return launch_comfyui(extra_args)
 
 
 @mcp.tool()

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -66,7 +66,31 @@ _MAX_WATCH_TIMEOUT = 3600.0
 
 
 class ComfyCliError(RuntimeError):
-    """comfy-cli was missing, timed out, or returned an error envelope."""
+    """comfy-cli was missing, timed out, or returned an error envelope.
+
+    ``code`` carries the envelope's structured ``error.code`` when the failure
+    came from an error envelope (else ``None`` for missing-binary/timeout/no-JSON
+    cases), so callers can branch on a specific outcome instead of scraping the
+    message string.
+    """
+
+    def __init__(self, *args: object, code: str | None = None) -> None:
+        super().__init__(*args)
+        self.code = code
+
+
+# comfy-cli's error code for "I have no server pid recorded to stop" — the one
+# stop failure ``restart_comfyui`` treats as benign (see its docstring).
+_NO_RECORDED_SERVER_CODE = "no_recorded_server"
+
+
+def _is_no_recorded_server(exc: ComfyCliError) -> bool:
+    """True when ``exc`` is comfy-cli's benign 'nothing recorded to stop' error.
+
+    Prefers the structured ``code`` and falls back to the message so it also
+    recognizes the error when only the human-readable string carries the marker.
+    """
+    return exc.code == _NO_RECORDED_SERVER_CODE or _NO_RECORDED_SERVER_CODE in str(exc)
 
 
 def _run_comfy(*args: str, timeout: float | None = None) -> Any:
@@ -124,7 +148,8 @@ def _unwrap_envelope(
         raise ComfyCliError(
             f"comfy {' '.join(args)} failed "
             f"[{err.get('code', 'unknown')}]: "
-            f"{err.get('message') or stderr.strip()[:500]}"
+            f"{err.get('message') or stderr.strip()[:500]}",
+            code=err.get("code"),
         )
     return envelope.get("data")
 
@@ -631,6 +656,14 @@ def get_queue() -> Any:
 # suffix would fall back to ``application/octet-stream`` and not render).
 _INLINE_IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg", ".gif", ".webp")
 
+# Bounds on what ``fetch_outputs(inline_images=True)`` base64-inlines into the
+# reply, mirroring the module's other output caps (``_TRACEBACK_TAIL_MAX_CHARS``,
+# ``_EXCEPTION_TEXT_MAX_CHARS``): a big batch or high-res render must not force an
+# unbounded allocation / blow the agent's context. The on-disk copies in
+# ``out_dir`` are untouched — only the inline preview is capped.
+_INLINE_IMAGE_MAX_COUNT = 8
+_INLINE_IMAGE_MAX_BYTES = 16 * 1024 * 1024
+
 
 def _iter_strings(obj: Any) -> Any:
     """Yield every string value nested anywhere inside ``obj`` (dicts/lists/scalars)."""
@@ -644,31 +677,68 @@ def _iter_strings(obj: Any) -> Any:
             yield from _iter_strings(value)
 
 
+def _is_within(root: str, path: str) -> bool:
+    """True if ``path`` (already realpath'd) is ``root`` itself or nested under it."""
+    return path == root or path.startswith(root + os.sep)
+
+
 def _collect_output_images(data: Any, out_dir: str) -> list[str]:
     """Resolve image files referenced by ``comfy download``'s data to on-disk paths.
 
     Walks every string in the envelope ``data``, keeps those with an image
-    suffix, resolves each against ``out_dir`` when it is not already an existing
-    absolute/relative path, and returns the files that actually exist on disk
-    (deduped, order-preserving). Anything that does not resolve to a real file is
-    skipped — inline return is best-effort and never masks the on-disk copy.
+    suffix, and returns the ones that resolve to a real file **inside**
+    ``out_dir`` (deduped, order-preserving). ``comfy download -o out_dir`` writes
+    every file it produces into ``out_dir``, so scoping to that directory is what
+    keeps the inline preview honest: a bare/relative name binds to the copy just
+    written rather than a same-named file in the process CWD, and an absolute or
+    ``../``-traversal path that escapes ``out_dir`` (an input reference, a URL
+    basename, or an outright traversal in the metadata) is rejected instead of
+    read and inlined. Inline return is best-effort and never masks the on-disk
+    copy.
     """
+    out_root = os.path.realpath(out_dir)
     resolved: dict[str, None] = {}
     for value in _iter_strings(data):
         if not value.lower().endswith(_INLINE_IMAGE_SUFFIXES):
             continue
-        # Try the path as given, then relative to out_dir, then just its
-        # basename inside out_dir — comfy-cli may report absolute paths, paths
-        # relative to out_dir, or bare filenames depending on the invocation.
+        # Most-specific form first (the value as given, then joined onto out_dir,
+        # then bare basename in out_dir) — but every candidate must resolve to a
+        # real file INSIDE out_dir. Containment is what neutralizes the CWD
+        # shadow (a bare "gen.png" resolves to CWD/gen.png, outside out_dir, so
+        # it's rejected in favor of the out_dir copy) and the `../` traversal.
         for candidate in (
             value,
             os.path.join(out_dir, value),
             os.path.join(out_dir, os.path.basename(value)),
         ):
-            if os.path.isfile(candidate):
-                resolved.setdefault(os.path.abspath(candidate), None)
+            real = os.path.realpath(candidate)
+            if _is_within(out_root, real) and os.path.isfile(real):
+                resolved.setdefault(real, None)
                 break
     return list(resolved)
+
+
+def _select_inline_images(paths: list[str]) -> list[str]:
+    """Cap the inlined set to ``_INLINE_IMAGE_MAX_COUNT`` files / aggregate bytes.
+
+    Preserves order and stops as soon as either bound would be exceeded, so a
+    large batch or a high-res render can't force an unbounded base64 payload into
+    the reply. Unreadable files are skipped (the on-disk copy still stands).
+    """
+    selected: list[str] = []
+    total = 0
+    for path in paths:
+        if len(selected) >= _INLINE_IMAGE_MAX_COUNT:
+            break
+        try:
+            size = os.path.getsize(path)
+        except OSError:
+            continue
+        if selected and total + size > _INLINE_IMAGE_MAX_BYTES:
+            break
+        selected.append(path)
+        total += size
+    return selected
 
 
 @mcp.tool()
@@ -693,15 +763,21 @@ def fetch_outputs(
     that mode the return is a list whose first element is comfy-cli's usual
     metadata and whose remaining elements are the image files just written; a
     non-image output (or ``url_only=True``, which downloads no bytes) simply
-    yields no inline images.
+    yields no inline images. The inline preview is capped
+    (``_INLINE_IMAGE_MAX_COUNT`` files / ``_INLINE_IMAGE_MAX_BYTES`` aggregate) so
+    a large batch can't blow up the reply — the on-disk copies are never capped.
     """
     args = ["download", prompt_id, "-o", out_dir]
     if url_only:
         args.append("--url-only")
     data = _run_comfy(*args, timeout=300.0)
-    if not inline_images:
+    # ``url_only=True`` downloads no bytes, so there is nothing on disk to inline
+    # — short-circuit rather than let basename matching surface stale files from
+    # a previous run into ``out_dir`` (which would contradict the docstring).
+    if not inline_images or url_only:
         return data
-    images = [Image(path=path) for path in _collect_output_images(data, out_dir)]
+    paths = _select_inline_images(_collect_output_images(data, out_dir))
+    images = [Image(path=path) for path in paths]
     return [data, *images]
 
 
@@ -756,16 +832,18 @@ def restart_comfyui(extra_args: list[str] | None = None) -> Any:
     separator), so a restart is also how you relaunch with different flags.
     Returns the new server's status (``launch_comfyui``'s envelope data).
 
-    The stop step is best-effort: if comfy-cli has no recorded server to stop
-    (e.g. nothing is running, or ComfyUI was started outside comfy-cli), that
-    ``ComfyCliError`` is swallowed and the launch proceeds — a restart should
-    still bring the server up. Any genuine problem the failed stop would cause
-    (such as the old process still holding the port) surfaces from the launch.
+    The stop step is best-effort ONLY for the benign "nothing to stop" case: if
+    comfy-cli has no recorded server (e.g. nothing is running, or ComfyUI was
+    started outside comfy-cli) it returns the ``no_recorded_server`` code, which
+    is swallowed so the restart still brings the server up. Any OTHER stop
+    failure (a process that couldn't be killed, a permission error, a comfy-cli
+    malfunction) is re-raised rather than silently masked behind the launch.
     """
     try:
         stop_comfyui()
-    except ComfyCliError:
-        pass
+    except ComfyCliError as exc:
+        if not _is_no_recorded_server(exc):
+            raise
     return launch_comfyui(extra_args)
 
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -837,6 +837,41 @@ def test_restart_comfyui_tolerates_no_recorded_server(monkeypatch):
     assert launched == [["--cpu"]]  # launch happened despite the stop error
 
 
+def test_restart_comfyui_reraises_genuine_stop_failure(monkeypatch):
+    """A stop failure that ISN'T 'no recorded server' propagates — launch is skipped."""
+    launched: list = []
+
+    def fake_stop():
+        raise server.ComfyCliError(
+            "comfy stop failed [permission_denied]: cannot kill pid 7",
+            code="permission_denied",
+        )
+
+    monkeypatch.setattr(server, "stop_comfyui", fake_stop)
+    monkeypatch.setattr(
+        server, "launch_comfyui", lambda extra_args=None: launched.append(extra_args)
+    )
+
+    with pytest.raises(server.ComfyCliError, match="permission_denied"):
+        server.restart_comfyui()
+    assert launched == []  # genuine failure is not masked by a relaunch
+
+
+def test_error_envelope_populates_structured_code(patched_run):
+    """ComfyCliError from an error envelope carries the code as an attribute, not just text."""
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": False,
+            "error": {"code": "server_not_running", "message": "ComfyUI not running"},
+        }
+    )
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("env")
+    assert excinfo.value.code == "server_not_running"
+
+
 def test_restart_comfyui_returns_new_server_status(monkeypatch):
     """restart returns launch_comfyui's data (the fresh server status), not stop's."""
     monkeypatch.setattr(server, "stop_comfyui", lambda: {"stopped": True})
@@ -877,7 +912,7 @@ def test_fetch_outputs_inline_images_returns_image_content(patched_run, tmp_path
 def test_fetch_outputs_inline_images_resolves_nested_absolute_paths(
     patched_run, tmp_path
 ):
-    """Absolute image paths nested anywhere in the data are found and returned."""
+    """Absolute image paths nested anywhere in the data (under out_dir) are found."""
     img = tmp_path / "a.jpg"
     img.write_bytes(b"jpeg-bytes")
     patched_run(
@@ -888,12 +923,120 @@ def test_fetch_outputs_inline_images_resolves_nested_absolute_paths(
         }
     )
 
-    # out_dir is unrelated here — the data carries an absolute path.
-    result = server.fetch_outputs("pid", "/some/other/dir", inline_images=True)
+    # The absolute path the data carries lives inside out_dir (comfy download -o
+    # writes there), so it is inlined.
+    result = server.fetch_outputs("pid", str(tmp_path), inline_images=True)
 
     images = [r for r in result if isinstance(r, server.Image)]
     assert len(images) == 1
     assert images[0].to_image_content().mimeType == "image/jpeg"
+
+
+def test_fetch_outputs_inline_images_rejects_paths_outside_out_dir(
+    patched_run, tmp_path
+):
+    """A real image referenced by the data but living OUTSIDE out_dir is not inlined.
+
+    comfy download only writes into out_dir, so an absolute/`..` path escaping it
+    is an input reference or a traversal, never a file this job produced.
+    """
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    outside = tmp_path / "elsewhere.png"
+    outside.write_bytes(_FAKE_PNG)  # a real image, but outside out_dir
+
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": True,
+            # both an absolute escape and a ../ traversal that resolve outside
+            "data": {"abs": str(outside), "rel": "../elsewhere.png"},
+        }
+    )
+
+    result = server.fetch_outputs("pid", str(out_dir), inline_images=True)
+
+    assert not any(isinstance(r, server.Image) for r in result)
+
+
+def test_fetch_outputs_inline_images_prefers_out_dir_over_cwd(
+    patched_run, tmp_path, monkeypatch
+):
+    """A bare filename binds to the copy in out_dir, not a same-named file in the CWD."""
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "gen.png").write_bytes(_FAKE_PNG)  # the real output
+
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    (cwd / "gen.png").write_bytes(b"cwd-decoy-not-this-one")  # a CWD shadow
+    monkeypatch.chdir(cwd)
+
+    patched_run({"type": "envelope", "ok": True, "data": {"downloaded": ["gen.png"]}})
+
+    result = server.fetch_outputs("pid", str(out_dir), inline_images=True)
+
+    images = [r for r in result if isinstance(r, server.Image)]
+    assert len(images) == 1
+    import base64
+
+    # the out_dir copy, never the CWD decoy
+    assert base64.b64decode(images[0].to_image_content().data) == _FAKE_PNG
+
+
+def test_fetch_outputs_url_only_returns_no_inline_images(patched_run, tmp_path):
+    """url_only downloads no bytes, so inline_images can't surface stale out_dir files."""
+    # A stale image from a prior run whose basename the emitted URL echoes.
+    (tmp_path / "old.png").write_bytes(_FAKE_PNG)
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": True,
+            "data": {"urls": ["http://localhost:8188/view/old.png"]},
+        }
+    )
+
+    result = server.fetch_outputs(
+        "pid", str(tmp_path), url_only=True, inline_images=True
+    )
+
+    # Bare envelope data — no [data, Image...] wrapping, no stale file inlined.
+    assert result == {"urls": ["http://localhost:8188/view/old.png"]}
+
+
+def test_fetch_outputs_inline_images_caps_count(patched_run, tmp_path):
+    """No more than _INLINE_IMAGE_MAX_COUNT images are inlined, however many exist."""
+    names = [f"g{i}.png" for i in range(server._INLINE_IMAGE_MAX_COUNT + 5)]
+    for name in names:
+        (tmp_path / name).write_bytes(_FAKE_PNG)
+    patched_run({"type": "envelope", "ok": True, "data": {"downloaded": names}})
+
+    result = server.fetch_outputs("pid", str(tmp_path), inline_images=True)
+
+    images = [r for r in result if isinstance(r, server.Image)]
+    assert len(images) == server._INLINE_IMAGE_MAX_COUNT
+
+
+def test_fetch_outputs_inline_images_caps_aggregate_bytes(
+    patched_run, tmp_path, monkeypatch
+):
+    """Inlining stops once the aggregate byte budget would be exceeded."""
+    monkeypatch.setattr(server, "_INLINE_IMAGE_MAX_BYTES", 10)
+    for name in ("a.png", "b.png", "c.png"):
+        (tmp_path / name).write_bytes(b"1234567")  # 7 bytes each
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": True,
+            "data": {"downloaded": ["a.png", "b.png", "c.png"]},
+        }
+    )
+
+    result = server.fetch_outputs("pid", str(tmp_path), inline_images=True)
+
+    images = [r for r in result if isinstance(r, server.Image)]
+    # first (7B) fits; second would push to 14B > 10B budget -> stop.
+    assert len(images) == 1
 
 
 def test_fetch_outputs_inline_images_skips_non_image_and_missing(patched_run, tmp_path):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -791,3 +791,146 @@ def test_run_workflow_wait_false_uses_plain_json_no_stream(monkeypatch):
     assert result == {"prompt_id": "p1"}
     assert seen["args"] == ("run", "--workflow", "wf.json")  # no --wait
     assert seen["timeout"] == 60.0
+
+
+# --- restart_comfyui (stop -> launch composition) --------------------------
+
+
+def test_restart_comfyui_runs_stop_then_launch(patched_run):
+    """restart is a thin `comfy stop` then `comfy launch --background` composition."""
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"pid": 7}})
+
+    # patched_run's fake emits the same envelope for every call, so launch's
+    # data ({"pid": 7}) is what restart returns.
+    assert server.restart_comfyui() == {"pid": 7}
+
+    assert len(calls) == 2  # exactly stop then launch, nothing else
+    assert calls[0]["cmd"][4:] == ["stop"]
+    assert calls[1]["cmd"][4:] == ["launch", "--background"]
+
+
+def test_restart_comfyui_forwards_extra_args_to_launch(patched_run):
+    """extra_args ride the launch step after the `--` separator, not the stop."""
+    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+
+    server.restart_comfyui(["--port", "8189"])
+
+    assert calls[0]["cmd"][4:] == ["stop"]  # stop takes no extras
+    assert calls[1]["cmd"][4:] == ["launch", "--background", "--", "--port", "8189"]
+
+
+def test_restart_comfyui_tolerates_no_recorded_server(monkeypatch):
+    """A failed stop (nothing recorded to stop) is swallowed; launch still runs."""
+    launched: list = []
+
+    def fake_stop():
+        raise server.ComfyCliError("comfy stop failed [no_recorded_server]: none")
+
+    def fake_launch(extra_args=None):
+        launched.append(extra_args)
+        return {"pid": 1}
+
+    monkeypatch.setattr(server, "stop_comfyui", fake_stop)
+    monkeypatch.setattr(server, "launch_comfyui", fake_launch)
+
+    assert server.restart_comfyui(["--cpu"]) == {"pid": 1}
+    assert launched == [["--cpu"]]  # launch happened despite the stop error
+
+
+def test_restart_comfyui_returns_new_server_status(monkeypatch):
+    """restart returns launch_comfyui's data (the fresh server status), not stop's."""
+    monkeypatch.setattr(server, "stop_comfyui", lambda: {"stopped": True})
+    monkeypatch.setattr(
+        server, "launch_comfyui", lambda extra_args=None: {"pid": 42, "port": 8188}
+    )
+
+    assert server.restart_comfyui() == {"pid": 42, "port": 8188}
+
+
+# --- fetch_outputs inline image return -------------------------------------
+
+# A few bytes standing in for a PNG — Image just base64-encodes the file, it
+# does not decode/validate the pixels, so any bytes exercise the round-trip.
+_FAKE_PNG = b"\x89PNG\r\n\x1a\nfake-pixels"
+
+
+def test_fetch_outputs_inline_images_returns_image_content(patched_run, tmp_path):
+    """inline_images=True returns [metadata, Image...] for each downloaded image."""
+    (tmp_path / "gen.png").write_bytes(_FAKE_PNG)
+    patched_run({"type": "envelope", "ok": True, "data": {"downloaded": ["gen.png"]}})
+
+    result = server.fetch_outputs("pid", str(tmp_path), inline_images=True)
+
+    assert isinstance(result, list)
+    assert result[0] == {"downloaded": ["gen.png"]}  # metadata preserved first
+    images = [r for r in result[1:] if isinstance(r, server.Image)]
+    assert len(images) == 1
+
+    content = images[0].to_image_content()
+    assert content.type == "image"
+    assert content.mimeType == "image/png"
+    import base64
+
+    assert base64.b64decode(content.data) == _FAKE_PNG  # the real file bytes
+
+
+def test_fetch_outputs_inline_images_resolves_nested_absolute_paths(
+    patched_run, tmp_path
+):
+    """Absolute image paths nested anywhere in the data are found and returned."""
+    img = tmp_path / "a.jpg"
+    img.write_bytes(b"jpeg-bytes")
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": True,
+            "data": {"files": [{"path": str(img), "node": "SaveImage"}]},
+        }
+    )
+
+    # out_dir is unrelated here — the data carries an absolute path.
+    result = server.fetch_outputs("pid", "/some/other/dir", inline_images=True)
+
+    images = [r for r in result if isinstance(r, server.Image)]
+    assert len(images) == 1
+    assert images[0].to_image_content().mimeType == "image/jpeg"
+
+
+def test_fetch_outputs_inline_images_skips_non_image_and_missing(patched_run, tmp_path):
+    """Non-image outputs and dangling references yield no inline images."""
+    (tmp_path / "notes.txt").write_bytes(b"hello")
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": True,
+            "data": {"downloaded": ["notes.txt", "ghost.png"]},
+        }
+    )
+
+    result = server.fetch_outputs("pid", str(tmp_path), inline_images=True)
+
+    assert result[0] == {"downloaded": ["notes.txt", "ghost.png"]}
+    assert not any(isinstance(r, server.Image) for r in result)  # neither qualifies
+
+
+def test_fetch_outputs_inline_images_still_downloads(patched_run, tmp_path):
+    """Inline return is additive: the `comfy download -o` copy command is unchanged."""
+    (tmp_path / "gen.png").write_bytes(_FAKE_PNG)
+    calls = patched_run(
+        {"type": "envelope", "ok": True, "data": {"downloaded": ["gen.png"]}}
+    )
+
+    server.fetch_outputs("pid", str(tmp_path), inline_images=True)
+
+    # Same passthrough argv as the plain path — no --url-only, still copies bytes.
+    assert calls[0]["cmd"][4:] == ["download", "pid", "-o", str(tmp_path)]
+
+
+def test_fetch_outputs_default_return_is_unchanged(patched_run, tmp_path):
+    """Without inline_images the bare envelope data is returned (no list wrapping)."""
+    (tmp_path / "gen.png").write_bytes(_FAKE_PNG)
+    patched_run({"type": "envelope", "ok": True, "data": {"downloaded": ["gen.png"]}})
+
+    result = server.fetch_outputs("pid", str(tmp_path))
+
+    assert result == {"downloaded": ["gen.png"]}  # dict, not a [data, ...] list


### PR DESCRIPTION
## ELI-5

Two small conveniences for an agent driving a local ComfyUI:

- **`restart_comfyui`** — one call that stops the running ComfyUI and starts a
  fresh one (there's no `comfy restart`, so it just does stop-then-launch). Great
  for relaunching with different flags or recovering a wedged server.
- **`fetch_outputs(..., inline_images=True)`** — as well as copying a finished
  job's images to disk (unchanged), it can now hand the images straight back to
  the agent as inline image content, so it can *see* the render without a second
  read step.

## Summary

Two thin-wrapper additions to `server.py`, both additive and opt-in — no existing
behavior changes.

## Changes

- **`restart_comfyui(extra_args=None)`** — composes the existing `stop_comfyui`
  and `launch_comfyui` tools (stop-then-launch; there is no `comfy restart`
  subcommand). Forwards `extra_args` to the fresh server after the `--` separator
  exactly as `launch_comfyui` does, and returns the new server's launch status.
  The stop step is **best-effort**: if comfy-cli has no recorded server to stop
  (nothing running, or ComfyUI started outside comfy-cli), that `ComfyCliError`
  is swallowed and the launch proceeds — a restart should still bring the server
  up. Any real problem a failed stop would cause (e.g. the old process still
  holding the port) surfaces from the subsequent launch.
- **`fetch_outputs` inline image return** — new opt-in `inline_images=False`
  param. When `True`, after the usual `comfy download … -o <out_dir>` copy, the
  tool returns a list `[metadata, <images…>]` where each image is inline MCP
  image content (base64) via `mcp.server.fastmcp.Image`. The on-disk copy is
  unchanged; the download argv is byte-for-byte identical. A small helper walks
  the envelope data for image-suffixed strings, resolves each against `out_dir`,
  and only returns files that actually exist on disk (best-effort — never masks
  the copy). Restricted to suffixes `Image` maps to a real `image/*` MIME type.
- README tool table updated (added `restart_comfyui`, extended the `fetch_outputs`
  row).

## Motivation

Two gaps identified in the competitive gap analysis (2026-07-06): agents wanting
to bounce the local server, and wanting to see a render inline without a second
read.

## Testing

- [x] Existing tests pass (`pytest` — 104 passed, 1 skipped: the e2e smoke that
      needs a real `comfy` binary)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- New tests mirror the existing passthrough pattern in `tests/test_wrapper.py`:
  restart runs `stop` then `launch --background` (with/without extras), tolerates
  a no-recorded-server stop, and returns the launch status; inline images return
  `[metadata, Image…]`, resolve nested/absolute paths, skip non-image and missing
  files, and leave the default (non-inline) return and the download argv unchanged.

## Additional Notes

- **Scope note:** the source ticket bundled a third item, `download_model`, but
  that tool **already landed on `main`** (with its own tests) in an earlier PR, so
  this PR only adds the two remaining items. The mentioned prerequisite PR (a
  `get_logs`/version bump sharing `server.py`) is neither open nor present on
  `main`, so this branches directly off `main`.
- **Judgment call — best-effort stop in `restart_comfyui`:** swallowing the
  `no_recorded_server` case (vs. propagating it) makes "restart" bring up a server
  that wasn't previously running. Genuine stop failures still surface via the
  launch. Declared here rather than escalated.
- **Judgment call — graceful `url_only` + `inline_images`:** combining them yields
  no inline images (no bytes were downloaded) rather than raising; documented in
  the docstring.
- **Pre-existing drift (left as-is):** the README's "Twenty-two tools" prose count
  and table were already stale on `main` (31 tools registered). I updated only the
  rows my change touches rather than doing a full reconciliation out of scope.
- 3.10 compatibility relies on `from __future__ import annotations`; only 3.14 was
  run locally (CI covers both).
