### PR TITLE
feat: add get_logs tool and require comfy-cli >= 1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engi
 ## Prerequisites
 
 - **Python ≥ 3.10.**
-- **comfy-cli** on your `PATH`: `pip install comfy-cli`. This is the engine every tool wraps.
+- **comfy-cli ≥ 1.12.0** on your `PATH`: `pip install 'comfy-cli>=1.12.0'`. This is the engine
+  every tool wraps; the server refuses to run against an older comfy-cli with an upgrade message.
 - **A ComfyUI workspace.** If you don't have one, `comfy-cli` can create it: `comfy install`
   sets up a ComfyUI workspace it will point at. (An existing ComfyUI checkout works too — see
   `comfy set-default <path>`.)
@@ -111,7 +112,7 @@ Zero to a generated image:
 1. **Install the pieces.**
 
    ```bash
-   pip install comfy-cli          # the engine
+   pip install 'comfy-cli>=1.12.0'  # the engine (>= 1.12.0 required)
    comfy install                  # create a ComfyUI workspace (skip if you have one)
    pip install .                  # this MCP server → the `comfy-local-mcp` command
    ```
@@ -143,7 +144,7 @@ the originals stay in the ComfyUI workspace.
 
 ## Tools
 
-Twenty-two tools. Every tool runs `comfy` with the global `--json --where local` flags, unwraps
+Thirty-two tools. Every tool runs `comfy` with the global `--json --where local` flags, unwraps
 comfy-cli's `envelope/1`, and returns its `data`.
 
 | Tool | Wraps | Purpose |
@@ -158,6 +159,7 @@ comfy-cli's `envelope/1`, and returns its `data`.
 | `fetch_outputs(prompt_id, out_dir, url_only=False)` | `comfy download <prompt_id> --where local -o <out_dir> [--url-only]` | Wraps `comfy download --where local` to write a finished local job's outputs into `out_dir`; `url_only=True` emits the output URLs without copying bytes. |
 | `launch_comfyui(extra_args=None)` | `comfy launch --background [-- <extras>]` | Start the local ComfyUI detached; forwards `extra_args` to ComfyUI. |
 | `stop_comfyui()` | `comfy stop` | Stop the ComfyUI that comfy-cli launched (only its own recorded pid). |
+| `get_logs(tail=200)` | `comfy logs --tail <tail>` | Tail the background ComfyUI's captured log (`<workspace>/user/comfyui_<port>.log`) — closes the debugging loop after a detached `launch_comfyui`. Returns `{lines, path, truncated}`; a missing log file returns `{"error": "no_log_file", …}` rather than raising. |
 | `discover()` | `comfy discover` | comfy-cli's self-describing surface (commands, arg schemas, error codes) — learn the CLI's own contract at runtime. |
 | `which()` | `comfy which` | Which ComfyUI install/workspace comfy-cli currently targets (a lighter answer than `server_info`). |
 | `search_templates(query="")` | `comfy templates ls` (filtered client-side) | Find a built-in workflow template by name/description; empty `query` lists all. |

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -8,9 +8,14 @@ with the Comfy Cloud MCP — comfy-cli is the engine.
 Tools so far: the run -> get-output core loop plus job management
 (``job_status`` / ``wait_for_job`` / ``watch_job`` / ``get_execution_error`` /
 ``cancel_job`` / ``get_queue``), the ``launch_comfyui`` / ``stop_comfyui``
-lifecycle pair (``comfy launch --background`` / ``comfy stop``), and the
+lifecycle pair (``comfy launch --background`` / ``comfy stop``) with ``get_logs``
+(``comfy logs``) to read a detached launch's captured output, and the
 ``discover`` / ``which`` introspection pair (``comfy discover`` /
 ``comfy which``) that lets an agent learn the CLI's own contract and selection.
+
+Requires comfy-cli >= 1.12.0 (the ``comfy logs`` verb + the ``envelope/1``
+contract): :func:`_run_comfy` guards this once, up front, with an actionable
+upgrade error so a stale install fails clearly rather than cryptically.
 
 NOTE: the exact ``comfy`` invocation + envelope shape still need a smoke test
 against a real comfy-cli install and a running local ComfyUI.
@@ -21,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -50,6 +56,8 @@ This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
 - When custom nodes or models may be missing, pre-flight with `validate_workflow`
   before running.
 - Manage in-flight work with `get_queue` (list jobs) and `cancel_job`.
+- After a detached `launch_comfyui`, read the background server's own output with
+  `get_logs` — it tails the captured ComfyUI log (invisible otherwise).
 
 Everything targets the LOCAL server only — there is no cloud access here.
 """
@@ -63,9 +71,80 @@ COMFY_BIN = os.environ.get("COMFY_BIN", "comfy")
 # can't hold a `comfy jobs watch` child open effectively forever (1 hour).
 _MAX_WATCH_TIMEOUT = 3600.0
 
+# comfy-cli floor. `comfy logs` (get_logs) and the structured `envelope/1`
+# contract this server relies on require comfy-cli >= 1.12.0; against an older
+# install `comfy logs` doesn't exist and would surface as a cryptic "No such
+# command", so `_run_comfy` guards this once, up front, with an upgrade message.
+_MIN_COMFY_CLI = (1, 12, 0)
+_MIN_COMFY_CLI_STR = "1.12.0"
+
+# The version guard shells out to `comfy --version`; memoize so it runs at most
+# once per process (it sits on the hot path of every _run_comfy call).
+_version_checked = False
+
 
 class ComfyCliError(RuntimeError):
-    """comfy-cli was missing, timed out, or returned an error envelope."""
+    """comfy-cli was missing, timed out, or returned an error envelope.
+
+    ``code`` carries comfy-cli's structured ``error.code`` when the failure came
+    from an error envelope (``None`` for local failures like a missing binary or
+    a timeout), so callers can branch on a specific code without string-matching
+    the message — e.g. ``get_logs`` swallows ``no_log_file`` but re-raises the rest.
+    """
+
+    def __init__(self, message: str, code: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _parse_version(text: str) -> tuple[int, int, int] | None:
+    """Extract the first dotted numeric version (e.g. ``1.12.0``) from ``text``.
+
+    Returns a ``(major, minor, patch)`` tuple (a missing patch defaults to 0), or
+    ``None`` when no version-looking token is present.
+    """
+    match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", text)
+    if match is None:
+        return None
+    major, minor, patch = match.groups(default="0")
+    return int(major), int(minor), int(patch)
+
+
+def _check_comfy_version() -> None:
+    """Guard: refuse to run against a comfy-cli older than :data:`_MIN_COMFY_CLI`.
+
+    Runs ``comfy --version`` once per process (memoized via ``_version_checked``).
+    If the reported version is below the floor, raises a clear, actionable
+    :class:`ComfyCliError` telling the user to upgrade — so a stale install fails
+    with "upgrade comfy-cli to >= 1.12.0" instead of a cryptic "No such command:
+    logs" deep inside a tool call. Fails OPEN on anything it can't positively read
+    as too-old (an unparseable ``--version``, a ``--version`` that errors) so a
+    future comfy-cli output-format change can never wedge a working install.
+    """
+    global _version_checked
+    if _version_checked:
+        return
+    try:
+        proc = subprocess.run(
+            [COMFY_BIN, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30.0,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        _version_checked = True  # fail open — never block on a flaky `--version`
+        return
+    version = _parse_version(f"{proc.stdout}\n{proc.stderr}")
+    if version is not None and version < _MIN_COMFY_CLI:
+        # Deliberately do NOT memoize a too-old verdict: if the user upgrades and
+        # retries within the same process, re-check rather than latch the failure.
+        raise ComfyCliError(
+            f"comfy-cli {'.'.join(map(str, version))} is too old — this server "
+            f"requires comfy-cli >= {_MIN_COMFY_CLI_STR}. Upgrade it with "
+            f"`pip install --upgrade 'comfy-cli>={_MIN_COMFY_CLI_STR}'`."
+        )
+    _version_checked = True
 
 
 def _run_comfy(*args: str, timeout: float | None = None) -> Any:
@@ -80,6 +159,7 @@ def _run_comfy(*args: str, timeout: float | None = None) -> Any:
             f"`{COMFY_BIN}` not found on PATH. Install comfy-cli "
             "(`pip install comfy-cli`) or set the COMFY_BIN env var."
         )
+    _check_comfy_version()
     # Global flags (--json, --where) MUST precede the subcommand in comfy-cli;
     # a trailing --json errors with "No such option". (Verified against comfy-cli.)
     cmd = [COMFY_BIN, "--json", "--where", "local", *args]
@@ -120,10 +200,12 @@ def _unwrap_envelope(
         )
     if not envelope.get("ok", False):
         err = envelope.get("error") or {}
+        code = err.get("code", "unknown")
         raise ComfyCliError(
             f"comfy {' '.join(args)} failed "
-            f"[{err.get('code', 'unknown')}]: "
-            f"{err.get('message') or stderr.strip()[:500]}"
+            f"[{code}]: "
+            f"{err.get('message') or stderr.strip()[:500]}",
+            code=code,
         )
     return envelope.get("data")
 
@@ -252,6 +334,7 @@ async def _run_comfy_streaming(
             f"`{COMFY_BIN}` not found on PATH. Install comfy-cli "
             "(`pip install comfy-cli`) or set the COMFY_BIN env var."
         )
+    _check_comfy_version()
     # --json-stream is a global flag and, like --json/--where, MUST precede the
     # subcommand; a trailing form errors with "No such option".
     cmd = [COMFY_BIN, "--json-stream", "--where", "local", *args]
@@ -680,6 +763,35 @@ def stop_comfyui() -> Any:
     message, rather than killing an unrelated process.
     """
     return _run_comfy("stop", timeout=60.0)
+
+
+# comfy-cli's `logs` reports this error code when no persisted log file exists
+# yet (nothing has been launched in the background, so nothing was captured).
+_NO_LOG_FILE_CODE = "no_log_file"
+
+
+@mcp.tool()
+def get_logs(tail: int = 200) -> Any:
+    """Return the tail of the LOCAL background ComfyUI's captured log file.
+
+    Wraps ``comfy logs --tail <tail>``. comfy-cli persists a background ComfyUI's
+    stdout/stderr to ``<workspace>/user/comfyui_<port>.log`` (written when it is
+    started via ``launch_comfyui`` / ``comfy launch --background``), so this
+    closes the debugging loop after a detached launch — the server's output is
+    otherwise invisible. Returns ``{lines, path, truncated}``: the last ``tail``
+    log lines, the file they came from, and whether older lines were dropped.
+
+    If no log file exists yet (nothing was launched in the background), comfy-cli
+    returns a ``no_log_file`` error envelope; rather than raise, this tool returns
+    it as data — ``{"error": "no_log_file", "message": ...}`` — so "no logs yet"
+    reads as a normal answer instead of a failure. Every other error still raises.
+    """
+    try:
+        return _run_comfy("logs", "--tail", str(tail), timeout=60.0)
+    except ComfyCliError as exc:
+        if exc.code == _NO_LOG_FILE_CODE:
+            return {"error": _NO_LOG_FILE_CODE, "message": str(exc)}
+        raise
 
 
 @mcp.tool()

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -103,7 +103,14 @@ def _parse_version(text: str) -> tuple[int, int, int] | None:
     Returns a ``(major, minor, patch)`` tuple (a missing patch defaults to 0), or
     ``None`` when no version-looking token is present.
     """
-    match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", text)
+    # Prefer a version token that follows the word "version" (comfy-cli prints
+    # "comfy-cli, version X.Y.Z"), so we don't latch onto an earlier dotted
+    # token — a Python version, a path segment like ``.../3.10/...`` — and end
+    # up comparing the wrong value. Fall back to the first dotted-numeric token
+    # anywhere in the text (still fails OPEN on no match, per the guard's docs).
+    match = re.search(r"version[^\d]*(\d+)\.(\d+)(?:\.(\d+))?", text, re.IGNORECASE)
+    if match is None:
+        match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", text)
     if match is None:
         return None
     major, minor, patch = match.groups(default="0")
@@ -129,11 +136,18 @@ def _check_comfy_version() -> None:
             [COMFY_BIN, "--version"],
             capture_output=True,
             text=True,
+            errors="replace",  # never crash on undecodable `--version` bytes
             timeout=30.0,
             check=False,
         )
+    except subprocess.TimeoutExpired:
+        # A hung `--version` is latched so we don't re-block every later call on
+        # the same 30s wait; fail OPEN for the rest of the process.
+        _version_checked = True
+        return
     except (OSError, subprocess.SubprocessError):
-        _version_checked = True  # fail open — never block on a flaky `--version`
+        # A transient spawn failure fails OPEN for THIS call but is NOT latched —
+        # a later call re-checks rather than permanently disabling the guard.
         return
     version = _parse_version(f"{proc.stdout}\n{proc.stderr}")
     if version is not None and version < _MIN_COMFY_CLI:
@@ -199,7 +213,9 @@ def _unwrap_envelope(
             f"stderr: {stderr.strip()[:500]}"
         )
     if not envelope.get("ok", False):
-        err = envelope.get("error") or {}
+        err = envelope.get("error")
+        if not isinstance(err, dict):  # tolerate a malformed non-dict `error`
+            err = {}
         code = err.get("code", "unknown")
         raise ComfyCliError(
             f"comfy {' '.join(args)} failed "
@@ -334,7 +350,10 @@ async def _run_comfy_streaming(
             f"`{COMFY_BIN}` not found on PATH. Install comfy-cli "
             "(`pip install comfy-cli`) or set the COMFY_BIN env var."
         )
-    _check_comfy_version()
+    # `_check_comfy_version` runs a synchronous `comfy --version` (up to 30s on
+    # the first call per process); offload it so the async event loop is never
+    # blocked while it runs.
+    await asyncio.to_thread(_check_comfy_version)
     # --json-stream is a global flag and, like --json/--where, MUST precede the
     # subcommand; a trailing form errors with "No such option".
     cmd = [COMFY_BIN, "--json-stream", "--where", "local", *args]
@@ -769,6 +788,12 @@ def stop_comfyui() -> Any:
 # yet (nothing has been launched in the background, so nothing was captured).
 _NO_LOG_FILE_CODE = "no_log_file"
 
+# Bounds for get_logs' caller-controlled `tail`: at least 1 line (a negative
+# value would forward a malformed `--tail -N`), capped so an absurd request
+# can't make comfy-cli read/return an enormous log slice.
+_MIN_LOG_TAIL = 1
+_MAX_LOG_TAIL = 10000
+
 
 @mcp.tool()
 def get_logs(tail: int = 200) -> Any:
@@ -785,7 +810,12 @@ def get_logs(tail: int = 200) -> Any:
     returns a ``no_log_file`` error envelope; rather than raise, this tool returns
     it as data — ``{"error": "no_log_file", "message": ...}`` — so "no logs yet"
     reads as a normal answer instead of a failure. Every other error still raises.
+
+    ``tail`` is clamped to ``[1, 10000]`` before forwarding, so a negative value
+    can't produce a malformed ``--tail -N`` and an absurd value can't make
+    comfy-cli read back an enormous log slice.
     """
+    tail = max(_MIN_LOG_TAIL, min(int(tail), _MAX_LOG_TAIL))
     try:
         return _run_comfy("logs", "--tail", str(tail), timeout=60.0)
     except ComfyCliError as exc:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared pytest fixtures.
+
+The comfy-cli version guard (`server._check_comfy_version`) shells out to
+`comfy --version` once per process from inside `_run_comfy`. The unit tests stub
+`subprocess.run` to emit canned envelopes and assert the exact argv — a stray
+`comfy --version` call would consume that stub and pollute those assertions. So
+by default we mark the guard "already checked" for every test; the dedicated
+guard tests (`test_wrapper.py`) re-enable it explicitly and mock `--version`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from comfy_local_mcp import server
+
+
+@pytest.fixture(autouse=True)
+def _skip_version_guard(monkeypatch):
+    """Neutralize the once-per-process comfy-cli version guard for unit tests."""
+    monkeypatch.setattr(server, "_version_checked", True)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -92,6 +92,160 @@ def test_missing_binary_raises(monkeypatch):
         server._run_comfy("env")
 
 
+def test_error_envelope_carries_structured_code(patched_run):
+    """The raised ComfyCliError exposes the envelope's error.code (not just text)."""
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": False,
+            "error": {"code": "server_not_running", "message": "down"},
+        }
+    )
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("env")
+
+    assert excinfo.value.code == "server_not_running"
+
+
+# --- comfy-cli version guard -------------------------------------------------
+
+
+def _fake_version(stdout: str, *, stderr: str = "", raises: Exception | None = None):
+    """A `subprocess.run` stand-in for `comfy --version`; records each call."""
+    calls: list[list[str]] = []
+
+    def fake(cmd, capture_output, text, timeout, check):  # noqa: ARG001
+        calls.append(cmd)
+        if raises is not None:
+            raise raises
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=stderr)
+
+    return fake, calls
+
+
+def test_version_guard_raises_on_old_comfy_cli(monkeypatch):
+    """A comfy-cli below the floor raises an actionable upgrade error."""
+    monkeypatch.setattr(server, "_version_checked", False)
+    fake, calls = _fake_version("comfy-cli, version 1.11.0")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    with pytest.raises(server.ComfyCliError, match=r"too old.*1\.12\.0"):
+        server._check_comfy_version()
+
+    assert calls[0] == [server.COMFY_BIN, "--version"]
+    # A too-old verdict is NOT memoized, so a later retry re-checks.
+    assert server._version_checked is False
+
+
+def test_version_guard_blocks_run_comfy_on_old_cli(monkeypatch):
+    """The guard fires from inside `_run_comfy`, before any real subcommand runs."""
+    monkeypatch.setattr(server, "_version_checked", False)
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    fake, _ = _fake_version("comfy version 1.9.9")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    with pytest.raises(server.ComfyCliError, match="too old"):
+        server._run_comfy("logs", "--tail", "10")
+
+
+def test_version_guard_allows_new_comfy_cli_and_memoizes(monkeypatch):
+    """A comfy-cli at/above the floor passes and shells out only once."""
+    monkeypatch.setattr(server, "_version_checked", False)
+    fake, calls = _fake_version("comfy-cli, version 1.12.0")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    server._check_comfy_version()
+    assert server._version_checked is True
+
+    server._check_comfy_version()  # memoized: no second `comfy --version`
+    assert len(calls) == 1
+
+
+def test_version_guard_fails_open_on_unparseable_version(monkeypatch):
+    """An unreadable `--version` must not block an otherwise-working install."""
+    monkeypatch.setattr(server, "_version_checked", False)
+    fake, _ = _fake_version("comfy-cli (dev build, no tag)")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    server._check_comfy_version()  # no raise
+    assert server._version_checked is True
+
+
+def test_version_guard_fails_open_when_version_errors(monkeypatch):
+    """A `comfy --version` that can't be spawned fails OPEN, not closed."""
+    monkeypatch.setattr(server, "_version_checked", False)
+    fake, _ = _fake_version("", raises=OSError("boom"))
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    server._check_comfy_version()  # no raise
+    assert server._version_checked is True
+
+
+def test_parse_version_reads_two_and_three_part_and_none():
+    assert server._parse_version("comfy-cli, version 1.12") == (1, 12, 0)
+    assert server._parse_version("v2.0.5 extra") == (2, 0, 5)
+    assert server._parse_version("no version token here") is None
+
+
+# --- get_logs ---------------------------------------------------------------
+
+
+def test_get_logs_maps_command_and_returns_data(patched_run):
+    """get_logs wraps `comfy logs --tail <n>` and returns the envelope data."""
+    payload = {
+        "lines": ["boot ok", "listening on :8188"],
+        "path": "/ws/user/comfyui_8188.log",
+        "truncated": False,
+    }
+    calls = patched_run({"type": "envelope", "ok": True, "data": payload})
+
+    assert server.get_logs() == payload
+
+    cmd = calls[0]["cmd"]
+    assert cmd[1:4] == ["--json", "--where", "local"]  # global flags first
+    assert cmd[4:] == ["logs", "--tail", "200"]  # default tail, stringified
+
+
+def test_get_logs_forwards_custom_tail(patched_run):
+    """A custom tail is stringified and forwarded to `--tail`."""
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"lines": []}})
+
+    server.get_logs(tail=50)
+
+    assert calls[0]["cmd"][4:] == ["logs", "--tail", "50"]
+
+
+def test_get_logs_no_log_file_returned_not_raised(patched_run):
+    """A `no_log_file` error envelope is returned as data, not raised."""
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": False,
+            "error": {"code": "no_log_file", "message": "no log file for local yet"},
+        }
+    )
+
+    result = server.get_logs()
+
+    assert result["error"] == "no_log_file"
+    assert "no log file" in result["message"]
+
+
+def test_get_logs_other_error_still_raises(patched_run):
+    """Any other error code keeps raising — only `no_log_file` is swallowed."""
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": False,
+            "error": {"code": "server_not_running", "message": "ComfyUI not running"},
+        }
+    )
+
+    with pytest.raises(server.ComfyCliError, match="server_not_running"):
+        server.get_logs()
+
+
 def test_cancel_job_maps_command_and_returns_data(patched_run):
     """cancel_job wraps `comfy jobs cancel <id>` and returns the envelope data."""
     calls = patched_run({"type": "envelope", "ok": True, "data": {"cancelled": "abc"}})

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -115,7 +115,7 @@ def _fake_version(stdout: str, *, stderr: str = "", raises: Exception | None = N
     """A `subprocess.run` stand-in for `comfy --version`; records each call."""
     calls: list[list[str]] = []
 
-    def fake(cmd, capture_output, text, timeout, check):  # noqa: ARG001
+    def fake(cmd, capture_output, text, timeout, check, errors=None):  # noqa: ARG001
         calls.append(cmd)
         if raises is not None:
             raise raises
@@ -173,9 +173,23 @@ def test_version_guard_fails_open_on_unparseable_version(monkeypatch):
 
 
 def test_version_guard_fails_open_when_version_errors(monkeypatch):
-    """A `comfy --version` that can't be spawned fails OPEN, not closed."""
+    """A `comfy --version` that can't be spawned fails OPEN, not closed —
+    and a transient spawn error is NOT latched, so a later call re-checks."""
     monkeypatch.setattr(server, "_version_checked", False)
     fake, _ = _fake_version("", raises=OSError("boom"))
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    server._check_comfy_version()  # no raise
+    assert server._version_checked is False  # transient error not latched
+
+
+def test_version_guard_latches_on_timeout(monkeypatch):
+    """A hung `--version` (timeout) fails OPEN and IS latched, so a later call
+    doesn't re-block on the same 30s wait."""
+    monkeypatch.setattr(server, "_version_checked", False)
+    fake, _ = _fake_version(
+        "", raises=subprocess.TimeoutExpired(cmd="comfy --version", timeout=30.0)
+    )
     monkeypatch.setattr(server.subprocess, "run", fake)
 
     server._check_comfy_version()  # no raise
@@ -186,6 +200,16 @@ def test_parse_version_reads_two_and_three_part_and_none():
     assert server._parse_version("comfy-cli, version 1.12") == (1, 12, 0)
     assert server._parse_version("v2.0.5 extra") == (2, 0, 5)
     assert server._parse_version("no version token here") is None
+
+
+def test_parse_version_prefers_token_after_version_keyword():
+    """A leading dotted token (a Python version) must not be mistaken for the
+    comfy-cli version when a `version X.Y.Z` token is present."""
+    assert server._parse_version("Python 3.10.2\ncomfy-cli, version 1.12.0") == (
+        1,
+        12,
+        0,
+    )
 
 
 # --- get_logs ---------------------------------------------------------------
@@ -214,6 +238,18 @@ def test_get_logs_forwards_custom_tail(patched_run):
     server.get_logs(tail=50)
 
     assert calls[0]["cmd"][4:] == ["logs", "--tail", "50"]
+
+
+def test_get_logs_clamps_negative_and_huge_tail(patched_run):
+    """A negative tail can't forward a malformed `--tail -N`, and an absurd tail
+    is capped so comfy-cli isn't asked for an enormous slice."""
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"lines": []}})
+
+    server.get_logs(tail=-5)
+    assert calls[-1]["cmd"][4:] == ["logs", "--tail", str(server._MIN_LOG_TAIL)]
+
+    server.get_logs(tail=10**9)
+    assert calls[-1]["cmd"][4:] == ["logs", "--tail", str(server._MAX_LOG_TAIL)]
 
 
 def test_get_logs_no_log_file_returned_not_raised(patched_run):


### PR DESCRIPTION
## ELI-5

When you start ComfyUI in the background, its logs used to vanish — you had no way to see why a launch failed. comfy-cli 1.12.0 started saving those logs to a file, so this adds a `get_logs` tool that reads them back. It also makes comfy-cli 1.12.0 the required minimum and checks the installed version up front, so an old install gives a clear "please upgrade" message instead of a confusing "no such command" error later.

## Summary

Wire comfy-cli's new `comfy logs` verb into the MCP as a thin `get_logs` passthrough (closes the debugging loop after a detached `launch_comfyui`), make the comfy-cli ≥ 1.12.0 floor explicit, and enforce it with a startup version guard.

## Changes

- **`get_logs(tail=200)`** — thin `_run_comfy` passthrough to `comfy logs --tail <tail>`, returning the `{lines, path, truncated}` envelope data. A missing log file's `no_log_file` error envelope is returned as data (`{"error": "no_log_file", …}`) rather than raised, so "no logs yet" is a normal answer.
- **Startup version guard** — `_run_comfy` / `_run_comfy_streaming` read `comfy --version` once per process (memoized) and raise an actionable upgrade error when comfy-cli is below 1.12.0, so a stale install fails with "upgrade comfy-cli to >= 1.12.0" instead of a cryptic "No such command: logs". Fails **open** on anything it can't positively read as too-old (unparseable/erroring `--version`) so a future output-format change can't wedge a working install.
- **`ComfyCliError.code`** — the exception now carries comfy-cli's structured `error.code`, so callers branch on a code instead of string-matching the message (used by `get_logs`).
- **README** — prerequisite + install steps bumped to `comfy-cli >= 1.12.0`; new `get_logs` row added to the tool table.

## Motivation

comfy-cli 1.12.0 adds `comfy logs`, which persists a background ComfyUI's output to `<workspace>/user/comfyui_<port>.log`. This exposes it through the MCP and makes the new floor a first-class, guarded requirement.

## Testing

- [x] Existing tests pass (`pytest`) — plus new tests for `get_logs` (success / custom tail / `no_log_file` / other-error-still-raises) and the version guard (old → raise, new → pass+memoize, unparseable/errored → fail-open) matching the existing `test_wrapper.py` mock pattern.
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Green on Python 3.10 **and** 3.14 locally (CI matrix).

## Additional Notes

- **Thin-wrapper preserved** — every tool remains a `_run_comfy` passthrough; no HTTP client.
- **Judgment calls:**
  - The version guard was added to **both** `_run_comfy` and `_run_comfy_streaming` (streaming-only tools like `watch_job` / `run_workflow(wait=True)` should be guarded too); memoization means it still shells out at most once per process.
  - A new autouse `tests/conftest.py` fixture neutralizes the once-per-process guard for the existing unit tests (which stub `subprocess.run`); the guard's own tests re-enable it explicitly.
  - The tool-count line in the README was already stale (said "Twenty-two"; there were 31) — corrected to the accurate 32 while adding the new row.
- **Smoke-test assumptions** (consistent with the existing module NOTE, unverifiable without a real 1.12.0 install here): the error code for a missing log file is exactly `no_log_file`, and `comfy --version` prints its version as the first dotted-number token in the output. The version guard's fail-open design means a wrong assumption degrades to "not blocked," never a false block of a working install.