### PR TITLE
docs: public-launch polish — README beta + community health files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in this repo.
+* @mattmillerai

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Report something that isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Please fill out the sections
+        below so we can reproduce and fix it.
+
+        For security vulnerabilities, **do not** open a public issue — follow
+        [SECURITY.md](https://github.com/Comfy-Org/comfy-local-mcp/blob/main/SECURITY.md)
+        instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected instead.
+      placeholder: Calling `run_workflow` returned … but I expected …
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The minimal sequence of tool calls (or the prompt you gave your agent) that triggers the bug.
+      placeholder: |
+        1. Call `server_info`
+        2. Call `run_workflow` with `...`
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output
+      description: |
+        Any error message, stack trace, or the tool's JSON response. This is
+        automatically formatted as code, so no need for backticks.
+
+        Please redact any secrets, tokens, or private paths before pasting.
+      render: shell
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: comfy-local-mcp version
+      description: "`pip show comfy-local-mcp` (or the commit SHA if installed from source)."
+      placeholder: 0.1.0
+    validations:
+      required: false
+  - type: input
+    id: comfy-cli-version
+    attributes:
+      label: comfy-cli version
+      description: "`comfy --version` — comfy-cli is the engine every tool wraps."
+      placeholder: e.g. 1.x.x
+    validations:
+      required: false
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, and MCP client (Claude Code / Claude Desktop / Cursor / …).
+      placeholder: macOS 14, Python 3.12, Claude Code
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Comfy-Org/comfy-local-mcp/security/advisories/new
+    about: Please report security issues privately — do not open a public issue. See SECURITY.md.
+  - name: Question or discussion
+    url: https://github.com/Comfy-Org/comfy-local-mcp/discussions
+    about: For usage questions and open-ended discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: Suggest a new tool or an improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! Before filing, please note the **thin-wrapper**
+        architecture rule: every tool is a passthrough to a `comfy` subcommand
+        (see [AGENTS.md](https://github.com/Comfy-Org/comfy-local-mcp/blob/main/AGENTS.md)).
+        If the capability you want doesn't exist
+        in [comfy-cli](https://github.com/Comfy-Org/comfy-cli) yet, the right
+        home for it is usually a comfy-cli change rather than this repo.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the use case or the gap you're hitting today.
+      placeholder: When I ask my agent to …, there's no tool that …
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What tool or behavior would you like? If it maps to a `comfy` subcommand, name it.
+      placeholder: A `foo` tool wrapping `comfy bar --baz`.
+    validations:
+      required: true
+  - type: dropdown
+    id: comfy-cli-support
+    attributes:
+      label: Does comfy-cli already support this?
+      description: Whether the underlying `comfy` subcommand exists today.
+      options:
+        - "Yes — comfy-cli already has the subcommand"
+        - "No — it would need a comfy-cli change first"
+        - "Not sure"
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds you're using today, or other approaches you weighed.
+    validations:
+      required: false

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**support@comfy.org**.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to comfy-local-mcp
+
+Thanks for your interest in improving `comfy-local-mcp`! This is a small,
+standalone [MCP](https://modelcontextprotocol.io) server that lets AI agents
+drive a user's **local** ComfyUI by shelling out to
+[`comfy-cli`](https://github.com/Comfy-Org/comfy-cli).
+
+By participating in this project you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## The one architecture rule — thin wrapper only
+
+Before you write any code, read [`AGENTS.md`](AGENTS.md). The core rule:
+
+**Every tool is a passthrough to the `comfy` binary.** There is exactly one way
+to reach comfy-cli — the `_run_comfy(*args)` helper in
+`src/comfy_local_mcp/server.py`, which shells out to
+`comfy --json --where local <args>`, parses comfy-cli's versioned `envelope/1`
+result, and returns its `data`. Do not bypass it.
+
+This means:
+
+- **No HTTP client.** This server never talks to ComfyUI (or anything else) over
+  HTTP directly — comfy-cli owns all I/O with ComfyUI.
+- **New functionality belongs in comfy-cli.** If a feature can't be expressed as
+  a `comfy` subcommand, the fix is a comfy-cli change, not a workaround here.
+- **No code from the cloud MCP.** Don't copy code, patterns, or dependencies
+  from the Comfy Cloud MCP — this repo is local-only and single-process.
+
+A PR that breaks any of these guardrails will be asked to change. See
+[`AGENTS.md`](AGENTS.md) for the full rationale.
+
+## Dev setup
+
+Python ≥ 3.10. Everything runs through pip + setuptools.
+
+```bash
+pip install -e '.[dev]'    # install with dev extras (pytest, ruff)
+```
+
+## Run the checks
+
+CI (`.github/workflows/ci.yml`) runs these three on Python 3.10 and 3.14 for
+every PR. Get them green locally before pushing:
+
+```bash
+pytest                     # run the tests
+ruff check .               # lint
+ruff format --check .      # format check (run `ruff format .` to fix)
+```
+
+The tests mock comfy-cli — they never require a real ComfyUI or the `comfy`
+binary, so `pytest` runs anywhere. There is also an opt-in end-to-end smoke test
+(`./scripts/smoke.sh`) that drives the real tools against a running local
+ComfyUI; it **skips** cleanly when ComfyUI or the `comfy` binary is absent.
+
+## Adding or changing a tool
+
+- Every tool is a thin `_run_comfy(...)` call — keep it that way.
+- Add or update the tool's test in the same PR (`tests/` mirrors the tool
+  groups: `test_wrapper.py`, `test_parser.py`, `test_discovery.py`,
+  `test_templates.py`, …).
+- Keep [`README.md`](README.md) and [`AGENTS.md`](AGENTS.md) in sync when you
+  change the tool set, the architecture rule, or the toolchain.
+
+## Opening a pull request
+
+1. Fork and branch off `main`.
+2. Make your change, with tests, and get the three checks above green.
+3. Open a PR and fill in [the template](.github/PULL_REQUEST_TEMPLATE.md).
+
+## Reporting bugs and requesting features
+
+Use the [issue templates](.github/ISSUE_TEMPLATE/) — a bug report or a feature
+request. For anything security-sensitive, follow [`SECURITY.md`](SECURITY.md)
+instead of opening a public issue.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It is a small, standalone codebase. Each tool shells out to the `comfy` command 
 `--where local --json`, parses comfy-cli's `envelope/1` output, and returns it. There is no HTTP
 client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engine.
 
-> **Status:** early POC. Twenty-two tools, core loop validated end-to-end against a live local
+> **Status:** beta. Twenty-two tools, core loop validated end-to-end against a live local
 > ComfyUI (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on
 > Python 3.10 and 3.14.
 
@@ -199,6 +199,14 @@ It needs a running local ComfyUI (`COMFYUI_URL`, default `http://127.0.0.1:8188`
 **and** the `comfy` binary on `PATH` (or `COMFY_BIN`). Without both it **skips**
 rather than fails, so it's safe to run anywhere — and the plain `pytest` gate stays
 green on CI runners that have neither.
+
+## Contributing
+
+Contributions are welcome. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for dev
+setup (`pip install -e '.[dev]'`, `pytest`, `ruff`) and the thin-wrapper
+architecture rule, and [`AGENTS.md`](AGENTS.md) for the full guidelines. This
+project follows a [Code of Conduct](CODE_OF_CONDUCT.md). To report a
+vulnerability, see [`SECURITY.md`](SECURITY.md).
 
 ## License
 


### PR DESCRIPTION
## ELI-5

The project is ready to show the world, so this PR tidies up the "front door."
It stops calling itself an "early POC" (it's a working **beta** now), and adds
the standard files an open-source repo is expected to have: how to contribute, a
code of conduct, and templates so people file clean bug reports and feature
requests. No product code changes — this is docs/governance only.

## Summary

Public-launch polish for `comfy-local-mcp`. Documentation and community-health
files only; **no `server.py` / tool changes**, so it's safe to land alongside
in-flight tool PRs.

## Changes

- **README** — soften the status from "early POC" to **beta** (kept honest: the
  core `server_info → run_workflow → fetch_outputs` loop is validated e2e), and
  add a **Contributing** section linking the new files.
- **`CONTRIBUTING.md`** — dev setup (`pip install -e '.[dev]'`, `pytest`,
  `ruff check` / `ruff format --check`) and the thin-wrapper architecture rule,
  linking `AGENTS.md` as the source of truth.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1; enforcement contact
  `support@comfy.org`.
- **`.github/ISSUE_TEMPLATE/`** — `bug_report.yml`, `feature_request.yml`, and a
  `config.yml` chooser that routes security reports to the private advisory flow.
- **`.github/CODEOWNERS`** — `* @mattmillerai`.

## Motivation

Bring the repo to public-launch polish (target Fri 2026-07-10).

## Testing

- [x] `pytest` — 95 passed, 1 skipped (the e2e smoke test skips without a live
  ComfyUI), run against a clean `pip install -e '.[dev]'` in the worktree.
- [x] `ruff check .` — all checks passed.
- [x] `ruff format --check .` — all files formatted.
- [x] Issue-template YAML validated (parses cleanly).
- Docs-only change; no runtime surface to exercise.

## Additional Notes — judgment calls

- **CODEOWNERS was not actually staged.** The ticket described it as
  "already-staged," but there was no staged/existing `.github/CODEOWNERS` on
  `main`, so I created it fresh with the exact specified content (`* @mattmillerai`).
- **Repo topics set directly.** I applied `mcp`, `comfyui`,
  `model-context-protocol`, `ai-agents`, `comfy-cli` via
  `gh repo edit --add-topic` (the ticket's first option) — verified present. No
  maintainer action needed there.
- **Small additions beyond the strict list:** an issue-template `config.yml`
  (security-advisory routing + discussions link) and a README "Contributing"
  section, both to make the new health files discoverable and keep links
  resolving.
- Issue-template markdown links to `SECURITY.md` / `AGENTS.md` use full
  `blob/main` URLs because relative paths from `.github/ISSUE_TEMPLATE/` don't
  resolve reliably in GitHub issue forms.
