### PR TITLE
feat: add generate_image tool wrapping comfy generate (BE-2536)

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -394,16 +394,20 @@ async def generate_image(
     Everything targets the LOCAL server (``--where local`` is injected by
     ``_run_comfy``), so there is no cloud reachability here.
     """
-    checkpoint_args = ["--checkpoint", checkpoint] if checkpoint else []
+    # Pass the free-form text as ``--flag=value`` so a prompt (or checkpoint)
+    # that begins with ``-`` is read as the value rather than mis-parsed by
+    # comfy-cli as an option token. The leading-dash guards elsewhere reject
+    # such input, but a prompt legitimately can start with ``-``, so we keep it
+    # instead of rejecting it.
+    checkpoint_args = [f"--checkpoint={checkpoint}"] if checkpoint else []
     if not wait:
         # Fire-and-return: no stream to follow, so keep the plain --json path.
         return _run_comfy(
-            "generate", "--prompt", prompt, *checkpoint_args, timeout=60.0
+            "generate", f"--prompt={prompt}", *checkpoint_args, timeout=60.0
         )
     return await _run_comfy_streaming(
         "generate",
-        "--prompt",
-        prompt,
+        f"--prompt={prompt}",
         *checkpoint_args,
         "--wait",
         ctx=ctx,

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -383,7 +383,9 @@ async def generate_image(
     streams live progress as MCP progress notifications (per-node execution +
     sampler step counts) so a long generation is not a silent block; with
     ``wait=False`` it submits and returns immediately with a ``prompt_id`` to
-    poll via ``job_status``.
+    poll via ``job_status``. ``timeout_seconds`` only bounds the ``wait=True``
+    streaming path; the ``wait=False`` submit-and-return branch uses a fixed
+    short timeout, so callers should not expect it to govern that case.
 
     This is the quickest path to an image. For full control — choosing a
     template, editing its graph, or running a hand-authored workflow — use the

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -361,6 +361,55 @@ async def run_workflow(
 
 
 @mcp.tool()
+async def generate_image(
+    prompt: str,
+    checkpoint: str | None = None,
+    wait: bool = True,
+    timeout_seconds: float = 600.0,
+    ctx: Context | None = None,
+) -> Any:
+    """Generate an image from a text prompt on the LOCAL ComfyUI — the fast on-ramp.
+
+    Wraps ``comfy generate --prompt <prompt>``: a single call that turns a text
+    prompt into an image, so an agent does not have to hand-assemble a workflow
+    graph. comfy-cli owns the text->workflow injection (which node/slot the
+    prompt fills, the default graph, checkpoint selection); this tool is a pure
+    passthrough to that verb. Returns the same envelope shape as
+    ``run_workflow`` (``prompt_id`` + outputs).
+
+    Pass ``checkpoint`` to pick a specific checkpoint model (forwarded to
+    ``comfy generate --checkpoint``); omit it to let comfy-cli choose a default.
+    With ``wait=True`` (default) this waits until the generation finishes and
+    streams live progress as MCP progress notifications (per-node execution +
+    sampler step counts) so a long generation is not a silent block; with
+    ``wait=False`` it submits and returns immediately with a ``prompt_id`` to
+    poll via ``job_status``.
+
+    This is the quickest path to an image. For full control — choosing a
+    template, editing its graph, or running a hand-authored workflow — use the
+    ``search_templates`` -> ``fetch_template`` -> ``run_workflow`` chain instead.
+
+    Everything targets the LOCAL server (``--where local`` is injected by
+    ``_run_comfy``), so there is no cloud reachability here.
+    """
+    checkpoint_args = ["--checkpoint", checkpoint] if checkpoint else []
+    if not wait:
+        # Fire-and-return: no stream to follow, so keep the plain --json path.
+        return _run_comfy(
+            "generate", "--prompt", prompt, *checkpoint_args, timeout=60.0
+        )
+    return await _run_comfy_streaming(
+        "generate",
+        "--prompt",
+        prompt,
+        *checkpoint_args,
+        "--wait",
+        ctx=ctx,
+        timeout=timeout_seconds,
+    )
+
+
+@mcp.tool()
 def job_status(prompt_id: str) -> Any:
     """Check a submitted job's status (queued / running / completed / error).
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,99 @@
+# Shared test helpers for the streaming (``--json-stream``) tool paths.
+#
+# ``run_workflow``, ``watch_job`` and ``generate_image`` all drive the same
+# ``subprocess.Popen`` NDJSON streaming path, so their tests share the fakes and
+# the ``patched_stream`` fixture defined here rather than each redefining them.
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from comfy_local_mcp import server
+
+
+class _FakeProc:
+    """A minimal stand-in for ``subprocess.Popen`` over a canned NDJSON stream."""
+
+    def __init__(self, cmd, stdout_text, stderr_text=""):
+        self.cmd = cmd
+        self.stdout = io.StringIO(stdout_text)
+        self.stderr = io.StringIO(stderr_text)
+        self.returncode = 0
+        self.killed = False
+
+    def poll(self):
+        return self.returncode  # already "finished" once the stream is drained
+
+    def wait(self):
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+
+
+class _RecordingCtx:
+    """A fake FastMCP Context that records each ``report_progress`` call."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def report_progress(self, progress, total=None, message=None):
+        self.calls.append({"progress": progress, "total": total, "message": message})
+
+
+@pytest.fixture
+def patched_stream(monkeypatch):
+    """Patch ``shutil.which`` + ``subprocess.Popen`` for the streaming path.
+
+    Returns ``setup(stdout_text) -> procs`` — the list capturing each spawned
+    ``_FakeProc`` (so the test can assert the command line that was run).
+    """
+
+    def setup(stdout_text: str) -> list[_FakeProc]:
+        procs: list[_FakeProc] = []
+
+        def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
+            proc = _FakeProc(cmd, stdout_text)
+            procs.append(proc)
+            return proc
+
+        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+        monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+        return procs
+
+    return setup
+
+
+# A queued event (2-node manifest), a per-node step progress event, two
+# node-completion events, then the success envelope on the last line.
+_OK_STREAM = (
+    "\n".join(
+        json.dumps(evt)
+        for evt in [
+            {
+                "schema": "event/1",
+                "type": "queued",
+                "nodes": [{"node_id": "1"}, {"node_id": "2"}],
+            },
+            {"schema": "event/1", "type": "executing", "node": "1", "title": "Load"},
+            {
+                "schema": "event/1",
+                "type": "progress",
+                "node": "1",
+                "completed": 5,
+                "total": 10,
+            },
+            {"schema": "event/1", "type": "executed", "node": "1", "title": "Load"},
+            {"schema": "event/1", "type": "executed", "node": "2", "title": "Save"},
+            {
+                "schema": "envelope/1",
+                "type": "envelope",
+                "ok": True,
+                "data": {"outputs": ["/x.png"]},
+            },
+        ]
+    )
+    + "\n"
+)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,90 @@
+# Tests for the ``generate_image`` tool — the thin passthrough to
+# ``comfy generate`` (text prompt -> image). The streaming fakes and the
+# ``patched_stream`` fixture live in ``conftest.py`` and are shared with the
+# other streaming tools' tests.
+from __future__ import annotations
+
+import asyncio
+
+from conftest import _OK_STREAM, _RecordingCtx
+
+from comfy_local_mcp import server
+
+
+def test_generate_image_streams_and_maps_command(patched_stream):
+    """wait=True drives `comfy --json-stream … generate --prompt … --wait`."""
+    procs = patched_stream(_OK_STREAM)
+    ctx = _RecordingCtx()
+
+    result = asyncio.run(server.generate_image("a red fox in snow", ctx=ctx))
+
+    assert result == {"outputs": ["/x.png"]}  # same envelope shape as run_workflow
+    assert len(ctx.calls) >= 1  # progress notifications forwarded when wait=True
+
+    cmd = procs[0].cmd
+    assert cmd[0] == server.COMFY_BIN
+    assert cmd[1:4] == ["--json-stream", "--where", "local"]  # global flags first
+    # No checkpoint given -> no --checkpoint pair in the command.
+    assert cmd[4:] == ["generate", "--prompt", "a red fox in snow", "--wait"]
+
+
+def test_generate_image_forwards_checkpoint_when_streaming(patched_stream):
+    """A checkpoint is forwarded as `--checkpoint <name>` before `--wait`."""
+    procs = patched_stream(_OK_STREAM)
+
+    asyncio.run(server.generate_image("a cat", checkpoint="sd_xl.safetensors"))
+
+    assert procs[0].cmd[4:] == [
+        "generate",
+        "--prompt",
+        "a cat",
+        "--checkpoint",
+        "sd_xl.safetensors",
+        "--wait",
+    ]
+
+
+def test_generate_image_wait_false_uses_plain_json_no_stream(monkeypatch):
+    """wait=False keeps the plain --json _run_comfy path (no streaming, no --wait)."""
+    seen: dict = {}
+
+    def fake_run_comfy(*args, timeout=None):
+        seen["args"] = args
+        seen["timeout"] = timeout
+        return {"prompt_id": "p1"}
+
+    def boom(*a, **k):  # streaming must not be taken for wait=False
+        raise AssertionError("wait=False must not stream")
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run_comfy)
+    monkeypatch.setattr(server, "_run_comfy_streaming", boom)
+
+    result = asyncio.run(server.generate_image("a red fox in snow", wait=False))
+
+    assert result == {"prompt_id": "p1"}
+    assert seen["args"] == ("generate", "--prompt", "a red fox in snow")  # no --wait
+    assert seen["timeout"] == 60.0
+
+
+def test_generate_image_wait_false_forwards_checkpoint(monkeypatch):
+    """wait=False still forwards a checkpoint to `comfy generate --checkpoint`."""
+    seen: dict = {}
+
+    def fake_run_comfy(*args, timeout=None):
+        seen["args"] = args
+        return {"prompt_id": "p2"}
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run_comfy)
+
+    server_result = asyncio.run(
+        server.generate_image("a dog", checkpoint="dreamshaper.safetensors", wait=False)
+    )
+
+    assert server_result == {"prompt_id": "p2"}
+    assert seen["args"] == (
+        "generate",
+        "--prompt",
+        "a dog",
+        "--checkpoint",
+        "dreamshaper.safetensors",
+    )

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -24,22 +24,34 @@ def test_generate_image_streams_and_maps_command(patched_stream):
     cmd = procs[0].cmd
     assert cmd[0] == server.COMFY_BIN
     assert cmd[1:4] == ["--json-stream", "--where", "local"]  # global flags first
-    # No checkpoint given -> no --checkpoint pair in the command.
-    assert cmd[4:] == ["generate", "--prompt", "a red fox in snow", "--wait"]
+    # No checkpoint given -> no --checkpoint token in the command. The prompt is
+    # passed as --prompt=<value> so a leading dash can't be misread as a flag.
+    assert cmd[4:] == ["generate", "--prompt=a red fox in snow", "--wait"]
 
 
 def test_generate_image_forwards_checkpoint_when_streaming(patched_stream):
-    """A checkpoint is forwarded as `--checkpoint <name>` before `--wait`."""
+    """A checkpoint is forwarded as `--checkpoint=<name>` before `--wait`."""
     procs = patched_stream(_OK_STREAM)
 
     asyncio.run(server.generate_image("a cat", checkpoint="sd_xl.safetensors"))
 
     assert procs[0].cmd[4:] == [
         "generate",
-        "--prompt",
-        "a cat",
-        "--checkpoint",
-        "sd_xl.safetensors",
+        "--prompt=a cat",
+        "--checkpoint=sd_xl.safetensors",
+        "--wait",
+    ]
+
+
+def test_generate_image_leading_dash_prompt_is_not_parsed_as_flag(patched_stream):
+    """A prompt starting with `-` is kept as the value via `--prompt=<value>`."""
+    procs = patched_stream(_OK_STREAM)
+
+    asyncio.run(server.generate_image("--not-a-flag, just text"))
+
+    assert procs[0].cmd[4:] == [
+        "generate",
+        "--prompt=--not-a-flag, just text",
         "--wait",
     ]
 
@@ -62,7 +74,7 @@ def test_generate_image_wait_false_uses_plain_json_no_stream(monkeypatch):
     result = asyncio.run(server.generate_image("a red fox in snow", wait=False))
 
     assert result == {"prompt_id": "p1"}
-    assert seen["args"] == ("generate", "--prompt", "a red fox in snow")  # no --wait
+    assert seen["args"] == ("generate", "--prompt=a red fox in snow")  # no --wait
     assert seen["timeout"] == 60.0
 
 
@@ -83,8 +95,6 @@ def test_generate_image_wait_false_forwards_checkpoint(monkeypatch):
     assert server_result == {"prompt_id": "p2"}
     assert seen["args"] == (
         "generate",
-        "--prompt",
-        "a dog",
-        "--checkpoint",
-        "dreamshaper.safetensors",
+        "--prompt=a dog",
+        "--checkpoint=dreamshaper.safetensors",
     )

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -21,6 +21,7 @@ import subprocess
 import time
 
 import pytest
+from conftest import _OK_STREAM, _RecordingCtx
 
 from comfy_local_mcp import server
 
@@ -479,92 +480,6 @@ def test_which_maps_command_and_returns_data(patched_run):
 # --- streaming run_workflow(wait=True) -------------------------------------
 
 
-class _FakeProc:
-    """A minimal stand-in for ``subprocess.Popen`` over a canned NDJSON stream."""
-
-    def __init__(self, cmd, stdout_text, stderr_text=""):
-        self.cmd = cmd
-        self.stdout = io.StringIO(stdout_text)
-        self.stderr = io.StringIO(stderr_text)
-        self.returncode = 0
-        self.killed = False
-
-    def poll(self):
-        return self.returncode  # already "finished" once the stream is drained
-
-    def wait(self):
-        return self.returncode
-
-    def kill(self):
-        self.killed = True
-
-
-class _RecordingCtx:
-    """A fake FastMCP Context that records each ``report_progress`` call."""
-
-    def __init__(self):
-        self.calls: list[dict] = []
-
-    async def report_progress(self, progress, total=None, message=None):
-        self.calls.append({"progress": progress, "total": total, "message": message})
-
-
-@pytest.fixture
-def patched_stream(monkeypatch):
-    """Patch ``shutil.which`` + ``subprocess.Popen`` for the streaming path.
-
-    Returns ``setup(stdout_text) -> procs`` — the list capturing each spawned
-    ``_FakeProc`` (so the test can assert the command line that was run).
-    """
-
-    def setup(stdout_text: str) -> list[_FakeProc]:
-        procs: list[_FakeProc] = []
-
-        def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
-            proc = _FakeProc(cmd, stdout_text)
-            procs.append(proc)
-            return proc
-
-        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-        monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
-        return procs
-
-    return setup
-
-
-# A queued event (2-node manifest), a per-node step progress event, two
-# node-completion events, then the success envelope on the last line.
-_OK_STREAM = (
-    "\n".join(
-        json.dumps(evt)
-        for evt in [
-            {
-                "schema": "event/1",
-                "type": "queued",
-                "nodes": [{"node_id": "1"}, {"node_id": "2"}],
-            },
-            {"schema": "event/1", "type": "executing", "node": "1", "title": "Load"},
-            {
-                "schema": "event/1",
-                "type": "progress",
-                "node": "1",
-                "completed": 5,
-                "total": 10,
-            },
-            {"schema": "event/1", "type": "executed", "node": "1", "title": "Load"},
-            {"schema": "event/1", "type": "executed", "node": "2", "title": "Save"},
-            {
-                "schema": "envelope/1",
-                "type": "envelope",
-                "ok": True,
-                "data": {"outputs": ["/x.png"]},
-            },
-        ]
-    )
-    + "\n"
-)
-
-
 def test_run_workflow_streams_progress_and_returns_data(patched_stream):
     """wait=True drives --json-stream, emits progress, returns the envelope data."""
     procs = patched_stream(_OK_STREAM)
@@ -791,85 +706,3 @@ def test_run_workflow_wait_false_uses_plain_json_no_stream(monkeypatch):
     assert result == {"prompt_id": "p1"}
     assert seen["args"] == ("run", "--workflow", "wf.json")  # no --wait
     assert seen["timeout"] == 60.0
-
-
-# --- generate_image (thin passthrough to `comfy generate`) -----------------
-
-
-def test_generate_image_streams_and_maps_command(patched_stream):
-    """wait=True drives `comfy --json-stream … generate --prompt … --wait`."""
-    procs = patched_stream(_OK_STREAM)
-    ctx = _RecordingCtx()
-
-    result = asyncio.run(server.generate_image("a red fox in snow", ctx=ctx))
-
-    assert result == {"outputs": ["/x.png"]}  # same envelope shape as run_workflow
-    assert len(ctx.calls) >= 1  # progress notifications forwarded when wait=True
-
-    cmd = procs[0].cmd
-    assert cmd[0] == server.COMFY_BIN
-    assert cmd[1:4] == ["--json-stream", "--where", "local"]  # global flags first
-    # No checkpoint given -> no --checkpoint pair in the command.
-    assert cmd[4:] == ["generate", "--prompt", "a red fox in snow", "--wait"]
-
-
-def test_generate_image_forwards_checkpoint_when_streaming(patched_stream):
-    """A checkpoint is forwarded as `--checkpoint <name>` before `--wait`."""
-    procs = patched_stream(_OK_STREAM)
-
-    asyncio.run(server.generate_image("a cat", checkpoint="sd_xl.safetensors"))
-
-    assert procs[0].cmd[4:] == [
-        "generate",
-        "--prompt",
-        "a cat",
-        "--checkpoint",
-        "sd_xl.safetensors",
-        "--wait",
-    ]
-
-
-def test_generate_image_wait_false_uses_plain_json_no_stream(monkeypatch):
-    """wait=False keeps the plain --json _run_comfy path (no streaming, no --wait)."""
-    seen: dict = {}
-
-    def fake_run_comfy(*args, timeout=None):
-        seen["args"] = args
-        seen["timeout"] = timeout
-        return {"prompt_id": "p1"}
-
-    def boom(*a, **k):  # streaming must not be taken for wait=False
-        raise AssertionError("wait=False must not stream")
-
-    monkeypatch.setattr(server, "_run_comfy", fake_run_comfy)
-    monkeypatch.setattr(server, "_run_comfy_streaming", boom)
-
-    result = asyncio.run(server.generate_image("a red fox in snow", wait=False))
-
-    assert result == {"prompt_id": "p1"}
-    assert seen["args"] == ("generate", "--prompt", "a red fox in snow")  # no --wait
-    assert seen["timeout"] == 60.0
-
-
-def test_generate_image_wait_false_forwards_checkpoint(monkeypatch):
-    """wait=False still forwards a checkpoint to `comfy generate --checkpoint`."""
-    seen: dict = {}
-
-    def fake_run_comfy(*args, timeout=None):
-        seen["args"] = args
-        return {"prompt_id": "p2"}
-
-    monkeypatch.setattr(server, "_run_comfy", fake_run_comfy)
-
-    server_result = asyncio.run(
-        server.generate_image("a dog", checkpoint="dreamshaper.safetensors", wait=False)
-    )
-
-    assert server_result == {"prompt_id": "p2"}
-    assert seen["args"] == (
-        "generate",
-        "--prompt",
-        "a dog",
-        "--checkpoint",
-        "dreamshaper.safetensors",
-    )

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -791,3 +791,85 @@ def test_run_workflow_wait_false_uses_plain_json_no_stream(monkeypatch):
     assert result == {"prompt_id": "p1"}
     assert seen["args"] == ("run", "--workflow", "wf.json")  # no --wait
     assert seen["timeout"] == 60.0
+
+
+# --- generate_image (thin passthrough to `comfy generate`) -----------------
+
+
+def test_generate_image_streams_and_maps_command(patched_stream):
+    """wait=True drives `comfy --json-stream … generate --prompt … --wait`."""
+    procs = patched_stream(_OK_STREAM)
+    ctx = _RecordingCtx()
+
+    result = asyncio.run(server.generate_image("a red fox in snow", ctx=ctx))
+
+    assert result == {"outputs": ["/x.png"]}  # same envelope shape as run_workflow
+    assert len(ctx.calls) >= 1  # progress notifications forwarded when wait=True
+
+    cmd = procs[0].cmd
+    assert cmd[0] == server.COMFY_BIN
+    assert cmd[1:4] == ["--json-stream", "--where", "local"]  # global flags first
+    # No checkpoint given -> no --checkpoint pair in the command.
+    assert cmd[4:] == ["generate", "--prompt", "a red fox in snow", "--wait"]
+
+
+def test_generate_image_forwards_checkpoint_when_streaming(patched_stream):
+    """A checkpoint is forwarded as `--checkpoint <name>` before `--wait`."""
+    procs = patched_stream(_OK_STREAM)
+
+    asyncio.run(server.generate_image("a cat", checkpoint="sd_xl.safetensors"))
+
+    assert procs[0].cmd[4:] == [
+        "generate",
+        "--prompt",
+        "a cat",
+        "--checkpoint",
+        "sd_xl.safetensors",
+        "--wait",
+    ]
+
+
+def test_generate_image_wait_false_uses_plain_json_no_stream(monkeypatch):
+    """wait=False keeps the plain --json _run_comfy path (no streaming, no --wait)."""
+    seen: dict = {}
+
+    def fake_run_comfy(*args, timeout=None):
+        seen["args"] = args
+        seen["timeout"] = timeout
+        return {"prompt_id": "p1"}
+
+    def boom(*a, **k):  # streaming must not be taken for wait=False
+        raise AssertionError("wait=False must not stream")
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run_comfy)
+    monkeypatch.setattr(server, "_run_comfy_streaming", boom)
+
+    result = asyncio.run(server.generate_image("a red fox in snow", wait=False))
+
+    assert result == {"prompt_id": "p1"}
+    assert seen["args"] == ("generate", "--prompt", "a red fox in snow")  # no --wait
+    assert seen["timeout"] == 60.0
+
+
+def test_generate_image_wait_false_forwards_checkpoint(monkeypatch):
+    """wait=False still forwards a checkpoint to `comfy generate --checkpoint`."""
+    seen: dict = {}
+
+    def fake_run_comfy(*args, timeout=None):
+        seen["args"] = args
+        return {"prompt_id": "p2"}
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run_comfy)
+
+    server_result = asyncio.run(
+        server.generate_image("a dog", checkpoint="dreamshaper.safetensors", wait=False)
+    )
+
+    assert server_result == {"prompt_id": "p2"}
+    assert seen["args"] == (
+        "generate",
+        "--prompt",
+        "a dog",
+        "--checkpoint",
+        "dreamshaper.safetensors",
+    )


### PR DESCRIPTION
## ELI-5

Today, to turn a text prompt into an image an agent has to chain four tools
(`search_templates` → `get_template` → `fetch_template` → `run_workflow`) *and*
guess which slot the prompt goes in. This adds one tool, `generate_image("a red
fox in snow")`, that does the whole thing in a single call. It is a thin
passthrough to comfy-cli's new `comfy generate` verb — all the "which node is the
prompt, which is the checkpoint" graph work lives in comfy-cli, not here.

## Summary

Adds a `generate_image` MCP tool that shells out to `comfy generate`, giving
agents a single-call prompt→image on-ramp. It mirrors `run_workflow`'s
streaming/non-streaming shape and stays a pure passthrough per the thin-wrapper
doctrine (`AGENTS.md:14-31`): no socket, no JSON graph edit, everything routes
through the existing `_run_comfy` / `_run_comfy_streaming` helpers.

## Changes

- `src/comfy_local_mcp/server.py`: new `generate_image(prompt, checkpoint=None,
  wait=True, timeout_seconds=600.0, ctx=None)` tool. `wait=True` streams live
  progress via `_run_comfy_streaming("generate", "--prompt", prompt, ..., "--wait")`
  (same MCP progress path as `run_workflow`); `wait=False` submits via the plain
  `_run_comfy` path and returns a `prompt_id`. `checkpoint` is forwarded as
  `comfy generate --checkpoint <name>` when provided.
- `tests/test_wrapper.py`: four tests following the existing patterns — assert
  `comfy generate` is invoked with the right args for both `wait` modes and
  with/without `checkpoint` (streaming path patches `subprocess.Popen`, non-wait
  path patches `_run_comfy`). No live-server dependency.

## Motivation

BE-2536 (BE-2533 spike): `generate_image(prompt)` is the single most common
competitor tool. The thin-wrapper doctrine forbids doing the graph edit in this
repo, so the prompt-injection lives in comfy-cli's `generate` verb and this tool
is a pure passthrough to it.

## Testing

- [x] Existing tests pass (`pytest` — 99 passed, 1 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually — unit tests mock comfy-cli (per `AGENTS.md`); the live
  path is covered by `e2e/test_smoke.py` against a real ComfyUI + comfy-cli.

## Additional Notes

- **Merge gate / dependency:** this tool is a passthrough to `comfy generate`,
  which ships in a sibling comfy-cli child ticket. **Do not merge until that verb
  is available on the released `comfy` binary the MCP invokes** — until then the
  tool is correct but has nothing to call. Unit tests do not depend on it.
- **Judgment call:** I extracted the checkpoint args to a local
  `checkpoint_args = ["--checkpoint", checkpoint] if checkpoint else []` (vs the
  inline splat in the ticket) so both the `wait`/non-`wait` branches share it —
  functionally identical to the spec's `*(['--checkpoint', checkpoint] if
  checkpoint else [])`.
- No argument-injection guard on `prompt`/`checkpoint` (unlike `watch_job`'s
  leading-dash `prompt_id` guard) because both are passed as the value *after* an
  explicit `--prompt` / `--checkpoint` option, not as a bare positional, so
  comfy-cli's parser can't misread a leading `-` as a flag.
- No new error-handling paths: errors from `comfy generate` propagate as the
  existing `ComfyCliError` / unwrapped envelope errors via the shared helpers.
