### PR TITLE
fix(get_logs): cap oversized log lines to bound agent context (BE-2388)

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -1273,6 +1273,13 @@ _NO_LOG_FILE_CODE = "no_log_file"
 _MIN_LOG_TAIL = 1
 _MAX_LOG_TAIL = 10000
 
+# Character cap on each returned log line. `_MAX_LOG_TAIL` bounds the line COUNT,
+# but a single pathological line — a base64 blob or tensor dump from a buggy or
+# hostile custom node — could still be megabytes and flood an agent's context.
+# Cap each line individually, mirroring the `_cap_text` guard on
+# get_execution_error's free-text fields.
+_MAX_LOG_LINE_CHARS = 4000
+
 
 @mcp.tool()
 def get_logs(tail: int = 200) -> Any:
@@ -1292,15 +1299,20 @@ def get_logs(tail: int = 200) -> Any:
 
     ``tail`` is clamped to ``[1, 10000]`` before forwarding, so a negative value
     can't produce a malformed ``--tail -N`` and an absurd value can't make
-    comfy-cli read back an enormous log slice.
+    comfy-cli read back an enormous log slice. Each returned line is also capped
+    to ``_MAX_LOG_LINE_CHARS`` so a single pathological line (a base64 blob or
+    tensor dump from a buggy node) can't flood the caller's context.
     """
     tail = max(_MIN_LOG_TAIL, min(int(tail), _MAX_LOG_TAIL))
     try:
-        return _run_comfy("logs", "--tail", str(tail), timeout=60.0)
+        data = _run_comfy("logs", "--tail", str(tail), timeout=60.0)
     except ComfyCliError as exc:
         if exc.code == _NO_LOG_FILE_CODE:
             return {"error": _NO_LOG_FILE_CODE, "message": str(exc)}
         raise
+    if isinstance(data, dict) and isinstance(data.get("lines"), list):
+        data["lines"] = [_cap_text(line, _MAX_LOG_LINE_CHARS) for line in data["lines"]]
+    return data
 
 
 @mcp.tool()

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -597,14 +597,6 @@ async def _run_comfy_streaming(
             stderr_future.cancel()
 
 
-def _parse_version(text: str) -> tuple[int, int, int] | None:
-    """Extract a ``(major, minor, patch)`` tuple from a version string, or None."""
-    match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", text)
-    if match is None:
-        return None
-    return tuple(int(part) if part else 0 for part in match.groups())  # type: ignore[return-value]
-
-
 def _detect_comfy_cli_version() -> str | None:
     """Best-effort comfy-cli version via ``comfy --version`` (None if undetermined).
 
@@ -1273,11 +1265,12 @@ _NO_LOG_FILE_CODE = "no_log_file"
 _MIN_LOG_TAIL = 1
 _MAX_LOG_TAIL = 10000
 
-# Character cap on each returned log line. `_MAX_LOG_TAIL` bounds the line COUNT,
-# but a single pathological line — a base64 blob or tensor dump from a buggy or
-# hostile custom node — could still be megabytes and flood an agent's context.
-# Cap each line individually, mirroring the `_cap_text` guard on
-# get_execution_error's free-text fields.
+# Hard character cap on each returned log line. `_MAX_LOG_TAIL` bounds the line
+# COUNT, but a single pathological line — a base64 blob or tensor dump from a
+# buggy or hostile custom node — could still be megabytes and flood an agent's
+# context. Cap each line individually, mirroring the `_cap_text` guard on
+# get_execution_error's free-text fields. This is a TOTAL cap: the truncation
+# marker is charged against it (see get_logs) so a capped line never exceeds it.
 _MAX_LOG_LINE_CHARS = 4000
 
 
@@ -1311,7 +1304,10 @@ def get_logs(tail: int = 200) -> Any:
             return {"error": _NO_LOG_FILE_CODE, "message": str(exc)}
         raise
     if isinstance(data, dict) and isinstance(data.get("lines"), list):
-        data["lines"] = [_cap_text(line, _MAX_LOG_LINE_CHARS) for line in data["lines"]]
+        # Charge the truncation marker against the cap so a capped line's TOTAL
+        # length (content + marker) never exceeds `_MAX_LOG_LINE_CHARS`.
+        content_limit = _MAX_LOG_LINE_CHARS - len(_TRACEBACK_TRUNCATION_MARKER)
+        data["lines"] = [_cap_text(line, content_limit) for line in data["lines"]]
     return data
 
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -70,7 +70,7 @@ def test_unwrap_rejects_incompatible_major_even_on_error_envelope():
 def test_incompatible_envelope_propagates_through_run_comfy(monkeypatch):
     """The assertion guards every tool: a bad-schema envelope raises via _run_comfy."""
 
-    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
         import json
 
         out = json.dumps({"schema": "envelope/99", "type": "envelope", "ok": True})
@@ -220,7 +220,7 @@ def patched_env(monkeypatch):
 
         calls: list[dict] = []
 
-        def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+        def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
             calls.append({"cmd": cmd})
             return subprocess.CompletedProcess(
                 cmd, 0, stdout=json.dumps(envelope), stderr=""

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1354,3 +1354,24 @@ def test_fetch_outputs_default_return_is_unchanged(patched_run, tmp_path):
     result = server.fetch_outputs("pid", str(tmp_path))
 
     assert result == {"downloaded": ["gen.png"]}  # dict, not a [data, ...] list
+
+
+def test_get_logs_caps_oversized_line(patched_run):
+    """A single pathological (megabyte) log line is truncated; normal lines pass through."""
+    blob = "x" * (server._MAX_LOG_LINE_CHARS + 5_000)
+    payload = {
+        "lines": ["startup ok\n", blob, "loaded checkpoint\n"],
+        "path": "/ws/user/comfyui_8188.log",
+        "truncated": False,
+    }
+    patched_run({"type": "envelope", "ok": True, "data": payload})
+
+    result = server.get_logs()
+    lines = result["lines"]
+
+    assert lines[0] == "startup ok\n"  # short line untouched
+    assert lines[2] == "loaded checkpoint\n"
+    assert len(lines[1]) <= server._MAX_LOG_LINE_CHARS + len(
+        server._TRACEBACK_TRUNCATION_MARKER
+    )
+    assert lines[1].endswith(server._TRACEBACK_TRUNCATION_MARKER)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1371,7 +1371,6 @@ def test_get_logs_caps_oversized_line(patched_run):
 
     assert lines[0] == "startup ok\n"  # short line untouched
     assert lines[2] == "loaded checkpoint\n"
-    assert len(lines[1]) <= server._MAX_LOG_LINE_CHARS + len(
-        server._TRACEBACK_TRUNCATION_MARKER
-    )
+    # TOTAL length (content + marker) never exceeds the hard cap.
+    assert len(lines[1]) <= server._MAX_LOG_LINE_CHARS
     assert lines[1].endswith(server._TRACEBACK_TRUNCATION_MARKER)


### PR DESCRIPTION
## ELI-5

ComfyUI writes a running diary to its console — "loaded checkpoint", "custom node X failed to import", "out of memory". When a generation breaks for a reason that isn't tied to one specific prompt, that diary is where the real story is. This PR adds a `get_logs` MCP tool so an agent can read the tail of that diary. It's a thin wrapper over the new `comfy logs` verb — ask for the last N lines, get them back.

## Summary

Adds an `@mcp.tool()` `get_logs(tail=200)` that returns the tail of the LOCAL ComfyUI console log captured when the server was launched via `launch_comfyui` / `comfy launch --background`. This is the diagnostics surface for failures NOT tied to a single prompt's `execution_error` (custom-node import failures, model-load errors, OOM, startup warnings).

## Changes

- `get_logs(tail: int = 200)` placed next to `server_info` (logs are a server-level concern).
- `tail` clamped to `1..2000` via a new `_MAX_LOG_TAIL` constant (mirrors the `watch_job` timeout-clamp idiom) so an agent can't request an unbounded dump. `2000` matches comfy-cli's own machine-mode line cap, above which `comfy logs --json` reports `truncated: true`.
- Calls `_run_comfy("logs", "--tail", str(tail), timeout=60.0)` and returns its `data` (`{lines, path, truncated}`). `_run_comfy` already injects `--json --where local` and unwraps the envelope, and raises `ComfyCliError` carrying `no_log_file` when the server was never launched via comfy — surfaced as-is.

## Motivation

Sibling comfy-cli ticket landed `comfy logs` (persist background ComfyUI logs + the verb). This exposes it through the MCP — the highest-value diagnostics surface for non-prompt failures. Closes BE-2388.

## Testing

- [x] Existing tests pass (`pytest`) — 100 passed, 1 skipped.
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually (describe below)

Added 4 tests (5 cases): argv maps to `('logs','--tail','200')`, `tail` clamps down to 2000 and up to 1 (0/-5), and the `no_log_file` error propagates as `ComfyCliError`.

**Manual smoke** against a real comfy-cli install (`comfy logs` verb present): verified the exact wrapper invocation `comfy --json --where local logs --tail 200` returns a valid `envelope/1` — exercised the `no_log_file` error path (no server launched), which returned `{"ok": false, "error": {"code": "no_log_file", ...}}` as expected.

## Additional Notes

- **Judgment call / not exercised live:** the success-path payload shape (`{lines, path, truncated}`) was not driven against a running ComfyUI in this smoke — only the `no_log_file` error path was. The success shape is comfy-cli's documented `comfy logs --json` contract (the sibling ticket); the wrapper returns `_run_comfy`'s unwrapped `data` verbatim without reshaping it, so there's no MCP-side transform to get wrong.
