### PR TITLE
fix(e2e): await run_workflow — async drift broke the live smoke

### DIFF
--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -15,6 +15,7 @@ failure. Run it on a machine that has both with::
 
 from __future__ import annotations
 
+import asyncio
 import os
 import shutil
 import urllib.error
@@ -95,7 +96,9 @@ def test_no_model_round_trip(tmp_path):
     assert info, f"server_info() returned nothing usable: {info!r}"
 
     # 2. Run the checkpoint-free EmptyImage -> SaveImage workflow to completion.
-    result = server.run_workflow(str(_WORKFLOW), wait=True, timeout_seconds=180.0)
+    # run_workflow went async in #11 (MCP progress streaming); drive it to
+    # completion from this sync test the way a plain client would.
+    result = asyncio.run(server.run_workflow(str(_WORKFLOW), wait=True, timeout_seconds=180.0))
     prompt_id = _extract_prompt_id(result)
     assert prompt_id, f"no prompt_id in run_workflow result: {result!r}"
 

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -98,7 +98,9 @@ def test_no_model_round_trip(tmp_path):
     # 2. Run the checkpoint-free EmptyImage -> SaveImage workflow to completion.
     # run_workflow went async in #11 (MCP progress streaming); drive it to
     # completion from this sync test the way a plain client would.
-    result = asyncio.run(server.run_workflow(str(_WORKFLOW), wait=True, timeout_seconds=180.0))
+    result = asyncio.run(
+        server.run_workflow(str(_WORKFLOW), wait=True, timeout_seconds=180.0)
+    )
     prompt_id = _extract_prompt_id(result)
     assert prompt_id, f"no prompt_id in run_workflow result: {result!r}"
 


### PR DESCRIPTION
## ELI-5

The end-to-end smoke test calls the `run_workflow` tool like a normal function, but #11 quietly turned that tool `async` — so the test was inspecting an unstarted coroutine instead of a result and failed the moment anyone ran it for real. CI never noticed because the test politely skips itself when no ComfyUI is running.

## What

One-line fix (+import): drive `run_workflow` with `asyncio.run(...)` in the sync test.

## Verified

Live round-trip on an M-series Mac (MPS): `server_info → run_workflow (EmptyImage→SaveImage) → fetch_outputs` → valid PNG on disk, 31.8s. Unit suite still 41/41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)