### PR TITLE
fix(search_models): pass query via --text, not positional (BE-2952)

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -933,7 +933,9 @@ def search_models(query: str = "", folder: str = "") -> Any:
 
     Thin passthrough with three modes, in precedence order:
 
-    - ``query`` given → ``comfy models search <query>`` (match model filenames).
+    - ``query`` given → ``comfy models search --text <query>`` (match model
+      filenames). ``--text`` is required: comfy-cli's ``search`` takes the query
+      as an option, not a positional (a positional exits 2 with a usage error).
     - else ``folder`` given → ``comfy models list-folder <folder>`` (list one
       model folder, e.g. ``checkpoints``, ``loras``).
     - else (both empty) → ``comfy models list-folders`` (list the folder names).
@@ -944,7 +946,7 @@ def search_models(query: str = "", folder: str = "") -> Any:
     "which model files does this install have?", not "tell me about this model".
     """
     if query:
-        return _run_comfy("models", "search", query, timeout=60.0)
+        return _run_comfy("models", "search", "--text", query, timeout=60.0)
     if folder:
         return _run_comfy("models", "list-folder", folder, timeout=60.0)
     return _run_comfy("models", "list-folders", timeout=60.0)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -169,9 +169,11 @@ def test_nodes_categories_argv(monkeypatch):
 
 
 def test_search_models_query_uses_search(monkeypatch):
+    # BE-2952: comfy-cli 1.12's `models search` takes the query as `--text`,
+    # not a positional — a positional exits 2 ("returned no JSON (exit 2)").
     calls = _stub_comfy(monkeypatch, _ok(["sd_xl_base.safetensors"]))
     assert server.search_models(query="xl") == ["sd_xl_base.safetensors"]
-    assert calls[0][4:] == ["models", "search", "xl"]
+    assert calls[0][4:] == ["models", "search", "--text", "xl"]
 
 
 def test_search_models_folder_uses_list_folder(monkeypatch):
@@ -189,7 +191,7 @@ def test_search_models_empty_lists_folders(monkeypatch):
 def test_search_models_query_takes_precedence_over_folder(monkeypatch):
     calls = _stub_comfy(monkeypatch, _ok([]))
     server.search_models(query="xl", folder="checkpoints")
-    assert calls[0][4:] == ["models", "search", "xl"]
+    assert calls[0][4:] == ["models", "search", "--text", "xl"]
 
 
 def test_discovery_surfaces_error_envelope(monkeypatch):


### PR DESCRIPTION
## ELI-5

`search_models(query="...")` was telling comfy-cli `comfy models search ace`. But comfy-cli 1.12 wants `comfy models search --text ace` — you have to hand it the word with a `--text` label, not just drop it on the floor. Without the label, comfy-cli got confused, exited with an error, and the tool reported `comfy-cli returned no JSON (exit 2)` for every search. This PR adds the `--text` label. That's the whole fix.

## Summary

Fixes [#33](https://github.com/Comfy-Org/comfy-local-mcp/issues/33) (BE-2952): `search_models` in query mode passed the query as a positional argument, but comfy-cli 1.12's `models search` takes it as the `--text` option. A positional exits 2 with a usage error, which surfaced as `ComfyCliError: comfy-cli returned no JSON (exit 2)` on every query-mode call.

## Changes

- `search_models`: emit `comfy models search --text <query>` instead of `comfy models search <query>` (`server.py`).
- Updated the docstring to document the `--text` requirement.
- Corrected the two existing argv-pinning tests in `test_discovery.py` that had locked in the buggy positional form.

## Motivation

Closes #33. The tool's query mode was 100% broken against comfy-cli 1.12.0.

**Re-verified the other two modes against the same CLI contract** (ticket item 2). Read comfy-cli's `command/models/search.py`:
- `list-folder <folder>` — `folder` is a `typer.Argument` (positional). Wrapper already correct; **unchanged**.
- `list-folders` — no positional args. Wrapper already correct; **unchanged**.

Only `search` uses an option (`--text` / `-t`) for the query, so only that mode needed the fix. No drift in the other two.

## Testing

- [x] Existing tests pass (`pytest` — 95 passed, 1 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually against a live workspace — **could not run in this environment** (no `comfy` binary on PATH / no running local ComfyUI). See note below.

The argv shape for all three modes is now pinned by unit tests (`test_discovery.py`): `search` → `["models", "search", "--text", <q>]`, `list-folder` → `["models", "list-folder", <folder>]`, `list-folders` → `["models", "list-folders"]`, plus query-takes-precedence-over-folder.

## Additional Notes

**Unmet-by-me acceptance criterion:** the ticket's live round-trip (`search_models(query="ace", folder="checkpoints")` against a workspace containing `ace_step_1.5_turbo_aio.safetensors`) could not be exercised here — this box has no `comfy` on PATH and no running local ComfyUI. The fix is verified at the argv level against comfy-cli's own `search_cmd` source (`--text`/`-t` is the query option; a positional exits 2), and the change is a pure passthrough-contract correction. A reviewer with a live workspace should confirm the round-trip before/after merge.
