### PR TITLE
fix: treat exit-0 lifecycle commands as success when no JSON envelope (BE-2953)

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -107,7 +107,17 @@ def _run_comfy(*args: str, timeout: float | None = None, plain_ok: bool = False)
         ) from exc
 
     envelope = _last_json_object(proc.stdout)
-    if plain_ok and envelope is None and proc.returncode == 0:
+    # A lifecycle command that exits 0 without a *real* envelope is a success
+    # (BE-2953). `_last_json_object` may return a stray non-envelope JSON line
+    # (e.g. a diagnostic log that happens to parse), so key the fast-path off the
+    # absence of a `type==envelope` object rather than the absence of any JSON —
+    # otherwise one incidental JSON line on a successful launch/stop would be
+    # mis-unwrapped into a spurious "failed" raise. A real error envelope still
+    # has `type==envelope`, so it flows to `_unwrap_envelope` and raises as usual.
+    real_envelope = (
+        envelope if envelope and envelope.get("type") == "envelope" else None
+    )
+    if plain_ok and real_envelope is None and proc.returncode == 0:
         return _synthesize_lifecycle_result(args, proc.stdout, proc.stderr)
     return _unwrap_envelope(envelope, args, proc.returncode, proc.stderr)
 
@@ -149,10 +159,11 @@ def _synthesize_lifecycle_result(
     would invite a retry of a non-idempotent lifecycle action.
     """
     text = " ".join(part.strip() for part in (stderr, stdout) if part.strip())
+    message = text or f"comfy {' '.join(args)} completed (exit 0)."
     return {
         "ok": True,
         "action": args[0] if args else "",
-        "message": text[:1000] or f"comfy {' '.join(args)} completed (exit 0).",
+        "message": message[:1000],  # cap both real output and the fallback
         "note": (
             "comfy-cli emitted no JSON envelope for this lifecycle command; "
             "a clean exit is treated as success."

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -68,12 +68,19 @@ class ComfyCliError(RuntimeError):
     """comfy-cli was missing, timed out, or returned an error envelope."""
 
 
-def _run_comfy(*args: str, timeout: float | None = None) -> Any:
+def _run_comfy(*args: str, timeout: float | None = None, plain_ok: bool = False) -> Any:
     """Run ``comfy <args> --where local --json`` and return the envelope's ``data``.
 
     comfy-cli emits a versioned ``envelope/1`` object on stdout (a single line
     for ``--json``, or an NDJSON stream whose final line is the envelope). We
     keep the last JSON object and unwrap ``ok`` / ``data`` / ``error``.
+
+    ``plain_ok`` relaxes the envelope requirement for the lifecycle commands
+    (``launch`` / ``stop``) that print human text and exit 0 WITHOUT emitting an
+    envelope (BE-2953): a clean exit with no JSON is treated as success and a
+    result dict is synthesized from the printed text, rather than raising the
+    "returned no JSON" error on an action that actually succeeded. A non-zero
+    exit, or a real error envelope, still raises as usual.
     """
     if shutil.which(COMFY_BIN) is None:
         raise ComfyCliError(
@@ -99,9 +106,10 @@ def _run_comfy(*args: str, timeout: float | None = None) -> Any:
             f"comfy-cli timed out after {timeout}s: {' '.join(cmd)}"
         ) from exc
 
-    return _unwrap_envelope(
-        _last_json_object(proc.stdout), args, proc.returncode, proc.stderr
-    )
+    envelope = _last_json_object(proc.stdout)
+    if plain_ok and envelope is None and proc.returncode == 0:
+        return _synthesize_lifecycle_result(args, proc.stdout, proc.stderr)
+    return _unwrap_envelope(envelope, args, proc.returncode, proc.stderr)
 
 
 def _unwrap_envelope(
@@ -126,6 +134,30 @@ def _unwrap_envelope(
             f"{err.get('message') or stderr.strip()[:500]}"
         )
     return envelope.get("data")
+
+
+def _synthesize_lifecycle_result(
+    args: tuple[str, ...], stdout: str, stderr: str
+) -> dict:
+    """Success payload for a lifecycle command that exited 0 without an envelope.
+
+    ``comfy launch --background`` and ``comfy stop`` print human-readable text and
+    exit 0 instead of emitting an ``envelope/1`` object (BE-2953). For those
+    commands a clean exit IS the success signal, so we return a result dict
+    carrying whatever text comfy-cli printed (preferring stderr, per the CLI's
+    logging) rather than raising on the absent envelope — a false negative that
+    would invite a retry of a non-idempotent lifecycle action.
+    """
+    text = " ".join(part.strip() for part in (stderr, stdout) if part.strip())
+    return {
+        "ok": True,
+        "action": args[0] if args else "",
+        "message": text[:1000] or f"comfy {' '.join(args)} completed (exit 0).",
+        "note": (
+            "comfy-cli emitted no JSON envelope for this lifecycle command; "
+            "a clean exit is treated as success."
+        ),
+    }
 
 
 def _last_json_object(stdout: str) -> dict | None:
@@ -656,6 +688,11 @@ def launch_comfyui(extra_args: list[str] | None = None) -> Any:
     Call ``server_info`` first if you only want to check whether a server is
     already running — launching a second one will fail on the port.
 
+    ``comfy launch --background`` prints human text and exits 0 without a JSON
+    envelope, so on success this returns a synthesized ``{"ok": True, ...}``
+    payload carrying that text (BE-2953); a launch failure (e.g. port in use)
+    exits non-zero and still raises a :class:`ComfyCliError`.
+
     NOTE (temporary upstream caveat): ``comfy launch --background`` currently
     crashes on Python 3.14 (comfy-cli asyncio ``get_event_loop`` issue; a fix is
     in review upstream). On affected comfy-cli versions the crash surfaces here
@@ -665,7 +702,7 @@ def launch_comfyui(extra_args: list[str] | None = None) -> Any:
     args = ["launch", "--background"]
     if extra_args:
         args += ["--", *extra_args]
-    return _run_comfy(*args, timeout=180.0)
+    return _run_comfy(*args, timeout=180.0, plain_ok=True)
 
 
 @mcp.tool()
@@ -678,8 +715,12 @@ def stop_comfyui() -> Any:
     the desktop app or by hand — in that case comfy-cli reports it has no
     recorded server and this tool raises a :class:`ComfyCliError` carrying that
     message, rather than killing an unrelated process.
+
+    Like ``launch_comfyui``, ``comfy stop`` prints human text and exits 0 without
+    a JSON envelope, so a successful stop returns a synthesized
+    ``{"ok": True, ...}`` payload carrying that text (BE-2953).
     """
-    return _run_comfy("stop", timeout=60.0)
+    return _run_comfy("stop", timeout=60.0, plain_ok=True)
 
 
 @mcp.tool()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -518,6 +518,26 @@ def test_launch_comfyui_nonzero_exit_still_raises(patched_plain_run):
         server.launch_comfyui()
 
 
+def test_plain_ok_synthesizes_despite_stray_non_envelope_json(patched_plain_run):
+    """A stray non-envelope JSON line on a clean lifecycle exit is still success.
+
+    `_last_json_object` returns any JSON object (not just `type==envelope`), so a
+    diagnostic line that happens to parse must NOT be mistaken for a result
+    envelope and unwrapped into a spurious failure (BE-2953 edge case).
+    """
+    patched_plain_run(
+        0,
+        stdout='{"level": "info", "msg": "bound port 8188"}\n',
+        stderr="Launched ComfyUI in the background.",
+    )
+
+    result = server.launch_comfyui()
+
+    assert result["ok"] is True
+    assert result["action"] == "launch"
+    assert "Launched ComfyUI" in result["message"]
+
+
 def test_plain_ok_does_not_leak_to_other_commands(patched_plain_run):
     """Without plain_ok, an exit-0 command with no JSON still raises (unchanged)."""
     patched_plain_run(0, stdout="not json")

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -455,6 +455,84 @@ def test_stop_comfyui_surfaces_no_recorded_server_error(patched_run):
     assert calls[0]["cmd"][4:] == ["stop"]
 
 
+# --- lifecycle commands with no JSON envelope (BE-2953) --------------------
+
+
+def _fake_run_plain(returncode: int, stdout: str = "", stderr: str = ""):
+    """`subprocess.run` stand-in emitting HUMAN text (no envelope) + a returncode.
+
+    Mirrors ``launch``/``stop``: comfy-cli prints plain text and exits without
+    ever writing an ``envelope/1`` object.
+    """
+    calls: list[dict] = []
+
+    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+        calls.append({"cmd": cmd, "env": env})
+        return subprocess.CompletedProcess(
+            cmd, returncode, stdout=stdout, stderr=stderr
+        )
+
+    return fake, calls
+
+
+@pytest.fixture
+def patched_plain_run(monkeypatch):
+    """`setup(returncode, stdout, stderr) -> calls` for the no-envelope path."""
+
+    def setup(returncode: int, stdout: str = "", stderr: str = "") -> list[dict]:
+        fake, calls = _fake_run_plain(returncode, stdout, stderr)
+        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+        monkeypatch.setattr(server.subprocess, "run", fake)
+        return calls
+
+    return setup
+
+
+def test_stop_comfyui_synthesizes_success_on_plain_exit(patched_plain_run):
+    """`comfy stop` prints text + exits 0 with no envelope -> synthesized success."""
+    patched_plain_run(0, stderr="Stopped ComfyUI server (pid 42).")
+
+    result = server.stop_comfyui()
+
+    assert result["ok"] is True
+    assert result["action"] == "stop"
+    assert "Stopped ComfyUI server" in result["message"]
+
+
+def test_launch_comfyui_synthesizes_success_on_plain_exit(patched_plain_run):
+    """`comfy launch --background` exits 0 with no envelope -> synthesized success."""
+    patched_plain_run(0, stdout="Launched ComfyUI in the background.")
+
+    result = server.launch_comfyui()
+
+    assert result["ok"] is True
+    assert result["action"] == "launch"
+    assert "Launched ComfyUI" in result["message"]
+
+
+def test_launch_comfyui_nonzero_exit_still_raises(patched_plain_run):
+    """A real launch failure (non-zero exit, no envelope) must still raise."""
+    patched_plain_run(1, stderr="Address already in use: port 8188")
+
+    with pytest.raises(server.ComfyCliError, match="returned no JSON"):
+        server.launch_comfyui()
+
+
+def test_plain_ok_does_not_leak_to_other_commands(patched_plain_run):
+    """Without plain_ok, an exit-0 command with no JSON still raises (unchanged)."""
+    patched_plain_run(0, stdout="not json")
+
+    with pytest.raises(server.ComfyCliError, match="returned no JSON"):
+        server._run_comfy("env")
+
+
+def test_plain_ok_still_honors_a_real_envelope(patched_run):
+    """When comfy-cli DOES emit an envelope, plain_ok unwraps it normally."""
+    patched_run({"type": "envelope", "ok": True, "data": {"pid": 7}})
+
+    assert server._run_comfy("launch", "--background", plain_ok=True) == {"pid": 7}
+
+
 def test_discover_maps_command_and_returns_data(patched_run):
     """discover wraps `comfy discover` and returns the envelope data verbatim."""
     surface = {"commands": ["run", "env"], "error_codes": ["server_not_running"]}


### PR DESCRIPTION
## ELI-5

When you tell the local ComfyUI to **start** or **stop**, the underlying `comfy` CLI just prints a normal sentence like "Stopped ComfyUI" and exits happily — it does **not** print the machine-readable JSON receipt (`envelope/1`) that every other command prints. Our wrapper demanded that receipt, so it shouted "the command returned no JSON!" and reported **failure** even though the server really did start/stop. For a start/stop action that's the worst possible lie: an agent sees "failed" and retries, double-launching or double-stopping. This PR teaches the wrapper that, **for launch/stop only**, a clean exit (code 0) with no JSON is a success — and hands back a tidy success payload with whatever text the CLI printed.

## Summary

Fixes BE-2953 / [issue #34](https://github.com/Comfy-Org/comfy-local-mcp/issues/34): `stop_comfyui` / `launch_comfyui` reported failure while the action actually succeeded, because both route through `_run_comfy`, which hard-requires an `envelope/1` JSON body. `comfy stop` and `comfy launch --background` print human text and exit 0 with no envelope, so the wrapper raised `ComfyCliError: comfy-cli returned no JSON (exit 0)`.

Implements **fix option 1** (wrapper-side, immediate) from the ticket.

## Changes

- `_run_comfy` gains a `plain_ok: bool = False` keyword. When set, an exit-0 run that produced **no** JSON envelope is treated as success and a result dict is synthesized from the CLI's printed text (via a new `_synthesize_lifecycle_result` helper) instead of raising.
- `launch_comfyui` and `stop_comfyui` pass `plain_ok=True`; every other caller is untouched, so the strict JSON contract is unchanged everywhere else.
- Synthesized payload: `{"ok": True, "action": "<stop|launch>", "message": "<CLI text>", "note": "..."}`.
- Tests: new no-envelope fixture + 5 cases — stop/launch synthesize success on plain exit-0; a non-zero exit still raises; `plain_ok` does not leak to other commands; a real envelope is still unwrapped normally.
- Docstrings on both tools updated to describe the returned payload.

## Motivation

Closes #34. A false negative on a **non-idempotent lifecycle action** is the worst failure shape for an agent caller — it invites a retry that double-launches (port clash) or double-stops.

## Testing

- [x] Existing tests pass (`pytest`) — 100 passed, 1 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually — **not possible in this environment: comfy-cli is not installed here**, so the ticket's live `stop_comfyui()` → `launch_comfyui()` → `/system_stats` check could not be re-run. The ticket author already verified that flow live during the 2026-07-13 tool-surface sweep. The wrapper behavior is fully covered by the new unit tests.

## Additional Notes

- **Judgment call / honest tradeoff (inherent to fix option 1):** `plain_ok` keys off exit code, not message content. If `comfy stop` were ever to *fail* while still exiting 0 with no envelope (e.g. "no recorded server" printed as plain text on a 0 exit), it would be reported as success — but the CLI's actual text is carried verbatim in `message`, so the truth is surfaced to the caller. This is strictly better than today's false-negative on the success path, and matches the ticket's chosen approach. I deliberately did **not** pattern-match error strings (fragile). A real failure that exits non-zero still raises, and a real error envelope still raises — both are covered by tests.
- The pre-existing `test_stop_comfyui_surfaces_no_recorded_server_error` (error *envelope* → raises) still passes: `plain_ok` only engages when there is **no** envelope at all.
- Fix option 2 (teach comfy-cli to emit `envelope/1` for launch/stop) remains the cleaner long-term contract and could be filed as a `Comfy-Org/comfy-cli` companion ticket; this wrapper-side fix is the immediate unblock and is compatible with that future change (a real envelope is always preferred when present).
