### PR TITLE
feat: verify comfy-cli envelope/version compatibility in server_info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,13 @@ authors = [{ name = "Comfy Org" }]
 dependencies = [
     "mcp>=1.2.0",
 ]
+# comfy-cli is intentionally NOT a declared dependency: this server shells out
+# to whatever `comfy` binary PATH/COMFY_BIN resolves to (which may differ from a
+# pip-installed one), and the envelope/discover contract it wraps is carried by a
+# specific comfy-cli build rather than a hard-pinnable PyPI release. Compatibility
+# is enforced at RUNTIME instead — `server_info` asserts the comfy-cli envelope
+# schema major and, when COMFY_CLI_MIN_VERSION is set, a minimum version. See
+# src/comfy_local_mcp/server.py (ENVELOPE_SCHEMA_MAJOR / MIN_COMFY_CLI_VERSION).
 
 [project.optional-dependencies]
 dev = ["pytest>=8", "ruff>=0.15,<0.16"]

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -197,15 +197,17 @@ def _envelope_schema(envelope: dict) -> str | None:
 def _envelope_major(envelope: dict) -> int | None:
     """Major version an envelope declares via ``schema`` (``envelope/<N>``), or None.
 
-    ``None`` means the envelope did not declare a schema at all — comfy-cli
-    builds that predate the tagged ``schema`` field simply omit it. We treat
-    that as "unknown, assume compatible" (see :func:`_unwrap_envelope`) rather
-    than reject it, so only a POSITIVELY different major trips the assertion.
+    ``None`` means the ``schema`` string is absent OR present-but-unparseable.
+    :func:`_unwrap_envelope` disambiguates the two: it only calls this once it
+    knows a ``schema`` was declared, so a ``None`` here then means "declared but
+    not ``envelope/<N>``" and is refused. The pattern is fully anchored, so a
+    decorated schema like ``envelope/1-foo`` or a future ``envelope-v2`` does
+    NOT masquerade as a bare major.
     """
     schema = _envelope_schema(envelope)
     if not schema:
         return None
-    match = re.match(r"envelope/(\d+)", schema.strip())
+    match = re.fullmatch(r"envelope/(\d+)", schema.strip())
     return int(match.group(1)) if match else None
 
 
@@ -229,10 +231,14 @@ def _unwrap_envelope(
             f"comfy-cli returned no JSON (exit {returncode}). "
             f"stderr: {stderr.strip()[:500]}"
         )
-    major = _envelope_major(envelope)
-    if major is not None and major != ENVELOPE_SCHEMA_MAJOR:
+    # A declared schema must be a recognized ``envelope/<N>`` whose major matches.
+    # Absent schema -> assume compatible (older comfy-cli); declared-but-unparseable
+    # or a different major -> refuse loudly rather than fail open on a shape we
+    # can't vouch for.
+    schema = _envelope_schema(envelope)
+    if schema is not None and _envelope_major(envelope) != ENVELOPE_SCHEMA_MAJOR:
         raise ComfyCliError(
-            f"incompatible comfy-cli envelope schema {_envelope_schema(envelope)!r}: "
+            f"incompatible comfy-cli envelope schema {schema!r}: "
             f"this server speaks envelope/{ENVELOPE_SCHEMA_MAJOR}. "
             "Upgrade or pin comfy-cli to a version whose envelope contract matches."
         )
@@ -488,12 +494,19 @@ def _detect_comfy_cli_version() -> str | None:
             [COMFY_BIN, "--version"],
             capture_output=True,
             text=True,
+            errors="replace",  # never crash on non-UTF-8 bytes; report None instead
             timeout=30.0,
             check=False,
         )
     except (subprocess.SubprocessError, OSError):
         return None
-    parsed = _parse_version(f"{proc.stdout}\n{proc.stderr}")
+    # Only trust stdout on a clean exit: a non-zero exit or a stderr warning can
+    # carry an unrelated dotted number (an embedded Python / ComfyUI core version)
+    # that _parse_version's first-match would wrongly report as the CLI version,
+    # then falsely trip or bypass the COMFY_CLI_MIN_VERSION floor.
+    if proc.returncode != 0:
+        return None
+    parsed = _parse_version(proc.stdout)
     return ".".join(str(part) for part in parsed) if parsed else None
 
 
@@ -517,16 +530,25 @@ def _check_comfy_cli_version() -> dict:
     if MIN_COMFY_CLI_VERSION:
         floor = _parse_version(MIN_COMFY_CLI_VERSION)
         got = _parse_version(detected) if detected else None
-        if floor is not None and got is not None and got < floor:
+        if floor is None:
+            # A misconfigured floor (e.g. "2" or "latest") would otherwise make
+            # the whole check a silent no-op: the deployment believes it enforces
+            # a minimum that never runs. Warn loudly instead of failing open.
+            report["warnings"].append(
+                f"COMFY_CLI_MIN_VERSION={MIN_COMFY_CLI_VERSION!r} is not a parseable "
+                'version (expected e.g. "1.5.0"), so the configured minimum was '
+                "NOT enforced."
+            )
+        elif got is None:
+            report["warnings"].append(
+                "could not determine the comfy-cli version, so the configured "
+                f"minimum {MIN_COMFY_CLI_VERSION} was not verified."
+            )
+        elif got < floor:
             raise ComfyCliError(
                 f"comfy-cli {detected} is older than the required minimum "
                 f"{MIN_COMFY_CLI_VERSION} (set via COMFY_CLI_MIN_VERSION). "
                 "Upgrade comfy-cli to a compatible version."
-            )
-        if got is None:
-            report["warnings"].append(
-                "could not determine the comfy-cli version, so the configured "
-                f"minimum {MIN_COMFY_CLI_VERSION} was not verified."
             )
     elif detected is None:
         report["warnings"].append("could not determine the comfy-cli version.")
@@ -551,10 +573,10 @@ def server_info() -> Any:
     alongside the ``comfy env`` data.
     """
     envelope, _stdout, args, returncode, stderr = _run_comfy_raw("env", timeout=60.0)
+    # _unwrap_envelope has already raised if envelope was None, so it is non-None here.
     data = _unwrap_envelope(envelope, args, returncode, stderr)
     compat = _check_comfy_cli_version()
-    if envelope is not None:
-        compat["envelope_schema"] = _envelope_schema(envelope)
+    compat["envelope_schema"] = _envelope_schema(envelope)
     if isinstance(data, dict):
         return {**data, "compatibility": compat}
     return {"env": data, "compatibility": compat}

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -63,6 +64,22 @@ mcp = FastMCP("comfy-local-mcp", instructions=INSTRUCTIONS)
 # Allow overriding the binary (e.g. a venv path) without touching code.
 COMFY_BIN = os.environ.get("COMFY_BIN", "comfy")
 
+# The envelope schema major version this server speaks. comfy-cli tags every
+# result with a ``schema`` like ``envelope/1``; the whole contract (result
+# shape, error codes) is versioned by that major. A mismatch means comfy-cli
+# made a breaking change to the shape this wrapper parses, so we refuse it
+# loudly (``_unwrap_envelope``) rather than silently misread its ``data``.
+ENVELOPE_SCHEMA_MAJOR = 1
+
+# Optional minimum comfy-cli version, opt-in via the ``COMFY_CLI_MIN_VERSION``
+# env var (e.g. ``"1.5.0"``). Unset by default ON PURPOSE: the envelope-schema
+# assertion above is the load-bearing compatibility gate, and the contract this
+# server wraps is carried by a specific comfy-cli build reached through
+# PATH/COMFY_BIN — not a PyPI release we could meaningfully hard-pin. Deployments
+# that DO know their required floor enforce it by setting this; ``server_info``
+# then rejects an older CLI (see ``_check_comfy_cli_version``).
+MIN_COMFY_CLI_VERSION = os.environ.get("COMFY_CLI_MIN_VERSION") or None
+
 # Hard ceiling for a single bounded watch so `float('inf')` / an absurd value
 # can't hold a `comfy jobs watch` child open effectively forever (1 hour).
 _MAX_WATCH_TIMEOUT = 3600.0
@@ -96,19 +113,17 @@ def _is_no_recorded_server(exc: ComfyCliError) -> bool:
     return exc.code == _NO_RECORDED_SERVER_CODE or _NO_RECORDED_SERVER_CODE in str(exc)
 
 
-def _run_comfy(*args: str, timeout: float | None = None, plain_ok: bool = False) -> Any:
-    """Run ``comfy <args> --where local --json`` and return the envelope's ``data``.
+def _run_comfy_raw(
+    *args: str, timeout: float | None = None
+) -> tuple[dict | None, str, tuple[str, ...], int, str]:
+    """Run ``comfy --json --where local <args>`` and return the RAW envelope + context.
 
-    comfy-cli emits a versioned ``envelope/1`` object on stdout (a single line
-    for ``--json``, or an NDJSON stream whose final line is the envelope). We
-    keep the last JSON object and unwrap ``ok`` / ``data`` / ``error``.
-
-    ``plain_ok`` relaxes the envelope requirement for the lifecycle commands
-    (``launch`` / ``stop``) that print human text and exit 0 WITHOUT emitting an
-    envelope (BE-2953): a clean exit with no JSON is treated as success and a
-    result dict is synthesized from the printed text, rather than raising the
-    "returned no JSON" error on an action that actually succeeded. A non-zero
-    exit, or a real error envelope, still raises as usual.
+    The shared subprocess half of :func:`_run_comfy`: it resolves the binary,
+    runs comfy-cli, and returns ``(envelope, stdout, args, returncode, stderr)``
+    WITHOUT unwrapping — so a caller that needs the envelope itself (e.g.
+    ``server_info`` reading the versioned ``schema``) can inspect it, or the raw
+    ``stdout`` (e.g. the lifecycle-success synthesizer), while :func:`_run_comfy`
+    just unwraps it down to ``data``.
     """
     if shutil.which(COMFY_BIN) is None:
         raise ComfyCliError(
@@ -134,7 +149,30 @@ def _run_comfy(*args: str, timeout: float | None = None, plain_ok: bool = False)
             f"comfy-cli timed out after {timeout}s: {' '.join(cmd)}"
         ) from exc
 
-    envelope = _last_json_object(proc.stdout)
+    return (
+        _last_json_object(proc.stdout),
+        proc.stdout,
+        args,
+        proc.returncode,
+        proc.stderr,
+    )
+
+
+def _run_comfy(*args: str, timeout: float | None = None, plain_ok: bool = False) -> Any:
+    """Run ``comfy <args> --where local --json`` and return the envelope's ``data``.
+
+    comfy-cli emits a versioned ``envelope/1`` object on stdout (a single line
+    for ``--json``, or an NDJSON stream whose final line is the envelope). We
+    keep the last JSON object and unwrap ``ok`` / ``data`` / ``error``.
+
+    ``plain_ok`` relaxes the envelope requirement for the lifecycle commands
+    (``launch`` / ``stop``) that print human text and exit 0 WITHOUT emitting an
+    envelope (BE-2953): a clean exit with no JSON is treated as success and a
+    result dict is synthesized from the printed text, rather than raising the
+    "returned no JSON" error on an action that actually succeeded. A non-zero
+    exit, or a real error envelope, still raises as usual.
+    """
+    envelope, stdout, args, returncode, stderr = _run_comfy_raw(*args, timeout=timeout)
     # A lifecycle command that exits 0 without a *real* envelope is a success
     # (BE-2953). `_last_json_object` may return a stray non-envelope JSON line
     # (e.g. a diagnostic log that happens to parse), so key the fast-path off the
@@ -145,9 +183,30 @@ def _run_comfy(*args: str, timeout: float | None = None, plain_ok: bool = False)
     real_envelope = (
         envelope if envelope and envelope.get("type") == "envelope" else None
     )
-    if plain_ok and real_envelope is None and proc.returncode == 0:
-        return _synthesize_lifecycle_result(args, proc.stdout, proc.stderr)
-    return _unwrap_envelope(envelope, args, proc.returncode, proc.stderr)
+    if plain_ok and real_envelope is None and returncode == 0:
+        return _synthesize_lifecycle_result(args, stdout, stderr)
+    return _unwrap_envelope(envelope, args, returncode, stderr)
+
+
+def _envelope_schema(envelope: dict) -> str | None:
+    """The envelope's declared ``schema`` string (e.g. ``"envelope/1"``), or None."""
+    value = envelope.get("schema")
+    return value if isinstance(value, str) else None
+
+
+def _envelope_major(envelope: dict) -> int | None:
+    """Major version an envelope declares via ``schema`` (``envelope/<N>``), or None.
+
+    ``None`` means the envelope did not declare a schema at all — comfy-cli
+    builds that predate the tagged ``schema`` field simply omit it. We treat
+    that as "unknown, assume compatible" (see :func:`_unwrap_envelope`) rather
+    than reject it, so only a POSITIVELY different major trips the assertion.
+    """
+    schema = _envelope_schema(envelope)
+    if not schema:
+        return None
+    match = re.match(r"envelope/(\d+)", schema.strip())
+    return int(match.group(1)) if match else None
 
 
 def _unwrap_envelope(
@@ -158,11 +217,24 @@ def _unwrap_envelope(
     Shared by the plain (`--json`) and streaming (`--json-stream`) paths so both
     have identical terminal behavior: return ``data`` on success, and raise a
     :class:`ComfyCliError` carrying the envelope's ``error.code`` on failure.
+
+    Also the envelope-version assertion: if comfy-cli declares an envelope
+    ``schema`` whose major differs from :data:`ENVELOPE_SCHEMA_MAJOR`, the whole
+    result shape is presumed incompatible and we refuse it with a clear error
+    (rather than silently misreading a differently-shaped ``data``). An envelope
+    with no declared schema is assumed compatible.
     """
     if envelope is None:
         raise ComfyCliError(
             f"comfy-cli returned no JSON (exit {returncode}). "
             f"stderr: {stderr.strip()[:500]}"
+        )
+    major = _envelope_major(envelope)
+    if major is not None and major != ENVELOPE_SCHEMA_MAJOR:
+        raise ComfyCliError(
+            f"incompatible comfy-cli envelope schema {_envelope_schema(envelope)!r}: "
+            f"this server speaks envelope/{ENVELOPE_SCHEMA_MAJOR}. "
+            "Upgrade or pin comfy-cli to a version whose envelope contract matches."
         )
     if not envelope.get("ok", False):
         err = envelope.get("error") or {}
@@ -392,15 +464,100 @@ async def _run_comfy_streaming(
             stderr_future.cancel()
 
 
+def _parse_version(text: str) -> tuple[int, int, int] | None:
+    """Extract a ``(major, minor, patch)`` tuple from a version string, or None."""
+    match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", text)
+    if match is None:
+        return None
+    return tuple(int(part) if part else 0 for part in match.groups())  # type: ignore[return-value]
+
+
+def _detect_comfy_cli_version() -> str | None:
+    """Best-effort comfy-cli version via ``comfy --version`` (None if undetermined).
+
+    A version string is a NICE-TO-HAVE, not load-bearing: comfy-cli builds that
+    don't expose ``--version`` (or whose output we can't parse) return ``None``
+    here and are reported as "unknown" rather than rejected — the envelope-schema
+    assertion is the real gate. Kept separate from :func:`_run_comfy` because
+    ``--version`` is a plain flag, not a ``--json`` envelope command.
+    """
+    if shutil.which(COMFY_BIN) is None:
+        return None
+    try:
+        proc = subprocess.run(
+            [COMFY_BIN, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30.0,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    parsed = _parse_version(f"{proc.stdout}\n{proc.stderr}")
+    return ".".join(str(part) for part in parsed) if parsed else None
+
+
+def _check_comfy_cli_version() -> dict:
+    """Compatibility report for the comfy-cli backing this server.
+
+    Reports the detected comfy-cli version, the configured floor, and the
+    envelope schema major this server speaks. Raises :class:`ComfyCliError` ONLY
+    on a POSITIVE incompatibility — a detected version below a configured
+    :data:`MIN_COMFY_CLI_VERSION`. An undetectable version is reported as
+    ``None`` with a warning, never a hard failure, so a comfy-cli that simply
+    doesn't expose ``--version`` still works.
+    """
+    detected = _detect_comfy_cli_version()
+    report: dict[str, Any] = {
+        "comfy_cli_version": detected,
+        "min_comfy_cli_version": MIN_COMFY_CLI_VERSION,
+        "envelope_schema_major": ENVELOPE_SCHEMA_MAJOR,
+        "warnings": [],
+    }
+    if MIN_COMFY_CLI_VERSION:
+        floor = _parse_version(MIN_COMFY_CLI_VERSION)
+        got = _parse_version(detected) if detected else None
+        if floor is not None and got is not None and got < floor:
+            raise ComfyCliError(
+                f"comfy-cli {detected} is older than the required minimum "
+                f"{MIN_COMFY_CLI_VERSION} (set via COMFY_CLI_MIN_VERSION). "
+                "Upgrade comfy-cli to a compatible version."
+            )
+        if got is None:
+            report["warnings"].append(
+                "could not determine the comfy-cli version, so the configured "
+                f"minimum {MIN_COMFY_CLI_VERSION} was not verified."
+            )
+    elif detected is None:
+        report["warnings"].append("could not determine the comfy-cli version.")
+    return report
+
+
 @mcp.tool()
 def server_info() -> Any:
-    """Report the local ComfyUI / comfy-cli environment.
+    """Report the local ComfyUI / comfy-cli environment and verify compatibility.
 
     Wraps ``comfy env``. Returns whether a local ComfyUI server is running and
     its URL, plus the selected workspace and Python info. Call this first to
     confirm a local ComfyUI is up before running a workflow.
+
+    Also the compatibility gate for the unpinned comfy-cli this server shells
+    out to: it asserts comfy-cli's envelope schema major matches the
+    ``envelope/N`` this wrapper parses, and — when a ``COMFY_CLI_MIN_VERSION``
+    floor is configured — that comfy-cli meets it. On a mismatch it raises
+    :class:`ComfyCliError` saying so, catching an incompatible comfy-cli here
+    rather than deep inside a later tool. On success it attaches a
+    ``compatibility`` block (detected version, floor, envelope schema, warnings)
+    alongside the ``comfy env`` data.
     """
-    return _run_comfy("env", timeout=60.0)
+    envelope, _stdout, args, returncode, stderr = _run_comfy_raw("env", timeout=60.0)
+    data = _unwrap_envelope(envelope, args, returncode, stderr)
+    compat = _check_comfy_cli_version()
+    if envelope is not None:
+        compat["envelope_schema"] = _envelope_schema(envelope)
+    if isinstance(data, dict):
+        return {**data, "compatibility": compat}
+    return {"env": data, "compatibility": compat}
 
 
 @mcp.tool()

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -47,6 +47,14 @@ def test_unwrap_rejects_incompatible_envelope_major():
         server._unwrap_envelope(envelope, ("env",), 0, "")
 
 
+@pytest.mark.parametrize("schema", ["envelope-v2", "envelope/1-foo", "v2", "envelope/"])
+def test_unwrap_rejects_declared_but_unparseable_schema(schema):
+    """A declared schema that isn't a bare ``envelope/<N>`` fails closed, not open."""
+    envelope = {"schema": schema, "type": "envelope", "ok": True, "data": {"x": 1}}
+    with pytest.raises(server.ComfyCliError, match="incompatible comfy-cli envelope"):
+        server._unwrap_envelope(envelope, ("env",), 0, "")
+
+
 def test_unwrap_rejects_incompatible_major_even_on_error_envelope():
     """An incompatible schema is reported as such, not as its (untrusted) error."""
     envelope = {
@@ -99,7 +107,7 @@ def test_detect_version_none_when_binary_missing(monkeypatch):
 def test_detect_version_parses_cli_output(monkeypatch):
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
 
-    def fake(cmd, capture_output, text, timeout, check):  # noqa: ARG001
+    def fake(cmd, capture_output, text, errors, timeout, check):  # noqa: ARG001
         assert cmd == [server.COMFY_BIN, "--version"]
         return subprocess.CompletedProcess(
             cmd, 0, stdout="comfy-cli, 1.12.0\n", stderr=""
@@ -107,6 +115,20 @@ def test_detect_version_parses_cli_output(monkeypatch):
 
     monkeypatch.setattr(server.subprocess, "run", fake)
     assert server._detect_comfy_cli_version() == "1.12.0"
+
+
+def test_detect_version_ignores_stderr_and_nonzero_exit(monkeypatch):
+    """Only stdout on a clean exit is trusted; a stderr number / bad exit -> None."""
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+
+    def fake(cmd, capture_output, text, errors, timeout, check):  # noqa: ARG001
+        # Non-zero exit, and a misleading dotted number only on stderr.
+        return subprocess.CompletedProcess(
+            cmd, 1, stdout="", stderr="Python 3.11.7 error\n"
+        )
+
+    monkeypatch.setattr(server.subprocess, "run", fake)
+    assert server._detect_comfy_cli_version() is None
 
 
 def test_detect_version_none_on_subprocess_error(monkeypatch):
@@ -161,6 +183,18 @@ def test_check_raises_when_version_below_floor(monkeypatch):
 
     with pytest.raises(server.ComfyCliError, match="older than the required minimum"):
         server._check_comfy_cli_version()
+
+
+@pytest.mark.parametrize("bad_floor", ["2", "latest", "v-next"])
+def test_check_warns_when_floor_is_unparseable(monkeypatch, bad_floor):
+    """A misconfigured floor must not silently no-op: warn instead of failing open."""
+    monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", bad_floor)
+    monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.12.0")
+
+    report = server._check_comfy_cli_version()
+
+    assert report["warnings"]  # warns the floor was unparseable / not enforced
+    assert any("not a parseable" in w for w in report["warnings"])
 
 
 def test_check_warns_but_does_not_raise_when_floor_set_and_version_unknown(monkeypatch):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,256 @@
+"""Tests for the comfy-cli compatibility gate (BE-2997).
+
+comfy-cli is unpinned — it comes from PATH at whatever version — so the whole
+contract (envelope shape, flag ordering, error codes) rests on an unversioned
+dependency. These lock in the runtime checks that guard it:
+
+1. ``_unwrap_envelope`` refuses an envelope whose declared ``schema`` major
+   differs from the ``envelope/N`` this server parses, and passes an envelope
+   that declares no schema (backward compatible with older comfy-cli builds).
+2. ``server_info`` reports a ``compatibility`` block and, when a
+   ``COMFY_CLI_MIN_VERSION`` floor is configured, rejects an older comfy-cli.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from comfy_local_mcp import server
+
+
+# --- envelope-version assertion (_unwrap_envelope) --------------------------
+
+
+def test_unwrap_accepts_matching_envelope_major():
+    """An ``envelope/1`` schema (the version we speak) unwraps to ``data``."""
+    envelope = {
+        "schema": "envelope/1",
+        "type": "envelope",
+        "ok": True,
+        "data": {"x": 1},
+    }
+    assert server._unwrap_envelope(envelope, ("env",), 0, "") == {"x": 1}
+
+
+def test_unwrap_accepts_schemaless_envelope():
+    """An envelope with no ``schema`` is assumed compatible (older comfy-cli)."""
+    envelope = {"type": "envelope", "ok": True, "data": {"x": 1}}
+    assert server._unwrap_envelope(envelope, ("env",), 0, "") == {"x": 1}
+
+
+def test_unwrap_rejects_incompatible_envelope_major():
+    """A future ``envelope/2`` is a breaking contract change -> refused loudly."""
+    envelope = {"schema": "envelope/2", "type": "envelope", "ok": True, "data": {}}
+    with pytest.raises(server.ComfyCliError, match="incompatible comfy-cli envelope"):
+        server._unwrap_envelope(envelope, ("env",), 0, "")
+
+
+def test_unwrap_rejects_incompatible_major_even_on_error_envelope():
+    """An incompatible schema is reported as such, not as its (untrusted) error."""
+    envelope = {
+        "schema": "envelope/2",
+        "type": "envelope",
+        "ok": False,
+        "error": {"code": "whatever", "message": "boom"},
+    }
+    with pytest.raises(server.ComfyCliError, match="incompatible comfy-cli envelope"):
+        server._unwrap_envelope(envelope, ("env",), 0, "")
+
+
+def test_incompatible_envelope_propagates_through_run_comfy(monkeypatch):
+    """The assertion guards every tool: a bad-schema envelope raises via _run_comfy."""
+
+    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+        import json
+
+        out = json.dumps({"schema": "envelope/99", "type": "envelope", "ok": True})
+        return subprocess.CompletedProcess(cmd, 0, stdout=out, stderr="")
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    with pytest.raises(server.ComfyCliError, match="incompatible comfy-cli envelope"):
+        server._run_comfy("env")
+
+
+# --- version parsing / detection --------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("comfy-cli 1.12.0", (1, 12, 0)),
+        ("comfy version 1.5", (1, 5, 0)),
+        ("v2.0.3\n", (2, 0, 3)),
+        ("no version here", None),
+    ],
+)
+def test_parse_version(text, expected):
+    assert server._parse_version(text) == expected
+
+
+def test_detect_version_none_when_binary_missing(monkeypatch):
+    monkeypatch.setattr(server.shutil, "which", lambda _: None)
+    assert server._detect_comfy_cli_version() is None
+
+
+def test_detect_version_parses_cli_output(monkeypatch):
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+
+    def fake(cmd, capture_output, text, timeout, check):  # noqa: ARG001
+        assert cmd == [server.COMFY_BIN, "--version"]
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="comfy-cli, 1.12.0\n", stderr=""
+        )
+
+    monkeypatch.setattr(server.subprocess, "run", fake)
+    assert server._detect_comfy_cli_version() == "1.12.0"
+
+
+def test_detect_version_none_on_subprocess_error(monkeypatch):
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+
+    def boom(*a, **k):
+        raise OSError("cannot exec")
+
+    monkeypatch.setattr(server.subprocess, "run", boom)
+    assert server._detect_comfy_cli_version() is None
+
+
+# --- version floor (_check_comfy_cli_version) -------------------------------
+
+
+def test_check_reports_version_without_floor(monkeypatch):
+    """No floor configured: report the version, no warning, never raise."""
+    monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", None)
+    monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.12.0")
+
+    report = server._check_comfy_cli_version()
+
+    assert report["comfy_cli_version"] == "1.12.0"
+    assert report["min_comfy_cli_version"] is None
+    assert report["envelope_schema_major"] == server.ENVELOPE_SCHEMA_MAJOR
+    assert report["warnings"] == []
+
+
+def test_check_warns_when_version_unknown_and_no_floor(monkeypatch):
+    monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", None)
+    monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: None)
+
+    report = server._check_comfy_cli_version()
+
+    assert report["comfy_cli_version"] is None
+    assert report["warnings"]  # a non-empty warning about the unknown version
+
+
+def test_check_passes_when_version_meets_floor(monkeypatch):
+    monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", "1.5.0")
+    monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.12.0")
+
+    report = server._check_comfy_cli_version()
+
+    assert report["min_comfy_cli_version"] == "1.5.0"
+    assert report["warnings"] == []
+
+
+def test_check_raises_when_version_below_floor(monkeypatch):
+    monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", "1.10.0")
+    monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.5.0")
+
+    with pytest.raises(server.ComfyCliError, match="older than the required minimum"):
+        server._check_comfy_cli_version()
+
+
+def test_check_warns_but_does_not_raise_when_floor_set_and_version_unknown(monkeypatch):
+    """An undetectable version never hard-fails, even with a floor configured."""
+    monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", "1.10.0")
+    monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: None)
+
+    report = server._check_comfy_cli_version()
+
+    assert report["comfy_cli_version"] is None
+    assert report["warnings"]  # warns that the floor could not be verified
+
+
+# --- server_info integration ------------------------------------------------
+
+
+@pytest.fixture
+def patched_env(monkeypatch):
+    """Patch comfy-cli so ``server_info`` sees a given ``comfy env`` envelope."""
+
+    def setup(envelope: dict, version: str | None = "1.12.0") -> list[dict]:
+        import json
+
+        calls: list[dict] = []
+
+        def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+            calls.append({"cmd": cmd})
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=json.dumps(envelope), stderr=""
+            )
+
+        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+        monkeypatch.setattr(server.subprocess, "run", fake)
+        monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: version)
+        return calls
+
+    return setup
+
+
+def test_server_info_attaches_compatibility_block(patched_env, monkeypatch):
+    monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", None)
+    calls = patched_env(
+        {
+            "schema": "envelope/1",
+            "type": "envelope",
+            "ok": True,
+            "data": {"running": True, "url": "http://127.0.0.1:8188"},
+        }
+    )
+
+    result = server.server_info()
+
+    assert result["running"] is True  # original comfy env data preserved
+    compat = result["compatibility"]
+    assert compat["comfy_cli_version"] == "1.12.0"
+    assert compat["envelope_schema"] == "envelope/1"
+    assert compat["envelope_schema_major"] == server.ENVELOPE_SCHEMA_MAJOR
+    assert calls[0]["cmd"][4:] == ["env"]  # still `comfy env`
+
+
+def test_server_info_raises_on_incompatible_envelope(patched_env, monkeypatch):
+    monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", None)
+    patched_env({"schema": "envelope/2", "type": "envelope", "ok": True, "data": {}})
+
+    with pytest.raises(server.ComfyCliError, match="incompatible comfy-cli envelope"):
+        server.server_info()
+
+
+def test_server_info_raises_on_version_below_floor(patched_env, monkeypatch):
+    monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", "2.0.0")
+    patched_env(
+        {
+            "schema": "envelope/1",
+            "type": "envelope",
+            "ok": True,
+            "data": {"running": False},
+        },
+        version="1.12.0",
+    )
+
+    with pytest.raises(server.ComfyCliError, match="older than the required minimum"):
+        server.server_info()
+
+
+def test_server_info_wraps_non_dict_env_data(patched_env, monkeypatch):
+    """If `comfy env` ever returns non-dict data, it is still returned with compat."""
+    monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", None)
+    patched_env({"schema": "envelope/1", "type": "envelope", "ok": True, "data": "raw"})
+
+    result = server.server_info()
+
+    assert result["env"] == "raw"
+    assert result["compatibility"]["envelope_schema"] == "envelope/1"


### PR DESCRIPTION
## ELI-5

This server is just a thin wrapper that runs the `comfy` command (comfy-cli) under the hood. But it never checked *which* comfy-cli it was talking to — comfy-cli comes from your `PATH` at whatever version, and the whole contract (the `envelope/1` result shape, flag ordering, error codes) silently assumed it matched. If comfy-cli ever changed that shape, this server would quietly misread the results. Now `server_info` (the "call me first" handshake) checks that comfy-cli speaks a compatible envelope version and, optionally, meets a minimum version — and says so clearly if it doesn't.

## Summary

Adds a runtime compatibility gate for the (unpinned) comfy-cli this server shells out to. Previously `pyproject.toml` declared only `mcp>=1.2.0` and comfy-cli was reached from `PATH` with no minimum-version check and no envelope-version assertion at startup.

## Changes

- **Envelope-version assertion (`_unwrap_envelope`).** Every comfy-cli result is now checked: if comfy-cli declares an envelope `schema` whose *major* differs from the `envelope/1` this wrapper parses, it is refused with a clear `ComfyCliError` instead of being silently misread. An envelope that declares no `schema` is assumed compatible (backward-compatible with older comfy-cli builds), so only a *positively different* major trips the guard. This covers all tools + the streaming path, not just `server_info`.
- **`server_info` compatibility report.** `server_info` now attaches a `compatibility` block (detected comfy-cli version, configured floor, observed envelope schema, warnings) alongside the `comfy env` data, and enforces an **optional** minimum version via the `COMFY_CLI_MIN_VERSION` env var — raising a clear error when the backing comfy-cli is too old ("catch it at the handshake, not deep inside a later tool").
- **Best-effort, fail-open version detection.** Version comes from `comfy --version`; an undetectable/unparseable version is reported as `unknown` with a warning rather than a hard failure, so a comfy-cli that does not expose `--version` still works.
- **Docs.** `pyproject.toml` gains a comment explaining why comfy-cli is *not* a hard-pinned dependency; README documents `COMFY_CLI_MIN_VERSION` and the updated `server_info` behavior.
- Refactor: split `_run_comfy` into `_run_comfy_raw` (subprocess → raw envelope) + `_run_comfy` (unwrap), so `server_info` can inspect the envelope's `schema`. Behavior-preserving.

## Motivation

The entire contract rests on an unversioned dependency. This adds the startup compatibility check the repo lacked, analogous in spirit to how the cloud MCP pins its CLI backend — surfaced through `server_info` and its error, per the ticket. Linked via the `be-2997` branch name (repo is destined-public: no tracker refs in title/body per AGENTS.md).

## Judgment calls (please sanity-check)

- **No hard pyproject pin of comfy-cli — deliberate.** The ticket contrasts with the cloud MCP pinning comfy-cli to an immutable commit. I did **not** add `comfy-cli>=X` to `dependencies`, because (a) the server runs whatever `COMFY_BIN`/`PATH` resolves to, which a pip pin does not bind, and (b) the `envelope/1`/`discover`/`--where local` contract this server wraps is **not present in public comfy-cli** (currently 1.12.0 on PyPI) — it is carried by a specific comfy-cli build, so any PyPI floor I could name would install an *incompatible* engine and give false confidence. The correct, honest mechanism is the **runtime** check here; the version floor is operator-configurable for deployments that know their good version. Flagging in case a symbolic pin is still wanted.
- **Version floor defaults OFF.** With no `COMFY_CLI_MIN_VERSION` set, the always-on envelope-schema assertion is the only gate and it denies nothing on a working comfy-cli. This keeps the change from spuriously rejecting valid installs on an unverifiable premise.
- **Not exercised against a live comfy-cli.** comfy-cli is not installed in this environment, so the checks are unit-tested against the envelope contract the repo already documents and parses (`envelope/1`), not run end-to-end. The guards are default-open (envelope/1 and schemaless both pass; floor off), so they deny no working capability by default.

## Testing

- [x] Existing tests pass (`pytest`) — 116 passed, 1 skipped (e2e, needs live comfy-cli)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] New tests in `tests/test_compat.py` cover: envelope-major accept/reject (incl. schemaless + error envelopes + propagation through `_run_comfy`), version parse/detect, floor enforcement (pass/reject/warn-when-unknown), and `server_info` integration.

## Additional Notes

The envelope assertion is intentionally placed at the parse seam so it guards every tool, exceeding the "at minimum `server_info`" ask. No behavior change for a compatible (`envelope/1`) or older-schemaless comfy-cli.