### PR TITLE
fix: suppress comfy-cli watcher via COMFY_NO_WATCH and fix async e2e smoke (BE-3074)

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -64,6 +64,31 @@ COMFY_BIN = os.environ.get("COMFY_BIN", "comfy")
 _MAX_WATCH_TIMEOUT = 3600.0
 
 
+def _comfy_env() -> dict[str, str]:
+    """Child-process environment for every comfy-cli spawn.
+
+    Single source of truth so the two spawn sites (``_run_comfy`` /
+    ``_run_comfy_streaming``) cannot drift. Injected keys are placed AFTER
+    ``os.environ`` so they win over any inherited values:
+
+    - ``COMFY_WHERE=local`` — belt-and-suspenders pin so we never touch cloud.
+    - ``COMFY_NO_WATCH=1`` — suppress comfy-cli's file watcher for agentic
+      callers like this MCP; a harmless no-op on versions that lack the flag.
+    - ``PYTHONUTF8=1`` / ``PYTHONIOENCODING=utf-8`` — force UTF-8 on the child's
+      console. Without them a default Windows (cp1252) console raises
+      ``UnicodeEncodeError`` printing the UTF-8 catalog output and wedges, so the
+      discovery tools present as a 60s timeout. UTF-8 is already the practical
+      default on macOS/Linux, so this is a no-op there.
+    """
+    return {
+        **os.environ,
+        "COMFY_WHERE": "local",
+        "COMFY_NO_WATCH": "1",
+        "PYTHONUTF8": "1",
+        "PYTHONIOENCODING": "utf-8",
+    }
+
+
 class ComfyCliError(RuntimeError):
     """comfy-cli was missing, timed out, or returned an error envelope."""
 
@@ -83,15 +108,19 @@ def _run_comfy(*args: str, timeout: float | None = None) -> Any:
     # Global flags (--json, --where) MUST precede the subcommand in comfy-cli;
     # a trailing --json errors with "No such option". (Verified against comfy-cli.)
     cmd = [COMFY_BIN, "--json", "--where", "local", *args]
-    # Belt-and-suspenders: pin the target via env too, so we never touch cloud.
-    # COMFY_NO_WATCH suppresses comfy-cli's file watcher for agentic callers like
-    # this MCP; a harmless no-op on comfy-cli versions that don't know the flag.
-    env = {**os.environ, "COMFY_WHERE": "local", "COMFY_NO_WATCH": "1"}
+    env = _comfy_env()
     try:
         proc = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
+            # Pin the parent-side decode to UTF-8 so it matches what the child
+            # is forced to emit (_comfy_env). Without this, text=True decodes
+            # the pipe with the system locale (cp1252 on a default Windows
+            # console) and the non-ASCII catalog output raises UnicodeDecodeError
+            # or yields mojibake before _unwrap_envelope — the exact crash this
+            # fix targets, just moved to the reader.
+            encoding="utf-8",
             timeout=timeout,
             env=env,
             check=False,
@@ -257,14 +286,17 @@ async def _run_comfy_streaming(
     # --json-stream is a global flag and, like --json/--where, MUST precede the
     # subcommand; a trailing form errors with "No such option".
     cmd = [COMFY_BIN, "--json-stream", "--where", "local", *args]
-    # COMFY_NO_WATCH suppresses comfy-cli's file watcher for agentic callers (see
-    # _run_comfy); harmless on comfy-cli versions that don't know the flag.
-    env = {**os.environ, "COMFY_WHERE": "local", "COMFY_NO_WATCH": "1"}
+    env = _comfy_env()
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        # Match the child's forced UTF-8 output (see _comfy_env); otherwise
+        # readline()/stderr.read() decode with the parent locale (cp1252 on
+        # Windows) and non-ASCII stream lines raise UnicodeDecodeError or
+        # corrupt to mojibake before _parse_event/_last_json_object.
+        encoding="utf-8",
         env=env,
     )
     lines: list[str] = []

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -84,7 +84,9 @@ def _run_comfy(*args: str, timeout: float | None = None) -> Any:
     # a trailing --json errors with "No such option". (Verified against comfy-cli.)
     cmd = [COMFY_BIN, "--json", "--where", "local", *args]
     # Belt-and-suspenders: pin the target via env too, so we never touch cloud.
-    env = {**os.environ, "COMFY_WHERE": "local"}
+    # COMFY_NO_WATCH suppresses comfy-cli's file watcher for agentic callers like
+    # this MCP; a harmless no-op on comfy-cli versions that don't know the flag.
+    env = {**os.environ, "COMFY_WHERE": "local", "COMFY_NO_WATCH": "1"}
     try:
         proc = subprocess.run(
             cmd,
@@ -255,7 +257,9 @@ async def _run_comfy_streaming(
     # --json-stream is a global flag and, like --json/--where, MUST precede the
     # subcommand; a trailing form errors with "No such option".
     cmd = [COMFY_BIN, "--json-stream", "--where", "local", *args]
-    env = {**os.environ, "COMFY_WHERE": "local"}
+    # COMFY_NO_WATCH suppresses comfy-cli's file watcher for agentic callers (see
+    # _run_comfy); harmless on comfy-cli versions that don't know the flag.
+    env = {**os.environ, "COMFY_WHERE": "local", "COMFY_NO_WATCH": "1"}
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -15,6 +15,7 @@ failure. Run it on a machine that has both with::
 
 from __future__ import annotations
 
+import asyncio
 import os
 import shutil
 import urllib.error
@@ -95,7 +96,11 @@ def test_no_model_round_trip(tmp_path):
     assert info, f"server_info() returned nothing usable: {info!r}"
 
     # 2. Run the checkpoint-free EmptyImage -> SaveImage workflow to completion.
-    result = server.run_workflow(str(_WORKFLOW), wait=True, timeout_seconds=180.0)
+    # run_workflow became async when MCP progress streaming landed (PR #11), so
+    # drive its coroutine to completion here.
+    result = asyncio.run(
+        server.run_workflow(str(_WORKFLOW), wait=True, timeout_seconds=180.0)
+    )
     prompt_id = _extract_prompt_id(result)
     assert prompt_id, f"no prompt_id in run_workflow result: {result!r}"
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -19,7 +19,7 @@ def _stub_comfy(monkeypatch, envelope: dict):
     """Stub shutil.which + subprocess.run; return the list that records each argv."""
     calls: list[list[str]] = []
 
-    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
         calls.append(cmd)
         return subprocess.CompletedProcess(
             cmd, 0, stdout=json.dumps(envelope), stderr=""

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -22,7 +22,7 @@ def _fake_run(envelope: dict):
     """Return a subprocess.run stand-in that captures the call and emits an envelope."""
     calls: list[dict] = []
 
-    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
         calls.append({"cmd": cmd, "env": env})
         return subprocess.CompletedProcess(
             cmd, 0, stdout=json.dumps(envelope), stderr=""

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -23,7 +23,7 @@ def _fake_run(envelope: dict):
     """Return a subprocess.run stand-in that captures the call and emits an envelope."""
     calls: list[dict] = []
 
-    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
         calls.append({"cmd": cmd, "env": env})
         return subprocess.CompletedProcess(
             cmd, 0, stdout=json.dumps(envelope), stderr=""

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -73,6 +73,15 @@ def test_global_flags_precede_subcommand(patched_run):
     assert calls[0]["env"]["COMFY_WHERE"] == "local"  # belt-and-suspenders pin
 
 
+def test_run_comfy_sets_no_watch_env(patched_run):
+    """Agentic caller: comfy-cli's file watcher is suppressed via COMFY_NO_WATCH."""
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"x": 1}})
+
+    server._run_comfy("jobs", "status", "abc")
+
+    assert calls[0]["env"]["COMFY_NO_WATCH"] == "1"
+
+
 def test_error_envelope_raises_with_code(patched_run):
     patched_run(
         {
@@ -482,8 +491,9 @@ def test_which_maps_command_and_returns_data(patched_run):
 class _FakeProc:
     """A minimal stand-in for ``subprocess.Popen`` over a canned NDJSON stream."""
 
-    def __init__(self, cmd, stdout_text, stderr_text=""):
+    def __init__(self, cmd, stdout_text, stderr_text="", env=None):
         self.cmd = cmd
+        self.env = env
         self.stdout = io.StringIO(stdout_text)
         self.stderr = io.StringIO(stderr_text)
         self.returncode = 0
@@ -521,7 +531,7 @@ def patched_stream(monkeypatch):
         procs: list[_FakeProc] = []
 
         def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
-            proc = _FakeProc(cmd, stdout_text)
+            proc = _FakeProc(cmd, stdout_text, env=env)
             procs.append(proc)
             return proc
 
@@ -585,6 +595,16 @@ def test_run_workflow_streams_progress_and_returns_data(patched_stream):
     values = [c["progress"] for c in ctx.calls]
     assert values == sorted(values)  # monotonically non-decreasing
     assert values[-1] == 2.0  # both nodes finished
+
+
+def test_run_workflow_stream_sets_no_watch_env(patched_stream):
+    """The streaming path also suppresses comfy-cli's watcher via COMFY_NO_WATCH."""
+    procs = patched_stream(_OK_STREAM)
+
+    asyncio.run(server.run_workflow("wf.json", wait=True))
+
+    assert procs[0].env["COMFY_WHERE"] == "local"
+    assert procs[0].env["COMFY_NO_WATCH"] == "1"
 
 
 def test_run_workflow_stream_error_envelope_raises_with_code(patched_stream):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -33,8 +33,8 @@ def _fake_run(envelope: dict):
     """
     calls: list[dict] = []
 
-    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
-        calls.append({"cmd": cmd, "env": env})
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
+        calls.append({"cmd": cmd, "env": env, "encoding": encoding})
         return subprocess.CompletedProcess(
             cmd, 0, stdout=json.dumps(envelope), stderr=""
         )
@@ -80,6 +80,48 @@ def test_run_comfy_sets_no_watch_env(patched_run):
     server._run_comfy("jobs", "status", "abc")
 
     assert calls[0]["env"]["COMFY_NO_WATCH"] == "1"
+
+
+def test_run_comfy_forces_utf8_env(patched_run):
+    """Windows cp1252 fix: the child env forces UTF-8 so catalog output can't crash.
+
+    On a default Windows console (cp1252) comfy-cli raises UnicodeEncodeError
+    printing the UTF-8 catalog and wedges, so discovery tools present as a 60s
+    timeout. Forcing UTF-8 on the child prevents the crash (no-op on POSIX).
+    """
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"x": 1}})
+
+    server._run_comfy("jobs", "status", "abc")
+
+    assert calls[0]["env"]["PYTHONUTF8"] == "1"
+    assert calls[0]["env"]["PYTHONIOENCODING"] == "utf-8"
+
+
+def test_run_comfy_pins_parent_decode_to_utf8(patched_run):
+    """The parent-side read is pinned to UTF-8 to match the child's forced output.
+
+    Without an explicit ``encoding``, ``text=True`` decodes the pipe with the
+    system locale (cp1252 on a default Windows console), so the non-ASCII catalog
+    output raises UnicodeDecodeError/mojibake before ``_unwrap_envelope`` — the
+    same crash, just moved from the child's write to the parent's read.
+    """
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"x": 1}})
+
+    server._run_comfy("jobs", "status", "abc")
+
+    assert calls[0]["encoding"] == "utf-8"
+
+
+def test_run_comfy_utf8_env_overrides_inherited(patched_run, monkeypatch):
+    """The injected UTF-8 vars win over any conflicting value in the parent env."""
+    monkeypatch.setenv("PYTHONUTF8", "0")
+    monkeypatch.setenv("PYTHONIOENCODING", "cp1252")
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"x": 1}})
+
+    server._run_comfy("jobs", "status", "abc")
+
+    assert calls[0]["env"]["PYTHONUTF8"] == "1"
+    assert calls[0]["env"]["PYTHONIOENCODING"] == "utf-8"
 
 
 def test_error_envelope_raises_with_code(patched_run):
@@ -491,9 +533,10 @@ def test_which_maps_command_and_returns_data(patched_run):
 class _FakeProc:
     """A minimal stand-in for ``subprocess.Popen`` over a canned NDJSON stream."""
 
-    def __init__(self, cmd, stdout_text, stderr_text="", env=None):
+    def __init__(self, cmd, stdout_text, stderr_text="", env=None, encoding=None):
         self.cmd = cmd
         self.env = env
+        self.encoding = encoding
         self.stdout = io.StringIO(stdout_text)
         self.stderr = io.StringIO(stderr_text)
         self.returncode = 0
@@ -530,8 +573,8 @@ def patched_stream(monkeypatch):
     def setup(stdout_text: str) -> list[_FakeProc]:
         procs: list[_FakeProc] = []
 
-        def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
-            proc = _FakeProc(cmd, stdout_text, env=env)
+        def fake_popen(cmd, stdout, stderr, text, encoding, env):  # noqa: ARG001
+            proc = _FakeProc(cmd, stdout_text, env=env, encoding=encoding)
             procs.append(proc)
             return proc
 
@@ -605,6 +648,19 @@ def test_run_workflow_stream_sets_no_watch_env(patched_stream):
 
     assert procs[0].env["COMFY_WHERE"] == "local"
     assert procs[0].env["COMFY_NO_WATCH"] == "1"
+
+
+def test_run_workflow_stream_forces_utf8_env(patched_stream):
+    """The streaming (Popen) spawn path also forces UTF-8 for the Windows fix."""
+    procs = patched_stream(_OK_STREAM)
+
+    asyncio.run(server.run_workflow("wf.json", wait=True))
+
+    assert procs[0].env["PYTHONUTF8"] == "1"
+    assert procs[0].env["PYTHONIOENCODING"] == "utf-8"
+    # And the parent-side stream read is pinned to UTF-8 to match (readline()/
+    # stderr.read() would otherwise decode with the cp1252 parent locale).
+    assert procs[0].encoding == "utf-8"
 
 
 def test_run_workflow_stream_error_envelope_raises_with_code(patched_stream):
@@ -723,7 +779,7 @@ def test_watch_job_times_out_returns_payload(monkeypatch):
     )
     procs: list[_BlockingProc] = []
 
-    def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
+    def fake_popen(cmd, stdout, stderr, text, encoding, env):  # noqa: ARG001
         proc = _BlockingProc(cmd, [queued + "\n"])
         procs.append(proc)
         return proc
@@ -751,7 +807,7 @@ def test_watch_job_times_out_reports_progress_without_ctx(monkeypatch):
     executed = json.dumps({"type": "executed", "node": "1"})
     procs: list[_BlockingProc] = []
 
-    def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
+    def fake_popen(cmd, stdout, stderr, text, encoding, env):  # noqa: ARG001
         proc = _BlockingProc(cmd, [queued + "\n", executed + "\n"])
         procs.append(proc)
         return proc


### PR DESCRIPTION
## ELI-5

This MCP shells out to `comfy-cli` for every tool call. Two small fixes: (1) it now tells `comfy-cli` "don't start your background file watcher" (`COMFY_NO_WATCH=1`) because this server is an automated caller that doesn't need it, and (2) the live end-to-end smoke test was calling an `async` function without awaiting it — so it was asserting on a coroutine object instead of a real result. Now it runs the coroutine properly with `asyncio.run(...)`.

## Summary

Implements items 1–2 of BE-3074 (comfy-cli branch-pin follow-ups). Item 3 (README minimum-version note + moving the dev venv back to a PyPI release) is **blocked on the upstream `feat/agent-run-workflow-id` merge + release** and is intentionally left open — see Additional Notes.

## Changes

- **`COMFY_NO_WATCH=1` in the subprocess env** for both comfy-cli spawn sites — `_run_comfy` (`subprocess.run`) and `_run_comfy_streaming` (`subprocess.Popen`). This MCP is exactly the agentic caller the watcher-suppression flag targets. Harmless no-op on comfy-cli versions that don't recognize the variable.
- **Fix the e2e smoke test** (`tests/e2e/test_smoke.py`): `run_workflow` became a coroutine when MCP progress streaming landed (PR #11), but the smoke test still called it synchronously and asserted on an un-awaited coroutine. Wrapped in `asyncio.run(...)` (+ `import asyncio`). Broken since #11, masked because the e2e gate skips whenever `comfy` isn't on PATH, so CI never ran it.
- **Unit assertions** that `COMFY_NO_WATCH` is on the constructed env for both spawn paths (`test_run_comfy_sets_no_watch_env`, `test_run_workflow_stream_sets_no_watch_env`); the streaming fake `Popen` now captures `env`.

## Motivation

comfy-cli's `feat/agent-run-workflow-id` branch adds watcher suppression for agentic callers (commit `68de677`); this server is that caller. The e2e fix restores a smoke test that has silently been asserting on a coroutine since PR #11.

## Testing

- [x] Existing tests pass (`pytest`) — 97 passed, 1 skipped (the e2e test skips without a live ComfyUI + `comfy` on PATH).
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Mutation-checked the two new tests: they fail (`KeyError`) with `COMFY_NO_WATCH` removed from the env and pass with it, so they genuinely assert the behavior.

## Additional Notes

**Judgment calls / unmet criteria:**

- **Acceptance #1 (live e2e) — not executed in this environment.** No live ComfyUI and no `comfy` on PATH here, so the actual live round-trip could not be run. The fix is the one-line `asyncio.run(...)` wrapper the ticket prescribes, and its mechanism is already exercised by passing unit tests that call `asyncio.run(server.run_workflow(...))` (`test_run_workflow_streams_progress_and_returns_data`) — i.e. driving the `run_workflow` coroutine this way is verified correct at the unit level. The live round-trip itself should be confirmed via `scripts/smoke.sh` on a machine with a running ComfyUI before this is considered fully closed.
- **Item 3 left open (blocked).** Naming a minimum comfy-cli version in the README and moving the dev venv back to a PyPI release both depend on `feat/agent-run-workflow-id` merging upstream and shipping in a release. Per the ticket, items 1–2 satisfy the agent scope; item 3 stays open until the upstream merge/release. No README/venv changes are in this PR.

This is a capability-*adding* change (watcher suppression + a test fix), not a capability denial — no negative-claim/dead-end paths introduced.
