### PR TITLE
fix(search_templates): filter real rows payload, compact projection, pagination + gallery-filter passthrough (BE-3342)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ comfy-cli's `envelope/1`, and returns its `data`.
 | `stop_comfyui()` | `comfy stop` | Stop the ComfyUI that comfy-cli launched (only its own recorded pid). |
 | `discover()` | `comfy discover` | comfy-cli's self-describing surface (commands, arg schemas, error codes) — learn the CLI's own contract at runtime. |
 | `which()` | `comfy which` | Which ComfyUI install/workspace comfy-cli currently targets (a lighter answer than `server_info`). |
-| `search_templates(query="")` | `comfy templates ls` (filtered client-side) | Find a built-in workflow template by name/description; empty `query` lists all. |
+| `search_templates(query="", limit=25, offset=0, tag="", type="", model="", provider="", exclude_api=False)` | `comfy templates ls [--tag/--type/--model/--provider …]` | Find a built-in workflow template: free-text `query` (client-side over name/title/description/tags/models), paged via `limit`/`offset`, narrowed by the `tag`/`type`/`model`/`provider` gallery filters or `exclude_api=True`. Returns `{total, shown, offset, rows:[{name,title,description,output_type}]}`. |
 | `get_template(name)` | `comfy templates show <name>` | Show one template's details/schema before fetching it. |
 | `fetch_template(name, out_path)` | `comfy templates fetch <name> --out <path>` | Write a template's runnable workflow JSON to `out_path`; returns the absolute path for `run_workflow`. |
 | `search_nodes(query)` | `comfy nodes search <query>` | Find node classes in the **live local** `object_info` (includes installed custom nodes). |

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -715,6 +715,10 @@ def which() -> Any:
 # blowing the MCP client's tool-output cap.
 _TEMPLATE_LIST_FIELDS = ("name", "title", "description", "output_type")
 
+# Upper bound on a single page so an oversized `limit` can't build a response
+# that trips the MCP client's tool-output cap; callers page the rest via `offset`.
+_TEMPLATE_LIST_MAX_LIMIT = 200
+
 
 def _template_matches(row: dict, query_lower: str) -> bool:
     """True if ``query_lower`` (already lowercased) matches a template ``row``.
@@ -765,7 +769,7 @@ def search_templates(
     - ``exclude_api=True`` — drop rows carrying the ``API`` tag (templates that
       call a hosted API and need a key), approximating "runnable locally".
       comfy-cli's ``--tag`` only includes, so this negation is applied here.
-    - ``limit`` (default 25) / ``offset`` — page the filtered rows.
+    - ``limit`` (default 25, capped at 200) / ``offset`` — page the filtered rows.
 
     Returns ``{"total", "shown", "offset", "rows"}`` where ``total`` is the
     filtered match count, ``rows`` is the current page projected down to
@@ -777,6 +781,10 @@ def search_templates(
     a runnable workflow JSON and pass that path straight to ``run_workflow`` — a
     working generation without hand-authoring workflow JSON.
     """
+    if limit < 0:
+        raise ComfyCliError(f"invalid limit: {limit} (must be >= 0)")
+    limit = min(limit, _TEMPLATE_LIST_MAX_LIMIT)
+
     args = ["templates", "ls"]
     for flag, value in (
         ("--tag", tag),
@@ -785,6 +793,11 @@ def search_templates(
         ("--provider", provider),
     ):
         if value:
+            if value.startswith("-"):
+                # comfy-cli parses a leading-dash value as an option/flag; reject
+                # it rather than let `templates ls` misread the filter (argument
+                # injection).
+                raise ComfyCliError(f"invalid {flag} value: {value!r} (leading '-')")
             args += [flag, value]
     data = _run_comfy(*args, timeout=60.0)
 
@@ -799,7 +812,15 @@ def search_templates(
             f"`rows` list, got {shape}. comfy-cli's output shape may have drifted."
         )
 
-    rows = [r for r in data["rows"] if isinstance(r, dict)]
+    rows = data["rows"]
+    bad = sum(1 for r in rows if not isinstance(r, dict))
+    if bad:
+        # Fail loudly on shape drift rather than silently dropping rows (which
+        # would undercount `total`), matching the payload guard above.
+        raise ComfyCliError(
+            f"unexpected `comfy templates ls` payload: {bad} of {len(rows)} rows "
+            "are not objects. comfy-cli's output shape may have drifted."
+        )
     if exclude_api:
         rows = [
             r
@@ -814,7 +835,7 @@ def search_templates(
 
     total = len(rows)
     offset = max(0, offset)
-    page = rows[offset : offset + limit] if limit >= 0 else []
+    page = rows[offset : offset + limit]
     projected = [{k: r.get(k) for k in _TEMPLATE_LIST_FIELDS} for r in page]
     return {
         "total": total,

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -42,8 +42,11 @@ This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
   Prefer this over `run_workflow(wait=True)` for slow runs so nothing blocks.
   For LIVE progress on an already-submitted job, `watch_job(prompt_id)` tails
   its execution events (bounded, like `wait_for_job`).
-- Start from a template: `search_templates` to find one, `fetch_template` to save
-  its workflow JSON, then `run_workflow` on that file. To change the prompt / seed
+- Start from a template: `search_templates(query=...)` to find one (free-text
+  search, paged 25 at a time via `limit`/`offset`; narrow with `tag`/`type`/
+  `model`/`provider`, or `exclude_api=True` for templates that run without a
+  hosted-API key), `fetch_template` to save its workflow JSON, then `run_workflow`
+  on that file. To change the prompt / seed
   / steps / model of a fetched template before running, inspect its tweakable slots
   with `list_workflow_slots` and edit them with `set_workflow_slot` (non-destructive
   by default) — the loop is `fetch_template` -> `set_workflow_slot` -> `run_workflow`.
@@ -706,50 +709,119 @@ def which() -> Any:
     return _run_comfy("which", timeout=60.0)
 
 
-def _template_matches(item: Any, query_lower: str) -> bool:
-    """True if ``query_lower`` (already lowercased) is a substring of a template entry.
+# The compact per-row projection returned by the listing. The full detail
+# (tags / models / providers / category_title) is what ``get_template(name)``
+# returns — keeping the listing slim is what stops the full 558-row catalog from
+# blowing the MCP client's tool-output cap.
+_TEMPLATE_LIST_FIELDS = ("name", "title", "description", "output_type")
 
-    Handles both shapes comfy-cli might emit for a template: a bare name string,
-    or a dict of fields (name / title / description / …) — we match against every
-    string value so the query hits any of them.
+
+def _template_matches(row: dict, query_lower: str) -> bool:
+    """True if ``query_lower`` (already lowercased) matches a template ``row``.
+
+    Case-insensitive substring match over the free-text fields ``name`` /
+    ``title`` / ``description`` plus the string items inside the ``tags`` and
+    ``models`` list values — deliberately NOT every string value, so a query
+    like ``"image"`` does not hit ``output_type`` on hundreds of rows.
     """
-    if isinstance(item, str):
-        return query_lower in item.lower()
-    if isinstance(item, dict):
-        return any(
-            isinstance(v, str) and query_lower in v.lower() for v in item.values()
-        )
+    for key in ("name", "title", "description"):
+        value = row.get(key)
+        if isinstance(value, str) and query_lower in value.lower():
+            return True
+    for key in ("tags", "models"):
+        for item in row.get(key) or []:
+            if isinstance(item, str) and query_lower in item.lower():
+                return True
     return False
 
 
 @mcp.tool()
-def search_templates(query: str = "") -> Any:
-    """Search the built-in ComfyUI workflow templates by name/description.
+def search_templates(
+    query: str = "",
+    limit: int = 25,
+    offset: int = 0,
+    tag: str = "",
+    type: str = "",
+    model: str = "",
+    provider: str = "",
+    exclude_api: bool = False,
+) -> Any:
+    """Search the built-in ComfyUI workflow-template gallery.
 
-    Wraps ``comfy templates ls``. When ``query`` is non-empty the listing is
-    filtered client-side (case-insensitive substring match against each
-    template's name and any text fields) — comfy-cli's ``ls`` has no server-side
-    filter argument, so the narrowing happens here; an empty ``query`` returns
-    the full list.
+    Wraps ``comfy templates ls``, whose payload is
+    ``{total_in_gallery, matched, shown, filters, rows: [...]}`` — one ``row``
+    per template with ``name / title / output_type / category_title / tags /
+    models / providers / description``. The full catalog is ~558 rows, far too
+    large to return whole, so this narrows and pages it:
+
+    - ``query`` — free-text, case-insensitive substring match applied
+      client-side over each row's ``name`` / ``title`` / ``description`` and the
+      items in its ``tags`` / ``models`` lists (comfy-cli's ``ls`` has no
+      free-text search flag, so this narrowing happens here).
+    - ``tag`` / ``type`` / ``model`` / ``provider`` — forwarded to comfy-cli as
+      ``--tag`` / ``--type`` / ``--model`` / ``--provider`` gallery filters
+      (``--tag`` and ``--type`` are exact-match, ``--model`` / ``--provider``
+      substring). Combine with ``query`` for free text on top.
+    - ``exclude_api=True`` — drop rows carrying the ``API`` tag (templates that
+      call a hosted API and need a key), approximating "runnable locally".
+      comfy-cli's ``--tag`` only includes, so this negation is applied here.
+    - ``limit`` (default 25) / ``offset`` — page the filtered rows.
+
+    Returns ``{"total", "shown", "offset", "rows"}`` where ``total`` is the
+    filtered match count, ``rows`` is the current page projected down to
+    ``name / title / description / output_type`` (page again with ``offset`` to
+    see more), and ``get_template(name)`` is the full-detail path.
 
     Step 1 of the template on-ramp: pick a ``name`` from the results, inspect it
     with ``get_template(name)``, then ``fetch_template(name, out_path)`` to write
     a runnable workflow JSON and pass that path straight to ``run_workflow`` — a
     working generation without hand-authoring workflow JSON.
     """
-    data = _run_comfy("templates", "ls", timeout=60.0)
-    if not query:
-        return data
-    q = query.lower()
-    if isinstance(data, list):
-        return [item for item in data if _template_matches(item, q)]
-    if isinstance(data, dict) and isinstance(data.get("templates"), list):
-        return {
-            **data,
-            "templates": [t for t in data["templates"] if _template_matches(t, q)],
-        }
-    # Unknown shape — return it unfiltered rather than silently dropping data.
-    return data
+    args = ["templates", "ls"]
+    for flag, value in (
+        ("--tag", tag),
+        ("--type", type),
+        ("--model", model),
+        ("--provider", provider),
+    ):
+        if value:
+            args += [flag, value]
+    data = _run_comfy(*args, timeout=60.0)
+
+    if not isinstance(data, dict) or not isinstance(data.get("rows"), list):
+        shape = (
+            "keys {" + ", ".join(sorted(map(str, data))) + "}"
+            if isinstance(data, dict)
+            else data.__class__.__name__
+        )
+        raise ComfyCliError(
+            "unexpected `comfy templates ls` payload: expected a dict with a "
+            f"`rows` list, got {shape}. comfy-cli's output shape may have drifted."
+        )
+
+    rows = [r for r in data["rows"] if isinstance(r, dict)]
+    if exclude_api:
+        rows = [
+            r
+            for r in rows
+            if not any(
+                isinstance(t, str) and t.lower() == "api" for t in r.get("tags") or []
+            )
+        ]
+    if query:
+        q = query.lower()
+        rows = [r for r in rows if _template_matches(r, q)]
+
+    total = len(rows)
+    offset = max(0, offset)
+    page = rows[offset : offset + limit] if limit >= 0 else []
+    projected = [{k: r.get(k) for k in _TEMPLATE_LIST_FIELDS} for r in page]
+    return {
+        "total": total,
+        "shown": len(projected),
+        "offset": offset,
+        "rows": projected,
+    }
 
 
 @mcp.tool()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -246,6 +246,51 @@ def test_search_templates_bad_shape_raises(monkeypatch):
         server.search_templates()
 
 
+def test_search_templates_non_dict_rows_raise(monkeypatch):
+    """Non-dict rows are shape drift -> raise loudly, never silently dropped (BE-3342).
+
+    Silently filtering them would undercount `total` and vanish templates, which
+    contradicts the loud-fail guard the rest of the function is built around.
+    """
+    monkeypatch.setattr(
+        server, "_run_comfy", lambda *a, **k: _payload(rows=ROWS[:1] + ["bare-string"])
+    )
+    with pytest.raises(server.ComfyCliError, match="not objects"):
+        server.search_templates()
+
+
+def test_search_templates_rejects_leading_dash_filter_values(monkeypatch):
+    """A filter value starting with '-' is rejected before it reaches comfy-cli argv."""
+    _patch_ls(monkeypatch)
+    for kwargs in (
+        {"tag": "--foo"},
+        {"type": "-x"},
+        {"model": "--bar"},
+        {"provider": "-p"},
+    ):
+        with pytest.raises(server.ComfyCliError, match="leading '-'"):
+            server.search_templates(**kwargs)
+
+
+def test_search_templates_negative_limit_raises(monkeypatch):
+    """A negative limit is a caller typo -> raise, not a silently-empty page."""
+    _patch_ls(monkeypatch)
+    with pytest.raises(server.ComfyCliError, match="limit"):
+        server.search_templates(limit=-1)
+
+
+def test_search_templates_limit_capped(monkeypatch):
+    """An oversized limit is clamped so the response can't blow the tool-output cap."""
+    big = [
+        dict(ROWS[0], name=f"t{i}") for i in range(server._TEMPLATE_LIST_MAX_LIMIT + 50)
+    ]
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: _payload(rows=big))
+
+    result = server.search_templates(limit=10_000)
+    assert result["total"] == len(big)  # total still reports the full match count
+    assert result["shown"] == server._TEMPLATE_LIST_MAX_LIMIT  # page is capped
+
+
 def test_get_template_argv(monkeypatch):
     """Passthrough: `comfy --json --where local templates show <name>`."""
     fake, calls = _fake_run(

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,12 +1,17 @@
 """Tests for the template tools — the search -> fetch -> run_workflow on-ramp.
 
 These lock in the passthrough argv (global flags before the subcommand, same
-rule the wrapper enforces) and the two behaviors the tools own on top of the
-passthrough:
-1. ``search_templates`` filters ``comfy templates ls`` client-side, since the
-   CLI has no server-side filter arg.
-2. ``fetch_template`` returns the ABSOLUTE output path so it can be handed
-   straight to ``run_workflow``.
+rule the wrapper enforces) and the behaviors ``search_templates`` owns on top of
+comfy-cli's real ``templates ls`` payload:
+
+1. comfy-cli emits ``{total_in_gallery, matched, shown, filters, rows: [...]}`` —
+   the row list is keyed ``rows`` (verified against comfy-cli
+   ``comfy_cli/command/templates.py`` ``ls_cmd``). ``search_templates`` filters
+   ``rows`` client-side (free-text ``query`` the CLI has no flag for), forwards
+   the CLI's own ``--tag/--type/--model/--provider`` gallery filters, drops
+   API-tagged rows on ``exclude_api``, and pages via ``limit``/``offset``.
+2. A payload with no ``rows`` list is a shape drift -> raise, never a raw dump.
+3. ``fetch_template`` returns the ABSOLUTE output path for ``run_workflow``.
 """
 
 from __future__ import annotations
@@ -14,6 +19,8 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+
+import pytest
 
 from comfy_local_mcp import server
 
@@ -31,51 +38,212 @@ def _fake_run(envelope: dict):
     return fake, calls
 
 
-def test_search_templates_argv(monkeypatch):
-    """Passthrough: `comfy --json --where local templates ls`, empty query = full list."""
-    data = ["flux_dev", "sd15_basic"]
-    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": data})
+# A representative slice of the real comfy-cli `templates ls` payload shape.
+ROWS = [
+    {
+        "name": "image_to_image",
+        "title": "Image to Image",
+        "output_type": "image",
+        "category_title": "Image",
+        "tags": [],
+        "models": ["SD1.5"],
+        "providers": [],
+        "description": "Basic image to image starter.",
+    },
+    {
+        "name": "flux_i2i",
+        "title": "Flux I2I",
+        "output_type": "image",
+        "category_title": "Image",
+        "tags": ["API"],
+        "models": ["Flux"],
+        "providers": ["Black Forest Labs"],
+        "description": "image to image with the Flux API.",
+    },
+    {
+        "name": "seedream_5",
+        "title": "Seedream 5",
+        "output_type": "image",
+        "category_title": "Image",
+        "tags": ["API"],
+        "models": ["Seedream"],
+        "providers": ["ByteDance"],
+        "description": "Text to image via Seedream 5.",
+    },
+    {
+        "name": "basic_txt2img",
+        "title": "Basic Text to Image",
+        "output_type": "image",
+        "category_title": "Image",
+        "tags": [],
+        "models": ["SD1.5"],
+        "providers": [],
+        "description": "Simple prompt to picture.",
+    },
+    {
+        "name": "clip_maker",
+        "title": "Clip Maker",
+        "output_type": "video",
+        "category_title": "Video",
+        "tags": [],
+        "models": ["Wan"],
+        "providers": [],
+        "description": "Make short clips from a prompt.",
+    },
+]
+
+
+def _payload(rows=None) -> dict:
+    rows = ROWS if rows is None else rows
+    return {
+        "total_in_gallery": 558,
+        "matched": len(rows),
+        "shown": len(rows),
+        "filters": {
+            "type": None,
+            "category": None,
+            "tag": None,
+            "model": None,
+            "provider": None,
+            "name": None,
+        },
+        "rows": rows,
+    }
+
+
+def _patch_ls(monkeypatch, rows=None):
+    """Make `_run_comfy` return the real-shape payload directly (filter-logic tests)."""
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: _payload(rows))
+
+
+def _rows(result) -> list[dict]:
+    return result["rows"]
+
+
+def _names(result) -> list[str]:
+    return [r["name"] for r in _rows(result)]
+
+
+def test_search_templates_argv_and_empty_query_pages(monkeypatch):
+    """Passthrough `comfy --json --where local templates ls`; empty query = first page + total."""
+    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": _payload()})
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
     monkeypatch.setattr(server.subprocess, "run", fake)
 
-    assert server.search_templates() == data
+    result = server.search_templates()
 
     cmd = calls[0]["cmd"]
     assert cmd[1:4] == ["--json", "--where", "local"]  # global flags first
-    assert cmd[4:] == ["templates", "ls"]  # subcommand strictly after
+    assert cmd[4:] == ["templates", "ls"]  # no client-only flags forwarded
+    # Empty query never returns the whole catalog: paged + a total count.
+    assert result["total"] == len(ROWS)
+    assert result["offset"] == 0
+    assert result["shown"] == len(ROWS)  # fixture is smaller than the default limit
 
 
-def test_search_templates_filters_list_client_side(monkeypatch):
-    """Non-empty query narrows the `ls` output (CLI has no filter arg)."""
-    data = ["flux_dev", "flux_schnell", "sd15_basic"]
-    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: data)
-
-    assert server.search_templates("flux") == ["flux_dev", "flux_schnell"]
-    assert server.search_templates("FLUX") == [
-        "flux_dev",
-        "flux_schnell",
-    ]  # case-insensitive
-    assert server.search_templates("nope") == []
+def test_search_templates_compact_projection(monkeypatch):
+    """Listing rows carry only name/title/description/output_type — not the full detail."""
+    _patch_ls(monkeypatch)
+    row = _rows(server.search_templates())[0]
+    assert set(row) == {"name", "title", "description", "output_type"}
+    # The heavy fields live in get_template(name), not the listing.
+    assert "tags" not in row and "models" not in row and "category_title" not in row
 
 
-def test_search_templates_filters_dict_entries(monkeypatch):
-    """Matches across any text field of a dict-shaped template entry."""
-    data = [
-        {"name": "flux_dev", "description": "Flux dev text-to-image"},
-        {"name": "sd15_basic", "description": "Stable Diffusion 1.5"},
+def test_search_templates_query_narrows_reported_cases(monkeypatch):
+    """The two dogfooding queries return only their matches, not the whole catalog."""
+    _patch_ls(monkeypatch)
+
+    i2i = server.search_templates("image to image")
+    assert set(_names(i2i)) == {"image_to_image", "flux_i2i"}
+    assert i2i["total"] == 2
+
+    seedream = server.search_templates("seedream 5")
+    assert _names(seedream) == ["seedream_5"]
+
+    # Case-insensitive, and a miss returns an empty page (not the fallback dump).
+    assert _names(server.search_templates("IMAGE TO IMAGE")) == [
+        "image_to_image",
+        "flux_i2i",
     ]
-    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: data)
-
-    # Hit on description text, not just the name.
-    assert server.search_templates("stable diffusion") == [data[1]]
-    assert server.search_templates("text-to-image") == [data[0]]
+    assert server.search_templates("no-such-template")["total"] == 0
 
 
-def test_search_templates_unknown_shape_returned_unfiltered(monkeypatch):
-    """An unexpected data shape is returned as-is rather than silently dropped."""
-    data = {"count": 2}
-    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: data)
-    assert server.search_templates("flux") == data
+def test_search_templates_query_hits_tags_and_models_not_output_type(monkeypatch):
+    """Query matches tags/models list items, but never the output_type field."""
+    _patch_ls(monkeypatch)
+
+    # "wan" only appears in clip_maker's models list.
+    assert _names(server.search_templates("wan")) == ["clip_maker"]
+    # "seedream" appears in seedream_5's models (and name/title).
+    assert "seedream_5" in _names(server.search_templates("seedream"))
+    # "video" is ONLY clip_maker's output_type -> deliberately NOT matched,
+    # otherwise query="image" would hit output_type on hundreds of rows.
+    assert server.search_templates("video")["total"] == 0
+
+
+def test_search_templates_pagination(monkeypatch):
+    """limit/offset page the filtered rows deterministically; total is stable."""
+    _patch_ls(monkeypatch)
+
+    first = server.search_templates(limit=2, offset=0)
+    assert _names(first) == ["image_to_image", "flux_i2i"]
+    assert first["total"] == len(ROWS) and first["offset"] == 0 and first["shown"] == 2
+
+    second = server.search_templates(limit=2, offset=2)
+    assert _names(second) == ["seedream_5", "basic_txt2img"]
+    assert second["offset"] == 2
+
+    tail = server.search_templates(limit=2, offset=4)
+    assert _names(tail) == ["clip_maker"]  # last partial page
+    assert server.search_templates(limit=2, offset=100)["rows"] == []  # past the end
+
+
+def test_search_templates_forwards_gallery_filters(monkeypatch):
+    """tag/type/model/provider become the corresponding `templates ls` flags."""
+    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": _payload()})
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    server.search_templates(
+        tag="API", type="image", model="Flux", provider="Black Forest Labs"
+    )
+
+    assert calls[0]["cmd"][4:] == [
+        "templates",
+        "ls",
+        "--tag",
+        "API",
+        "--type",
+        "image",
+        "--model",
+        "Flux",
+        "--provider",
+        "Black Forest Labs",
+    ]
+
+
+def test_search_templates_exclude_api(monkeypatch):
+    """exclude_api drops every row whose tags include `API` (case-insensitive)."""
+    _patch_ls(monkeypatch)
+
+    kept = server.search_templates(exclude_api=True)
+    names = _names(kept)
+    assert "flux_i2i" not in names and "seedream_5" not in names
+    assert set(names) == {"image_to_image", "basic_txt2img", "clip_maker"}
+    assert kept["total"] == 3
+
+
+def test_search_templates_bad_shape_raises(monkeypatch):
+    """A payload with no `rows` list is a shape drift -> raise, never a raw dump."""
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: {"count": 2})
+    with pytest.raises(server.ComfyCliError, match="rows"):
+        server.search_templates("flux")
+
+    # A bare list (an older/other shape) is likewise rejected, not returned.
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: ["flux_dev"])
+    with pytest.raises(server.ComfyCliError, match="rows"):
+        server.search_templates()
 
 
 def test_get_template_argv(monkeypatch):


### PR DESCRIPTION
## ELI-5

`search_templates` was supposed to let an agent type "image to image" and get back a couple of matching templates. Instead it dumped the **entire** 558-template catalog (~252k characters) every single time — blowing the tool-output limit and forcing agents to grep a file. The reason: the code filtered a list it thought was keyed `templates`, but real comfy-cli names it `rows`, so the filter never ran and everything fell through to a "return it all unfiltered" branch. This PR filters the real `rows` payload, returns a slim paged result (25 at a time), and forwards comfy-cli's own gallery filters.

## Summary

Fixes the three independent breakages in `search_templates` reported in the 2026-07-16 dogfooding session (BE-3342): the `query` filter was dead code against real comfy-cli output, the unfiltered catalog blew the MCP tool-output cap, and comfy-cli's real gallery filters weren't exposed.

## Changes

- **Filter the real payload shape.** comfy-cli's `templates ls` emits `{total_in_gallery, matched, shown, filters, rows: [...]}` (verified against the comfy-cli checkout at `v1.11.0-8-ge05522e`, `comfy_cli/command/templates.py` `ls_cmd`). The old code only filtered a `templates`-keyed or bare-list shape — neither of which comfy-cli ever emits — so every real call hit the "return unfiltered" fallback. Now filters `data["rows"]`.
- **Explicit `_template_matches`.** Case-insensitive substring over `name`/`title`/`description` plus the string items in `tags`/`models` — deliberately **not** every string value, so `query="image"` doesn't hit `output_type` on hundreds of rows.
- **Compact projection.** Listing rows carry only `name`/`title`/`description`/`output_type`; `tags`/`models`/`providers`/`category_title` are dropped from the listing (`get_template(name)` is the full-detail path).
- **Pagination.** New `limit: int = 25` / `offset: int = 0`, applied after filtering. Returns `{"total", "shown", "offset", "rows"}` so agents can page. Empty query now returns the first page + a total count, never the whole catalog.
- **Gallery-filter passthrough.** New optional `tag` / `type` / `model` / `provider` params forwarded as `templates ls` flags; `query` stays client-side free text on top.
- **`exclude_api: bool = False`.** Client-side drop of rows whose `tags` include `API` (comfy-cli's `--tag` only includes; no negation), approximating "runnable locally without a hosted-API key".
- **Fail loud on shape drift.** A payload with no `rows` list now raises a clear `ComfyCliError` naming the unexpected shape instead of silently dumping the raw catalog.
- **Tests** rewritten to the real `rows`-keyed payload shape; the old `test_search_templates_unknown_shape_returned_unfiltered` (which locked in the buggy fallback) is inverted to assert the raise. Covers both reported queries, compact projection, default limit, offset paging, tags/models-not-output_type matching, flag forwarding, and `exclude_api`.
- **Docs.** Fixed the docstring's false "no server-side filter" claim, documented the new return shape and params, and updated the INSTRUCTIONS on-ramp blurb + README tool table.

## Motivation

Reported by two independent field tests (Solomon: `query="image to image"` → 252,271 chars / 9,114 lines, called the single biggest friction of the session; Tiger: `query="seedream 5"` → same full-catalog dump). Closes BE-3342.

## Testing

- [x] Existing tests pass (`pytest`) — 99 passed, 1 skipped (pre-existing skip)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] New tests exercise the real `rows`-keyed payload shape

## Additional Notes

- **Negative-claim falsification (per the self-review discipline):** the added shape-drift `raise` is *fail-loud on malformed CLI output*, not a capability denial — `search_templates` itself works and is improved, and I grounded the `rows`-keyed payload shape empirically against the real comfy-cli source before adding the guard. `_run_comfy` already raises on error envelopes before this check, so the guard only fires on a genuinely unrecognized success payload.
- The "2 and 4 against the current index" acceptance figures are integration-level (they depend on the live gallery); the unit tests assert the filter logic deterministically on a representative fixture. Adding `tags`/`models` to the match set cannot inflate those two multi-word queries — the short token fields (`API`, `Flux`, `Seedream`) can't contain the phrases "image to image" / "seedream 5".
- Companion to PR #37's envelope/version-compat check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
