### PR TITLE
feat(partner-auth): document COMFY_API_KEY, pass CLI hint/details verbatim, bounded credential retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,30 @@ client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engi
   shell's `PATH` — so if `comfy` lives in a virtualenv or a non-standard location, set
   `COMFY_BIN` to its absolute path (e.g. `/path/to/venv/bin/comfy`). Every client example below
   shows where it goes.
+- **`COMFY_API_KEY` (optional — needed only for partner-API nodes).** Workflows that use
+  partner-API nodes (Seedream / Seedance / Nano Banana / Gemini / Veo / Kling / …) need a Comfy
+  credential, and — exactly like `COMFY_BIN` — an MCP client launches the server with its own
+  minimal environment, so a key from your shell won't reach it. Set `COMFY_API_KEY` in the
+  client registration `env` block. See **[Partner-API nodes](#partner-api-nodes)** below for the
+  full precedence chain; every client example shows where it goes.
+
+## Partner-API nodes
+
+Some ComfyUI nodes call out to Comfy's partner APIs (Seedream / Seedance / Nano Banana / Gemini /
+Veo / Kling / …). Running one **locally** still needs a Comfy credential, and comfy-cli resolves
+it in this order (first match wins):
+
+1. a per-call flag (not exposed by this server);
+2. a live Comfy Cloud OAuth session (`comfy cloud login`);
+3. the **`COMFY_API_KEY`** environment variable;
+4. a stored key set with `comfy auth set comfy-cloud-api-key --key <KEY>`.
+
+Because an MCP client spawns the server with its own minimal environment (the same reason
+`COMFY_BIN` exists), a `COMFY_API_KEY` from your interactive shell is **not** inherited — put it
+in the client registration `env` block (shown in every example below). If a run fails with
+`partner_node_requires_credential`, the error now carries comfy-cli's hint verbatim, including
+the `comfy auth set comfy-cloud-api-key --key …` fallback and the list of offending nodes; the
+server also retries a transient credential failure briefly before surfacing it.
 
 ## Install
 
@@ -49,14 +73,20 @@ server. Pick your client.
 
 > The `COMFY_BIN` env entry is shown in every example. Drop it if `comfy` is already on the
 > environment your client launches the server with; keep it (pointing at the absolute path) if
-> it isn't.
+> it isn't. `COMFY_API_KEY` is also shown, commented as optional — keep it only if you use
+> [partner-API nodes](#partner-api-nodes) (Seedream / Veo / Kling / Gemini / …); drop it
+> otherwise.
 
 ### Claude Code
 
 One command registers the server:
 
 ```bash
-claude mcp add comfy-local -e COMFY_BIN=/path/to/venv/bin/comfy -- comfy-local-mcp
+# COMFY_API_KEY is optional — add it only if you use partner-API nodes (see above).
+claude mcp add comfy-local \
+  -e COMFY_BIN=/path/to/venv/bin/comfy \
+  -e COMFY_API_KEY=<your-comfy-api-key> \
+  -- comfy-local-mcp
 ```
 
 Or, to check it into a project, add a `.mcp.json` at the repo root:
@@ -66,7 +96,10 @@ Or, to check it into a project, add a `.mcp.json` at the repo root:
   "mcpServers": {
     "comfy-local": {
       "command": "comfy-local-mcp",
-      "env": { "COMFY_BIN": "/path/to/venv/bin/comfy" }
+      "env": {
+        "COMFY_BIN": "/path/to/venv/bin/comfy",
+        "COMFY_API_KEY": "<your-comfy-api-key>"
+      }
     }
   }
 }
@@ -83,7 +116,10 @@ restart Claude Desktop:
   "mcpServers": {
     "comfy-local": {
       "command": "comfy-local-mcp",
-      "env": { "COMFY_BIN": "/path/to/venv/bin/comfy" }
+      "env": {
+        "COMFY_BIN": "/path/to/venv/bin/comfy",
+        "COMFY_API_KEY": "<your-comfy-api-key>"
+      }
     }
   }
 }
@@ -98,7 +134,10 @@ Add the server to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` in a proje
   "mcpServers": {
     "comfy-local": {
       "command": "comfy-local-mcp",
-      "env": { "COMFY_BIN": "/path/to/venv/bin/comfy" }
+      "env": {
+        "COMFY_BIN": "/path/to/venv/bin/comfy",
+        "COMFY_API_KEY": "<your-comfy-api-key>"
+      }
     }
   }
 }

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -54,6 +54,9 @@ This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
 - When custom nodes or models may be missing, pre-flight with `validate_workflow`
   before running.
 - Manage in-flight work with `get_queue` (list jobs) and `cancel_job`.
+- Partner-API nodes (Seedream/Veo/Kling/Gemini/…) require a Comfy credential in
+  the server's environment (`COMFY_API_KEY` in the client registration). A
+  credential error is retried briefly and surfaces a hint with alternatives.
 
 Everything targets the LOCAL server only — there is no cloud access here.
 """
@@ -72,9 +75,10 @@ class ComfyCliError(RuntimeError):
     """comfy-cli was missing, timed out, or returned an error envelope.
 
     ``code`` carries the envelope's structured ``error.code`` when the failure
-    came from an error envelope (else ``None`` for missing-binary/timeout/no-JSON
-    cases), so callers can branch on a specific outcome instead of scraping the
-    message string.
+    came from an error envelope (used to drive the bounded credential retry in
+    ``run_workflow``); it is ``None`` for local failures the wrapper raises
+    itself (missing binary, timeout, no-JSON output), so callers can branch on a
+    specific outcome instead of scraping the message string.
     """
 
     def __init__(self, *args: object, code: str | None = None) -> None:
@@ -166,12 +170,23 @@ def _unwrap_envelope(
         )
     if not envelope.get("ok", False):
         err = envelope.get("error") or {}
-        raise ComfyCliError(
+        code = err.get("code")
+        # Keep comfy-cli's actionable extras: `error.hint` (e.g. the working
+        # `comfy auth set comfy-cloud-api-key --key …` credential fallback) and
+        # useful `error.details` (e.g. the `partner_nodes` that lack a
+        # credential) — dropping them was the exact workaround testers needed.
+        parts = [
             f"comfy {' '.join(args)} failed "
-            f"[{err.get('code', 'unknown')}]: "
-            f"{err.get('message') or stderr.strip()[:500]}",
-            code=err.get("code"),
-        )
+            f"[{code or 'unknown'}]: "
+            f"{err.get('message') or stderr.strip()[:500]}"
+        ]
+        hint = err.get("hint")
+        if hint:
+            parts.append(f"hint: {hint}")
+        detail_str = _render_error_details(err.get("details"))
+        if detail_str:
+            parts.append(detail_str)
+        raise ComfyCliError("\n".join(parts), code=code)
     return envelope.get("data")
 
 
@@ -198,6 +213,27 @@ def _synthesize_lifecycle_result(
             "a clean exit is treated as success."
         ),
     }
+
+
+# Error-envelope ``error.details`` keys worth surfacing verbatim in the raised
+# message. ``partner_nodes`` names the offending nodes on a partner-credential
+# failure; keep the set small so a large envelope can't bloat the message.
+_SURFACED_DETAIL_KEYS = ("partner_nodes",)
+
+
+def _render_error_details(details: Any) -> str | None:
+    """Render the useful keys of an envelope's ``error.details`` for the message."""
+    if not isinstance(details, dict):
+        return None
+    parts: list[str] = []
+    for key in _SURFACED_DETAIL_KEYS:
+        value = details.get(key)
+        if not value:
+            continue
+        if isinstance(value, (list, tuple)):
+            value = ", ".join(str(v) for v in value)
+        parts.append(f"{key}: {value}")
+    return "; ".join(parts) if parts else None
 
 
 def _last_json_object(stdout: str) -> dict | None:
@@ -403,6 +439,27 @@ def server_info() -> Any:
     return _run_comfy("env", timeout=60.0)
 
 
+# comfy-cli error codes worth a short bounded retry from ``run_workflow`` —
+# transient credential failures the run's PREFLIGHT raises BEFORE the job is
+# submitted, so re-invoking `comfy run` cannot double-submit. Verified against
+# comfy-cli source (BE-3344):
+#   * `partner_node_requires_credential` — raised in run preflight
+#     (`command/run/__init__.py`) BEFORE `execution.queue()`; safe to retry.
+#   * `cloud_unauthorized` — only raised on the CLOUD execute path; it never
+#     fires on `--where local` (all this server ever runs), so it is dormant
+#     here. Included defensively per the field request; it can't double-submit.
+# `transient_auth` is deliberately EXCLUDED: on the local path it is raised
+# from the execution watcher (`command/run/execution.py` `on_error`) AFTER
+# submission, so retrying it would re-run a job that already executed.
+_RETRYABLE_CREDENTIAL_CODES = frozenset(
+    {"partner_node_requires_credential", "cloud_unauthorized"}
+)
+
+# Backoff (seconds) before each RETRY attempt — so up to 2 extra attempts after
+# the initial one, at 1s then 2s.
+_CREDENTIAL_RETRY_BACKOFFS = (1.0, 2.0)
+
+
 @mcp.tool()
 async def run_workflow(
     workflow_path: str,
@@ -418,18 +475,46 @@ async def run_workflow(
     as MCP progress notifications (per-node execution + sampler step counts) so
     a long generation is not a silent block; with ``wait=False`` it submits and
     returns immediately with a ``prompt_id`` to poll via ``job_status``.
+
+    Partner-API nodes (Seedream/Veo/Kling/Gemini/…) need a Comfy credential in
+    the server's environment (``COMFY_API_KEY`` in the client registration). A
+    transient credential failure is retried up to twice with a short backoff;
+    the surfaced error carries comfy-cli's hint (including the working
+    ``comfy auth set comfy-cloud-api-key`` fallback).
     """
-    if not wait:
-        # Fire-and-return: no stream to follow, so keep the plain --json path.
-        return _run_comfy("run", "--workflow", workflow_path, timeout=60.0)
-    return await _run_comfy_streaming(
-        "run",
-        "--workflow",
-        workflow_path,
-        "--wait",
-        ctx=ctx,
-        timeout=timeout_seconds,
-    )
+
+    async def _attempt() -> Any:
+        if not wait:
+            # Fire-and-return: no stream to follow, so keep the plain --json path.
+            return _run_comfy("run", "--workflow", workflow_path, timeout=60.0)
+        return await _run_comfy_streaming(
+            "run",
+            "--workflow",
+            workflow_path,
+            "--wait",
+            ctx=ctx,
+            timeout=timeout_seconds,
+        )
+
+    # Try once, then up to len(_CREDENTIAL_RETRY_BACKOFFS) more times on a
+    # transient credential code. ``backoff is None`` marks the final attempt.
+    for attempt, backoff in enumerate((*_CREDENTIAL_RETRY_BACKOFFS, None)):
+        try:
+            return await _attempt()
+        except ComfyCliError as exc:
+            retryable = exc.code in _RETRYABLE_CREDENTIAL_CODES
+            if backoff is None or not retryable:
+                if attempt and retryable:
+                    # Retries exhausted on a credential error: surface the
+                    # hint-bearing error, noting the retries already made.
+                    plural = "y" if attempt == 1 else "ies"
+                    raise ComfyCliError(
+                        f"{exc}\n(gave up after {attempt} retr{plural} on "
+                        f"transient `{exc.code}`)",
+                        code=exc.code,
+                    ) from exc
+                raise
+            await asyncio.sleep(backoff)
 
 
 @mcp.tool()

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -648,14 +648,6 @@ async def _run_comfy_streaming(
             stderr_future.cancel()
 
 
-def _parse_version(text: str) -> tuple[int, int, int] | None:
-    """Extract a ``(major, minor, patch)`` tuple from a version string, or None."""
-    match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", text)
-    if match is None:
-        return None
-    return tuple(int(part) if part else 0 for part in match.groups())  # type: ignore[return-value]
-
-
 def _detect_comfy_cli_version() -> str | None:
     """Best-effort comfy-cli version via ``comfy --version`` (None if undetermined).
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -169,20 +169,33 @@ def _unwrap_envelope(
             f"stderr: {stderr.strip()[:500]}"
         )
     if not envelope.get("ok", False):
-        err = envelope.get("error") or {}
+        # A malformed envelope may set `error` to a non-dict (e.g. a bare
+        # string); fall back to `{}` so `.get()` below can't raise AttributeError.
+        err = envelope.get("error")
+        if not isinstance(err, dict):
+            err = {}
         code = err.get("code")
+        # `error.code` can be any JSON type in a malformed envelope, including a
+        # non-hashable list/dict that would make the `in _RETRYABLE_...`
+        # membership test in run_workflow raise TypeError. Coerce to a string so
+        # the retry check and the rendered message both stay well-defined.
+        if code is not None and not isinstance(code, str):
+            code = str(code)
         # Keep comfy-cli's actionable extras: `error.hint` (e.g. the working
         # `comfy auth set comfy-cloud-api-key --key …` credential fallback) and
         # useful `error.details` (e.g. the `partner_nodes` that lack a
         # credential) — dropping them was the exact workaround testers needed.
+        # Each field is length-capped so a huge/malformed envelope can't bloat
+        # the message propagated to the MCP client.
+        message = err.get("message") or stderr.strip()[:_MAX_ERROR_FIELD_CHARS]
         parts = [
             f"comfy {' '.join(args)} failed "
             f"[{code or 'unknown'}]: "
-            f"{err.get('message') or stderr.strip()[:500]}"
+            f"{str(message)[:_MAX_ERROR_FIELD_CHARS]}"
         ]
         hint = err.get("hint")
         if hint:
-            parts.append(f"hint: {hint}")
+            parts.append(f"hint: {str(hint)[:_MAX_ERROR_FIELD_CHARS]}")
         detail_str = _render_error_details(err.get("details"))
         if detail_str:
             parts.append(detail_str)
@@ -220,6 +233,11 @@ def _synthesize_lifecycle_result(
 # failure; keep the set small so a large envelope can't bloat the message.
 _SURFACED_DETAIL_KEYS = ("partner_nodes",)
 
+# Per-field cap for the rendered error message (mirrors the stderr cap) so a
+# multi-KB `message`/`hint` or a huge `partner_nodes` array can't produce an
+# unbounded error string in the MCP client / logs.
+_MAX_ERROR_FIELD_CHARS = 500
+
 
 def _render_error_details(details: Any) -> str | None:
     """Render the useful keys of an envelope's ``error.details`` for the message."""
@@ -232,7 +250,7 @@ def _render_error_details(details: Any) -> str | None:
             continue
         if isinstance(value, (list, tuple)):
             value = ", ".join(str(v) for v in value)
-        parts.append(f"{key}: {value}")
+        parts.append(f"{key}: {str(value)[:_MAX_ERROR_FIELD_CHARS]}")
     return "; ".join(parts) if parts else None
 
 
@@ -485,8 +503,13 @@ async def run_workflow(
 
     async def _attempt() -> Any:
         if not wait:
-            # Fire-and-return: no stream to follow, so keep the plain --json path.
-            return _run_comfy("run", "--workflow", workflow_path, timeout=60.0)
+            # Fire-and-return: no stream to follow, so keep the plain --json
+            # path — but run the blocking subprocess in a worker thread so the
+            # submit doesn't stall the event loop (and other concurrent MCP
+            # requests) for up to the 60s timeout.
+            return await asyncio.to_thread(
+                _run_comfy, "run", "--workflow", workflow_path, timeout=60.0
+            )
         return await _run_comfy_streaming(
             "run",
             "--workflow",

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -70,7 +70,7 @@ def test_unwrap_rejects_incompatible_major_even_on_error_envelope():
 def test_incompatible_envelope_propagates_through_run_comfy(monkeypatch):
     """The assertion guards every tool: a bad-schema envelope raises via _run_comfy."""
 
-    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+    def fake(cmd, capture_output, text, timeout, env, check, encoding=None):  # noqa: ARG001
         import json
 
         out = json.dumps({"schema": "envelope/99", "type": "envelope", "ok": True})
@@ -220,7 +220,7 @@ def patched_env(monkeypatch):
 
         calls: list[dict] = []
 
-        def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+        def fake(cmd, capture_output, text, timeout, env, check, encoding=None):  # noqa: ARG001
             calls.append({"cmd": cmd})
             return subprocess.CompletedProcess(
                 cmd, 0, stdout=json.dumps(envelope), stderr=""

--- a/tests/test_partner_auth.py
+++ b/tests/test_partner_auth.py
@@ -85,6 +85,56 @@ def test_error_without_hint_or_details_still_raises_cleanly():
     assert excinfo.value.code == "server_not_running"
 
 
+# --- malformed-envelope hardening -------------------------------------------
+
+
+def test_non_dict_error_field_raises_cleanly():
+    """`error` as a bare string must not raise AttributeError (falls back to {})."""
+    envelope = {"type": "envelope", "ok": False, "error": "catastrophic failure"}
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(envelope, ("env",), 1, "boom")
+    # No code recoverable from a non-dict error; message still renders.
+    assert excinfo.value.code is None
+    assert "[unknown]" in str(excinfo.value)
+
+
+def test_non_string_error_code_is_coerced_not_crashing():
+    """A non-hashable `error.code` is coerced to str so the retry check is safe."""
+    envelope = {
+        "type": "envelope",
+        "ok": False,
+        "error": {"code": ["weird", "list"], "message": "nope"},
+    }
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(envelope, ("env",), 1, "")
+    err = excinfo.value
+    assert isinstance(err.code, str)
+    # The coerced code is a plain string, so the membership test can't raise.
+    assert err.code not in server._RETRYABLE_CREDENTIAL_CODES
+
+
+def test_oversized_error_fields_are_length_capped():
+    """A huge message/hint/partner_nodes list can't produce an unbounded string."""
+    envelope = {
+        "type": "envelope",
+        "ok": False,
+        "error": {
+            "code": "server_error",
+            "message": "x" * 10_000,
+            "hint": "y" * 10_000,
+            "details": {"partner_nodes": ["z" * 10_000]},
+        },
+    }
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(envelope, ("env",), 1, "")
+    msg = str(excinfo.value)
+    # Each rendered field is bounded; the whole message stays a small multiple
+    # of the per-field cap rather than tens of KB.
+    assert "x" * (server._MAX_ERROR_FIELD_CHARS + 1) not in msg
+    assert "y" * (server._MAX_ERROR_FIELD_CHARS + 1) not in msg
+    assert "z" * (server._MAX_ERROR_FIELD_CHARS + 1) not in msg
+
+
 # --- bounded retry ----------------------------------------------------------
 
 

--- a/tests/test_partner_auth.py
+++ b/tests/test_partner_auth.py
@@ -1,0 +1,209 @@
+"""Partner-API credential handling (BE-3344).
+
+Two behaviors:
+1. `_unwrap_envelope` must preserve `error.code` on `ComfyCliError.code` and
+   append `error.hint` verbatim + the useful `error.details` keys (at minimum
+   `partner_nodes`) to the raised message — the exact workaround testers needed
+   used to be silently dropped.
+2. `run_workflow` retries a bounded number of times on a *transient credential*
+   code, and ONLY on codes that comfy-cli raises pre-submission on the local
+   path (so a retry can't double-submit). `transient_auth` is deliberately not
+   retried: on the local path it is raised from the execution watcher AFTER
+   submission.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from comfy_local_mcp import server
+
+
+def _partner_error_envelope() -> dict:
+    """A fabricated `partner_node_requires_credential` error envelope."""
+    return {
+        "type": "envelope",
+        "ok": False,
+        "error": {
+            "code": "partner_node_requires_credential",
+            "message": "Workflow uses partner-API node(s) that need a credential.",
+            "hint": (
+                "re-submit with `--where cloud` (the CLI auto-injects the key "
+                "there), or store the key locally with "
+                "`comfy auth set comfy-cloud-api-key --key …`"
+            ),
+            "details": {
+                "partner_nodes": ["SeedreamNode", "KlingNode"],
+                "host": "127.0.0.1",
+                "port": 8188,
+            },
+        },
+    }
+
+
+# --- envelope fidelity ------------------------------------------------------
+
+
+def test_error_envelope_preserves_code_hint_and_partner_nodes():
+    """`.code` is set, and both the hint and `partner_nodes` survive to the message."""
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(
+            _partner_error_envelope(), ("run", "--workflow", "wf.json"), 1, ""
+        )
+
+    err = excinfo.value
+    assert err.code == "partner_node_requires_credential"  # structured attribute
+
+    msg = str(err)
+    assert "[partner_node_requires_credential]" in msg
+    assert "comfy auth set comfy-cloud-api-key" in msg  # hint verbatim
+    assert "partner_nodes: SeedreamNode, KlingNode" in msg  # details rendered
+    # Noisy detail keys are not surfaced (only the allow-listed ones).
+    assert "127.0.0.1" not in msg
+
+
+def test_local_wrapper_error_has_no_code():
+    """A failure the wrapper raises itself (no envelope) carries `code is None`."""
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(None, ("env",), 1, "boom")
+    assert excinfo.value.code is None
+
+
+def test_error_without_hint_or_details_still_raises_cleanly():
+    """A bare error envelope (no hint/details) formats without spurious blank lines."""
+    envelope = {
+        "type": "envelope",
+        "ok": False,
+        "error": {"code": "server_not_running", "message": "ComfyUI not running"},
+    }
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(envelope, ("env",), 1, "")
+    msg = str(excinfo.value)
+    assert msg == "comfy env failed [server_not_running]: ComfyUI not running"
+    assert excinfo.value.code == "server_not_running"
+
+
+# --- bounded retry ----------------------------------------------------------
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """Make the retry backoff instantaneous."""
+
+    async def _fast(_seconds):
+        return None
+
+    monkeypatch.setattr(server.asyncio, "sleep", _fast)
+
+
+def _cred_error(code: str = "partner_node_requires_credential") -> server.ComfyCliError:
+    return server.ComfyCliError(
+        f"comfy run --workflow wf.json failed [{code}]: needs a credential\n"
+        "hint: store the key locally with `comfy auth set comfy-cloud-api-key --key …`",
+        code=code,
+    )
+
+
+def test_retry_set_membership():
+    """The retry set is exactly the pre-submission-safe codes (regression guard)."""
+    assert "partner_node_requires_credential" in server._RETRYABLE_CREDENTIAL_CODES
+    assert "cloud_unauthorized" in server._RETRYABLE_CREDENTIAL_CODES
+    # transient_auth fires POST-submission on the local path -> never retried.
+    assert "transient_auth" not in server._RETRYABLE_CREDENTIAL_CODES
+
+
+def test_transient_then_success_succeeds_on_attempt_2(monkeypatch, no_sleep):
+    """A single transient credential failure is retried and the retry succeeds."""
+    calls = {"n": 0}
+
+    async def fake_stream(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _cred_error()
+        return {"outputs": ["/x.png"]}
+
+    monkeypatch.setattr(server, "_run_comfy_streaming", fake_stream)
+
+    result = asyncio.run(server.run_workflow("wf.json", wait=True))
+
+    assert result == {"outputs": ["/x.png"]}
+    assert calls["n"] == 2  # succeeded on the second attempt
+
+
+def test_persistent_failure_surfaces_final_hint_error(monkeypatch, no_sleep):
+    """Exhausted retries surface the hint-bearing error, noting the retries."""
+    calls = {"n": 0}
+
+    async def fake_stream(*args, **kwargs):
+        calls["n"] += 1
+        raise _cred_error()
+
+    monkeypatch.setattr(server, "_run_comfy_streaming", fake_stream)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        asyncio.run(server.run_workflow("wf.json", wait=True))
+
+    assert calls["n"] == 3  # 1 initial + 2 retries
+    msg = str(excinfo.value)
+    assert "comfy auth set comfy-cloud-api-key" in msg  # hint still present
+    assert "gave up after 2 retries" in msg  # retries were noted
+    assert excinfo.value.code == "partner_node_requires_credential"
+
+
+def test_non_retryable_code_fails_immediately(monkeypatch, no_sleep):
+    """A non-credential error is not retried."""
+    calls = {"n": 0}
+
+    async def fake_stream(*args, **kwargs):
+        calls["n"] += 1
+        raise server.ComfyCliError("boom", code="execution_error")
+
+    monkeypatch.setattr(server, "_run_comfy_streaming", fake_stream)
+
+    with pytest.raises(server.ComfyCliError, match="boom"):
+        asyncio.run(server.run_workflow("wf.json", wait=True))
+
+    assert calls["n"] == 1  # no retries
+
+
+def test_transient_auth_is_not_retried(monkeypatch, no_sleep):
+    """`transient_auth` fires post-submission on the local path -> retrying would double-submit."""
+    calls = {"n": 0}
+
+    async def fake_stream(*args, **kwargs):
+        calls["n"] += 1
+        raise server.ComfyCliError(
+            "Unauthorized: Please login first to use this node", code="transient_auth"
+        )
+
+    monkeypatch.setattr(server, "_run_comfy_streaming", fake_stream)
+
+    with pytest.raises(server.ComfyCliError, match="Unauthorized"):
+        asyncio.run(server.run_workflow("wf.json", wait=True))
+
+    assert calls["n"] == 1  # NOT retried
+
+
+def test_retry_applies_to_wait_false_path(monkeypatch, no_sleep):
+    """The bounded retry covers the async-submit (`wait=False`) path too."""
+    calls = {"n": 0}
+
+    def fake_run(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _cred_error()
+        return {"prompt_id": "p1"}
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run)
+
+    result = asyncio.run(server.run_workflow("wf.json", wait=False))
+
+    assert result == {"prompt_id": "p1"}
+    assert calls["n"] == 2  # retried on the plain --json path as well
+
+
+def test_instructions_mention_partner_credential():
+    """The handshake instructions name the partner-credential env var."""
+    assert "COMFY_API_KEY" in server.mcp.instructions


### PR DESCRIPTION
## ELI-5

Partner-API nodes (Seedream / Veo / Kling / Gemini / …) need a Comfy API key, but nobody was told to set one, and when a run failed the server threw away the exact "here's how to fix it" hint that comfy-cli produced. Three small fixes: **tell people how to set the key** (docs), **stop swallowing the hint** (so the fix instructions reach you), and **retry briefly** when the credential blip is transient.

## Summary

Makes partner-API nodes usable through comfy-local-mcp by closing three compounding gaps — all in this repo, no comfy-cli change, no HTTP client. The engine already honors `COMFY_API_KEY` and spreads `os.environ` into the child; the gaps were documentation, error fidelity, and the absence of any retry.

## Changes

- **Docs (`README.md`).** `COMFY_API_KEY` now appears in all four client registration examples (Claude Code CLI, `.mcp.json`, `claude_desktop_config.json`, `.cursor/mcp.json`), commented as optional-unless-you-use-partner-nodes. New **Partner-API nodes** subsection documents comfy-cli's credential precedence chain (per-call flag → live OAuth session → `COMFY_API_KEY` env → stored `comfy-cloud-api-key`) and names the `comfy auth set comfy-cloud-api-key --key …` fallback — same "clients launch the server with their own minimal env" story as the existing `COMFY_BIN` callout.
- **Error fidelity (`server.py`).** `ComfyCliError` now exposes `.code`. `_unwrap_envelope` (shared by the plain and streaming paths — one change site) appends the envelope's `error.hint` verbatim plus a compact render of useful `error.details` keys (at minimum `partner_nodes`) to the raised message. The workaround all three testers needed was in that hint and was being dropped.
- **Bounded retry (`run_workflow`, both wait paths).** On a `ComfyCliError` whose `.code` is a transient credential code, retries up to 2 extra attempts with 1s then 2s backoff. After exhaustion it surfaces the final hint-bearing error, noting the retries. Timeouts (code `None`) are not retried.
- **INSTRUCTIONS.** One factual line: partner-API nodes need a credential in the server's environment (`COMFY_API_KEY`), and credential errors carry a hint with alternatives.

## Motivation

Highest-signal cluster of the field-test session: partner nodes failed with `partner_node_requires_credential`, the only documented workaround was bypassing the MCP entirely, and the actionable hint never reached the user.

## Retry set — source verification (acceptance criterion: no retryable code can fire post-submission)

The proposed set was `{partner_node_requires_credential, transient_auth, cloud_unauthorized}`. Verified against comfy-cli source (local clone) and adjusted:

- **`partner_node_requires_credential`** — raised in the run **preflight** (`comfy_cli/command/run/__init__.py:234`) **before** `execution.queue()`. Pre-submission → safe to retry. **Kept.**
- **`cloud_unauthorized`** — every raise site (`run/__init__.py:588/610/718/720`) is on the **cloud** execute path; it never fires on `--where local`, which is all this server ever runs. Dormant here, cannot double-submit. **Kept** defensively (honors the field request) but effectively a no-op on the local path.
- **`transient_auth`** — on the local path it is produced by the execution watcher's `on_error` (`comfy_cli/command/run/execution.py:543`, via `execution_errors.classify`), which runs inside `watch_execution()` **after** `execution.queue()`. Retrying it would re-run a job that already executed. **Dropped** — exactly the "drop any code that can fire post-submission" check the ticket mandated.

So the final retry set is `{partner_node_requires_credential, cloud_unauthorized}`, and no member can fire after submission on the path `run_workflow` uses.

## Testing

- [x] Existing tests pass (`pytest`) — 105 passed, 1 skipped (e2e smoke, needs a live ComfyUI)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] New `tests/test_partner_auth.py`: fabricated `partner_node_requires_credential` envelope asserts `.code` + hint + `partner_nodes` all survive to the message; retry tests cover transient-then-success (attempt 2), persistent-failure-surfaces-hint, non-retryable-fails-immediately, `transient_auth`-not-retried, and the `wait=False` path.

## Additional Notes

- **Judgment call:** `cloud_unauthorized` is kept in the retry set even though it can't fire on the local path — it's provably safe (never post-submission here) and honors the explicit field request; flagged so a reviewer can drop it if preferred.
- No HTTP client and no cloud-MCP code introduced (AGENTS.md guardrail).
- Out of scope (v1), unchanged: OAuth login flow / `auth_status()` tool, any comfy-cli change, preflight credential checks before submission.
