### PR TITLE
fix: force UTF-8 in comfy-cli child env to unbrick Windows discovery tools (BE-3328)

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -114,6 +114,13 @@ def _run_comfy(*args: str, timeout: float | None = None) -> Any:
             cmd,
             capture_output=True,
             text=True,
+            # Pin the parent-side decode to UTF-8 so it matches what the child
+            # is forced to emit (_comfy_env). Without this, text=True decodes
+            # the pipe with the system locale (cp1252 on a default Windows
+            # console) and the non-ASCII catalog output raises UnicodeDecodeError
+            # or yields mojibake before _unwrap_envelope — the exact crash this
+            # fix targets, just moved to the reader.
+            encoding="utf-8",
             timeout=timeout,
             env=env,
             check=False,
@@ -285,6 +292,11 @@ async def _run_comfy_streaming(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        # Match the child's forced UTF-8 output (see _comfy_env); otherwise
+        # readline()/stderr.read() decode with the parent locale (cp1252 on
+        # Windows) and non-ASCII stream lines raise UnicodeDecodeError or
+        # corrupt to mojibake before _parse_event/_last_json_object.
+        encoding="utf-8",
         env=env,
     )
     lines: list[str] = []

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -64,6 +64,31 @@ COMFY_BIN = os.environ.get("COMFY_BIN", "comfy")
 _MAX_WATCH_TIMEOUT = 3600.0
 
 
+def _comfy_env() -> dict[str, str]:
+    """Child-process environment for every comfy-cli spawn.
+
+    Single source of truth so the two spawn sites (``_run_comfy`` /
+    ``_run_comfy_streaming``) cannot drift. Injected keys are placed AFTER
+    ``os.environ`` so they win over any inherited values:
+
+    - ``COMFY_WHERE=local`` — belt-and-suspenders pin so we never touch cloud.
+    - ``COMFY_NO_WATCH=1`` — suppress comfy-cli's file watcher for agentic
+      callers like this MCP; a harmless no-op on versions that lack the flag.
+    - ``PYTHONUTF8=1`` / ``PYTHONIOENCODING=utf-8`` — force UTF-8 on the child's
+      console. Without them a default Windows (cp1252) console raises
+      ``UnicodeEncodeError`` printing the UTF-8 catalog output and wedges, so the
+      discovery tools present as a 60s timeout. UTF-8 is already the practical
+      default on macOS/Linux, so this is a no-op there.
+    """
+    return {
+        **os.environ,
+        "COMFY_WHERE": "local",
+        "COMFY_NO_WATCH": "1",
+        "PYTHONUTF8": "1",
+        "PYTHONIOENCODING": "utf-8",
+    }
+
+
 class ComfyCliError(RuntimeError):
     """comfy-cli was missing, timed out, or returned an error envelope."""
 
@@ -83,10 +108,7 @@ def _run_comfy(*args: str, timeout: float | None = None) -> Any:
     # Global flags (--json, --where) MUST precede the subcommand in comfy-cli;
     # a trailing --json errors with "No such option". (Verified against comfy-cli.)
     cmd = [COMFY_BIN, "--json", "--where", "local", *args]
-    # Belt-and-suspenders: pin the target via env too, so we never touch cloud.
-    # COMFY_NO_WATCH suppresses comfy-cli's file watcher for agentic callers like
-    # this MCP; a harmless no-op on comfy-cli versions that don't know the flag.
-    env = {**os.environ, "COMFY_WHERE": "local", "COMFY_NO_WATCH": "1"}
+    env = _comfy_env()
     try:
         proc = subprocess.run(
             cmd,
@@ -257,9 +279,7 @@ async def _run_comfy_streaming(
     # --json-stream is a global flag and, like --json/--where, MUST precede the
     # subcommand; a trailing form errors with "No such option".
     cmd = [COMFY_BIN, "--json-stream", "--where", "local", *args]
-    # COMFY_NO_WATCH suppresses comfy-cli's file watcher for agentic callers (see
-    # _run_comfy); harmless on comfy-cli versions that don't know the flag.
-    env = {**os.environ, "COMFY_WHERE": "local", "COMFY_NO_WATCH": "1"}
+    env = _comfy_env()
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -19,7 +19,7 @@ def _stub_comfy(monkeypatch, envelope: dict):
     """Stub shutil.which + subprocess.run; return the list that records each argv."""
     calls: list[list[str]] = []
 
-    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
         calls.append(cmd)
         return subprocess.CompletedProcess(
             cmd, 0, stdout=json.dumps(envelope), stderr=""

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -22,7 +22,7 @@ def _fake_run(envelope: dict):
     """Return a subprocess.run stand-in that captures the call and emits an envelope."""
     calls: list[dict] = []
 
-    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
         calls.append({"cmd": cmd, "env": env})
         return subprocess.CompletedProcess(
             cmd, 0, stdout=json.dumps(envelope), stderr=""

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -23,7 +23,7 @@ def _fake_run(envelope: dict):
     """Return a subprocess.run stand-in that captures the call and emits an envelope."""
     calls: list[dict] = []
 
-    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
         calls.append({"cmd": cmd, "env": env})
         return subprocess.CompletedProcess(
             cmd, 0, stdout=json.dumps(envelope), stderr=""

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -82,6 +82,33 @@ def test_run_comfy_sets_no_watch_env(patched_run):
     assert calls[0]["env"]["COMFY_NO_WATCH"] == "1"
 
 
+def test_run_comfy_forces_utf8_env(patched_run):
+    """Windows cp1252 fix: the child env forces UTF-8 so catalog output can't crash.
+
+    On a default Windows console (cp1252) comfy-cli raises UnicodeEncodeError
+    printing the UTF-8 catalog and wedges, so discovery tools present as a 60s
+    timeout. Forcing UTF-8 on the child prevents the crash (no-op on POSIX).
+    """
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"x": 1}})
+
+    server._run_comfy("jobs", "status", "abc")
+
+    assert calls[0]["env"]["PYTHONUTF8"] == "1"
+    assert calls[0]["env"]["PYTHONIOENCODING"] == "utf-8"
+
+
+def test_run_comfy_utf8_env_overrides_inherited(patched_run, monkeypatch):
+    """The injected UTF-8 vars win over any conflicting value in the parent env."""
+    monkeypatch.setenv("PYTHONUTF8", "0")
+    monkeypatch.setenv("PYTHONIOENCODING", "cp1252")
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"x": 1}})
+
+    server._run_comfy("jobs", "status", "abc")
+
+    assert calls[0]["env"]["PYTHONUTF8"] == "1"
+    assert calls[0]["env"]["PYTHONIOENCODING"] == "utf-8"
+
+
 def test_error_envelope_raises_with_code(patched_run):
     patched_run(
         {
@@ -605,6 +632,16 @@ def test_run_workflow_stream_sets_no_watch_env(patched_stream):
 
     assert procs[0].env["COMFY_WHERE"] == "local"
     assert procs[0].env["COMFY_NO_WATCH"] == "1"
+
+
+def test_run_workflow_stream_forces_utf8_env(patched_stream):
+    """The streaming (Popen) spawn path also forces UTF-8 for the Windows fix."""
+    procs = patched_stream(_OK_STREAM)
+
+    asyncio.run(server.run_workflow("wf.json", wait=True))
+
+    assert procs[0].env["PYTHONUTF8"] == "1"
+    assert procs[0].env["PYTHONIOENCODING"] == "utf-8"
 
 
 def test_run_workflow_stream_error_envelope_raises_with_code(patched_stream):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -33,8 +33,8 @@ def _fake_run(envelope: dict):
     """
     calls: list[dict] = []
 
-    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
-        calls.append({"cmd": cmd, "env": env})
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
+        calls.append({"cmd": cmd, "env": env, "encoding": encoding})
         return subprocess.CompletedProcess(
             cmd, 0, stdout=json.dumps(envelope), stderr=""
         )
@@ -95,6 +95,21 @@ def test_run_comfy_forces_utf8_env(patched_run):
 
     assert calls[0]["env"]["PYTHONUTF8"] == "1"
     assert calls[0]["env"]["PYTHONIOENCODING"] == "utf-8"
+
+
+def test_run_comfy_pins_parent_decode_to_utf8(patched_run):
+    """The parent-side read is pinned to UTF-8 to match the child's forced output.
+
+    Without an explicit ``encoding``, ``text=True`` decodes the pipe with the
+    system locale (cp1252 on a default Windows console), so the non-ASCII catalog
+    output raises UnicodeDecodeError/mojibake before ``_unwrap_envelope`` — the
+    same crash, just moved from the child's write to the parent's read.
+    """
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"x": 1}})
+
+    server._run_comfy("jobs", "status", "abc")
+
+    assert calls[0]["encoding"] == "utf-8"
 
 
 def test_run_comfy_utf8_env_overrides_inherited(patched_run, monkeypatch):
@@ -518,9 +533,10 @@ def test_which_maps_command_and_returns_data(patched_run):
 class _FakeProc:
     """A minimal stand-in for ``subprocess.Popen`` over a canned NDJSON stream."""
 
-    def __init__(self, cmd, stdout_text, stderr_text="", env=None):
+    def __init__(self, cmd, stdout_text, stderr_text="", env=None, encoding=None):
         self.cmd = cmd
         self.env = env
+        self.encoding = encoding
         self.stdout = io.StringIO(stdout_text)
         self.stderr = io.StringIO(stderr_text)
         self.returncode = 0
@@ -557,8 +573,8 @@ def patched_stream(monkeypatch):
     def setup(stdout_text: str) -> list[_FakeProc]:
         procs: list[_FakeProc] = []
 
-        def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
-            proc = _FakeProc(cmd, stdout_text, env=env)
+        def fake_popen(cmd, stdout, stderr, text, encoding, env):  # noqa: ARG001
+            proc = _FakeProc(cmd, stdout_text, env=env, encoding=encoding)
             procs.append(proc)
             return proc
 
@@ -642,6 +658,9 @@ def test_run_workflow_stream_forces_utf8_env(patched_stream):
 
     assert procs[0].env["PYTHONUTF8"] == "1"
     assert procs[0].env["PYTHONIOENCODING"] == "utf-8"
+    # And the parent-side stream read is pinned to UTF-8 to match (readline()/
+    # stderr.read() would otherwise decode with the cp1252 parent locale).
+    assert procs[0].encoding == "utf-8"
 
 
 def test_run_workflow_stream_error_envelope_raises_with_code(patched_stream):
@@ -760,7 +779,7 @@ def test_watch_job_times_out_returns_payload(monkeypatch):
     )
     procs: list[_BlockingProc] = []
 
-    def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
+    def fake_popen(cmd, stdout, stderr, text, encoding, env):  # noqa: ARG001
         proc = _BlockingProc(cmd, [queued + "\n"])
         procs.append(proc)
         return proc
@@ -788,7 +807,7 @@ def test_watch_job_times_out_reports_progress_without_ctx(monkeypatch):
     executed = json.dumps({"type": "executed", "node": "1"})
     procs: list[_BlockingProc] = []
 
-    def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
+    def fake_popen(cmd, stdout, stderr, text, encoding, env):  # noqa: ARG001
         proc = _BlockingProc(cmd, [queued + "\n", executed + "\n"])
         procs.append(proc)
         return proc


### PR DESCRIPTION
## ELI-5

On a stock Windows 11 machine the terminal speaks an old character set (cp1252), not UTF-8. When comfy-cli tried to print the templates/nodes/models catalog (which contains characters like `→`), it crashed with `UnicodeEncodeError` and then hung instead of exiting — so the local MCP's discovery tools (`search_templates` / `search_nodes` / `search_models` / `server_info`) all looked like a 60-second timeout. This PR tells the comfy-cli child process to always use UTF-8, which is exactly the fix a dogfooding user (Purz) verified works 100% of the time. No effect on macOS/Linux, where UTF-8 is already the default.

## Summary

Inject `PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8` into the environment of every comfy-cli child process the server spawns, so a default Windows (cp1252) console can't crash mid-print on the UTF-8 catalog output and wedge the discovery tools.

## Changes

- Add a `_comfy_env()` helper that is the single source of truth for the child-process environment, so the two spawn sites (`_run_comfy` via `subprocess.run`, `_run_comfy_streaming` via `subprocess.Popen`) cannot drift. It carries `COMFY_WHERE=local`, `COMFY_NO_WATCH=1`, and the two new UTF-8 keys.
- Injected keys are placed **after** `**os.environ`, so they override any conflicting value inherited from the parent environment.
- Replace the two inline `env = {**os.environ, ...}` dicts with `env = _comfy_env()`.
- Tests: assert both spawn paths pass `PYTHONUTF8=1` + `PYTHONIOENCODING=utf-8`, plus an override test proving the injected values win over a conflicting parent env.

## Motivation

Windows dogfooding (Purz, RTX 5090, 2026-07-16): `comfy templates ls` emits a ~191KB UTF-8 JSON envelope and crashes on the first non-ASCII byte — `UnicodeEncodeError: 'charmap' codec can't encode character '→'`. Setting `PYTHONUTF8=1` + `PYTHONIOENCODING=utf-8` fixed it 100% of the time. This is the cheapest complete server-side mitigation and stays within the thin-passthrough guardrail (BE-3328).

## Testing

- [x] Existing tests pass (`pytest`) — 100 passed, 1 skipped (live e2e), via `uv run --extra dev pytest tests`
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)

## Additional Notes

- **Stacked on #38** (`matt/be-3074-comfy-cli-branch-pin-followups`), which edits these same two env-construction lines to add `COMFY_NO_WATCH: "1"`. Base is that branch; GitHub retargets to `main` when #38 merges. All three extra keys (`COMFY_NO_WATCH` + the two UTF-8 vars) are preserved per the ticket's merge note.
- **Negative-claim falsification:** N/A — this change *enables* the discovery tools on Windows; it adds no capability-denying / dead-end path.
- **Judgment call:** hoisted the two identical env dicts into `_comfy_env()` (the ticket's optional suggestion) rather than editing both inline, so the sites can't drift as keys accumulate.
- Out of scope (tracked separately): upstream comfy-cli cp1252 hardening; surfacing captured stderr in timeout errors (BE-3343); README Windows note (BE-3347).
