### PR TITLE
docs: onboarding-friction fixes + README tool-table parity test (BE-3347)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,21 @@ It is a small, standalone codebase. Each tool shells out to the `comfy` command 
 `--where local --json`, parses comfy-cli's `envelope/1` output, and returns it. There is no HTTP
 client and **no code shared with the Comfy Cloud MCP** — comfy-cli is the engine.
 
-> **Status:** beta. Twenty-two tools, core loop validated end-to-end against a live local
+> **Status:** beta. Thirty-one tools, core loop validated end-to-end against a live local
 > ComfyUI (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on
 > Python 3.10 and 3.14.
 
 ## Prerequisites
 
-- **Python ≥ 3.10.**
+- **Python ≥ 3.10.** Check first with `python3 --version`. On Python 3.9 — the
+  macOS **system** Python — the install fails only later, at `pip install` time,
+  as pip's generic "requires a different Python" resolution error, so confirm the
+  version up front rather than decoding that message.
+- **An Opus-class agent model.** Agent quality here is validated against **Claude
+  Opus-class models**; sessions driven by smaller models (e.g. Sonnet) repeatedly
+  broke in dogfooding — the multi-step tool loops (submit → poll → fetch, or
+  author → validate → run) are where they fall down. Use an Opus-class model for
+  anything beyond a single call.
 - **comfy-cli** on your `PATH`: `pip install comfy-cli`. This is the engine every tool wraps.
 - **A ComfyUI workspace.** If you don't have one, `comfy-cli` can create it: `comfy install`
   sets up a ComfyUI workspace it will point at. (An existing ComfyUI checkout works too — see
@@ -41,6 +49,10 @@ comfy-local-mcp        # serves the MCP over stdio
 `pip install` puts a `comfy-local-mcp` console script on your `PATH`; that command is what you
 point your AI client at below. (Installing into a dedicated venv is fine — just remember MCP
 clients may not see that venv's `PATH`, which is exactly what `COMFY_BIN` is for.)
+
+> **Using a `uv` venv?** uv-created virtualenvs ship **without** `pip`, so
+> `pip install .` fails inside one with `No module named pip` — use `uv pip
+> install .` instead.
 
 ## Configure your AI client
 
@@ -113,7 +125,7 @@ Zero to a generated image:
    ```bash
    pip install comfy-cli          # the engine
    comfy install                  # create a ComfyUI workspace (skip if you have one)
-   pip install .                  # this MCP server → the `comfy-local-mcp` command
+   pip install .                  # this MCP server (uv venv: `uv pip install .`)
    ```
 
 2. **Launch ComfyUI** and leave it running:
@@ -122,8 +134,11 @@ Zero to a generated image:
    comfy launch
    ```
 
-3. **Add the server to your client** using the snippet for your client above, then restart /
-   reload it so the tools appear.
+3. **Add the server to your client** using the snippet for your client above, then **fully
+   restart / reload the client** so the tools appear. Registering the server mid-session is
+   invisible until that restart — and an agent asked to use the tools *before* restarting may
+   **claim it did** while actually hallucinating the result. **Confirm the tools are really
+   loaded** (e.g. `/mcp` in Claude Code lists them) before trusting any output.
 
 4. **Ask your agent to run a workflow.** For example:
 
@@ -143,7 +158,7 @@ the originals stay in the ComfyUI workspace.
 
 ## Tools
 
-Twenty-two tools. Every tool runs `comfy` with the global `--json --where local` flags, unwraps
+Thirty-one tools. Every tool runs `comfy` with the global `--json --where local` flags, unwraps
 comfy-cli's `envelope/1`, and returns its `data`.
 
 | Tool | Wraps | Purpose |
@@ -151,6 +166,7 @@ comfy-cli's `envelope/1`, and returns its `data`.
 | `server_info()` | `comfy env` | Is a local ComfyUI running, where, and which workspace. **Call first.** |
 | `run_workflow(workflow_path, wait=True, timeout_seconds=600.0)` | `comfy run --workflow <path> [--wait]` | Run a workflow JSON; `wait=False` submits async and returns a `prompt_id`. |
 | `job_status(prompt_id)` | `comfy jobs status <prompt_id>` | Poll a submitted job's status + outputs. |
+| `get_execution_error(prompt_id)` | `comfy jobs status <prompt_id>` | After a run fails (`job_status` → `status: error`), the compact failure verdict — failing `node_type`/`node_id`, `exception_type`/`exception_message`, and a bounded traceback tail — for self-repair. Returns `error: None` on a healthy run, so it's safe to call speculatively. |
 | `wait_for_job(prompt_id, timeout_seconds=25.0)` | `comfy jobs status <prompt_id>` (polled) | Bounded wait until a job reaches a terminal status; returns a `{"timed_out": True, …}` payload on expiry. Chain several. |
 | `watch_job(prompt_id, timeout_seconds=600.0)` | `comfy jobs watch <prompt_id>` (streamed) | Tail an async-submitted job's live execution, streaming progress notifications; bounded, returns a `{"timed_out": True, …}` payload on expiry. Streaming counterpart to `wait_for_job`. |
 | `cancel_job(prompt_id)` | `comfy jobs cancel <prompt_id>` | Cancel a queued or running job. |
@@ -172,8 +188,9 @@ comfy-cli's `envelope/1`, and returns its `data`.
 | `nodes_types()` | `comfy nodes types` | All connection types (`MODEL`, `IMAGE`, …) ranked by connectivity. Reads the **live install**. |
 | `nodes_categories()` | `comfy nodes categories` | The node category tree. Reads the **live install**. |
 | `search_models(query="", folder="")` | `comfy models search` / `models list-folder <folder>` / `models list-folders` | List/search model files on disk. **Local:** filenames only, no cloud enrichment. |
+| `download_model(url, relative_path=None, filename=None)` | `comfy model download --url <url> [--relative-path <path>] [--filename <name>]` | Download a model file into the local models dir by direct HuggingFace/CivitAI URL (http/https only), optionally under `relative_path` (e.g. `models/loras`) and renamed via `filename`. Download-by-URL only — not a hub search. |
 | `upload_file(paths, overwrite=False)` | `comfy upload <files...> [--overwrite]` | Stage source images/masks into the local `input` dir (unlocks img2img / inpaint). |
-| `validate_workflow(workflow_path)` | `comfy validate --workflow <path>` | Pre-flight a workflow against the live `object_info` before a slow run; surfaces the structured error code on failure. |
+| `validate_workflow(workflow_path)` | `comfy validate --workflow <path>` | Pre-flight a workflow against the live `object_info` before a slow run; surfaces the structured error code on failure. On frontend-format (UI export) workflows, `non_node_key` warnings are **benign** (exports carry non-node top-level keys) — don't "repair" a valid workflow over them. |
 | `list_workflow_slots(workflow_path)` | `comfy workflow slots <path>` | List the agent-tweakable slots (addresses + current values) a frontend-format workflow exposes. |
 | `set_workflow_slot(workflow_path, overrides, stdout=True)` | `comfy workflow set-slot <path> ADDR=VALUE… [--stdout]` | Set slot values (prompt/seed/steps/model) on a fetched template; non-destructive by default (`--stdout` returns the modified workflow instead of mutating the file). |
 | `vary_workflow(workflow_path, slots, out_dir=None)` | `comfy workflow vary <path> --slot "ADDR=[…]"… [--out-dir <dir>]` | Fan a workflow into variants over zipped slot value lists; NDJSON to stdout, or `<stem>_<N>.json` files when `out_dir` is set. |
@@ -199,6 +216,14 @@ It needs a running local ComfyUI (`COMFYUI_URL`, default `http://127.0.0.1:8188`
 **and** the `comfy` binary on `PATH` (or `COMFY_BIN`). Without both it **skips**
 rather than fails, so it's safe to run anywhere — and the plain `pytest` gate stays
 green on CI runners that have neither.
+
+## Troubleshooting
+
+- **Windows: discovery tools hang or crash on non-ASCII output.** ComfyUI /
+  comfy-cli output can contain UTF-8 that Windows' default console encoding
+  (cp1252) can't decode. Set `PYTHONUTF8=1` (or `PYTHONIOENCODING=utf-8`) in the
+  environment your MCP client launches the server with — the same `env` block
+  that holds `COMFY_BIN` in the snippets above — to force UTF-8 I/O.
 
 ## Contributing
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -48,7 +48,9 @@ This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
   with `list_workflow_slots` and edit them with `set_workflow_slot` (non-destructive
   by default) — the loop is `fetch_template` -> `set_workflow_slot` -> `run_workflow`.
 - When custom nodes or models may be missing, pre-flight with `validate_workflow`
-  before running.
+  before running. On a frontend-format (UI export) workflow, `non_node_key`
+  warnings are BENIGN — frontend exports carry non-node top-level keys — so do
+  NOT "repair" an otherwise-valid workflow over them.
 - Manage in-flight work with `get_queue` (list jobs) and `cancel_job`.
 
 Everything targets the LOCAL server only — there is no cloud access here.

--- a/tests/test_readme_tools.py
+++ b/tests/test_readme_tools.py
@@ -23,7 +23,8 @@ from comfy_local_mcp import server
 README = Path(__file__).resolve().parent.parent / "README.md"
 
 # First column of a tool-table row: `| `tool_name(...)` | ... |`.
-_ROW_RE = re.compile(r"^\s*\|\s*`([a-z_]+)\(")
+# The name class includes digits so a tool like ``nodes_v2`` is still captured.
+_ROW_RE = re.compile(r"^\s*\|\s*`([a-z0-9_]+)\(")
 
 # Spelled-out English numbers, matching the README's prose voice ("Thirty-one
 # tools"). Covers 0..99 — well past any realistic tool count.
@@ -59,12 +60,17 @@ def _registered_tool_names() -> set[str]:
     return {tool.name for tool in asyncio.run(server.mcp.list_tools())}
 
 
-def _readme_table_tool_names(text: str) -> set[str]:
-    names: set[str] = set()
+def _readme_table_tool_names(text: str) -> list[str]:
+    """Tool names from the table's first column, in document order.
+
+    Returns a list (not a set) so callers can detect duplicate rows for the
+    same tool, which the one-row-per-tool contract forbids.
+    """
+    names: list[str] = []
     for line in text.splitlines():
         match = _ROW_RE.match(line)
         if match:
-            names.add(match.group(1))
+            names.append(match.group(1))
     return names
 
 
@@ -73,8 +79,12 @@ def test_readme_table_matches_registered_tools():
     registered = _registered_tool_names()
     table = _readme_table_tool_names(README.read_text(encoding="utf-8"))
 
-    missing = registered - table
-    extra = table - registered
+    duplicates = sorted({name for name in table if table.count(name) > 1})
+    assert not duplicates, f"README table has more than one row for: {duplicates}"
+
+    table_set = set(table)
+    missing = registered - table_set
+    extra = table_set - registered
     assert not missing, (
         f"tools registered but absent from the README table: {sorted(missing)}"
     )
@@ -84,12 +94,22 @@ def test_readme_table_matches_registered_tools():
 def test_readme_stated_count_matches_registered():
     """The prose count (both stated locations) matches the registered tool count."""
     count = len(_registered_tool_names())
-    phrase = f"{_int_to_words(count).capitalize()} tools"
-    occurrences = README.read_text(encoding="utf-8").count(phrase)
-    # The Status blockquote and the `## Tools` header both state the count; both
-    # must agree with the registry. Exactly two mentions keeps them in lockstep.
-    assert occurrences == 2, (
-        f"expected {phrase!r} stated in exactly 2 places (Status line + Tools "
-        f"header), found {occurrences}; update the count to match "
+    noun = "tool" if count == 1 else "tools"
+    phrase = f"{_int_to_words(count).capitalize()} {noun}"
+
+    text = README.read_text(encoding="utf-8")
+    # Both intended locations must state the count independently, so drift in
+    # one is caught even if a stray mention elsewhere keeps a bare total right.
+    status_line = next(
+        (line for line in text.splitlines() if "**Status:**" in line), ""
+    )
+    tools_section = text.split("## Tools", 1)[1] if "## Tools" in text else ""
+
+    assert phrase in status_line, (
+        f"Status blockquote must state {phrase!r}; update it to match "
+        f"{count} registered tools (found: {status_line.strip()!r})"
+    )
+    assert phrase in tools_section, (
+        f"the `## Tools` section must state {phrase!r}; update it to match "
         f"{count} registered tools"
     )

--- a/tests/test_readme_tools.py
+++ b/tests/test_readme_tools.py
@@ -1,0 +1,95 @@
+"""Parity check: the README tool table must list exactly the registered tools.
+
+Several open PRs each add more tools, so the ``## Tools`` table drifts out of
+sync silently. These tests enumerate the registered tools via FastMCP's
+in-process registry (``mcp.list_tools()`` — no ``comfy`` binary needed, same
+zero-dependency footing as the other mocked tests) and cross-check them against
+the README:
+
+- the set of tool names in the table's first column must equal the registered
+  set (deliberately removing a table row, or adding a tool without a row, fails);
+- the tool count stated in prose (the Status blockquote and the ``## Tools``
+  header) must match ``len(mcp.list_tools())``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+
+from comfy_local_mcp import server
+
+README = Path(__file__).resolve().parent.parent / "README.md"
+
+# First column of a tool-table row: `| `tool_name(...)` | ... |`.
+_ROW_RE = re.compile(r"^\s*\|\s*`([a-z_]+)\(")
+
+# Spelled-out English numbers, matching the README's prose voice ("Thirty-one
+# tools"). Covers 0..99 — well past any realistic tool count.
+_ONES = (
+    "zero one two three four five six seven eight nine ten eleven twelve "
+    "thirteen fourteen fifteen sixteen seventeen eighteen nineteen"
+).split()
+_TENS = [
+    "",
+    "",
+    "twenty",
+    "thirty",
+    "forty",
+    "fifty",
+    "sixty",
+    "seventy",
+    "eighty",
+    "ninety",
+]
+
+
+def _int_to_words(n: int) -> str:
+    """English words for 0..99, e.g. 31 -> ``"thirty-one"``."""
+    if not 0 <= n <= 99:
+        raise ValueError(f"unsupported count for prose check: {n}")
+    if n < 20:
+        return _ONES[n]
+    tens, ones = divmod(n, 10)
+    return _TENS[tens] if ones == 0 else f"{_TENS[tens]}-{_ONES[ones]}"
+
+
+def _registered_tool_names() -> set[str]:
+    return {tool.name for tool in asyncio.run(server.mcp.list_tools())}
+
+
+def _readme_table_tool_names(text: str) -> set[str]:
+    names: set[str] = set()
+    for line in text.splitlines():
+        match = _ROW_RE.match(line)
+        if match:
+            names.add(match.group(1))
+    return names
+
+
+def test_readme_table_matches_registered_tools():
+    """Every registered tool has exactly one table row, and vice versa."""
+    registered = _registered_tool_names()
+    table = _readme_table_tool_names(README.read_text(encoding="utf-8"))
+
+    missing = registered - table
+    extra = table - registered
+    assert not missing, (
+        f"tools registered but absent from the README table: {sorted(missing)}"
+    )
+    assert not extra, f"README table rows with no registered tool: {sorted(extra)}"
+
+
+def test_readme_stated_count_matches_registered():
+    """The prose count (both stated locations) matches the registered tool count."""
+    count = len(_registered_tool_names())
+    phrase = f"{_int_to_words(count).capitalize()} tools"
+    occurrences = README.read_text(encoding="utf-8").count(phrase)
+    # The Status blockquote and the `## Tools` header both state the count; both
+    # must agree with the registry. Exactly two mentions keeps them in lockstep.
+    assert occurrences == 2, (
+        f"expected {phrase!r} stated in exactly 2 places (Status line + Tools "
+        f"header), found {occurrences}; update the count to match "
+        f"{count} registered tools"
+    )


### PR DESCRIPTION
## ELI-5

New people kept tripping over the same small things when they first set up this
MCP server, and the README's tool list had quietly fallen behind the code. This
PR writes down the seven gotchas from the last dogfooding session and adds a test
so the tool list can never silently drift again.

## Summary

Docs-only onboarding fixes plus one guardrail test, from the 2026-07-16
dogfooding session (BE-3347). No tool behavior changes — the only `server.py`
edit is the `INSTRUCTIONS` handshake string.

## Changes

- **(a) Model guidance** — Prerequisites note: agent quality is validated against
  **Claude Opus-class** models; smaller models (e.g. Sonnet) repeatedly broke.
- **(b) uv venvs** — Install/Quickstart: uv venvs ship without `pip`, so
  `pip install .` fails there (`No module named pip`); use `uv pip install .`.
- **(c) Python-version check** — expanded the `Python ≥ 3.10` prerequisite: run
  `python3 --version` first; on 3.9 (macOS system Python) it only fails later at
  `pip install` time as pip's generic requires-python error.
- **(d) Windows UTF-8** — new Troubleshooting entry: set `PYTHONUTF8=1` (or
  `PYTHONIOENCODING=utf-8`) in the server's env. Documents the docs fallback only;
  the code fix is BE-3328 (out of scope here).
- **(e) Mid-session registration** — strengthened the restart note: registration
  is invisible until the client restarts, and an agent may *claim* it used the
  tools before then; verify they load (e.g. `/mcp` in Claude Code).
- **(f) Tool-table sync** — fixed the stale count (`Twenty-two` → `Thirty-one`)
  in both stated places and added the two missing rows (`download_model`,
  `get_execution_error`, arg signatures copied from `server.py`). Added
  `tests/test_readme_tools.py`.
- **(g) validate_workflow warnings** — documented that `non_node_key` warnings on
  frontend-format workflows are benign, in both the README table row and the
  `INSTRUCTIONS` constant (which rides every client handshake).

## The parity test

`tests/test_readme_tools.py` enumerates the registered tools via FastMCP
(`mcp.list_tools()` — no `comfy` binary needed, same footing as the other mocked
tests), parses the README table's first column, and asserts:
- the table's tool-name set exactly equals the registered set (adding a tool
  without a row, or deleting a row, fails);
- the prose count (both stated locations) equals `len(mcp.list_tools())`.

Verified the negative case: deleting the `download_model` row makes
`test_readme_table_matches_registered_tools` fail with
`tools registered but absent from the README table: ['download_model']`.

## Motivation

Seven cheap onboarding/docs gaps surfaced in dogfooding, none covered by the
open README-polish PR #26. See BE-3347.

## Testing

- [x] Existing tests pass (`pytest` — 97 passed, 1 skipped e2e)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — confirmed 31 registered tools via `mcp.list_tools()`;
  confirmed the parity test fails when a table row is removed and passes when
  restored.

## Additional Notes

- **Stacked on #26.** Base branch is `matt/be-2530-public-launch-polish`, not
  `main` — both PRs edit the README **Status** line (#26 does `early POC` →
  `beta`; this PR fixes the tool count on the same line), so this stacks on #26 to
  avoid a conflict. GitHub retargets to `main` when #26 merges; review sees only
  this PR's net diff.
- **Negative-claim falsification (self-review):** the diff is additive docs + a
  parity test — it adds no throw/deny path and flips no test to a dead-end. The
  one phrase that reads like a denial, `download_model` "not a hub search," just
  restates the shipped tool's own docstring (comfy-cli has no hub search); it is
  not a new capability I'm denying, so there is no dead-end to falsify.
- **Out of scope (per ticket):** the Windows subprocess-encoding code fix
  (BE-3328), a `sys.version_info` startup guard, comfy-cli warning wording, and
  full auto-generation of the table markdown (the sync **check** is what's
  required).
