### PR TITLE
docs(validate_workflow): disclose known comfy-cli validator blind spots (BE-3360)

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -1038,6 +1038,25 @@ def validate_workflow(workflow_path: str) -> Any:
     raises :class:`ComfyCliError` carrying comfy-cli's structured error code
     (e.g. ``workflow_unknown_nodes``) and message, so a missing-node or
     missing-model problem stays actionable instead of failing deep inside a run.
+
+    Known blind spots (upstream comfy-cli, fixes in progress): a passing result
+    does NOT currently guarantee the server will accept the workflow.
+
+    1. Missing required inputs are not detected — a node lacking a required
+       input (e.g. KSampler without ``seed``) validates clean, but the server
+       rejects it with ``required_input_missing``.
+    2. ``COMFY_DYNAMICCOMBO_V3`` inputs (e.g. ClaudeNode ``model``) are not
+       checked — invalid selection keys, missing required dotted sub-inputs
+       (``model.max_tokens``, …), and misspelled sub-keys all pass, yet the
+       server rejects with ``required_input_missing``.
+    3. Frontend/UI-export workflow files are not actually validated — wrapper
+       keys produce benign ``non_node_key`` warnings, zero nodes are checked,
+       and the result is vacuously valid. Ignore those ``non_node_key``
+       warnings (do not "fix" the file); export API format (or rely on
+       ``run_workflow``'s auto-conversion) if validation fidelity matters.
+
+    Treat ``valid:true`` as necessary-not-sufficient and rely on
+    ``run_workflow`` errors for final authority.
     """
     return _run_comfy("validate", "--workflow", workflow_path, timeout=60.0)
 


### PR DESCRIPTION
## ELI-5

`validate_workflow` is a thin wrapper around `comfy validate`. Right now it can say "looks good!" for a workflow the server then refuses to run — the underlying validator has confirmed gaps. Agents are told to pre-flight with this tool, so a clean pass gets over-trusted. This PR is a **docstring-only** heads-up: it lists the three known blind spots so anyone reading the tool description knows a pass is necessary-but-not-sufficient and to trust `run_workflow` for the final word. No behavior changes.

## Summary

Adds a `Known blind spots (upstream comfy-cli, fixes in progress)` paragraph to the `validate_workflow` tool docstring. Per the thin-passthrough guardrail, the actual validator fixes land in `Comfy-Org/comfy-cli`; this is the interim disclosure only (BE-3360, follows the BE-3349 investigation).

## Changes

- `src/comfy_local_mcp/server.py` — `validate_workflow` docstring only. Documents that `valid:true` does NOT currently guarantee server acceptance:
  1. Missing required inputs aren't detected (e.g. KSampler without `seed`) → server rejects with `required_input_missing`.
  2. `COMFY_DYNAMICCOMBO_V3` inputs (e.g. ClaudeNode `model`) aren't checked — bad selection keys, missing dotted sub-inputs (`model.max_tokens`, …), misspelled sub-keys all pass → server rejects with `required_input_missing`.
  3. Frontend/UI-export files aren't actually validated — wrapper keys yield benign `non_node_key` warnings, zero nodes checked, result is vacuously valid; ignore those warnings (don't "fix" the file), export API format or rely on `run_workflow`'s auto-conversion for fidelity.
  - Closes with: treat `valid:true` as necessary-not-sufficient; rely on `run_workflow` errors for final authority.
- Kept the whole docstring at 29 lines (< ~35) so it stays scannable in MCP clients.

## Motivation

Agents pre-flight with this tool (`server.py` INSTRUCTIONS) and over-trust a clean pass. Until the comfy-cli fixes ship, the disclosure keeps the tool honest.

## Testing

- [x] Existing tests pass (`pytest`) — 95 passed, 1 skipped (live e2e)
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] No test asserts the docstring text (verified via grep) — no snapshots to update

## Additional Notes

Docstring-only; no functional change, so no behavior tests added (matches the ticket's Tests section). The blind-spot content is transcribed verbatim from the ticket's confirmed BE-3349 findings.

**Negative-claim falsification note:** the docstring adds gap-disclosure wording ("not detected"/"not checked") but denies no capability and adds no dead-end — it redirects readers to working paths (`run_workflow` as authority, export-API format), so the falsification discipline is satisfied (nothing is being walled off).
