### PR TITLE
feat: add auth_status tool + credential steering in INSTRUCTIONS (BE-3366)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ comfy-cli's `envelope/1`, and returns its `data`.
 | Tool | Wraps | Purpose |
 |---|---|---|
 | `server_info()` | `comfy env` | Is a local ComfyUI running, where, and which workspace. **Call first.** |
+| `auth_status()` | `comfy cloud whoami` | Comfy Cloud credential status for partner-API nodes (read-only, never returns secrets). Adds a local `registration_env_key_present` bool for the `COMFY_API_KEY` registration-env slot whoami can't see. |
 | `run_workflow(workflow_path, wait=True, timeout_seconds=600.0)` | `comfy run --workflow <path> [--wait]` | Run a workflow JSON; `wait=False` submits async and returns a `prompt_id`. |
 | `job_status(prompt_id)` | `comfy jobs status <prompt_id>` | Poll a submitted job's status + outputs. |
 | `wait_for_job(prompt_id, timeout_seconds=25.0)` | `comfy jobs status <prompt_id>` (polled) | Bounded wait until a job reaches a terminal status; returns a `{"timed_out": True, …}` payload on expiry. Chain several. |

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -51,11 +51,16 @@ This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
   before running.
 - Manage in-flight work with `get_queue` (list jobs) and `cancel_job`.
 - Before running a workflow whose nodes call partner APIs (Seedream / Veo /
-  Kling / Gemini / …), call `auth_status` to check Comfy Cloud credentials. If
-  it reports not signed in, tell the USER to authenticate, in this order:
-  (1) run `comfy cloud login` in a terminal (canonical), or (2) set
-  `COMFY_API_KEY` in the MCP client's registration env, or (3) persist a key
-  with `comfy cloud set-key --key …`. Never put a key in a workflow file.
+  Kling / Gemini / …), call `auth_status` to check Comfy Cloud credentials.
+  Treat credentials as GOOD if `signed_in` is true OR
+  `registration_env_key_present` is true — a registration-env key authenticates
+  partner-API runs even though whoami can't see it, so do NOT nag the user to
+  re-auth in that case. Only when BOTH are false, tell the USER to
+  authenticate, in this order: (1) run `comfy cloud login` in a terminal
+  (canonical), or (2) set `COMFY_API_KEY` in the MCP client's registration env,
+  or (3) persist a key with `comfy cloud set-key` (avoid passing it inline as an
+  argument, which leaks the key into shell history). Never put a key in a
+  workflow file.
 
 Everything targets the LOCAL server only — there is no cloud access here.
 """
@@ -357,15 +362,19 @@ def auth_status() -> Any:
     ``api_key_source`` — whoami inspects only the cloud-purpose
     ``COMFY_CLOUD_API_KEY`` / stored key slot. So this tool ALSO reports
     ``registration_env_key_present`` (a local presence check — a bool, never
-    the value) so that path is at least visible.
+    the value) so that path is at least visible. The flag is ALWAYS present in
+    the returned mapping; on the rare non-dict whoami payload the raw value is
+    nested under ``whoami`` alongside it.
     """
     data = _run_comfy("cloud", "whoami", timeout=30.0)
     present = bool(os.environ.get("COMFY_API_KEY"))
     # Add the local presence flag WITHOUT altering any whoami field comfy-cli
-    # returned (which stays redacted as-is); only augment the dict shape.
+    # returned (which stays redacted as-is); only augment the dict shape. Always
+    # report the flag as the docstring promises: if whoami ever hands back a
+    # non-dict payload, wrap it under `whoami` rather than dropping the flag.
     if isinstance(data, dict):
         return {**data, "registration_env_key_present": present}
-    return data
+    return {"whoami": data, "registration_env_key_present": present}
 
 
 @mcp.tool()

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -50,6 +50,12 @@ This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
 - When custom nodes or models may be missing, pre-flight with `validate_workflow`
   before running.
 - Manage in-flight work with `get_queue` (list jobs) and `cancel_job`.
+- Before running a workflow whose nodes call partner APIs (Seedream / Veo /
+  Kling / Gemini / …), call `auth_status` to check Comfy Cloud credentials. If
+  it reports not signed in, tell the USER to authenticate, in this order:
+  (1) run `comfy cloud login` in a terminal (canonical), or (2) set
+  `COMFY_API_KEY` in the MCP client's registration env, or (3) persist a key
+  with `comfy cloud set-key --key …`. Never put a key in a workflow file.
 
 Everything targets the LOCAL server only — there is no cloud access here.
 """
@@ -329,6 +335,37 @@ def server_info() -> Any:
     confirm a local ComfyUI is up before running a workflow.
     """
     return _run_comfy("env", timeout=60.0)
+
+
+@mcp.tool()
+def auth_status() -> Any:
+    """Comfy Cloud credential status for partner-API nodes (read-only; never returns secrets).
+
+    Wraps ``comfy cloud whoami`` and returns comfy-cli's whoami payload as-is:
+    ``signed_in``, ``auth_method`` (``oauth`` / ``api_key`` / ``null``),
+    ``api_key_source`` (``env`` / ``store``), ``base_url``, plus
+    ``expired`` / ``session`` (already REDACTED by comfy-cli) / ``stale_base_url``
+    when a session exists. Secrets are pre-redacted upstream — this passes the
+    payload through unchanged and never re-derives or returns key material.
+
+    Call this before running a workflow whose nodes hit partner APIs
+    (Seedream / Veo / Kling / Gemini / …) to self-diagnose credentials; the
+    server instructions cover what to tell the user when not signed in.
+
+    BLIND SPOT: a ``COMFY_API_KEY`` set in the MCP client's registration env
+    (injected per-run for ``comfy run --api-key``) is NOT reflected in
+    ``api_key_source`` — whoami inspects only the cloud-purpose
+    ``COMFY_CLOUD_API_KEY`` / stored key slot. So this tool ALSO reports
+    ``registration_env_key_present`` (a local presence check — a bool, never
+    the value) so that path is at least visible.
+    """
+    data = _run_comfy("cloud", "whoami", timeout=30.0)
+    present = bool(os.environ.get("COMFY_API_KEY"))
+    # Add the local presence flag WITHOUT altering any whoami field comfy-cli
+    # returned (which stays redacted as-is); only augment the dict shape.
+    if isinstance(data, dict):
+        return {**data, "registration_env_key_present": present}
+    return data
 
 
 @mcp.tool()

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -608,14 +608,6 @@ async def _run_comfy_streaming(
             stderr_future.cancel()
 
 
-def _parse_version(text: str) -> tuple[int, int, int] | None:
-    """Extract a ``(major, minor, patch)`` tuple from a version string, or None."""
-    match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", text)
-    if match is None:
-        return None
-    return tuple(int(part) if part else 0 for part in match.groups())  # type: ignore[return-value]
-
-
 def _detect_comfy_cli_version() -> str | None:
     """Best-effort comfy-cli version via ``comfy --version`` (None if undetermined).
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -69,10 +69,10 @@ This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
   re-auth in that case. Only when BOTH are false, tell the USER to
   authenticate, in this order: (1) run `comfy cloud login` in a terminal
   (canonical), or (2) set `COMFY_API_KEY` in the MCP client's registration env,
-  or (3) persist a key with `comfy cloud set-key` (avoid passing it inline as an
-  argument, which leaks the key into shell history). Never put a key in a
-  workflow file. If a run still hits a credential error despite good
-  `auth_status`, it is retried briefly and surfaces a hint with alternatives.
+  or (3) persist a key with `comfy auth set comfy-cloud-api-key --key <KEY>`.
+  Never put a key in a workflow file. If a run still hits a credential error
+  despite good `auth_status`, it is retried briefly and surfaces a hint with
+  alternatives.
 - After a detached `launch_comfyui`, read the background server's own output with
   `get_logs` — it tails the captured ComfyUI log (invisible otherwise).
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -70,7 +70,7 @@ def test_unwrap_rejects_incompatible_major_even_on_error_envelope():
 def test_incompatible_envelope_propagates_through_run_comfy(monkeypatch):
     """The assertion guards every tool: a bad-schema envelope raises via _run_comfy."""
 
-    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
         import json
 
         out = json.dumps({"schema": "envelope/99", "type": "envelope", "ok": True})
@@ -220,7 +220,7 @@ def patched_env(monkeypatch):
 
         calls: list[dict] = []
 
-        def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+        def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
             calls.append({"cmd": cmd})
             return subprocess.CompletedProcess(
                 cmd, 0, stdout=json.dumps(envelope), stderr=""

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -416,6 +416,121 @@ def test_server_instructions_cover_canonical_flows():
         assert tool in instructions
 
 
+def test_auth_status_maps_command_and_passes_payload_through(patched_run, monkeypatch):
+    """auth_status wraps `comfy --json --where local cloud whoami`, payload unchanged."""
+    whoami = {
+        "signed_in": True,
+        "auth_method": "oauth",
+        "api_key_source": "store",
+        "base_url": "https://api.comfy.example",
+        "expired": False,
+    }
+    calls = patched_run({"type": "envelope", "ok": True, "data": whoami})
+    # No registration env key set -> the added flag is False, everything else as-is.
+    monkeypatch.delenv("COMFY_API_KEY", raising=False)
+
+    result = server.auth_status()
+
+    cmd = calls[0]["cmd"]
+    assert cmd[1:4] == ["--json", "--where", "local"]  # global flags first
+    assert cmd[4:] == [
+        "cloud",
+        "whoami",
+    ]  # whoami is not target-routed; --where local is harmless
+    # Every whoami field passes through unchanged; only the local flag is added.
+    for key, value in whoami.items():
+        assert result[key] == value
+    assert result["registration_env_key_present"] is False
+
+
+def test_auth_status_signed_out_payload_passes_through(patched_run, monkeypatch):
+    """A signed-out whoami (signed_in false, auth_method null) passes through cleanly."""
+    whoami = {
+        "signed_in": False,
+        "auth_method": None,
+        "api_key_source": None,
+        "base_url": "https://api.comfy.example",
+    }
+    patched_run({"type": "envelope", "ok": True, "data": whoami})
+    monkeypatch.delenv("COMFY_API_KEY", raising=False)
+
+    result = server.auth_status()
+
+    assert result["signed_in"] is False
+    assert result["auth_method"] is None
+    assert result["registration_env_key_present"] is False
+
+
+def test_auth_status_reports_registration_env_presence_not_value(
+    patched_run, monkeypatch
+):
+    """The COMFY_API_KEY registration-env blind spot is reported as presence only."""
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": True,
+            "data": {"signed_in": False, "auth_method": None},
+        }
+    )
+    monkeypatch.setenv("COMFY_API_KEY", "sk-super-secret-value")
+
+    result = server.auth_status()
+
+    assert result["registration_env_key_present"] is True
+    # Presence only — the actual key material must never appear in the payload.
+    assert "sk-super-secret-value" not in json.dumps(result)
+
+
+def test_auth_status_never_returns_key_material(patched_run, monkeypatch):
+    """A realistic redacted whoami stays redacted — no key/token material leaks out."""
+    # comfy-cli pre-redacts secrets; the tool must pass them through, never re-derive.
+    whoami = {
+        "signed_in": True,
+        "auth_method": "api_key",
+        "api_key_source": "env",
+        "base_url": "https://api.comfy.example",
+        "expired": False,
+        "session": {"api_key": "***REDACTED***", "token": "***REDACTED***"},
+        "stale_base_url": False,
+    }
+    patched_run({"type": "envelope", "ok": True, "data": whoami})
+    monkeypatch.delenv("COMFY_API_KEY", raising=False)
+
+    dumped = json.dumps(server.auth_status())
+
+    assert "REDACTED" in dumped  # the redaction placeholder survives unchanged
+    # No un-redacted-looking key/token material in the returned dict.
+    assert "sk-" not in dumped
+    for token_word in ("secret", "bearer"):
+        assert token_word not in dumped.lower()
+
+
+def test_auth_status_error_envelope_raises(patched_run):
+    """A failing `comfy cloud whoami` surfaces comfy-cli's error envelope."""
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": False,
+            "error": {"code": "not_signed_in", "message": "no credentials"},
+        }
+    )
+
+    with pytest.raises(server.ComfyCliError, match="not_signed_in"):
+        server.auth_status()
+
+
+def test_server_instructions_cover_credential_steering():
+    """Instructions steer an agent to auth_status + the three-step credential order."""
+    instructions = server.mcp.instructions
+
+    assert "auth_status" in instructions
+    # The three credential steps must appear, in the canonical order.
+    login = instructions.index("comfy cloud login")
+    env_key = instructions.index("COMFY_API_KEY")
+    set_key = instructions.index("comfy cloud set-key")
+    assert login < env_key < set_key  # (1) login, (2) registration env, (3) set-key
+
+
 def test_launch_comfyui_passes_background_flag(patched_run):
     """launch_comfyui must run `comfy … launch --background` (detached start)."""
     calls = patched_run({"type": "envelope", "ok": True, "data": {"pid": 42}})

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -783,7 +783,7 @@ def test_server_instructions_cover_credential_steering():
     # The three credential steps must appear, in the canonical order.
     login = instructions.index("comfy cloud login")
     env_key = instructions.index("COMFY_API_KEY")
-    set_key = instructions.index("comfy cloud set-key")
+    set_key = instructions.index("comfy auth set comfy-cloud-api-key")
     assert login < env_key < set_key  # (1) login, (2) registration env, (3) set-key
 
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -481,6 +481,20 @@ def test_auth_status_reports_registration_env_presence_not_value(
     assert "sk-super-secret-value" not in json.dumps(result)
 
 
+def test_auth_status_reports_flag_even_for_non_dict_payload(patched_run, monkeypatch):
+    """A non-dict whoami payload still carries registration_env_key_present."""
+    # Defensive: whoami normally returns an object, but if it ever hands back a
+    # non-dict (null / list), the flag must still be present per the docstring.
+    patched_run({"type": "envelope", "ok": True, "data": None})
+    monkeypatch.setenv("COMFY_API_KEY", "sk-super-secret-value")
+
+    result = server.auth_status()
+
+    assert result["registration_env_key_present"] is True
+    assert result["whoami"] is None
+    assert "sk-super-secret-value" not in json.dumps(result)
+
+
 def test_auth_status_never_returns_key_material(patched_run, monkeypatch):
     """A realistic redacted whoami stays redacted — no key/token material leaks out."""
     # comfy-cli pre-redacts secrets; the tool must pass them through, never re-derive.


### PR DESCRIPTION
## ELI-5

An agent that wants to run a workflow using a partner model (Seedream, Veo, Kling, Gemini, …) needs to be signed in to Comfy Cloud. Today there is no way to *check* that from the MCP, so agents flailed when credentials were missing. This adds a tiny read-only tool — `auth_status` — that asks comfy-cli "am I signed in?" and returns the answer (with all secrets already redacted by comfy-cli). It also adds a short note in the server's startup instructions telling an agent to check auth first and, if not signed in, exactly how to tell the user to fix it.

## Summary

Adds a read-only `auth_status` tool and canonical credential steering to the server INSTRUCTIONS so an agent can self-diagnose Comfy Cloud credentials before running partner-API workflows (BE-3366).

## Changes

- **`auth_status` tool** (`src/comfy_local_mcp/server.py`) — thin passthrough over `comfy cloud whoami` (`_run_comfy("cloud", "whoami", timeout=30.0)`), following the `server_info` thin-tool pattern. Returns comfy-cli's whoami payload (`signed_in`, `auth_method`, `api_key_source`, `base_url`, plus `expired`/`session`(redacted)/`stale_base_url` when a session exists) **unchanged** — secrets are pre-redacted upstream and passed through as-is, never re-derived.
- The tool **additionally reports `registration_env_key_present`** (a local `bool(os.environ.get("COMFY_API_KEY"))` — presence only, never the value) to cover the documented blind spot: a `COMFY_API_KEY` registration-env key (per-run injection for `comfy run --api-key`) is *not* reflected in whoami's `api_key_source`, which only inspects the cloud-purpose `COMFY_CLOUD_API_KEY`/stored slot.
- **INSTRUCTIONS credential paragraph** — before running a workflow with partner-API nodes, call `auth_status`; if not signed in, tell the USER to authenticate in this explicit order: (1) `comfy cloud login` (canonical), (2) set `COMFY_API_KEY` in the MCP client registration env, (3) persist a key with `comfy cloud set-key --key …`.
- **No preflight added to `run_workflow`** — comfy-cli already fail-fasts with `partner_node_requires_credential` before submit, so a preflight would be redundant (per the ticket).
- README Tools table gains an `auth_status` row.
- 6 new tests in `tests/test_wrapper.py` (mock `subprocess.run`).

## Motivation

comfy-local-mcp had no way for an agent to self-diagnose credentials before partner-API workflows, and the INSTRUCTIONS carried no credential guidance. Agents flailed inconsistently when credentials were missing.

## Testing

- [x] Existing tests pass (`pytest` — 101 passed, 1 skipped e2e)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] New unit tests cover: correct argv (`comfy --json --where local cloud whoami`), signed-in and signed-out payload passthrough, redacted-fixture no-leak (asserts no key/token material in the returned dict), the `registration_env_key_present` presence-not-value behavior, error-envelope propagation, and the three-step INSTRUCTIONS order.

## Additional Notes

- **`--where local` on `whoami` — human-verify step (could not run live here):** `comfy-cli` is not installed in this build environment, so I could not run the live smoke test to confirm `--where local` is harmless for the un-routed `whoami` subcommand. The argv is asserted by unit test; the "is it harmless at runtime?" check needs one live `comfy --json --where local cloud whoami` against a real comfy-cli install (per the ticket's "verify once in the smoke test").
- **"returns data unchanged" vs the added flag:** the whoami fields comfy-cli returns are passed through byte-for-byte (verified field-by-field in the tests); `registration_env_key_present` is the one *locally-computed* field the ticket explicitly asks the tool to add — nothing comfy-cli returned is altered or dropped.
- **Rebase note (BE-3344, PR #42, still open):** BE-3344 rewrites much of `server.py`'s error handling and INSTRUCTIONS. It is **not** merged, so per the ticket I added the steering paragraph to the current INSTRUCTIONS. Whichever of #42 / this PR merges second will hit a trivial INSTRUCTIONS merge conflict — resolve by keeping both paragraphs.
- **Negative-claim falsification:** N/A — this change is purely additive/enabling (a read-only diagnostic tool + steering that tells agents how to authenticate). It denies no capability and adds no dead-end/`STOP`/`not supported` path, so the falsification trigger does not fire.
- Pre-existing, left untouched: the README "Tools" header count and the module-level "Tools so far" narrative were already out of sync with `main` (they predate several merged tools); reconciling that drift is out of scope for this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
