### PR TITLE
fix(download_model): treat exit-0 no-envelope download as success (BE-3345)

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -302,7 +302,13 @@ def _run_comfy(*args: str, timeout: float | None = None, plain_ok: bool = False)
     )
     if plain_ok and real_envelope is None and returncode == 0:
         return _synthesize_plain_result(args, stdout, stderr)
-    return _unwrap_envelope(envelope, args, returncode, stderr)
+    # Enforce the envelope contract on the normal path too: pass `real_envelope`
+    # (not `envelope`) so a stray non-envelope JSON line — e.g. an incidental
+    # `{"ok": true, "data": ...}` diagnostic — can't be mis-unwrapped as a valid
+    # response for a non-`plain_ok` tool; it raises the "returned no JSON" error
+    # like any other missing envelope. A real error envelope still has
+    # `type==envelope`, so it flows through and raises with its code as usual.
+    return _unwrap_envelope(real_envelope, args, returncode, stderr)
 
 
 def _envelope_schema(envelope: dict) -> str | None:

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -204,11 +204,17 @@ def _synthesize_plain_result(args: tuple[str, ...], stdout: str, stderr: str) ->
             break
         action_parts.append(arg)
     text = " ".join(part.strip() for part in (stderr, stdout) if part.strip())
-    message = text or f"comfy {' '.join(args)} completed (exit 0)."
+    # Fallback echoes only the flag-free `action_parts`, never the raw args: a
+    # `model download` URL can carry a signed token / userinfo in its query
+    # string, and this message lands in the tool response and host-side logs.
+    message = text or f"comfy {' '.join(action_parts)} completed (exit 0)."
     return {
         "ok": True,
         "action": " ".join(action_parts),
-        "message": message[:1000],  # cap both real output and the fallback
+        # Keep the TAIL, not the front: `model download` streams verbose progress
+        # to stderr and the saved-path / `Done in …` metadata this payload exists
+        # to surface lands at the END, so a front slice would drop it as noise.
+        "message": message[-1000:],  # cap both real output and the fallback
         "note": (
             "comfy-cli emitted no JSON envelope for this command; "
             "a clean exit is treated as success."

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -103,12 +103,13 @@ def _run_comfy(*args: str, timeout: float | None = None, plain_ok: bool = False)
     for ``--json``, or an NDJSON stream whose final line is the envelope). We
     keep the last JSON object and unwrap ``ok`` / ``data`` / ``error``.
 
-    ``plain_ok`` relaxes the envelope requirement for the lifecycle commands
-    (``launch`` / ``stop``) that print human text and exit 0 WITHOUT emitting an
-    envelope (BE-2953): a clean exit with no JSON is treated as success and a
-    result dict is synthesized from the printed text, rather than raising the
-    "returned no JSON" error on an action that actually succeeded. A non-zero
-    exit, or a real error envelope, still raises as usual.
+    ``plain_ok`` relaxes the envelope requirement for the commands that print
+    human text and exit 0 WITHOUT emitting an envelope — the lifecycle verbs
+    ``launch`` / ``stop`` (BE-2953) and ``model download`` (BE-3345): a clean
+    exit with no JSON is treated as success and a result dict is synthesized
+    from the printed text, rather than raising the "returned no JSON" error on
+    an action that actually succeeded. A non-zero exit, or a real error
+    envelope, still raises as usual.
     """
     if shutil.which(COMFY_BIN) is None:
         raise ComfyCliError(
@@ -135,18 +136,19 @@ def _run_comfy(*args: str, timeout: float | None = None, plain_ok: bool = False)
         ) from exc
 
     envelope = _last_json_object(proc.stdout)
-    # A lifecycle command that exits 0 without a *real* envelope is a success
-    # (BE-2953). `_last_json_object` may return a stray non-envelope JSON line
-    # (e.g. a diagnostic log that happens to parse), so key the fast-path off the
-    # absence of a `type==envelope` object rather than the absence of any JSON —
-    # otherwise one incidental JSON line on a successful launch/stop would be
-    # mis-unwrapped into a spurious "failed" raise. A real error envelope still
-    # has `type==envelope`, so it flows to `_unwrap_envelope` and raises as usual.
+    # A plain_ok command that exits 0 without a *real* envelope is a success
+    # (BE-2953 launch/stop, BE-3345 model download). `_last_json_object` may
+    # return a stray non-envelope JSON line (e.g. a diagnostic log that happens
+    # to parse), so key the fast-path off the absence of a `type==envelope`
+    # object rather than the absence of any JSON — otherwise one incidental JSON
+    # line on a successful run would be mis-unwrapped into a spurious "failed"
+    # raise. A real error envelope still has `type==envelope`, so it flows to
+    # `_unwrap_envelope` and raises as usual.
     real_envelope = (
         envelope if envelope and envelope.get("type") == "envelope" else None
     )
     if plain_ok and real_envelope is None and proc.returncode == 0:
-        return _synthesize_lifecycle_result(args, proc.stdout, proc.stderr)
+        return _synthesize_plain_result(args, proc.stdout, proc.stderr)
     return _unwrap_envelope(envelope, args, proc.returncode, proc.stderr)
 
 
@@ -175,26 +177,40 @@ def _unwrap_envelope(
     return envelope.get("data")
 
 
-def _synthesize_lifecycle_result(
-    args: tuple[str, ...], stdout: str, stderr: str
-) -> dict:
-    """Success payload for a lifecycle command that exited 0 without an envelope.
+def _synthesize_plain_result(args: tuple[str, ...], stdout: str, stderr: str) -> dict:
+    """Success payload for a ``plain_ok`` command that exited 0 without an envelope.
 
-    ``comfy launch --background`` and ``comfy stop`` print human-readable text and
-    exit 0 instead of emitting an ``envelope/1`` object (BE-2953). For those
-    commands a clean exit IS the success signal, so we return a result dict
-    carrying whatever text comfy-cli printed (preferring stderr, per the CLI's
-    logging) rather than raising on the absent envelope — a false negative that
-    would invite a retry of a non-idempotent lifecycle action.
+    Some comfy-cli commands print human-readable text and exit 0 instead of
+    emitting an ``envelope/1`` object: the lifecycle verbs ``launch`` / ``stop``
+    (BE-2953) and ``model download`` (BE-3345), whose stderr carries the progress
+    tail (e.g. ``Done in 55.8s``) and the saved-path text. For those a clean exit
+    IS the success signal, so we return a result dict carrying whatever text
+    comfy-cli printed (preferring stderr, per the CLI's logging) rather than
+    raising on the absent envelope — a false negative that would invite a retry
+    of an action that already succeeded (a non-idempotent lifecycle change, or a
+    bandwidth-expensive multi-GB refetch).
+
+    The synthesized ``message`` is the only result data available without an
+    envelope, so it carries the printed text verbatim (capped). This path is a
+    stopgap: once comfy-cli emits an envelope for a verb, a real envelope always
+    wins in the ``_run_comfy`` fast-path and this synthesis is bypassed.
     """
+    # `action` is the subcommand path: the leading non-flag tokens, so `launch
+    # --background` -> "launch", `stop` -> "stop", `model download --url ...` ->
+    # "model download". Stops at the first flag so option values never leak in.
+    action_parts: list[str] = []
+    for arg in args:
+        if arg.startswith("-"):
+            break
+        action_parts.append(arg)
     text = " ".join(part.strip() for part in (stderr, stdout) if part.strip())
     message = text or f"comfy {' '.join(args)} completed (exit 0)."
     return {
         "ok": True,
-        "action": args[0] if args else "",
+        "action": " ".join(action_parts),
         "message": message[:1000],  # cap both real output and the fallback
         "note": (
-            "comfy-cli emitted no JSON envelope for this lifecycle command; "
+            "comfy-cli emitted no JSON envelope for this command; "
             "a clean exit is treated as success."
         ),
     }
@@ -1334,8 +1350,16 @@ def download_model(
 
     DOWNLOAD-BY-URL ONLY: this is a fetch of a known URL, not a hub search —
     there is no HuggingFace/CivitAI browse or discovery here (comfy-cli has no
-    such search), so the caller must already have the direct model URL. Returns
-    comfy-cli's envelope ``data`` (the saved path / download metadata).
+    such search), so the caller must already have the direct model URL.
+
+    ``comfy model download`` streams human progress text to stderr and exits 0
+    WITHOUT emitting an ``envelope/1`` object, so on that clean-exit success this
+    returns a synthesized payload — ``{"ok": True, "action": ..., "message":
+    ..., "note": ...}`` whose ``message`` carries the CLI's printed text (the
+    "Done in …" tail and saved-path line) — rather than envelope ``data``
+    (BE-3345). If comfy-cli starts emitting an envelope for this verb, that real
+    envelope wins and its ``data`` (the saved path / download metadata) is
+    returned instead. A non-zero exit still raises :class:`ComfyCliError`.
     """
     # comfy-cli parses a leading-dash value as an option/flag; reject any so a
     # crafted argument can't be smuggled in as a CLI flag (argument injection).
@@ -1375,7 +1399,11 @@ def download_model(
     if filename:
         args += ["--filename", filename]
     # Generous timeout: multi-GB checkpoints can take a long time to fetch.
-    return _run_comfy(*args, timeout=1800.0)
+    # plain_ok=True: `comfy model download` exits 0 with human progress text and
+    # no envelope, so treat a clean exit as success instead of raising the
+    # "returned no JSON" false negative on a download that actually landed
+    # (BE-3345). A real error envelope or a non-zero exit still raises.
+    return _run_comfy(*args, timeout=1800.0, plain_ok=True)
 
 
 @mcp.tool()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -788,6 +788,20 @@ def test_plain_ok_does_not_leak_to_other_commands(patched_plain_run):
         server._run_comfy("env")
 
 
+def test_non_plain_ok_rejects_stray_non_envelope_json(patched_plain_run):
+    """A stray non-envelope JSON on the NORMAL path must NOT satisfy the contract.
+
+    Without `plain_ok`, an incidental object like `{"ok": true, "data": ...}`
+    (no `type==envelope`) must not be mis-unwrapped as a valid response — the
+    normal path passes `real_envelope`, so a stray diagnostic line raises the
+    "returned no JSON" error like any other missing envelope (CodeRabbit review).
+    """
+    patched_plain_run(0, stdout='{"ok": true, "data": {"x": 1}}\n')
+
+    with pytest.raises(server.ComfyCliError, match="returned no JSON"):
+        server._run_comfy("env")
+
+
 def test_plain_ok_still_honors_a_real_envelope(patched_run):
     """When comfy-cli DOES emit an envelope, plain_ok unwraps it normally."""
     patched_run({"type": "envelope", "ok": True, "data": {"pid": 7}})

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -554,6 +554,71 @@ def test_plain_ok_still_honors_a_real_envelope(patched_run):
     assert server._run_comfy("launch", "--background", plain_ok=True) == {"pid": 7}
 
 
+# --- download_model: no JSON envelope on a successful fetch (BE-3345) -------
+
+
+def test_download_model_synthesizes_success_on_plain_exit(patched_plain_run):
+    """`comfy model download` streams text + exits 0, no envelope -> success.
+
+    The download landed on disk (exit 0), so instead of raising the
+    "returned no JSON" false negative — which would invite a bandwidth-expensive
+    retry of a multi-GB fetch — a success payload is synthesized carrying the
+    CLI's printed tail (where "Done in …" and the saved path live).
+    """
+    patched_plain_run(
+        0,
+        stderr="Downloading x.safetensors...\nDone in 55.8s. Saved to /models/x.safetensors",
+    )
+
+    result = server.download_model("https://hf.co/x.safetensors")
+
+    assert result["ok"] is True
+    assert result["action"] == "model download"
+    assert "Done in 55.8s" in result["message"]
+
+
+def test_download_model_nonzero_exit_still_raises(patched_plain_run):
+    """A real download failure (non-zero exit, no envelope) must still raise."""
+    patched_plain_run(1, stderr="HTTP 404: model not found")
+
+    with pytest.raises(server.ComfyCliError, match="returned no JSON"):
+        server.download_model("https://hf.co/missing.safetensors")
+
+
+def test_download_model_synthesizes_despite_stray_non_envelope_json(patched_plain_run):
+    """A stray non-envelope JSON line on a clean download exit is still success.
+
+    `_last_json_object` returns any JSON object (not just `type==envelope`), so a
+    diagnostic line that happens to parse must NOT be mistaken for a result
+    envelope and unwrapped into a spurious failure (BE-3345 edge case).
+    """
+    patched_plain_run(
+        0,
+        stdout='{"level": "info", "msg": "connection reused"}\n',
+        stderr="Done in 12.3s. Saved to /models/x.safetensors",
+    )
+
+    result = server.download_model("https://hf.co/x.safetensors")
+
+    assert result["ok"] is True
+    assert result["action"] == "model download"
+    assert "Done in 12.3s" in result["message"]
+
+
+def test_download_model_still_honors_a_real_error_envelope(patched_run):
+    """A real error envelope on download still raises with its code (not synthesized)."""
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": False,
+            "error": {"code": "download_failed", "message": "checksum mismatch"},
+        }
+    )
+
+    with pytest.raises(server.ComfyCliError, match=r"download_failed"):
+        server.download_model("https://hf.co/x.safetensors")
+
+
 def test_discover_maps_command_and_returns_data(patched_run):
     """discover wraps `comfy discover` and returns the envelope data verbatim."""
     surface = {"commands": ["run", "env"], "error_codes": ["server_not_running"]}

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -605,6 +605,47 @@ def test_download_model_synthesizes_despite_stray_non_envelope_json(patched_plai
     assert "Done in 12.3s" in result["message"]
 
 
+def test_download_model_envelope_then_diagnostic_keeps_envelope_data(patched_plain_run):
+    """A real envelope FOLLOWED BY a diagnostic JSON line still wins (BE-3345).
+
+    `_last_json_object` prefers a `type==envelope` object over a later plain JSON
+    line, so a trailing diagnostic must NOT null out `real_envelope` and demote a
+    genuine success into the synthesized fast-path — the envelope's `data` (the
+    real saved-path metadata) must be returned, not the printed-text stopgap.
+    """
+    patched_plain_run(
+        0,
+        stdout=(
+            '{"type": "envelope", "ok": true, "data": {"saved": "/models/x"}}\n'
+            '{"level": "info", "msg": "cleanup done"}\n'
+        ),
+    )
+
+    result = server.download_model("https://hf.co/x.safetensors")
+
+    assert result == {"saved": "/models/x"}
+
+
+def test_download_model_error_envelope_then_diagnostic_still_raises(patched_plain_run):
+    """An error envelope followed by a diagnostic line still raises, not synthesized.
+
+    Even on exit 0, a trailing diagnostic JSON line must not mask an earlier
+    error envelope as a synthesized success — the error envelope is preferred and
+    propagates its code (BE-3345).
+    """
+    patched_plain_run(
+        0,
+        stdout=(
+            '{"type": "envelope", "ok": false, '
+            '"error": {"code": "download_failed", "message": "checksum mismatch"}}\n'
+            '{"level": "info", "msg": "cleanup done"}\n'
+        ),
+    )
+
+    with pytest.raises(server.ComfyCliError, match=r"download_failed"):
+        server.download_model("https://hf.co/x.safetensors")
+
+
 def test_download_model_still_honors_a_real_error_envelope(patched_run):
     """A real error envelope on download still raises with its code (not synthesized)."""
     patched_run(

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -619,6 +619,41 @@ def test_download_model_still_honors_a_real_error_envelope(patched_run):
         server.download_model("https://hf.co/x.safetensors")
 
 
+def test_download_model_keeps_saved_path_tail_on_verbose_output(patched_plain_run):
+    """A verbose multi-GB fetch caps to the TAIL so the saved-path survives.
+
+    `comfy model download` streams progress noise ahead of the `Done in …` /
+    saved-path tail that the synthesized payload exists to surface. A front-slice
+    cap would drop that tail as noise, so the message must keep the last chars.
+    """
+    tail = "Done in 903.4s. Saved to /models/checkpoints/big.safetensors"
+    noise = "\n".join(f"Downloading... {i}% ({i * 40} MiB)" for i in range(100))
+    patched_plain_run(0, stderr=f"{noise}\n{tail}")
+
+    result = server.download_model("https://hf.co/big.safetensors")
+
+    assert result["ok"] is True
+    assert len(result["message"]) <= 1000
+    assert "Saved to /models/checkpoints/big.safetensors" in result["message"]
+
+
+def test_download_model_fallback_omits_url_when_no_output(patched_plain_run):
+    """The no-output fallback message must not echo the (possibly signed) URL.
+
+    A `model download` URL can carry a token / userinfo in its query string; the
+    synthesized fallback lands in the tool response and host logs, so it reports
+    only the flag-free `model download` action, never the raw args.
+    """
+    patched_plain_run(0)  # exit 0 with no stdout/stderr -> fallback message
+
+    result = server.download_model("https://hf.co/x.safetensors?sig=SECRETTOKEN")
+
+    assert result["ok"] is True
+    assert "SECRETTOKEN" not in result["message"]
+    assert "hf.co" not in result["message"]
+    assert "model download" in result["message"]
+
+
 def test_discover_maps_command_and_returns_data(patched_run):
     """discover wraps `comfy discover` and returns the envelope data verbatim."""
     surface = {"commands": ["run", "env"], "error_codes": ["server_not_running"]}


### PR DESCRIPTION
## ELI-5

When you ask the server to download a model, the underlying `comfy model download` command prints its progress as plain text (like `Done in 55.8s`) and finishes with a success code — but it does **not** print the little machine-readable JSON receipt (an `envelope/1`) that our code expects. So even though the file downloaded fine, `download_model` was throwing a hard error: `comfy-cli returned no JSON (exit 0)`. To an agent that looks like the download **failed**, so it retries — re-fetching a multi-GB file for nothing.

PR #36 already solved this exact problem for the `launch`/`stop` commands by adding a `plain_ok=True` flag: "exited 0 with no JSON? that's a success, synthesize a result from the printed text." This PR just opts `download_model` into that same path.

## Summary

`download_model` reported a hard ERROR for downloads that actually succeeded, because `comfy model download` exits 0 without emitting an `envelope/1` object and `_run_comfy` unconditionally routed through `_unwrap_envelope` (which raises when stdout has no JSON). This extends PR #36's (BE-2953) exit-0-no-envelope success path to `download_model`.

## Changes

- **`download_model`** now calls `_run_comfy(*args, timeout=1800.0, plain_ok=True)` — a clean exit with no envelope is treated as success instead of raising the "returned no JSON" false negative.
- **Generalized `_synthesize_lifecycle_result` → `_synthesize_plain_result`**: de-lifecycled the `note` text so it reads correctly for any verb, and kept the payload shape `{"ok": True, "action": ..., "message": ..., "note": ...}`. `message` carries the CLI's printed text (stderr preferred) — for downloads that is where `Done in 55.8s` and the saved-path line live, the only result data available without an envelope.
- **`action`** is now derived from the leading non-flag argv tokens (stops at the first flag), so it reads `model download` for downloads while staying `launch` / `stop` for the lifecycle verbs (identical output for those). *(Judgment call — see Additional Notes.)*
- **Docstrings** updated: `download_model`, `_run_comfy`, and `_synthesize_plain_result` now describe the synthesized-payload success path.

## Motivation

Tiger's 2026-07-16 dogfooding: a download succeeded (exit 0, file on disk, confirmed via `search_models`, stderr showed `Done in 55.8s`) yet the tool raised `comfy-cli returned no JSON (exit 0)` as an ERROR — inviting a bandwidth-expensive retry of a multi-GB fetch.

## Testing

- [x] Existing tests pass (`pytest`) — 134 passed, 1 skipped (e2e).
- [x] Lint passes (`ruff check .`) — all checks passed.
- [x] Format check passes (`ruff format --check .`).

New unit tests mirror PR #36's lifecycle tests, for `download_model`:
- `test_download_model_synthesizes_success_on_plain_exit` — plain exit-0 success, `Done in 55.8s` asserted in `message`, `action == "model download"`.
- `test_download_model_nonzero_exit_still_raises` — non-zero exit with no envelope still raises `ComfyCliError`.
- `test_download_model_synthesizes_despite_stray_non_envelope_json` — a stray non-envelope JSON line on a clean exit is still success (not mis-unwrapped).
- `test_download_model_still_honors_a_real_error_envelope` — a real error envelope still raises with its code (synthesis does not shadow it).

The existing `test_download_model_url_only` already covers a real **success** envelope being unwrapped normally (not shadowed by the synthesis path). The arg-validation raises (leading-dash / scheme / traversal) are untouched and their tests still pass.

## Additional Notes

**Negative-claim falsification — N/A (does not fire).** This change does the *opposite* of denying a capability: it converts a spurious ERROR into the SUCCESS it should have been, removing a dead-end rather than adding one. No `not supported` / `STOP` / throw-deny path is introduced; the only preserved raise (non-zero exit / error envelope) already existed.

**Judgment call — `action` value.** The ticket asked only to rename the helper or parameterize the `note`. I additionally changed `action` from `args[0]` to the joined leading non-flag tokens, because a bare `args[0]` would yield the confusing `"model"` for downloads. Output is byte-identical for `launch`/`stop`; downloads now get the clearer `"model download"`. Low-risk and covered by tests.

**Out of scope (per ticket v1):** the upstream comfy-cli follow-up to emit an `envelope/1` for `model download` (when it ships, `plain_ok` becomes a harmless no-op — a real envelope always wins the fast-path); applying `plain_ok` to `upload_file` (not observed failing); download progress streaming / on-disk file verification (thin-passthrough per AGENTS.md).