### PR TITLE
perf(run_workflow): bound subprocess pipe threads to a dedicated executor (BE-3405)

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -24,6 +24,7 @@ import os
 import shutil
 import subprocess
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from urllib.parse import urlparse
 
@@ -69,6 +70,35 @@ _MAX_WATCH_TIMEOUT = 3600.0
 # its own, then fall through to the `finally` that kills it — never block on a
 # lingering child once the answer is already parsed.
 _POST_ENVELOPE_REAP_GRACE = 5.0
+
+# Dedicated, bounded thread pool for the blocking pipe reads / process waits in
+# `_run_comfy_streaming` (`stdout.readline`, `stderr.read`, `proc.wait`).
+#
+# Cancelling an `asyncio.to_thread` NEVER interrupts the underlying OS thread —
+# it stays parked on the pipe until the child is killed and its stdio closes.
+# On the success-envelope path the stderr reader is never awaited, only
+# cancelled, so it lingers until the `finally` kills the child (up to
+# `_POST_ENVELOPE_REAP_GRACE`). Running these on asyncio's shared *default*
+# executor means many concurrent `run_workflow(wait=True)` / `watch_job` calls
+# could pile parked readers/waiters onto that pool and starve unrelated
+# `to_thread` work for the grace window. Confining them to their own bounded
+# pool caps the blast radius to this pool; the `finally` block additionally
+# joins the stderr reader once the child is dead so it does not outlive the run.
+_PIPE_POOL_MAX_WORKERS = min(32, (os.cpu_count() or 1) + 4)
+_PIPE_EXECUTOR = ThreadPoolExecutor(
+    max_workers=_PIPE_POOL_MAX_WORKERS,
+    thread_name_prefix="comfy-pipe",
+)
+
+
+def _in_pipe_pool(func, *args):
+    """Off-load a blocking pipe read / process wait to the dedicated pool.
+
+    Mirrors :func:`asyncio.to_thread` but targets :data:`_PIPE_EXECUTOR`
+    instead of the loop's shared default executor, so subprocess pipe threads
+    can never saturate the pool other `to_thread` callers rely on.
+    """
+    return asyncio.get_running_loop().run_in_executor(_PIPE_EXECUTOR, func, *args)
 
 
 class ComfyCliError(RuntimeError):
@@ -287,7 +317,7 @@ async def _run_comfy_streaming(
         """
         assert proc.stdout is not None
         while True:
-            line = await asyncio.to_thread(proc.stdout.readline)
+            line = await _in_pipe_pool(proc.stdout.readline)
             if not line:  # EOF: comfy-cli closed stdout
                 return False
             lines.append(line)
@@ -307,7 +337,7 @@ async def _run_comfy_streaming(
 
     # Drain stderr concurrently so a chatty child can't deadlock on a full pipe.
     stderr_future = (
-        asyncio.ensure_future(asyncio.to_thread(proc.stderr.read))
+        asyncio.ensure_future(_in_pipe_pool(proc.stderr.read))
         if proc.stderr is not None
         else None
     )
@@ -323,7 +353,7 @@ async def _run_comfy_streaming(
             return True, None
         # EOF: the child has closed stdout, so a plain wait is safe and its
         # stderr is collectible for the error message.
-        returncode = await asyncio.to_thread(proc.wait)
+        returncode = await _in_pipe_pool(proc.wait)
         stderr = (await stderr_future) if stderr_future is not None else ""
         return False, _unwrap_envelope(
             _last_json_object("".join(lines)), args, returncode, stderr
@@ -364,7 +394,7 @@ async def _run_comfy_streaming(
         child_reaped = True
         try:
             await asyncio.wait_for(
-                asyncio.to_thread(proc.wait), timeout=_POST_ENVELOPE_REAP_GRACE
+                _in_pipe_pool(proc.wait), timeout=_POST_ENVELOPE_REAP_GRACE
             )
         except (asyncio.TimeoutError, TimeoutError):
             child_reaped = False  # lingering child; `finally` reaps it
@@ -385,9 +415,18 @@ async def _run_comfy_streaming(
         # (timeout, a report_progress error, or normal completion).
         if proc.poll() is None:
             proc.kill()
-            await asyncio.to_thread(proc.wait)
+            await _in_pipe_pool(proc.wait)
+        # The child is now dead, so its stderr pipe has EOF'd and the parked
+        # reader's `read()` returns promptly. Awaiting the future JOINS that
+        # thread back into the pool before we return — cancelling alone would
+        # not (a cancelled `to_thread`/`run_in_executor` leaves the OS thread
+        # parked until the read actually unblocks). Guard against the read
+        # having raised so cleanup never masks the real result/exception.
         if stderr_future is not None and not stderr_future.done():
-            stderr_future.cancel()
+            try:
+                await stderr_future
+            except Exception:
+                pass
 
 
 @mcp.tool()

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -101,6 +101,37 @@ def _in_pipe_pool(func, *args):
     return asyncio.get_running_loop().run_in_executor(_PIPE_EXECUTOR, func, *args)
 
 
+# Bound how long cleanup will block joining the parked stderr reader. `proc.kill`
+# reaps only the DIRECT comfy-cli child; a descendant that inherited the stderr
+# write fd keeps the pipe open, so the reader's `read()` never EOFs. Cap the join
+# so cleanup can never hang the tool call, and detach the reader on timeout.
+_STDERR_JOIN_GRACE = 5.0
+
+# Retain at most this many trailing chars of a child's stderr. The reader must
+# keep draining for the whole run (a chatty child would otherwise wedge on a full
+# stderr pipe), but retaining every byte lets a misbehaving child drive unbounded
+# allocation in this process — a memory-exhaustion DoS. Keep only the tail, where
+# the actual error / traceback that `_unwrap_envelope` falls back to usually is.
+_STDERR_MAX_CHARS = 64 * 1024
+_STDERR_READ_CHUNK = 64 * 1024
+
+
+def _drain_capped(stream: Any, limit: int) -> str:
+    """Read ``stream`` to EOF but keep only the trailing ``limit`` chars.
+
+    Draining to EOF keeps the child from blocking on a full stderr pipe; slicing
+    to the tail on every chunk bounds memory to ``limit`` + one chunk regardless
+    of how much the child spams.
+    """
+    tail = ""
+    while True:
+        chunk = stream.read(_STDERR_READ_CHUNK)
+        if not chunk:
+            break
+        tail = (tail + chunk)[-limit:]
+    return tail
+
+
 class ComfyCliError(RuntimeError):
     """comfy-cli was missing, timed out, or returned an error envelope."""
 
@@ -335,9 +366,12 @@ async def _run_comfy_streaming(
                     return True
                 await tracker.report(ctx, event)
 
-    # Drain stderr concurrently so a chatty child can't deadlock on a full pipe.
+    # Drain stderr concurrently so a chatty child can't deadlock on a full pipe;
+    # retain only the tail so it can't drive unbounded allocation here.
     stderr_future = (
-        asyncio.ensure_future(_in_pipe_pool(proc.stderr.read))
+        asyncio.ensure_future(
+            _in_pipe_pool(_drain_capped, proc.stderr, _STDERR_MAX_CHARS)
+        )
         if proc.stderr is not None
         else None
     )
@@ -408,7 +442,16 @@ async def _run_comfy_streaming(
             and stderr_future is not None
             and not (envelope or {}).get("ok", False)
         ):
-            stderr = await stderr_future
+            # The direct child exited during the grace, so its stderr pipe has
+            # normally EOF'd — but a descendant holding the write fd could still
+            # block this read. Bound it; `shield` keeps a timeout from cancelling
+            # the reader here so the `finally` join can still detach it.
+            try:
+                stderr = await asyncio.wait_for(
+                    asyncio.shield(stderr_future), _STDERR_JOIN_GRACE
+                )
+            except (asyncio.TimeoutError, TimeoutError):
+                stderr = ""
         return _unwrap_envelope(envelope, args, proc.returncode, stderr)
     finally:
         # Never leave a stray child or a dangling stderr reader on any exit path
@@ -416,15 +459,25 @@ async def _run_comfy_streaming(
         if proc.poll() is None:
             proc.kill()
             await _in_pipe_pool(proc.wait)
-        # The child is now dead, so its stderr pipe has EOF'd and the parked
-        # reader's `read()` returns promptly. Awaiting the future JOINS that
-        # thread back into the pool before we return — cancelling alone would
-        # not (a cancelled `to_thread`/`run_in_executor` leaves the OS thread
-        # parked until the read actually unblocks). Guard against the read
-        # having raised so cleanup never masks the real result/exception.
-        if stderr_future is not None and not stderr_future.done():
+        # The direct child is now dead, so its stderr pipe SHOULD EOF and the
+        # parked reader return promptly — awaiting the future JOINS that thread
+        # back into the pool (a cancelled `run_in_executor` leaves the OS thread
+        # parked until the read unblocks, so cancel alone would not). But
+        # `proc.kill()` only reaps the direct comfy-cli child; if it left a
+        # descendant holding the stderr write fd the pipe never EOFs and an
+        # unbounded join would hang the tool call forever. Bound the join and, on
+        # timeout, fall back to cancelling (detaches our await — the caller
+        # unblocks; the OS thread frees when the fd finally closes). `wait_for`
+        # cancels its inner future when cancelled, so even a `CancelledError`
+        # here detaches the reader before propagating. Awaiting also consumes any
+        # exception the read raised, so cleanup never masks the real
+        # result/exception and no "Future exception was never retrieved" warning
+        # is emitted.
+        if stderr_future is not None and not stderr_future.cancelled():
             try:
-                await stderr_future
+                await asyncio.wait_for(stderr_future, _STDERR_JOIN_GRACE)
+            except (asyncio.TimeoutError, TimeoutError):
+                stderr_future.cancel()
             except Exception:
                 pass
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -112,7 +112,7 @@ def _run_comfy(*args: str, timeout: float | None = None) -> Any:
 
 
 def _unwrap_envelope(
-    envelope: dict | None, args: tuple[str, ...], returncode: int, stderr: str
+    envelope: dict | None, args: tuple[str, ...], returncode: int | None, stderr: str
 ) -> Any:
     """Unwrap comfy-cli's ``envelope/1`` result, raising on error/absence.
 
@@ -274,14 +274,16 @@ async def _run_comfy_streaming(
     tracker = _StreamProgress()
 
     async def _pump() -> bool:
-        """Read stdout until the terminal envelope (preferred) or stdout EOF.
+        """Read stdout until the terminal ``envelope/1`` line or stdout EOF.
 
-        Returns True if the loop stopped on the ``type == "envelope"`` line (the
+        Returns True if the loop stopped on the terminal envelope (the
         authoritative result is already appended to ``lines``), False if it
-        stopped on stdout EOF. Breaking on the envelope — mirroring
-        :func:`_last_json_object`'s preference for it — keeps a fast run from
-        sitting in ``readline`` when comfy-cli lingers after emitting its
-        envelope (see ``_POST_ENVELOPE_REAP_GRACE``).
+        stopped on stdout EOF. Only the ``schema == "envelope/1"`` line is
+        treated as terminal — an earlier or relayed ``type == "envelope"`` line
+        that is not the run's result envelope (e.g. custom-node output) must not
+        abort the read and kill the still-running child. Breaking on the real
+        envelope keeps a fast run from sitting in ``readline`` when comfy-cli
+        lingers after emitting it (see ``_POST_ENVELOPE_REAP_GRACE``).
         """
         assert proc.stdout is not None
         while True:
@@ -293,10 +295,13 @@ async def _run_comfy_streaming(
             # watch still returns real progress; report() no-ops the notify.
             event = _parse_event(line)
             if event is not None:
-                if event.get("type") == "envelope":
-                    # Full result is in `lines`; _drain() unwraps it unchanged.
-                    # Don't block in readline for a child that may outlive its
-                    # own envelope under a pipe.
+                if (
+                    event.get("type") == "envelope"
+                    and event.get("schema") == "envelope/1"
+                ):
+                    # Full result is in `lines`; it is unwrapped unchanged after
+                    # the reap grace. Don't block in readline for a child that
+                    # may outlive its own envelope under a pipe.
                     return True
                 await tracker.report(ctx, event)
 
@@ -307,37 +312,39 @@ async def _run_comfy_streaming(
         else None
     )
 
-    async def _drain() -> Any:
-        # Read the stream, then reap the child and its stderr. Bounding this
-        # entire coroutine (not just _pump) means a child that closes stdout
-        # without exiting can't wedge the unbounded proc.wait/stderr read.
+    async def _read() -> tuple[bool, Any]:
+        # Read up to the terminal envelope, then — on the EOF path only — reap
+        # the child and its stderr. Both are bounded by the caller's `timeout`
+        # (a child that closes stdout without exiting can't wedge the unbounded
+        # proc.wait/stderr read). On the envelope path the reap is deliberately
+        # left to the caller so it runs OFF the client budget.
         got_envelope = await _pump()
         if got_envelope:
-            # We have the answer. Give the child a brief grace to exit, then
-            # fall through — the `finally` kills a still-live child. Do NOT
-            # await stderr_future here: stderr may never EOF while the child
-            # lives, and the envelope already carries any error message.
-            try:
-                await asyncio.wait_for(
-                    asyncio.to_thread(proc.wait), timeout=_POST_ENVELOPE_REAP_GRACE
-                )
-            except (asyncio.TimeoutError, TimeoutError):
-                pass  # lingering child; `finally` reaps it
-            returncode, stderr = proc.returncode, ""
-        else:
-            # EOF: the child has closed stdout, so a plain wait is safe and its
-            # stderr is collectible for the error message.
-            returncode = await asyncio.to_thread(proc.wait)
-            stderr = (await stderr_future) if stderr_future is not None else ""
-        return _unwrap_envelope(
+            return True, None
+        # EOF: the child has closed stdout, so a plain wait is safe and its
+        # stderr is collectible for the error message.
+        returncode = await asyncio.to_thread(proc.wait)
+        stderr = (await stderr_future) if stderr_future is not None else ""
+        return False, _unwrap_envelope(
             _last_json_object("".join(lines)), args, returncode, stderr
         )
 
     try:
+        # `_read` (reaching the envelope, plus the EOF-path reap) is bounded by
+        # the client's `timeout`. Once the envelope has been read it IS the
+        # answer; reaping a lingering child must NOT run on the client budget, or
+        # an envelope that lands within the reap grace of the deadline would be
+        # discarded and returned to sender as a spurious timeout (driving retries
+        # / duplicate jobs).
         try:
             if timeout is not None:
-                return await asyncio.wait_for(_drain(), timeout=timeout)
-            return await _drain()
+                got_envelope, eof_result = await asyncio.wait_for(
+                    _read(), timeout=timeout
+                )
+            else:
+                got_envelope, eof_result = await _read()
+            if not got_envelope:
+                return eof_result
         except (asyncio.TimeoutError, TimeoutError) as exc:
             if not raise_on_timeout:
                 # Bounded tail: report how far the run got instead of erroring
@@ -349,6 +356,30 @@ async def _run_comfy_streaming(
                 "going — check `job_status`, or for long generations submit "
                 "with `wait=False` and poll `wait_for_job` / `watch_job`."
             ) from exc
+
+        # Envelope path: the authoritative result is already in `lines`, read
+        # within the deadline. Give the child a brief grace to exit on a SEPARATE
+        # budget; the `finally` kills a still-live one.
+        envelope = _last_json_object("".join(lines))
+        child_reaped = True
+        try:
+            await asyncio.wait_for(
+                asyncio.to_thread(proc.wait), timeout=_POST_ENVELOPE_REAP_GRACE
+            )
+        except (asyncio.TimeoutError, TimeoutError):
+            child_reaped = False  # lingering child; `finally` reaps it
+        # stderr only matters for an error envelope whose `error.message` is
+        # empty (then `_unwrap_envelope` falls back to it). Collect it only when
+        # the child already exited during the grace — its stderr pipe has EOF'd,
+        # so the read can't block; a lingering child would, so skip it.
+        stderr = ""
+        if (
+            child_reaped
+            and stderr_future is not None
+            and not (envelope or {}).get("ok", False)
+        ):
+            stderr = await stderr_future
+        return _unwrap_envelope(envelope, args, proc.returncode, stderr)
     finally:
         # Never leave a stray child or a dangling stderr reader on any exit path
         # (timeout, a report_progress error, or normal completion).

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -63,6 +63,13 @@ COMFY_BIN = os.environ.get("COMFY_BIN", "comfy")
 # can't hold a `comfy jobs watch` child open effectively forever (1 hour).
 _MAX_WATCH_TIMEOUT = 3600.0
 
+# Once the terminal envelope is read the authoritative result is in hand, but
+# comfy-cli can outlive its own envelope under a pipe (observed with
+# comfy-cli v1.12.0 `--json-stream`). Give such a child a short grace to exit on
+# its own, then fall through to the `finally` that kills it — never block on a
+# lingering child once the answer is already parsed.
+_POST_ENVELOPE_REAP_GRACE = 5.0
+
 
 class ComfyCliError(RuntimeError):
     """comfy-cli was missing, timed out, or returned an error envelope."""
@@ -266,17 +273,31 @@ async def _run_comfy_streaming(
     lines: list[str] = []
     tracker = _StreamProgress()
 
-    async def _pump() -> None:
+    async def _pump() -> bool:
+        """Read stdout until the terminal envelope (preferred) or stdout EOF.
+
+        Returns True if the loop stopped on the ``type == "envelope"`` line (the
+        authoritative result is already appended to ``lines``), False if it
+        stopped on stdout EOF. Breaking on the envelope — mirroring
+        :func:`_last_json_object`'s preference for it — keeps a fast run from
+        sitting in ``readline`` when comfy-cli lingers after emitting its
+        envelope (see ``_POST_ENVELOPE_REAP_GRACE``).
+        """
         assert proc.stdout is not None
         while True:
             line = await asyncio.to_thread(proc.stdout.readline)
             if not line:  # EOF: comfy-cli closed stdout
-                break
+                return False
             lines.append(line)
             # Advance the tracker even without a ctx so a timed-out ctx-less
             # watch still returns real progress; report() no-ops the notify.
             event = _parse_event(line)
             if event is not None:
+                if event.get("type") == "envelope":
+                    # Full result is in `lines`; _drain() unwraps it unchanged.
+                    # Don't block in readline for a child that may outlive its
+                    # own envelope under a pipe.
+                    return True
                 await tracker.report(ctx, event)
 
     # Drain stderr concurrently so a chatty child can't deadlock on a full pipe.
@@ -287,12 +308,27 @@ async def _run_comfy_streaming(
     )
 
     async def _drain() -> Any:
-        # Read the whole stream, then reap the child and its stderr. Bounding
-        # this entire coroutine (not just _pump) means a child that closes
-        # stdout without exiting can't wedge the unbounded proc.wait/stderr read.
-        await _pump()
-        returncode = await asyncio.to_thread(proc.wait)
-        stderr = (await stderr_future) if stderr_future is not None else ""
+        # Read the stream, then reap the child and its stderr. Bounding this
+        # entire coroutine (not just _pump) means a child that closes stdout
+        # without exiting can't wedge the unbounded proc.wait/stderr read.
+        got_envelope = await _pump()
+        if got_envelope:
+            # We have the answer. Give the child a brief grace to exit, then
+            # fall through — the `finally` kills a still-live child. Do NOT
+            # await stderr_future here: stderr may never EOF while the child
+            # lives, and the envelope already carries any error message.
+            try:
+                await asyncio.wait_for(
+                    asyncio.to_thread(proc.wait), timeout=_POST_ENVELOPE_REAP_GRACE
+                )
+            except (asyncio.TimeoutError, TimeoutError):
+                pass  # lingering child; `finally` reaps it
+            returncode, stderr = proc.returncode, ""
+        else:
+            # EOF: the child has closed stdout, so a plain wait is safe and its
+            # stderr is collectible for the error message.
+            returncode = await asyncio.to_thread(proc.wait)
+            stderr = (await stderr_future) if stderr_future is not None else ""
         return _unwrap_envelope(
             _last_json_object("".join(lines)), args, returncode, stderr
         )
@@ -308,7 +344,10 @@ async def _run_comfy_streaming(
                 # (the finally below still kills the child).
                 return {"timed_out": True, "status": tracker.snapshot()}
             raise ComfyCliError(
-                f"comfy-cli timed out after {timeout}s: {' '.join(cmd)}"
+                f"comfy-cli timed out after {timeout}s: {' '.join(cmd)}. "
+                f"Progress so far: {tracker.snapshot()}. The run may still be "
+                "going — check `job_status`, or for long generations submit "
+                "with `wait=False` and poll `wait_for_job` / `watch_job`."
             ) from exc
     finally:
         # Never leave a stray child or a dangling stderr reader on any exit path
@@ -335,7 +374,7 @@ def server_info() -> Any:
 async def run_workflow(
     workflow_path: str,
     wait: bool = True,
-    timeout_seconds: float = 600.0,
+    timeout_seconds: float = 110.0,
     ctx: Context | None = None,
 ) -> Any:
     """Run a ComfyUI workflow JSON on the LOCAL ComfyUI.
@@ -346,6 +385,14 @@ async def run_workflow(
     as MCP progress notifications (per-node execution + sampler step counts) so
     a long generation is not a silent block; with ``wait=False`` it submits and
     returns immediately with a ``prompt_id`` to poll via ``job_status``.
+
+    ``timeout_seconds`` defaults to 110s — deliberately BELOW a typical MCP
+    client's ~120s tool budget, so a genuinely slow run surfaces this wrapper's
+    own actionable timeout (with a progress snapshot + next-step hint) instead
+    of an opaque client-side deadline. Keep it under your client's tool timeout;
+    for generations that may exceed it, submit with ``wait=False`` and poll
+    ``wait_for_job`` / ``watch_job`` (the server INSTRUCTIONS teach this flow)
+    rather than raising this bound.
     """
     if not wait:
         # Fire-and-return: no stream to follow, so keep the plain --json path.

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -826,7 +826,7 @@ class _LingeringProc:
         self._dead.wait(timeout=10.0)  # stdout never EOFs on its own
         return ""
 
-    def read(self):
+    def read(self, size=-1):  # noqa: ARG002 — size ignored; models a blocking pipe
         self._dead.wait(timeout=10.0)  # stderr never EOFs while the child lives
         return ""
 
@@ -1125,6 +1125,127 @@ def test_run_workflow_error_envelope_empty_message_falls_back_to_stderr(monkeypa
     assert "kaboom" in msg  # the stderr fallback filled the empty message
 
 
+# --- stderr drain is bounded in both memory and time --------------------------
+
+
+class _ChunkedStream:
+    """Fake pipe that hands back ``data`` in fixed ``chunk`` slices, then EOF.
+
+    Models a real pipe delivering stderr in many small reads (ignoring the
+    requested size), so a test can prove `_drain_capped` keeps reading to EOF
+    and retains the tail across chunk boundaries — not just within one read.
+    """
+
+    def __init__(self, data, chunk):
+        self._data = data
+        self._chunk = chunk
+        self._pos = 0
+
+    def read(self, size=-1):  # noqa: ARG002 — models a pipe: own chunk, not size
+        piece = self._data[self._pos : self._pos + self._chunk]
+        self._pos += len(piece)
+        return piece
+
+
+def test_drain_capped_retains_only_the_tail_across_chunks():
+    """`_drain_capped` drains to EOF but keeps at most ``limit`` trailing chars.
+
+    A verbose child must be fully drained (so it can't wedge on a full stderr
+    pipe) without letting its output drive unbounded allocation here — only the
+    tail, where the actual error/traceback lands, is retained.
+    """
+    data = "".join(f"line{i}\n" for i in range(1000))  # ~7 KB across many chunks
+    out = server._drain_capped(_ChunkedStream(data, chunk=64), limit=100)
+    assert out == data[-100:]
+    assert len(out) == 100
+    # Under the cap: returned whole. Empty: drains to "".
+    assert server._drain_capped(_ChunkedStream("short", chunk=64), 100) == "short"
+    assert server._drain_capped(_ChunkedStream("", chunk=64), 100) == ""
+
+
+class _StderrNeverEOFProc:
+    """Envelope-then-linger child whose stderr pipe never EOFs, even after kill.
+
+    Models comfy-cli leaving a descendant that inherited the stderr write fd:
+    ``kill()`` reaps the direct child (unblocking ``readline`` / ``wait``) but
+    the stderr ``read()`` never returns. The bounded ``finally`` join must
+    detach the parked reader instead of hanging the tool call forever.
+    """
+
+    def __init__(self, cmd, lines):
+        self.cmd = cmd
+        self._lines = list(lines)
+        self.stdout = self
+        self.stderr = self
+        self.returncode = None
+        self.killed = False
+        self._child_dead = threading.Event()  # set by kill(): the direct child
+        self._stderr_eof = threading.Event()  # NEVER set: descendant holds the fd
+
+    def readline(self):
+        if self._lines:
+            return self._lines.pop(0)
+        self._child_dead.wait(timeout=10.0)
+        return ""
+
+    def read(self, size=-1):  # noqa: ARG002 — parks past kill(); never EOFs
+        self._stderr_eof.wait(timeout=10.0)
+        return ""
+
+    def poll(self):
+        return self.returncode if self._child_dead.is_set() else None
+
+    def wait(self):
+        self._child_dead.wait(timeout=10.0)
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+        self._child_dead.set()  # reaps the direct child, NOT the stderr holder
+
+
+def test_envelope_path_does_not_hang_when_stderr_pipe_never_eofs(monkeypatch):
+    """A descendant holding the stderr write fd can't wedge cleanup forever.
+
+    ``proc.kill()`` reaps only the direct child; if a descendant keeps the
+    stderr pipe open the reader never EOFs. The ``finally`` join is bounded, so
+    the tool call still returns its already-read envelope instead of hanging.
+    """
+    lines = [
+        json.dumps({"type": "queued", "nodes": [{"node_id": "1"}]}) + "\n",
+        json.dumps(
+            {
+                "schema": "envelope/1",
+                "type": "envelope",
+                "ok": True,
+                "data": {"outputs": ["/out.png"]},
+            }
+        )
+        + "\n",
+    ]
+    proc = _StderrNeverEOFProc(cmd=["comfy"], lines=lines)
+
+    def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
+        return proc
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server, "_POST_ENVELOPE_REAP_GRACE", 0.05)
+    monkeypatch.setattr(server, "_STDERR_JOIN_GRACE", 0.05)
+
+    async def _drive():
+        # A regression (unbounded join) would blow this guard, not park for 30s.
+        return await asyncio.wait_for(
+            server.run_workflow("wf.json", wait=True, timeout_seconds=30.0),
+            timeout=5.0,
+        )
+
+    result = asyncio.run(_drive())
+    assert result == {"outputs": ["/out.png"]}
+    assert proc.killed  # the direct child was reaped even though stderr never EOF'd
+
+
 # --- bounded pipe-read pool: threads don't accumulate on the default executor -
 
 
@@ -1208,7 +1329,7 @@ def test_overlapping_streaming_runs_confine_and_release_pipe_threads(monkeypatch
             self._block_until_dead()
             return ""
 
-        def read(self):  # stderr.read — parks until the child is killed
+        def read(self, size=-1):  # noqa: ARG002 — size ignored; parks until killed
             self._block_until_dead()
             return ""
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -18,6 +18,7 @@ import asyncio
 import io
 import json
 import subprocess
+import threading
 import time
 
 import pytest
@@ -791,3 +792,190 @@ def test_run_workflow_wait_false_uses_plain_json_no_stream(monkeypatch):
     assert result == {"prompt_id": "p1"}
     assert seen["args"] == ("run", "--workflow", "wf.json")  # no --wait
     assert seen["timeout"] == 60.0
+
+
+# --- envelope-terminated read: don't wait on a lingering child ----------------
+
+
+class _LingeringProc:
+    """Fake Popen that emits ``lines`` (incl. the terminal envelope) then lingers.
+
+    Once the canned lines are exhausted ``stdout.readline`` blocks until the
+    child is killed, and ``wait()`` blocks the same way — modeling comfy-cli
+    outliving its own ``--json-stream`` envelope under a pipe. ``stderr.read``
+    blocks too, so a test also proves the envelope path never awaits stderr. The
+    block is bounded (10s) only so a buggy test can't hang the suite; the real
+    exit is ``kill()``.
+    """
+
+    def __init__(self, cmd, lines):
+        self.cmd = cmd
+        self._lines = list(lines)
+        self.stdout = self  # readline lives on the proc itself
+        self.stderr = self  # read() blocks the same way -> proves we don't await it
+        self.returncode = 0
+        self.killed = False
+        self._dead = threading.Event()
+
+    def readline(self):
+        if self._lines:
+            return self._lines.pop(0)
+        self._dead.wait(timeout=10.0)  # stdout never EOFs on its own
+        return ""
+
+    def read(self):
+        self._dead.wait(timeout=10.0)  # stderr never EOFs while the child lives
+        return ""
+
+    def poll(self):
+        return self.returncode if self._dead.is_set() else None
+
+    def wait(self):
+        self._dead.wait(timeout=10.0)  # a child that lingers past its envelope
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+        self._dead.set()
+
+
+def _lingering_popen(procs, stream_lines):
+    """A ``subprocess.Popen`` stand-in minting a fresh ``_LingeringProc`` per call."""
+
+    def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
+        proc = _LingeringProc(cmd, list(stream_lines))
+        procs.append(proc)
+        return proc
+
+    return fake_popen
+
+
+# Run events (2-node manifest + one completion) then the terminal envelope; the
+# child then lingers instead of closing stdout.
+_ENVELOPE_THEN_LINGER = [
+    json.dumps({"type": "queued", "nodes": [{"node_id": "1"}, {"node_id": "2"}]})
+    + "\n",
+    json.dumps({"type": "executed", "node": "1", "title": "Load"}) + "\n",
+    json.dumps(
+        {
+            "schema": "envelope/1",
+            "type": "envelope",
+            "ok": True,
+            "data": {"outputs": ["/x.png"]},
+        }
+    )
+    + "\n",
+]
+
+_ERROR_ENVELOPE_THEN_LINGER = [
+    json.dumps({"type": "queued", "nodes": [{"node_id": "1"}]}) + "\n",
+    json.dumps(
+        {
+            "schema": "envelope/1",
+            "type": "envelope",
+            "ok": False,
+            "error": {"code": "execution_error", "message": "boom"},
+        }
+    )
+    + "\n",
+]
+
+
+def test_run_workflow_returns_on_envelope_despite_lingering_child(monkeypatch):
+    """Child emits its envelope then never closes stdout: return promptly, reap it.
+
+    The core fix — the read loop terminates on the ``envelope`` line, so a fast
+    run does not sit in ``readline`` waiting for a child that outlives its own
+    envelope. The result comes back well under the tool timeout.
+    """
+    procs: list[_LingeringProc] = []
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(
+        server.subprocess, "Popen", _lingering_popen(procs, _ENVELOPE_THEN_LINGER)
+    )
+    # Tiny post-envelope grace so the lingering child is reaped fast in-test.
+    monkeypatch.setattr(server, "_POST_ENVELOPE_REAP_GRACE", 0.1)
+
+    start = time.monotonic()
+    result = asyncio.run(
+        server.run_workflow(
+            "wf.json", wait=True, timeout_seconds=30.0, ctx=_RecordingCtx()
+        )
+    )
+    elapsed = time.monotonic() - start
+
+    assert result == {"outputs": ["/x.png"]}  # the envelope's data, unwrapped
+    assert elapsed < 5.0  # did NOT block on the lingering child
+    assert procs[0].killed  # the child was killed / reaped on the way out
+
+
+def test_run_workflow_error_envelope_with_open_pipe_raises(monkeypatch):
+    """An error envelope followed by an open pipe still raises with its error code."""
+    procs: list[_LingeringProc] = []
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(
+        server.subprocess, "Popen", _lingering_popen(procs, _ERROR_ENVELOPE_THEN_LINGER)
+    )
+    monkeypatch.setattr(server, "_POST_ENVELOPE_REAP_GRACE", 0.1)
+
+    with pytest.raises(server.ComfyCliError, match="execution_error"):
+        asyncio.run(server.run_workflow("wf.json", wait=True, timeout_seconds=30.0))
+
+    assert procs[0].killed  # still reaped on the error path
+
+
+def test_two_overlapping_run_workflow_calls_complete_independently(monkeypatch):
+    """Two concurrent wait=True runs against independent children both finish.
+
+    There is no shared state in the wrapper (each call spawns its own child), so
+    the reported "second concurrent call hung" is the same envelope-vs-EOF wait —
+    with the envelope-terminated read, both return.
+    """
+    procs: list[_LingeringProc] = []
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(
+        server.subprocess, "Popen", _lingering_popen(procs, _ENVELOPE_THEN_LINGER)
+    )
+    monkeypatch.setattr(server, "_POST_ENVELOPE_REAP_GRACE", 0.1)
+
+    async def _both():
+        return await asyncio.gather(
+            server.run_workflow("a.json", wait=True, timeout_seconds=30.0),
+            server.run_workflow("b.json", wait=True, timeout_seconds=30.0),
+        )
+
+    results = asyncio.run(_both())
+
+    assert results == [{"outputs": ["/x.png"]}, {"outputs": ["/x.png"]}]
+    assert len(procs) == 2  # two independent children spawned
+    assert all(p.killed for p in procs)  # both cleaned up
+
+
+def test_run_workflow_timeout_error_includes_snapshot_and_hint(monkeypatch):
+    """A genuine timeout surfaces the progress snapshot + a job_status/wait=False hint."""
+    queued = json.dumps(
+        {"type": "queued", "nodes": [{"node_id": "1"}, {"node_id": "2"}]}
+    )
+    procs: list[_BlockingProc] = []
+
+    def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
+        proc = _BlockingProc(cmd, [queued + "\n"])
+        procs.append(proc)
+        return proc
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        asyncio.run(
+            server.run_workflow(
+                "wf.json", wait=True, timeout_seconds=0.25, ctx=_RecordingCtx()
+            )
+        )
+
+    msg = str(excinfo.value)
+    assert "timed out" in msg
+    assert "nodes_done" in msg  # tracker.snapshot() dict is embedded
+    assert "job_status" in msg  # actionable next-step hints
+    assert "wait=False" in msg
+    assert procs[0].killed  # the child was still cleaned up on timeout

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -813,7 +813,10 @@ class _LingeringProc:
         self._lines = list(lines)
         self.stdout = self  # readline lives on the proc itself
         self.stderr = self  # read() blocks the same way -> proves we don't await it
-        self.returncode = 0
+        # None until reaped, mirroring real Popen: while the child lingers past
+        # its envelope its returncode is unknown, and _unwrap_envelope must
+        # tolerate that (it ignores returncode whenever an envelope is present).
+        self.returncode = None
         self.killed = False
         self._dead = threading.Event()
 
@@ -836,6 +839,7 @@ class _LingeringProc:
 
     def kill(self):
         self.killed = True
+        self.returncode = -9  # reaped by SIGKILL
         self._dead.set()
 
 
@@ -979,3 +983,143 @@ def test_run_workflow_timeout_error_includes_snapshot_and_hint(monkeypatch):
     assert "job_status" in msg  # actionable next-step hints
     assert "wait=False" in msg
     assert procs[0].killed  # the child was still cleaned up on timeout
+
+
+# Non-terminal ``type == "envelope"`` line (relayed custom-node output, schema
+# ``event/1``) followed by the REAL terminal ``schema == "envelope/1"`` result.
+_SPURIOUS_ENVELOPE_THEN_REAL = [
+    json.dumps({"type": "queued", "nodes": [{"node_id": "1"}]}) + "\n",
+    json.dumps(
+        {
+            "schema": "event/1",
+            "type": "envelope",
+            "ok": True,
+            "data": {"spurious": "not the result"},
+        }
+    )
+    + "\n",
+    json.dumps({"type": "executed", "node": "1", "title": "Load"}) + "\n",
+    json.dumps(
+        {
+            "schema": "envelope/1",
+            "type": "envelope",
+            "ok": True,
+            "data": {"outputs": ["/real.png"]},
+        }
+    )
+    + "\n",
+]
+
+
+def test_run_workflow_returns_envelope_after_deadline_during_reap(monkeypatch):
+    """An envelope that lands before the deadline is returned even if reaping the
+    lingering child would overrun it.
+
+    Boundary case for the envelope-vs-deadline race: the authoritative result is
+    read within ``timeout``, but the post-envelope reap grace is LONGER than the
+    remaining budget. Because the reap runs off the client budget, the result
+    comes back instead of being discarded as a spurious timeout.
+    """
+    procs: list[_LingeringProc] = []
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(
+        server.subprocess, "Popen", _lingering_popen(procs, _ENVELOPE_THEN_LINGER)
+    )
+    # Grace (0.5s) deliberately exceeds the client timeout (0.2s): the OLD code
+    # ran the reap inside the client budget and raised; the fix returns the data.
+    monkeypatch.setattr(server, "_POST_ENVELOPE_REAP_GRACE", 0.5)
+
+    start = time.monotonic()
+    result = asyncio.run(
+        server.run_workflow(
+            "wf.json", wait=True, timeout_seconds=0.2, ctx=_RecordingCtx()
+        )
+    )
+    elapsed = time.monotonic() - start
+
+    assert result == {"outputs": ["/x.png"]}  # envelope data, not a timeout error
+    assert elapsed < 5.0  # reaped within the grace, not the 10s mock block
+    assert procs[0].killed  # lingering child still cleaned up
+
+
+def test_run_workflow_ignores_non_terminal_envelope_typed_line(monkeypatch):
+    """A relayed ``type == "envelope"`` line that isn't ``schema == "envelope/1"``
+    must not abort the read and return its payload as the result."""
+    procs: list[_LingeringProc] = []
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(
+        server.subprocess,
+        "Popen",
+        _lingering_popen(procs, _SPURIOUS_ENVELOPE_THEN_REAL),
+    )
+    monkeypatch.setattr(server, "_POST_ENVELOPE_REAP_GRACE", 0.1)
+
+    result = asyncio.run(
+        server.run_workflow(
+            "wf.json", wait=True, timeout_seconds=30.0, ctx=_RecordingCtx()
+        )
+    )
+
+    assert result == {
+        "outputs": ["/real.png"]
+    }  # the terminal envelope, not the spurious one
+    assert procs[0].killed
+
+
+class _ExitedErrorProc:
+    """Emits an error envelope with an empty message, then exits with stderr text.
+
+    Models an error run whose envelope carries no ``error.message`` but whose
+    stderr does — the envelope path must still surface that stderr text.
+    """
+
+    def __init__(self, cmd, lines, stderr_text):
+        self.cmd = cmd
+        self._lines = list(lines)
+        self.stdout = self
+        self.stderr = io.StringIO(stderr_text)
+        self.returncode = 1  # already exited by the time we reap
+        self.killed = False
+
+    def readline(self):
+        return self._lines.pop(0) if self._lines else ""
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self):
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+
+
+def test_run_workflow_error_envelope_empty_message_falls_back_to_stderr(monkeypatch):
+    """A message-less error envelope on the streaming path still reports stderr."""
+    lines = [
+        json.dumps({"type": "queued", "nodes": [{"node_id": "1"}]}) + "\n",
+        json.dumps(
+            {
+                "schema": "envelope/1",
+                "type": "envelope",
+                "ok": False,
+                "error": {"code": "execution_error", "message": ""},
+            }
+        )
+        + "\n",
+    ]
+    stderr_text = "Traceback (most recent call last):\nRuntimeError: kaboom"
+
+    def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
+        return _ExitedErrorProc(cmd, lines, stderr_text)
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server, "_POST_ENVELOPE_REAP_GRACE", 0.1)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        asyncio.run(server.run_workflow("wf.json", wait=True, timeout_seconds=30.0))
+
+    msg = str(excinfo.value)
+    assert "execution_error" in msg  # the envelope's error code
+    assert "kaboom" in msg  # the stderr fallback filled the empty message

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1123,3 +1123,153 @@ def test_run_workflow_error_envelope_empty_message_falls_back_to_stderr(monkeypa
     msg = str(excinfo.value)
     assert "execution_error" in msg  # the envelope's error code
     assert "kaboom" in msg  # the stderr fallback filled the empty message
+
+
+# --- bounded pipe-read pool: threads don't accumulate on the default executor -
+
+
+def test_pipe_executor_is_dedicated_and_bounded():
+    """The subprocess pipe reads run on their own bounded pool, not the default.
+
+    A dedicated `ThreadPoolExecutor` with a finite `max_workers` is what keeps
+    parked pipe-reader/waiter threads off asyncio's shared default executor, so
+    they can never starve unrelated `to_thread` work.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    assert isinstance(server._PIPE_EXECUTOR, ThreadPoolExecutor)
+    assert server._PIPE_EXECUTOR._max_workers == server._PIPE_POOL_MAX_WORKERS
+    assert server._PIPE_POOL_MAX_WORKERS >= 1  # bounded, non-zero
+
+
+def test_overlapping_streaming_runs_confine_and_release_pipe_threads(monkeypatch):
+    """N overlapping streaming runs keep their blocking pipe reads on the
+    dedicated pool and drain back to baseline once each run returns.
+
+    Each fake child emits its envelope then lingers with a blocked stderr pipe
+    (``read()`` never EOFs until the child is killed) — the exact shape that
+    parks a reader thread. This asserts the two halves of the fix together:
+
+    1. Isolation — every blocking ``readline`` / ``read`` / ``wait`` runs on a
+       ``_PIPE_EXECUTOR`` worker (``comfy-pipe`` prefix), NOT the loop's shared
+       default executor (whose threads are named ``asyncio_*``). On the old
+       ``asyncio.to_thread`` code these would land on the default pool and the
+       name assertion fails.
+    2. Baseline — after every run returns, no reader/waiter thread is still
+       parked: the ``finally`` joins the stderr reader once the child is dead
+       instead of leaving it parked on a cancelled future.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    n_runs = 6
+    parked = 0  # threads currently blocked in a fake pipe read / wait
+    peak_parked = 0
+    seen_thread_names: set[str] = set()
+    lock = threading.Lock()
+
+    # A generously sized dedicated pool so the test never deadlocks on a
+    # low-core host (a persistent stderr reader holds a slot for the whole run);
+    # the `comfy-pipe` prefix mirrors the real `_PIPE_EXECUTOR`.
+    test_pool = ThreadPoolExecutor(
+        max_workers=4 * n_runs, thread_name_prefix="comfy-pipe"
+    )
+    monkeypatch.setattr(server, "_PIPE_EXECUTOR", test_pool)
+
+    class _InstrumentedProc:
+        def __init__(self, cmd, lines):
+            self.cmd = cmd
+            self._lines = list(lines)
+            self.stdout = self
+            self.stderr = self
+            self.returncode = None
+            self.killed = False
+            self._dead = threading.Event()
+
+        def _record_thread(self):
+            with lock:
+                seen_thread_names.add(threading.current_thread().name)
+
+        def _block_until_dead(self):
+            nonlocal parked, peak_parked
+            self._record_thread()
+            with lock:
+                parked += 1
+                peak_parked = max(peak_parked, parked)
+            try:
+                self._dead.wait(timeout=10.0)  # real exit is kill(); bound as a guard
+            finally:
+                with lock:
+                    parked -= 1
+
+        def readline(self):
+            self._record_thread()
+            if self._lines:
+                return self._lines.pop(0)
+            self._block_until_dead()
+            return ""
+
+        def read(self):  # stderr.read — parks until the child is killed
+            self._block_until_dead()
+            return ""
+
+        def poll(self):
+            return self.returncode if self._dead.is_set() else None
+
+        def wait(self):
+            self._block_until_dead()
+            return self.returncode
+
+        def kill(self):
+            self.killed = True
+            self.returncode = -9
+            self._dead.set()
+
+    procs: list[_InstrumentedProc] = []
+
+    def fake_popen(cmd, stdout, stderr, text, env):  # noqa: ARG001
+        proc = _InstrumentedProc(cmd, list(_ENVELOPE_THEN_LINGER))
+        procs.append(proc)
+        return proc
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server, "_POST_ENVELOPE_REAP_GRACE", 0.2)
+
+    async def _run_many():
+        return await asyncio.gather(
+            *[
+                server.run_workflow(f"wf{i}.json", wait=True, timeout_seconds=30.0)
+                for i in range(n_runs)
+            ]
+        )
+
+    try:
+        results = asyncio.run(_run_many())
+
+        assert results == [{"outputs": ["/x.png"]}] * n_runs
+        assert len(procs) == n_runs
+        assert all(p.killed for p in procs)  # every child reaped
+
+        # The runs genuinely overlapped: at least the N stderr readers were
+        # parked at once (proves this isn't trivially serialized).
+        assert peak_parked >= n_runs
+
+        # (1) Isolation: everything ran on the dedicated pool, never the default.
+        assert seen_thread_names, "expected pipe reads to run on worker threads"
+        assert all(name.startswith("comfy-pipe") for name in seen_thread_names), (
+            seen_thread_names
+        )
+
+        # (2) Baseline: no pipe thread stays parked after the runs return. The
+        # only laggard is each timed-out reap `wait`, released by kill(); poll
+        # briefly so a sub-millisecond unwind race isn't read as a leak.
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            with lock:
+                if parked == 0:
+                    break
+            time.sleep(0.01)
+        with lock:
+            assert parked == 0, f"{parked} pipe thread(s) still parked at baseline"
+    finally:
+        test_pool.shutdown(wait=True)


### PR DESCRIPTION
## ELI-5

When we run a workflow and stream its progress, we start a couple of background
helper threads to read the child process's output pipes. Those threads sit and
wait ("park") on the pipe until there's data. The problem: on the happy path we
never wait for the stderr-reading thread to finish — we just *cancel* it, but
cancelling a `to_thread` doesn't actually wake the OS thread; it stays parked
until we later kill the child. All of these threads lived on Python's one
*shared* background thread pool, so if you fired off many streaming runs at
once, the parked helpers could hog that shared pool and slow down other work
for a few seconds.

This PR gives those pipe-reading threads their **own** small, fixed-size thread
pool so they can never crowd out anyone else, and it makes cleanup **wait for**
(join) the stderr reader once the child is dead instead of leaving it parked.

## Summary

Bounds the subprocess pipe-read / process-wait threads in
`_run_comfy_streaming` so they can't accumulate on asyncio's shared default
`ThreadPoolExecutor` under concurrent `run_workflow(wait=True)` / `watch_job`.

Deferred follow-up from the review of #44 (thread
[r3606118453](https://github.com/Comfy-Org/comfy-local-mcp/pull/44#discussion_r3606118453)) —
BE-3405.

## Changes

- **Dedicated bounded pool.** New module-level `_PIPE_EXECUTOR`
  (`ThreadPoolExecutor`, `max_workers = min(32, cpu+4)`, `thread_name_prefix="comfy-pipe"`)
  and a small `_in_pipe_pool()` helper. Every blocking `stdout.readline`,
  `stderr.read`, and `proc.wait` in `_run_comfy_streaming` now runs there
  instead of via `asyncio.to_thread` (the shared default executor), so parked
  pipe threads can never starve unrelated `to_thread` callers.
- **Join, don't just cancel.** In the `finally`, after `proc.kill()` closes the
  pipe (which lets the parked `read()` return EOF), we now `await` the
  `stderr_future` to join the reader thread back into the pool before returning,
  instead of only `cancel()`-ing it (a cancel leaves the OS thread parked until
  the read actually unblocks). Guarded with `except Exception` so cleanup never
  masks the real result/exception, and so `CancelledError` (a `BaseException`)
  still propagates.
- **Concurrency test.** `test_overlapping_streaming_runs_confine_and_release_pipe_threads`
  runs N=6 overlapping streaming runs against lingering children and asserts (1)
  every blocking pipe read/wait ran on a `comfy-pipe` worker (not the default
  `asyncio_*` pool), and (2) no reader/waiter thread stays parked once the runs
  return (drains to baseline). Plus `test_pipe_executor_is_dedicated_and_bounded`
  for the static config. Both fail on the pre-fix code and pass after.

## Motivation

Latent concurrency/resource-efficiency concern raised in #44's review, split
out so that PR could stay a focused correctness fix. The leak was bounded (the
`finally`'s `proc.kill()` releases the threads), but under many concurrent
streaming calls the parked reader/waiter threads could pile onto the shared
default executor and starve other `to_thread` work for up to
`_POST_ENVELOPE_REAP_GRACE` (5s).

## Testing

- [x] Existing tests pass (`pytest` — 104 passed, 1 e2e deselected)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] New tests verified to fail on the pre-fix branch and pass after.

## Additional Notes

- **Stacked on #44** (`matt/be-3329-run-workflow-envelope-timeout`) — the target
  code (`_POST_ENVELOPE_REAP_GRACE`, the never-awaited-on-success `stderr_future`)
  lives only on that branch, not `main`. Base is set to #44's branch; GitHub will
  retarget to `main` once #44 merges. If #44's conflicts (currently DIRTY vs main)
  are resolved by rewriting history, this branch may need a `git merge origin/<base>`
  refresh — no functional overlap is expected.
- **Judgment call — pool size.** Sized to match the default executor
  (`min(32, cpu+4)`) rather than a smaller fixed bound. The stderr reader holds
  one worker slot for a run's whole lifetime, so an arbitrarily large burst of
  concurrent runs can still saturate the pool — but that deadlock threshold is
  **identical to today's** behavior on the shared default pool, so this is not a
  regression; it only isolates the blast radius. A smaller bound would have made
  starvation *easier* to hit.
- **Judgment call — kept both halves** of the proposed "and/or" (dedicated pool
  *and* join-after-kill): the pool isolates the parked window during a run; the
  join makes release deterministic at return.
- No capability is denied by this change (pure internal concurrency), so the
  negative-claim falsification step does not apply.
