### PR TITLE
fix: remove shadowing duplicate _parse_version, unblock version-check tests (BE-3474)

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -597,14 +597,6 @@ async def _run_comfy_streaming(
             stderr_future.cancel()
 
 
-def _parse_version(text: str) -> tuple[int, int, int] | None:
-    """Extract a ``(major, minor, patch)`` tuple from a version string, or None."""
-    match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", text)
-    if match is None:
-        return None
-    return tuple(int(part) if part else 0 for part in match.groups())  # type: ignore[return-value]
-
-
 def _detect_comfy_cli_version() -> str | None:
     """Best-effort comfy-cli version via ``comfy --version`` (None if undetermined).
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -70,7 +70,7 @@ def test_unwrap_rejects_incompatible_major_even_on_error_envelope():
 def test_incompatible_envelope_propagates_through_run_comfy(monkeypatch):
     """The assertion guards every tool: a bad-schema envelope raises via _run_comfy."""
 
-    def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
         import json
 
         out = json.dumps({"schema": "envelope/99", "type": "envelope", "ok": True})
@@ -220,7 +220,7 @@ def patched_env(monkeypatch):
 
         calls: list[dict] = []
 
-        def fake(cmd, capture_output, text, timeout, env, check):  # noqa: ARG001
+        def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
             calls.append({"cmd": cmd})
             return subprocess.CompletedProcess(
                 cmd, 0, stdout=json.dumps(envelope), stderr=""


### PR DESCRIPTION
## ELI-5

`server.py` had **two** functions both named `_parse_version`. In Python the second one wins, so the good one (added in #24, which prefers the number right after the word "version") was being silently ignored and everyone got the naive one that just grabs the first `1.2.3`-looking number. That made `_parse_version("Python 3.10.2\ncomfy-cli, version 1.12.0")` return `(3, 10, 2)` instead of `(1, 12, 0)`, turning `main`'s test CI red. This deletes the stale duplicate so the good one is the only one.

## Summary

Removes the shadowing duplicate `_parse_version` in `src/comfy_local_mcp/server.py` so the keyword-preferring implementation (line 146, from #24) is the single definition. This is the pre-existing repo-wide breakage from BE-3474: two version-check systems landed independently and each defined `_parse_version`; the later (naive, first-match) one shadowed the earlier (keyword-preferring) one.

## Changes

- **`server.py`**: delete the stale naive `_parse_version` (`re.search(r"(\d+)\.(\d+)...")` first-match only). All callers — `_check_comfy_version` (line 198), `_detect_comfy_cli_version` (line 636), and the floor/detected comparison (lines 658–659) — now resolve to the keyword-preferring definition.
- **`tests/test_compat.py`**: add the `encoding` parameter to two `subprocess.run` mocks. See the note below.

## Motivation

`main` test CI is red. `tests/test_wrapper.py::test_parse_version_prefers_token_after_version_keyword` and 5 tests in `tests/test_compat.py` were failing.

## Testing

- [x] Existing tests pass (`uv run --extra dev pytest -q`) — **179 passed, 1 skipped** (was 6 failed / 24 passed on `main`).
- [x] Lint passes (`ruff check src tests` — all checks passed).
- [x] Format check passes (`ruff format --check src tests` — 12 files already formatted).

Verified the two version-check systems are compatible under the single parser: system B's callers only ever pass either a `comfy --version` stdout string (where the keyword-preferring parser is *strictly more correct* — it locks onto the token after "version" instead of an embedded Python/core number) or a bare version string like `1.12.0` / `MIN_COMFY_CLI_VERSION` (no "version" keyword ⇒ falls through to the same first-match ⇒ identical result). No behavior regression; the shadowing removal makes `_check_comfy_version` and `server_info`'s compat block use the parser #24 intended.

## Additional Notes

**Judgment call — a second, separate breakage was fixed to green the same CI.** When the ticket was filed, all 6 failures traced to the `_parse_version` shadowing. Since then, #38 (BE-3074, landed 2026-07-17) added `encoding="utf-8"` to `_run_comfy`'s `subprocess.run` (server.py:247) but did **not** update the `patched_env` / `_run_comfy` test mocks in `test_compat.py`, whose `fake()` signatures still omitted `encoding`. That `TypeError` — not the parser bug — was what actually failed the 5 `test_compat` tests on today's `main` (baseline confirmed: they fail at `server.py:247`, before any `_parse_version` call). The parser fix alone would have left CI red, so I added `encoding` to the two mock signatures. This is strictly test-only, zero product risk, and required to satisfy the ticket's acceptance criterion ("confirm all 6 failures clear"). Flagging it explicitly since it's outside the literal ticket title. No open PR covers it.
