### PR TITLE
chore: bump version to 0.2.0 for first tagged release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfy-local-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "Local MCP server for ComfyUI — a thin wrapper over comfy-cli."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/comfy_local_mcp/__init__.py
+++ b/src/comfy_local_mcp/__init__.py
@@ -1,3 +1,3 @@
 """comfy-local-mcp: a thin MCP wrapper over comfy-cli."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
## ELI5
The project has been shipping features for two weeks but still calls itself 0.1.0, and there has never been a tagged release. This bumps the version label to 0.2.0 so we can cut the repo's first GitHub release and give people a fixed point to install and report bugs against.

## Summary
- Bump `version` in `pyproject.toml` from 0.1.0 to 0.2.0
- Bump `__version__` in `src/comfy_local_mcp/__init__.py` to match

## Context
First tagged release of comfy-local-mcp. Everything merged since the initial 0.1.0 scaffold (tool surface expansion, comfy-cli >= 1.12.0 requirement, Apache-2.0 relicense, launch polish) rides in under this version. Once merged, the merge commit gets tagged `v0.2.0` and a GitHub release is published from it.

## Test plan
- [x] `pytest -m 'not e2e'` — 209 passed
- [x] `ruff check .` — clean
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)