### PR TITLE
ci(cursor-review): bump github-workflows pin to main tip (8b0ca00)

### DIFF
--- a/.github/workflows/ci-cursor-review.yml
+++ b/.github/workflows/ci-cursor-review.yml
@@ -33,9 +33,9 @@ jobs:
     # SHA-pinned. Bump this SHA to pick up upstream changes; keep workflows_ref
     # matching so prompts/scripts load from the same commit. The
     # bump-cursor-review-callers workflow updates this automatically.
-    uses: Comfy-Org/github-workflows/.github/workflows/cursor-review.yml@3aead23f38c2ecfb969112883aa29bef070ed5d5 # github-workflows main (3aead23)
+    uses: Comfy-Org/github-workflows/.github/workflows/cursor-review.yml@8b0ca00e1ac264c38edd46a2ad9361e486843cb3 # github-workflows main (8b0ca00)
     with:
-      workflows_ref: 3aead23f38c2ecfb969112883aa29bef070ed5d5
+      workflows_ref: 8b0ca00e1ac264c38edd46a2ad9361e486843cb3
       # Lockfiles, venvs, caches, and egg-info carry no review signal and would
       # only eat into the diff size cap. LICENSE/NOTICE are legal source-of-truth
       # files, so they stay in scope for future licensing-change review.


### PR DESCRIPTION
## What

Bumps the cursor-review caller pin from `3aead23` (github-workflows #31 merge) to the current default-branch tip `8b0ca00` (#27 merge) — both the `uses:` ref and the lock-step `workflows_ref`.

## Context

Only two upstream commits land in this window, neither changing `cursor-review.yml` behavior for this caller: #30 touches the auto-label reusable (no auto-label caller in this repo) and #27 moves the bump-callers list into the `CURSOR_REVIEW_CALLERS` repo variable. This repo IS in that variable, so future upstream changes to `cursor-review.yml` should auto-dispatch a bump PR here — this bump just re-syncs to tip so those diffs stay one-commit clean, and keeps the pin in lock-step with the same bump on agent-work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)