### PR TITLE
docs: add CLAUDE.md shim importing AGENTS.md (BE-3538)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- Agent instructions live in AGENTS.md (the cross-agent standard). This is a Claude Code shim: Claude reads only CLAUDE.md, so the import below pulls AGENTS.md in. Don't add content here — edit AGENTS.md. -->
+@AGENTS.md


### PR DESCRIPTION
## ELI-5

Claude Code only looks for a file called `CLAUDE.md` for its instructions — it never reads `AGENTS.md` and doesn't fall back to it. This repo keeps all agent instructions in `AGENTS.md` (the cross-tool standard). So this PR adds a tiny `CLAUDE.md` whose only job is to say "go read `AGENTS.md`" via an `@AGENTS.md` import. Nothing else changes; `AGENTS.md` stays the single source of truth.

## Summary

Adds a root `CLAUDE.md` shim that imports `AGENTS.md`, per the org-wide "Pillar 1: Agentic Engineering" standard (BE-3241 audit). Claude Code reads `CLAUDE.md` with no `AGENTS.md` fallback, so without this shim Claude Code gets no repo instructions.

## Changes

- Add root `CLAUDE.md` containing exactly the canonical shim (an explanatory HTML comment + `@AGENTS.md` import). Nothing else.

## Motivation

Org standard: `AGENTS.md` is the single source of truth; `CLAUDE.md` exists only as a shim so Claude Code (which reads only `CLAUDE.md`) picks up the same instructions. This repo had `AGENTS.md` (78 lines, compliant) but no `CLAUDE.md`.

## Testing

- [x] Existing tests pass (`pytest` — 227 passed, 1 skipped, run in a clean isolated venv against this branch's source)
- [x] Lint passes (`ruff check .` — all checks passed)
- [x] Format check passes (`ruff format --check .` — 13 files already formatted)
- [x] Verified `CLAUDE.md` content is byte-exact to the canonical shim (em-dash included) and `AGENTS.md` is unchanged

## Additional Notes

- Scope confirmed: the repo has only a root `AGENTS.md` (no nested `AGENTS.md` files that would each need a sibling shim) and no `.cursorrules`, so root `CLAUDE.md` is the complete change.
- The shim is a pure documentation addition — no code, no capability change; the negative-claim falsification check does not apply.
