### PR TITLE
feat: honor a configurable ComfyUI host for the run/queue tools (BE-3869)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,12 @@ By default the server drives ComfyUI on the local `127.0.0.1:8188`. Point it at 
 **elsewhere** — e.g. a GPU box reachable over a private network (Tailscale) — by setting one of:
 
 - **`COMFYUI_URL`** — a full URL, e.g. `http://gpu-box:8188` (host-only is fine; port defaults to
-  `8188`). Takes precedence over the pair below.
+  `8188`). Takes precedence over the pair below. Only the **host and port** are forwarded to
+  comfy-cli, so the URL must be plain `http://` with **no base path**: an `https://` scheme or a
+  reverse-proxy path (`http://gpu-box:8188/comfyui`) is rejected rather than silently downgraded to
+  http / dropped. Front a TLS/base-path proxy locally if you need one.
 - **`COMFYUI_HOST`** (+ optional **`COMFYUI_PORT`**, default `8188`) — e.g. `COMFYUI_HOST=gpu-box`.
+  A port without a host (setting only `COMFYUI_PORT`) is rejected — set the host too.
 
 Set it in the client registration `env` block (same place as `COMFY_BIN`). With nothing set,
 behavior is unchanged (local `127.0.0.1:8188`).

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Cloud MCP** — comfy-cli is the engine.
   `server_info`. Nothing here starts ComfyUI implicitly.
 
 <details>
-<summary><strong>Optional environment variables</strong> (<code>COMFY_BIN</code>, <code>COMFY_API_KEY</code>)</summary>
+<summary><strong>Optional environment variables</strong> (<code>COMFY_BIN</code>, <code>COMFY_API_KEY</code>, <code>COMFYUI_URL</code>)</summary>
 
 <br>
 
@@ -84,6 +84,12 @@ Cloud MCP** — comfy-cli is the engine.
   minimal environment, so a key from your shell won't reach it. Set `COMFY_API_KEY` in the
   client registration `env` block. See **[Partner-API nodes](#partner-api-nodes)** below for the
   full precedence chain; every client example shows where it goes.
+- **`COMFYUI_URL` / `COMFYUI_HOST` / `COMFYUI_PORT` (optional — drive a *remote* ComfyUI).** By
+  default every tool targets the local `127.0.0.1:8188`. Set `COMFYUI_URL`
+  (e.g. `http://gpu-box:8188`) — or the `COMFYUI_HOST` (+ optional `COMFYUI_PORT`, default `8188`)
+  pair — to point the **run / job** tools at a ComfyUI running elsewhere, e.g. a GPU box reachable
+  over a private network (Tailscale). See **[Driving a remote ComfyUI](#driving-a-remote-comfyui)**
+  for what is and isn't remoted. Unset ⇒ local behavior is unchanged.
 
 </details>
 
@@ -104,6 +110,40 @@ in the client registration `env` block (shown in every example below). If a run 
 `partner_node_requires_credential`, the error now carries comfy-cli's hint verbatim, including
 the `comfy auth set comfy-cloud-api-key --key …` fallback and the list of offending nodes; the
 server also retries a transient credential failure briefly before surfacing it.
+
+## Driving a remote ComfyUI
+
+By default the server drives ComfyUI on the local `127.0.0.1:8188`. Point it at a ComfyUI running
+**elsewhere** — e.g. a GPU box reachable over a private network (Tailscale) — by setting one of:
+
+- **`COMFYUI_URL`** — a full URL, e.g. `http://gpu-box:8188` (host-only is fine; port defaults to
+  `8188`). Takes precedence over the pair below.
+- **`COMFYUI_HOST`** (+ optional **`COMFYUI_PORT`**, default `8188`) — e.g. `COMFYUI_HOST=gpu-box`.
+
+Set it in the client registration `env` block (same place as `COMFY_BIN`). With nothing set,
+behavior is unchanged (local `127.0.0.1:8188`).
+
+When configured, the server forwards `--host` / `--port` to comfy-cli for exactly the verbs that
+accept them — `comfy run` and `comfy jobs …` — so the **run and job tools** target the remote:
+`run_workflow`, `job_status`, `wait_for_job`, `watch_job`, `cancel_job`, `get_queue`. `server_info`
+reports the configured target under a `comfy_target` block.
+
+**Not remoted (this repo is a thin wrapper and never opens its own socket):**
+
+- **Lifecycle** (`launch_comfyui`, `stop_comfyui`, `restart_comfyui`, `get_logs`) — these manage a
+  **local** ComfyUI process and stay local-only; they cannot start/stop or read logs from a remote
+  box. Start ComfyUI on the remote host yourself.
+- **Output download** (`fetch_outputs` → `comfy download`) and `search_templates` / `search_models`
+  / `generate_image` — the underlying comfy-cli verbs take **no** `--host`/`--port`, so they run
+  against comfy-cli's local default. Against a remote target, prefer `run_workflow(wait=True)` /
+  `job_status` (which return the remote job's `/view` output URLs) to retrieve results.
+- **Discovery / validation** (`search_nodes`, `get_node`, `validate_workflow`) — their comfy-cli
+  verbs *do* accept `--host`/`--port`, but this version forwards only to the run/job tools (the
+  ticket's scope), so they still target local. Remoting them is a planned follow-up; until then,
+  author/validate against a local ComfyUI matching the remote's node set.
+- The remote ComfyUI must be reachable and **unauthenticated** on that network (the private network
+  is the boundary); the server does not authenticate to it. `server_info` does not live-probe the
+  remote — reachability surfaces on the first run/job call.
 
 ## Install
 
@@ -255,7 +295,7 @@ the originals stay in the ComfyUI workspace.
 
 | Tool | Wraps | What it does |
 |---|---|---|
-| `server_info()` | `comfy env` | Is a local ComfyUI running, where, and which workspace. **Call first.** |
+| `server_info()` | `comfy env` | Is a local ComfyUI running, where, and which workspace. **Call first.** Reports the configured remote under a `comfy_target` block when `COMFYUI_URL`/`COMFYUI_HOST` is set (see [Driving a remote ComfyUI](#driving-a-remote-comfyui)). |
 | `auth_status()` | `comfy cloud whoami` | Comfy Cloud credential status for partner-API nodes (read-only, never returns secrets). Adds a local `registration_env_key_present` bool for the `COMFY_API_KEY` registration-env slot whoami can't see. |
 | `which()` | `comfy which` | Which ComfyUI install/workspace comfy-cli currently targets (a lighter answer than `server_info`). |
 | `get_logs(tail=200)` | `comfy logs --tail <tail>` | Tail the background ComfyUI's captured log (`<workspace>/user/comfyui_<port>.log`) — closes the debugging loop after a detached `launch_comfyui`. Returns `{lines, path, truncated}`; a missing log file returns `{"error": "no_log_file", …}` rather than raising. |

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -1,9 +1,12 @@
 """comfy-local-mcp — a thin MCP wrapper over comfy-cli.
 
 Every tool shells out to the ``comfy`` command (comfy-cli), pinned to the LOCAL
-target, asks for JSON, parses comfy-cli's versioned ``envelope/1`` result, and
-returns its ``data``. There is deliberately no HTTP client and no code shared
-with the Comfy Cloud MCP — comfy-cli is the engine.
+target (``--where local``, defaulting to ComfyUI on ``127.0.0.1:8188``), asks
+for JSON, parses comfy-cli's versioned ``envelope/1`` result, and returns its
+``data``. The run/queue tools can be pointed at a ComfyUI running ELSEWHERE by
+setting ``COMFYUI_URL`` / ``COMFYUI_HOST`` (see ``_comfy_target``), which
+forwards ``--host`` / ``--port`` to comfy-cli. There is deliberately no HTTP
+client and no code shared with the Comfy Cloud MCP — comfy-cli is the engine.
 
 Tools so far: the run -> get-output core loop plus job management
 (``job_status`` / ``wait_for_job`` / ``watch_job`` / ``get_execution_error`` /
@@ -84,6 +87,31 @@ mcp = FastMCP("comfy-local-mcp", instructions=INSTRUCTIONS)
 
 # Allow overriding the binary (e.g. a venv path) without touching code.
 COMFY_BIN = os.environ.get("COMFY_BIN", "comfy")
+
+# Optional: point the run/queue tools at a ComfyUI running ELSEWHERE (e.g. a GPU
+# box reachable over a private network / tailnet) instead of the implicit local
+# 127.0.0.1:8188. Configure with a single ``COMFYUI_URL`` (e.g.
+# ``http://10.0.0.5:8188``) OR the ``COMFYUI_HOST`` (+ optional ``COMFYUI_PORT``)
+# pair. When UNSET the tools behave byte-identically to the local-only default
+# (no ``--host`` forwarded); when set, ``_with_target`` forwards ``--host`` /
+# ``--port`` to the comfy-cli verbs that accept them (see ``_comfy_target`` /
+# ``_with_target`` and ``_TARGET_AWARE_SUBCOMMANDS`` below).
+DEFAULT_COMFYUI_PORT = 8188
+
+# The comfy-cli verbs this server forwards ``--host`` / ``--port`` to: ``comfy
+# run`` and every ``comfy jobs`` subcommand — the "run/queue" tools this ticket
+# scopes, and the pair comfy-cli's ``comfy_cli/host_port.py`` contractually
+# guarantees accept the options. Deliberately NOT forwarded (v1 scope):
+#   * ``env`` / ``download`` / ``upload`` / ``templates`` / ``models`` /
+#     ``generate`` / the lifecycle verbs take NO ``--host`` / ``--port`` at all,
+#     so forwarding would error "No such option" — they stay local-only (a real
+#     comfy-cli limitation; e.g. ``download`` can't fetch a remote job's files).
+#   * ``nodes`` / ``validate`` DO accept ``--host`` / ``--port`` in current
+#     comfy-cli, but remoting live discovery/validation is out of this pass's
+#     "run/queue" scope; forwarding them is a clean follow-up.
+# Forwarding is a no-op for the local default regardless, so unconfigured
+# behavior is unchanged for every tool.
+_TARGET_AWARE_SUBCOMMANDS = frozenset({"run", "jobs"})
 
 # The envelope schema major version this server speaks. comfy-cli tags every
 # result with a ``schema`` like ``envelope/1``; the whole contract (result
@@ -305,6 +333,69 @@ def _is_no_recorded_server(exc: ComfyCliError) -> bool:
     return exc.code == _NO_RECORDED_SERVER_CODE or _NO_RECORDED_SERVER_CODE in str(exc)
 
 
+def _comfy_target() -> tuple[str, int, str] | None:
+    """Resolve the configured ComfyUI ``(host, port, source)``, or None for local.
+
+    Precedence: ``COMFYUI_URL`` (a full URL, parsed into host + port) wins;
+    otherwise ``COMFYUI_HOST`` (+ optional ``COMFYUI_PORT``, default
+    :data:`DEFAULT_COMFYUI_PORT`). Returns ``None`` when nothing is set, so the
+    tools stay byte-identical to the local-only default (no ``--host`` forwarded,
+    comfy-cli's own 127.0.0.1:8188). Raises :class:`ComfyCliError` on a set but
+    malformed value rather than silently retargeting to the wrong place.
+    """
+    url = os.environ.get("COMFYUI_URL", "").strip()
+    if url:
+        # urlparse needs a scheme to populate .hostname/.port; a bare
+        # "host:port" is otherwise read as scheme:path. Prefix "//" so a
+        # scheme-less value parses as a netloc.
+        parsed = urlparse(url if "://" in url else f"//{url}")
+        try:
+            host, port = parsed.hostname, parsed.port
+        except ValueError as exc:  # out-of-range / non-numeric port in the URL
+            raise ComfyCliError(
+                f"COMFYUI_URL has an invalid port: {url!r} ({exc})."
+            ) from exc
+        if not host:
+            raise ComfyCliError(
+                f"COMFYUI_URL is set but names no host: {url!r}. "
+                "Use e.g. http://<host>:8188 (or set COMFYUI_HOST/COMFYUI_PORT)."
+            )
+        return host, port or DEFAULT_COMFYUI_PORT, "COMFYUI_URL"
+
+    host = os.environ.get("COMFYUI_HOST", "").strip()
+    if not host:
+        return None
+    raw_port = os.environ.get("COMFYUI_PORT", "").strip()
+    if not raw_port:
+        return host, DEFAULT_COMFYUI_PORT, "COMFYUI_HOST"
+    try:
+        port = int(raw_port)
+    except ValueError as exc:
+        raise ComfyCliError(
+            f"COMFYUI_PORT must be an integer, got {raw_port!r}."
+        ) from exc
+    if not (1 <= port <= 65535):
+        raise ComfyCliError(f"COMFYUI_PORT is out of range (1-65535): {port}.")
+    return host, port, "COMFYUI_HOST"
+
+
+def _with_target(args: tuple[str, ...]) -> tuple[str, ...]:
+    """Append ``--host`` / ``--port`` to a target-aware subcommand, if configured.
+
+    The flags are injected into the SUBCOMMAND args (after the ``run`` / ``jobs``
+    verb), never into the global ``--json`` / ``--where`` prefix, since
+    ``--host`` / ``--port`` are ``comfy run`` / ``comfy jobs`` subcommand options.
+    A no-op for the local default (``_comfy_target`` is None) and for any
+    subcommand that doesn't accept the flags (see :data:`_TARGET_AWARE_SUBCOMMANDS`),
+    so unconfigured behavior is byte-identical to today.
+    """
+    target = _comfy_target()
+    if target is None or not args or args[0] not in _TARGET_AWARE_SUBCOMMANDS:
+        return args
+    host, port, _source = target
+    return (*args, "--host", host, "--port", str(port))
+
+
 def _run_comfy_raw(
     *args: str, timeout: float | None = None
 ) -> tuple[dict | None, str, tuple[str, ...], int, str]:
@@ -323,6 +414,11 @@ def _run_comfy_raw(
             "(`pip install comfy-cli`) or set the COMFY_BIN env var."
         )
     _check_comfy_version()
+    # Forward --host/--port into the subcommand when a remote ComfyUI is
+    # configured (no-op for the local default; see _with_target). Reassigning
+    # args here means the forwarded flags also appear in the error/timeout
+    # context returned below, so a remote failure reports the real invocation.
+    args = _with_target(args)
     # Global flags (--json, --where) MUST precede the subcommand in comfy-cli;
     # a trailing --json errors with "No such option". (Verified against comfy-cli.)
     cmd = [COMFY_BIN, "--json", "--where", "local", *args]
@@ -749,6 +845,10 @@ async def _run_comfy_streaming(
     # the first call per process); offload it so the async event loop is never
     # blocked while it runs.
     await asyncio.to_thread(_check_comfy_version)
+    # Forward --host/--port into the subcommand for a configured remote ComfyUI
+    # (no-op for the local default; see _with_target). run_workflow(wait=True)
+    # -> `run` and watch_job -> `jobs watch` are both target-aware verbs.
+    args = _with_target(args)
     # --json-stream is a global flag and, like --json/--where, MUST precede the
     # subcommand; a trailing form errors with "No such option".
     cmd = [COMFY_BIN, "--json-stream", "--where", "local", *args]
@@ -1023,15 +1123,37 @@ def server_info() -> Any:
     rather than deep inside a later tool. On success it attaches a
     ``compatibility`` block (detected version, floor, envelope schema, warnings)
     alongside the ``comfy env`` data.
+
+    Remote target: when a remote ComfyUI is configured (``COMFYUI_URL`` or
+    ``COMFYUI_HOST`` — see :func:`_comfy_target`), a ``comfy_target`` block is
+    attached reporting the ``host`` / ``port`` the run/queue tools drive, so an
+    agent knows they are NOT targeting localhost. NOTE: the ``comfy env`` fields
+    (running / url / workspace / python) always describe the LOCAL comfy-cli
+    install — ``comfy env`` takes no ``--host`` — and this server never opens an
+    HTTP socket (AGENTS.md), so it does not live-probe the remote here;
+    reachability is confirmed by the first run/queue call, which targets the
+    same host.
     """
     envelope, _stdout, args, returncode, stderr = _run_comfy_raw("env", timeout=60.0)
     # _unwrap_envelope has already raised if envelope was None, so it is non-None here.
     data = _unwrap_envelope(envelope, args, returncode, stderr)
     compat = _check_comfy_cli_version()
     compat["envelope_schema"] = _envelope_schema(envelope)
-    if isinstance(data, dict):
-        return {**data, "compatibility": compat}
-    return {"env": data, "compatibility": compat}
+    report = dict(data) if isinstance(data, dict) else {"env": data}
+    report["compatibility"] = compat
+    target = _comfy_target()
+    if target is not None:
+        host, port, source = target
+        report["comfy_target"] = {
+            "host": host,
+            "port": port,
+            "source": source,
+            "note": (
+                "run/queue tools target this remote ComfyUI via --host/--port; "
+                "the env fields above describe the LOCAL comfy-cli install."
+            ),
+        }
+    return report
 
 
 # comfy-cli error codes worth a short bounded retry from ``run_workflow`` —

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -333,6 +333,40 @@ def _is_no_recorded_server(exc: ComfyCliError) -> bool:
     return exc.code == _NO_RECORDED_SERVER_CODE or _NO_RECORDED_SERVER_CODE in str(exc)
 
 
+def _redact_url(url: str) -> str:
+    """Return ``url`` with any ``user:pass@`` userinfo masked to ``***@``.
+
+    :class:`ComfyCliError` messages echo the offending config value and may reach
+    the MCP client or logs, so a credential embedded in ``COMFYUI_URL`` (e.g.
+    ``http://user:token@host``) must not be surfaced raw. Only the netloc
+    (scheme-separator up to the first path/query/fragment delimiter) is inspected
+    so a stray ``@`` in a path can't confuse the masking.
+    """
+    scheme_sep = url.find("://")
+    start = scheme_sep + 3 if scheme_sep != -1 else 0
+    end = len(url)
+    for delim in ("/", "?", "#"):
+        i = url.find(delim, start)
+        if i != -1:
+            end = min(end, i)
+    netloc = url[start:end]
+    if "@" in netloc:
+        return url[:start] + "***@" + netloc.rsplit("@", 1)[1] + url[end:]
+    return url
+
+
+def _strip_brackets(host: str) -> str:
+    """Strip surrounding ``[...]`` from a bracketed IPv6 host for consistency.
+
+    ``urlparse`` already returns an IPv6 ``.hostname`` bracket-free, so normalize
+    a bracketed ``COMFYUI_HOST`` (``[::1]``) the same way — both config paths then
+    forward a bare host to comfy-cli, which re-brackets it when building its URL.
+    """
+    if host.startswith("[") and host.endswith("]"):
+        return host[1:-1]
+    return host
+
+
 def _comfy_target() -> tuple[str, int, str] | None:
     """Resolve the configured ComfyUI ``(host, port, source)``, or None for local.
 
@@ -342,32 +376,66 @@ def _comfy_target() -> tuple[str, int, str] | None:
     tools stay byte-identical to the local-only default (no ``--host`` forwarded,
     comfy-cli's own 127.0.0.1:8188). Raises :class:`ComfyCliError` on a set but
     malformed value rather than silently retargeting to the wrong place.
+
+    comfy-cli's ``--host`` / ``--port`` carry only a host and port, so a
+    ``COMFYUI_URL`` that also names a non-``http`` scheme (``https://``) or a base
+    path (``/comfyui``) is REJECTED rather than silently dropped — otherwise a
+    user asking for TLS or a reverse-proxy path would be quietly downgraded.
     """
     url = os.environ.get("COMFYUI_URL", "").strip()
     if url:
         # urlparse needs a scheme to populate .hostname/.port; a bare
         # "host:port" is otherwise read as scheme:path. Prefix "//" so a
-        # scheme-less value parses as a netloc.
-        parsed = urlparse(url if "://" in url else f"//{url}")
+        # scheme-less value parses as a netloc. urlparse itself raises
+        # ValueError on a malformed value (e.g. an unbalanced IPv6 bracket
+        # "http://[::1"), so it lives inside the try alongside the .port access.
         try:
+            parsed = urlparse(url if "://" in url else f"//{url}")
             host, port = parsed.hostname, parsed.port
-        except ValueError as exc:  # out-of-range / non-numeric port in the URL
+        except ValueError as exc:  # bad port, or malformed URL (IPv6 brackets)
             raise ComfyCliError(
-                f"COMFYUI_URL has an invalid port: {url!r} ({exc})."
+                f"COMFYUI_URL is malformed: {_redact_url(url)!r} ({exc})."
             ) from exc
+        if parsed.scheme and parsed.scheme != "http":
+            raise ComfyCliError(
+                f"COMFYUI_URL scheme {parsed.scheme!r} is not supported "
+                f"({_redact_url(url)!r}): comfy-cli's --host/--port speak plain "
+                "http only, so an https:// target would be silently downgraded. "
+                "Use http://<host>:<port>."
+            )
+        if parsed.path not in ("", "/"):
+            raise ComfyCliError(
+                f"COMFYUI_URL must not include a path ({_redact_url(url)!r}): "
+                "comfy-cli forwards only host/port, so a reverse-proxy base path "
+                "would be dropped. Point COMFYUI_URL at the bare host:port."
+            )
         if not host:
             raise ComfyCliError(
-                f"COMFYUI_URL is set but names no host: {url!r}. "
+                f"COMFYUI_URL is set but names no host: {_redact_url(url)!r}. "
                 "Use e.g. http://<host>:8188 (or set COMFYUI_HOST/COMFYUI_PORT)."
             )
-        return host, port or DEFAULT_COMFYUI_PORT, "COMFYUI_URL"
+        # `port or DEFAULT` alone would treat an explicit :0 as absent and
+        # silently target 8188; reject it to match the COMFYUI_PORT path.
+        if port == 0:
+            raise ComfyCliError(
+                f"COMFYUI_URL port is out of range (1-65535): {_redact_url(url)!r}."
+            )
+        return _strip_brackets(host), port or DEFAULT_COMFYUI_PORT, "COMFYUI_URL"
 
     host = os.environ.get("COMFYUI_HOST", "").strip()
-    if not host:
-        return None
     raw_port = os.environ.get("COMFYUI_PORT", "").strip()
+    if not host:
+        # A port alone does not select a remote; raise rather than silently
+        # ignoring it and defaulting back to the local 127.0.0.1:8188.
+        if raw_port:
+            raise ComfyCliError(
+                "COMFYUI_PORT is set but COMFYUI_HOST is not; a port alone does "
+                "not select a remote. Set COMFYUI_HOST (or COMFYUI_URL) to "
+                "target a remote ComfyUI."
+            )
+        return None
     if not raw_port:
-        return host, DEFAULT_COMFYUI_PORT, "COMFYUI_HOST"
+        return _strip_brackets(host), DEFAULT_COMFYUI_PORT, "COMFYUI_HOST"
     try:
         port = int(raw_port)
     except ValueError as exc:
@@ -376,7 +444,7 @@ def _comfy_target() -> tuple[str, int, str] | None:
         ) from exc
     if not (1 <= port <= 65535):
         raise ComfyCliError(f"COMFYUI_PORT is out of range (1-65535): {port}.")
-    return host, port, "COMFYUI_HOST"
+    return _strip_brackets(host), port, "COMFYUI_HOST"
 
 
 def _with_target(args: tuple[str, ...]) -> tuple[str, ...]:
@@ -389,8 +457,15 @@ def _with_target(args: tuple[str, ...]) -> tuple[str, ...]:
     subcommand that doesn't accept the flags (see :data:`_TARGET_AWARE_SUBCOMMANDS`),
     so unconfigured behavior is byte-identical to today.
     """
+    # Check the verb FIRST, then resolve the target. A malformed
+    # COMFYUI_URL/PORT must not brick local-only verbs (server_info's `env`,
+    # download, the stop/logs lifecycle) that never touch the remote — they'd
+    # otherwise raise ComfyCliError here despite ignoring the target entirely,
+    # breaking the "local behavior unchanged" contract (BE-3869 review).
+    if not args or args[0] not in _TARGET_AWARE_SUBCOMMANDS:
+        return args
     target = _comfy_target()
-    if target is None or not args or args[0] not in _TARGET_AWARE_SUBCOMMANDS:
+    if target is None:
         return args
     host, port, _source = target
     return (*args, "--host", host, "--port", str(port))
@@ -1141,18 +1216,31 @@ def server_info() -> Any:
     compat["envelope_schema"] = _envelope_schema(envelope)
     report = dict(data) if isinstance(data, dict) else {"env": data}
     report["compatibility"] = compat
-    target = _comfy_target()
-    if target is not None:
-        host, port, source = target
+    # server_info is the "call first" diagnostic, so surface a malformed remote
+    # config as a data field rather than raising — an agent debugging its env
+    # then sees WHAT is wrong instead of an opaque failure of the whole tool.
+    try:
+        target = _comfy_target()
+    except ComfyCliError as exc:
         report["comfy_target"] = {
-            "host": host,
-            "port": port,
-            "source": source,
+            "error": str(exc),
             "note": (
-                "run/queue tools target this remote ComfyUI via --host/--port; "
-                "the env fields above describe the LOCAL comfy-cli install."
+                "COMFYUI_URL/COMFYUI_HOST is set but malformed; the run/queue "
+                "tools will raise this same error until it is fixed."
             ),
         }
+    else:
+        if target is not None:
+            host, port, source = target
+            report["comfy_target"] = {
+                "host": host,
+                "port": port,
+                "source": source,
+                "note": (
+                    "run/queue tools target this remote ComfyUI via --host/--port; "
+                    "the env fields above describe the LOCAL comfy-cli install."
+                ),
+            }
     return report
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,19 @@ def _skip_version_guard(monkeypatch):
     monkeypatch.setattr(server, "_version_checked", True)
 
 
+@pytest.fixture(autouse=True)
+def _clear_comfyui_target_env(monkeypatch):
+    """Default every test to the LOCAL target (no configured remote ComfyUI).
+
+    The run/queue tools forward ``--host`` / ``--port`` when ``COMFYUI_URL`` /
+    ``COMFYUI_HOST`` is set (see ``server._comfy_target``). A stray value in the
+    ambient environment would perturb the exact-argv assertions across the suite,
+    so clear all three here; the remote-targeting tests set them explicitly.
+    """
+    for var in ("COMFYUI_URL", "COMFYUI_HOST", "COMFYUI_PORT"):
+        monkeypatch.delenv(var, raising=False)
+
+
 class _FakeProc:
     """A minimal stand-in for ``subprocess.Popen`` over a canned NDJSON stream."""
 

--- a/tests/test_remote_host.py
+++ b/tests/test_remote_host.py
@@ -1,0 +1,286 @@
+"""Tests for driving a configurable (remote/tailnet) ComfyUI host.
+
+The run/queue tools normally target the implicit local 127.0.0.1:8188. Setting
+``COMFYUI_URL`` — or the ``COMFYUI_HOST`` / ``COMFYUI_PORT`` pair — points them
+at a ComfyUI running elsewhere by forwarding ``--host`` / ``--port`` to the
+comfy-cli verbs that accept them (``comfy run`` and every ``comfy jobs``
+subcommand). These lock in:
+
+1. ``_comfy_target`` env parsing (URL, host/port, defaults, malformed values).
+2. ``--host`` / ``--port`` forwarded into the SUBCOMMAND (not the global prefix)
+   for ``run`` / ``jobs``, and NOT for verbs that don't accept them (``env`` /
+   ``download`` / ``upload`` / …).
+3. Byte-identical local behavior when nothing is configured.
+4. ``server_info`` surfacing the configured ``comfy_target``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+
+import pytest
+from conftest import _OK_STREAM
+
+from comfy_local_mcp import server
+
+
+def _fake_run(envelope: dict):
+    """A ``subprocess.run`` stand-in that captures calls and emits ``envelope``."""
+    calls: list[dict] = []
+
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
+        calls.append({"cmd": cmd, "env": env})
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout=json.dumps(envelope), stderr=""
+        )
+
+    return fake, calls
+
+
+@pytest.fixture
+def patched_run(monkeypatch):
+    """Patch ``shutil.which`` + ``subprocess.run``; returns ``setup(envelope) -> calls``."""
+
+    def setup(envelope: dict) -> list[dict]:
+        fake, calls = _fake_run(envelope)
+        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+        monkeypatch.setattr(server.subprocess, "run", fake)
+        return calls
+
+    return setup
+
+
+# --- _comfy_target env parsing ---------------------------------------------
+
+
+def test_target_none_when_unset():
+    """Nothing configured -> None -> local default (byte-identical to today)."""
+    assert server._comfy_target() is None
+
+
+def test_target_from_host_defaults_port(monkeypatch):
+    monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
+    assert server._comfy_target() == (
+        "gpu.example",
+        server.DEFAULT_COMFYUI_PORT,
+        "COMFYUI_HOST",
+    )
+
+
+def test_target_from_host_and_port(monkeypatch):
+    monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
+    monkeypatch.setenv("COMFYUI_PORT", "9001")
+    assert server._comfy_target() == ("gpu.example", 9001, "COMFYUI_HOST")
+
+
+def test_target_from_url(monkeypatch):
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
+    assert server._comfy_target() == ("gpu.example", 9001, "COMFYUI_URL")
+
+
+def test_target_from_url_defaults_port(monkeypatch):
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example")
+    assert server._comfy_target() == (
+        "gpu.example",
+        server.DEFAULT_COMFYUI_PORT,
+        "COMFYUI_URL",
+    )
+
+
+def test_target_url_without_scheme(monkeypatch):
+    """A scheme-less ``host:port`` still parses (prefixed with ``//`` internally)."""
+    monkeypatch.setenv("COMFYUI_URL", "gpu.example:9001")
+    assert server._comfy_target() == ("gpu.example", 9001, "COMFYUI_URL")
+
+
+def test_target_url_ipv6(monkeypatch):
+    """An IPv6 URL yields the bare host (comfy-cli re-brackets it for its URLs)."""
+    monkeypatch.setenv("COMFYUI_URL", "http://[2001:db8::1]:8188")
+    assert server._comfy_target() == ("2001:db8::1", 8188, "COMFYUI_URL")
+
+
+def test_target_url_wins_over_host(monkeypatch):
+    """COMFYUI_URL takes precedence over the COMFYUI_HOST/PORT pair."""
+    monkeypatch.setenv("COMFYUI_URL", "http://from-url.example:1234")
+    monkeypatch.setenv("COMFYUI_HOST", "from-host.example")
+    monkeypatch.setenv("COMFYUI_PORT", "5678")
+    assert server._comfy_target() == ("from-url.example", 1234, "COMFYUI_URL")
+
+
+def test_target_url_no_host_raises(monkeypatch):
+    monkeypatch.setenv("COMFYUI_URL", "http://:8188")
+    with pytest.raises(server.ComfyCliError, match="names no host"):
+        server._comfy_target()
+
+
+def test_target_bad_port_raises(monkeypatch):
+    monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
+    monkeypatch.setenv("COMFYUI_PORT", "not-a-number")
+    with pytest.raises(server.ComfyCliError, match="COMFYUI_PORT must be an integer"):
+        server._comfy_target()
+
+
+def test_target_port_out_of_range_raises(monkeypatch):
+    monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
+    monkeypatch.setenv("COMFYUI_PORT", "70000")
+    with pytest.raises(server.ComfyCliError, match="out of range"):
+        server._comfy_target()
+
+
+# --- forwarding into _run_comfy (plain --json path) ------------------------
+
+
+def test_run_forwards_host_port_into_subcommand(patched_run, monkeypatch):
+    """`comfy run` gets --host/--port appended AFTER the verb, not in the global prefix."""
+    monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
+    monkeypatch.setenv("COMFYUI_PORT", "9001")
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"prompt_id": "p1"}})
+
+    server._run_comfy("run", "--workflow", "wf.json")
+
+    cmd = calls[0]["cmd"]
+    assert cmd[1:4] == ["--json", "--where", "local"]  # global prefix unchanged
+    assert cmd[4:] == [
+        "run",
+        "--workflow",
+        "wf.json",
+        "--host",
+        "gpu.example",
+        "--port",
+        "9001",
+    ]
+
+
+def test_jobs_forwards_host_port_into_subcommand(patched_run, monkeypatch):
+    """Every `comfy jobs` subcommand accepts --host/--port; they are forwarded."""
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
+    calls = patched_run({"type": "envelope", "ok": True, "data": {"status": "running"}})
+
+    server._run_comfy("jobs", "status", "abc")
+
+    assert calls[0]["cmd"][4:] == [
+        "jobs",
+        "status",
+        "abc",
+        "--host",
+        "gpu.example",
+        "--port",
+        "9001",
+    ]
+
+
+def test_env_is_not_forwarded_host_port(patched_run, monkeypatch):
+    """`comfy env` takes no --host/--port; forwarding would error 'No such option'."""
+    monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
+    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+
+    server._run_comfy("env")
+
+    assert calls[0]["cmd"][4:] == ["env"]  # untouched even with a remote configured
+
+
+def test_download_and_upload_not_forwarded(patched_run, monkeypatch):
+    """download / upload verbs don't accept --host/--port -> stay local-only."""
+    monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
+    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+
+    server._run_comfy("download", "abc", "-o", "/tmp/out")
+    server._run_comfy("upload", "a.png")
+
+    assert calls[0]["cmd"][4:] == ["download", "abc", "-o", "/tmp/out"]
+    assert calls[1]["cmd"][4:] == ["upload", "a.png"]
+
+
+def test_local_default_is_byte_identical(patched_run):
+    """With nothing configured the argv is exactly today's — no --host appended."""
+    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+
+    server._run_comfy("run", "--workflow", "wf.json")
+
+    assert calls[0]["cmd"][4:] == ["run", "--workflow", "wf.json"]  # no --host/--port
+
+
+# --- forwarding into the streaming (--json-stream) path --------------------
+
+
+def test_run_workflow_stream_forwards_host_port(patched_stream, monkeypatch):
+    """run_workflow(wait=True) streams `comfy run --wait` with --host/--port forwarded."""
+    monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
+    monkeypatch.setenv("COMFYUI_PORT", "9001")
+    procs = patched_stream(_OK_STREAM)
+
+    result = asyncio.run(server.run_workflow("wf.json", wait=True))
+
+    assert result == {"outputs": ["/x.png"]}
+    cmd = procs[0].cmd
+    assert cmd[1:4] == ["--json-stream", "--where", "local"]  # global prefix unchanged
+    assert cmd[4:] == [
+        "run",
+        "--workflow",
+        "wf.json",
+        "--wait",
+        "--host",
+        "gpu.example",
+        "--port",
+        "9001",
+    ]
+
+
+def test_watch_job_stream_forwards_host_port(patched_stream, monkeypatch):
+    """watch_job tails `comfy jobs watch <id>` with --host/--port forwarded."""
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
+    procs = patched_stream(_OK_STREAM)
+
+    asyncio.run(server.watch_job("pid"))
+
+    assert procs[0].cmd[4:] == [
+        "jobs",
+        "watch",
+        "pid",
+        "--host",
+        "gpu.example",
+        "--port",
+        "9001",
+    ]
+
+
+# --- server_info surfaces the configured target ----------------------------
+
+
+def _patch_env_for_server_info(monkeypatch):
+    """Stub `comfy env` + the version detection so `server_info()` runs offline."""
+    fake, _calls = _fake_run(
+        {
+            "schema": "envelope/1",
+            "type": "envelope",
+            "ok": True,
+            "data": {"running": False},
+        }
+    )
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+    monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", None)
+    monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.12.0")
+
+
+def test_server_info_reports_remote_target(monkeypatch):
+    _patch_env_for_server_info(monkeypatch)
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
+
+    result = server.server_info()
+
+    assert result["comfy_target"]["host"] == "gpu.example"
+    assert result["comfy_target"]["port"] == 9001
+    assert result["comfy_target"]["source"] == "COMFYUI_URL"
+    assert result["running"] is False  # local `comfy env` data still preserved
+    assert result["compatibility"]["envelope_schema"] == "envelope/1"
+
+
+def test_server_info_omits_target_when_local(monkeypatch):
+    _patch_env_for_server_info(monkeypatch)
+
+    result = server.server_info()
+
+    assert "comfy_target" not in result  # no remote configured -> no block

--- a/tests/test_remote_host.py
+++ b/tests/test_remote_host.py
@@ -129,6 +129,79 @@ def test_target_port_out_of_range_raises(monkeypatch):
         server._comfy_target()
 
 
+def test_target_url_https_scheme_rejected(monkeypatch):
+    """https:// can't be forwarded (comfy-cli speaks http) -> reject, don't downgrade."""
+    monkeypatch.setenv("COMFYUI_URL", "https://gpu.example:8188")
+    with pytest.raises(server.ComfyCliError, match="scheme"):
+        server._comfy_target()
+
+
+def test_target_url_with_path_rejected(monkeypatch):
+    """A reverse-proxy base path can't be forwarded -> reject, don't silently drop."""
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:8188/comfyui")
+    with pytest.raises(server.ComfyCliError, match="path"):
+        server._comfy_target()
+
+
+def test_target_url_root_path_allowed(monkeypatch):
+    """A bare trailing slash is not a real base path -> accepted."""
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001/")
+    assert server._comfy_target() == ("gpu.example", 9001, "COMFYUI_URL")
+
+
+def test_target_url_port_zero_rejected(monkeypatch):
+    """`:0` must not silently collapse to 8188 (the COMFYUI_PORT path rejects 0)."""
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:0")
+    with pytest.raises(server.ComfyCliError, match="out of range"):
+        server._comfy_target()
+
+
+def test_target_url_unbalanced_ipv6_raises_comfy_error(monkeypatch):
+    """A malformed URL (`http://[::1`) surfaces as ComfyCliError, not raw ValueError."""
+    monkeypatch.setenv("COMFYUI_URL", "http://[::1")
+    with pytest.raises(server.ComfyCliError, match="malformed"):
+        server._comfy_target()
+
+
+def test_target_url_redacts_userinfo_in_error(monkeypatch):
+    """A credential embedded in COMFYUI_URL is not echoed raw in the error message."""
+    monkeypatch.setenv("COMFYUI_URL", "https://user:sekret@gpu.example:8188")
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._comfy_target()
+    assert "sekret" not in str(excinfo.value)
+    assert "***@gpu.example" in str(excinfo.value)
+
+
+def test_target_host_strips_ipv6_brackets(monkeypatch):
+    """A bracketed COMFYUI_HOST is normalized bare, matching the URL path's hostname."""
+    monkeypatch.setenv("COMFYUI_HOST", "[::1]")
+    assert server._comfy_target() == (
+        "::1",
+        server.DEFAULT_COMFYUI_PORT,
+        "COMFYUI_HOST",
+    )
+
+
+def test_target_port_without_host_raises(monkeypatch):
+    """COMFYUI_PORT alone must not silently fall back to the local default."""
+    monkeypatch.setenv("COMFYUI_PORT", "9001")
+    with pytest.raises(server.ComfyCliError, match="COMFYUI_HOST is not"):
+        server._comfy_target()
+
+
+def test_local_only_verb_survives_malformed_config(patched_run, monkeypatch):
+    """A malformed COMFYUI_URL must not brick local-only verbs (env/download/...)."""
+    monkeypatch.setenv(
+        "COMFYUI_URL", "https://gpu.example"
+    )  # scheme rejected by _comfy_target
+    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+
+    # `env` never touches the remote, so it must run despite the bad config.
+    server._run_comfy("env")
+
+    assert calls[0]["cmd"][4:] == ["env"]
+
+
 # --- forwarding into _run_comfy (plain --json path) ------------------------
 
 
@@ -284,3 +357,14 @@ def test_server_info_omits_target_when_local(monkeypatch):
     result = server.server_info()
 
     assert "comfy_target" not in result  # no remote configured -> no block
+
+
+def test_server_info_reports_malformed_target_as_data(monkeypatch):
+    """A malformed remote config surfaces as a diagnostic field, not a hard failure."""
+    _patch_env_for_server_info(monkeypatch)
+    monkeypatch.setenv("COMFYUI_URL", "https://gpu.example")
+
+    result = server.server_info()
+
+    assert "error" in result["comfy_target"]
+    assert result["running"] is False  # local `comfy env` data still returned


### PR DESCRIPTION
## ELI-5

Today every tool talks to a ComfyUI on *this* machine (`127.0.0.1:8188`). This PR lets you point the **run and job** tools at a ComfyUI running **somewhere else** — e.g. a GPU box you reach over Tailscale — by setting an env var. Set nothing and everything behaves exactly as before.

## Summary

Adds an env-based ComfyUI target so the run/queue tools can drive a remote ComfyUI (the remote-eval topology: eval/agent runs anywhere, ComfyUI on the GPU box). comfy-cli already supports `comfy run --host/--port`; this forwards it.

## Changes

- **Config** — `_comfy_target()` resolves `COMFYUI_URL` (a full URL) or the `COMFYUI_HOST` (+ optional `COMFYUI_PORT`, default `8188`) pair to `(host, port, source)`. **Unset ⇒ `None` ⇒ byte-identical local behavior** (no `--host` forwarded; comfy-cli's own `127.0.0.1:8188`). Malformed values raise a clear `ComfyCliError` rather than silently retargeting.
- **Forwarding** — `_with_target()` appends `--host`/`--port` into the **subcommand** args (after the verb, never the global `--json`/`--where` prefix), for the verbs comfy-cli accepts them on: `comfy run` and every `comfy jobs` subcommand (the set `comfy_cli/host_port.py` contractually guarantees). Wired into **both** `_run_comfy` (plain `--json`) and `_run_comfy_streaming` (`--json-stream`), so `run_workflow` (wait + no-wait), `job_status`, `wait_for_job`, `watch_job`, `cancel_job`, `get_queue` all target the remote.
- **server_info** — attaches a `comfy_target` block (`host`/`port`/`source`) when a remote is configured, so an agent knows the run/queue tools are not on localhost.
- **README** — documents the knob alongside `COMFY_BIN`, plus what stays local-only.

## Motivation

Enables running the local-mcp eval suite (BE-3837) against a remote GPU ComfyUI over a private network instead of deploying the whole stack onto the GPU box. Closes BE-3869.

## Testing

- [x] Existing tests pass (`pytest`) — 247 passed, 1 skipped (live-ComfyUI e2e)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- New `tests/test_remote_host.py` (20 cases): env parsing (URL / host+port / defaults / IPv6 / precedence / malformed→raise); `--host`/`--port` land in the correct argv position for `run` + `jobs` on both the plain and streaming paths; **omitted** for verbs that don't accept them (`env`/`download`/`upload`); byte-identical unconfigured path; `server_info` surfaces/omits `comfy_target`. A conftest autouse fixture clears `COMFYUI_*` so the suite's exact-argv assertions are unperturbed by ambient env.

## Additional Notes — judgment calls & scope

- **`server_info`'s "health check targets the same host" (AC) is realized as *surfacing the target*, not a live HTTP probe.** The repo's hard **no-HTTP-client** rule (AGENTS.md) forbids hitting `/system_stats` directly, and comfy-cli has no host-aware "ping" verb (`comfy env` takes no `--host`; `comfy jobs ls` swallows an unreachable server and returns local state). So `server_info` reports the configured `comfy_target`, and reachability is confirmed by the first run/job call (which does target that host). Flagging as a partially-met AC — a genuine live probe isn't possible within the thin-wrapper architecture.
- **Forwarding scope = `run` + `jobs` only** (the ticket's "run/queue tools"). Verified against comfy-cli source which verbs accept `--host`/`--port`:
  - `run`, `jobs` — **accept** (forwarded). ✓
  - `env`, `download`, `upload`, `templates`, `models`, `generate`, lifecycle — take **no** `--host`/`--port` (a real comfy-cli limitation; e.g. `comfy download` can't fetch a remote job's files — use `run_workflow(wait=True)`/`job_status` `/view` URLs instead).
  - `nodes`, `validate` — **do** accept `--host`/`--port` in current comfy-cli, but remoting live discovery/validation is out of this pass's run/queue scope; a clean follow-up. (Called out because an earlier draft of the docs wrongly implied these can't be remoted — they can.)
- **Out of scope (per ticket v1):** remote lifecycle/logs (stay local-only), and auth to the remote (the private network is the boundary; ComfyUI is unauthenticated).