### PR TITLE
ci: add AGENTS.md integrity check (thin caller of shared workflow) (BE-3922)

### DIFF
--- a/.github/workflows/agents-md-integrity.yml
+++ b/.github/workflows/agents-md-integrity.yml
@@ -1,0 +1,21 @@
+name: AGENTS.md Integrity
+
+# Thin caller for the shared reusable AGENTS.md integrity check. The checker
+# lives in Comfy-Org/github-workflows (single source of truth), loaded from
+# the pinned workflows_ref — never from this repo's checkout. Bump the SHA to
+# pick up upstream changes and keep `workflows_ref` matching so the check
+# script loads from the same commit; the upstream bump dispatcher
+# (AGENTS_MD_CALLERS) opens SHA-bump PRs automatically once registered.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  agents-md:
+    permissions:
+      contents: read
+    uses: Comfy-Org/github-workflows/.github/workflows/agents-md-integrity.yml@fe6b08e278c27ceacf2651cf441d0752ca2e78ee # github-workflows main (fe6b08e)
+    with:
+      workflows_ref: fe6b08e278c27ceacf2651cf441d0752ca2e78ee


### PR DESCRIPTION
## What

Adds the thin PR-time caller for the shared reusable **AGENTS.md integrity**
check to this repo (BE-3922). The checker itself lives in
`Comfy-Org/github-workflows` (single source of truth) and is loaded from the
pinned `workflows_ref` — never from this repo's checkout, so a PR can't rewrite
the checker.

- New file: `.github/workflows/agents-md-integrity.yml`
- Full-SHA pin to `fe6b08e278c27ceacf2651cf441d0752ca2e78ee` per the
  github-workflows README convention. The `v1` tag points at `4d9cb6b8`, which
  **predates** this reusable workflow, so it is not used. `workflows_ref`
  matches the `uses:` pin so the check script loads from the same commit.
- All inputs stay at defaults; no secrets needed.

## Preflight (verified before adding the caller)

Ran the merged checker from github-workflows `fe6b08e` against a fresh export of
`origin/main`:

```
Result: AGENTS.md integrity OK.
```

PASS, clean (no warnings) — this repo is compliant (BE-3538 Done), so the caller
is safe to add.

## Auto-bump registration

Registered `Comfy-Org/comfy-local-mcp` in the `AGENTS_MD_CALLERS` repo variable
on `Comfy-Org/github-workflows` (idempotent create-or-append, verified
persisted) so the upstream bump dispatcher (BE-3585) opens SHA-bump PRs
automatically. Current members:

```
["Comfy-Org/cloud","Comfy-Org/comfy-infra","Comfy-Org/comfy-local-mcp","Comfy-Org/comfy-toolbox","Comfy-Org/evals"]
```

## Judgment calls

- Kept the caller minimal per the ticket's exact spec (no `concurrency` block
  like the repo's other workflows). The reusable workflow manages its own runs
  and the ticket specified verbatim content; matching the spec over the local
  house-style flourish.

---

**Follow-up (human/ops):** make `AGENTS.md integrity` a required status check in
branch protection.

## CI note — unrelated pre-existing failure

The `cla-assistant` check is **red for a repo-wide CI misconfiguration, not this
diff.** It fails at the setup step before evaluating CLA status:

```
##[error]Please add a personal access token as an environment variable for
writing signatures in a remote repository/organization ...
##[error]Could not retrieve repository contents. Status: unknown
```

The action (added in #60) is missing its PAT secret, so it errors regardless of
contributor/commit content. This is an ops fix on the CLA workflow, out of scope
for BE-3922. This ticket's gate — `agents-md / AGENTS.md integrity` — is **green**,
along with tests (py3.10/3.14), TruffleHog, and the full cursor-review panel.
