### PR TITLE
feat(server_info): attach a comfy-outdated freshness block

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Cloud MCP** — comfy-cli is the engine.
 - **Python ≥ 3.10.**
 - **comfy-cli ≥ 1.12.0** on your `PATH`: `pip install 'comfy-cli>=1.12.0'`. This is the engine
   every tool wraps; the server refuses to run against an older comfy-cli with an upgrade message.
+  The `server_info` `freshness` block additionally needs the first comfy-cli release **after**
+  1.12.0 that ships the `comfy outdated` verb; on a comfy-cli without it the block degrades to
+  `freshness: {"error": …}` and everything else works unchanged.
 - **A ComfyUI workspace.** If you don't have one, `comfy-cli` can create it: `comfy install`
   sets up a ComfyUI workspace it will point at. (An existing ComfyUI checkout works too — see
   `comfy set-default <path>`.)
@@ -255,7 +258,7 @@ the originals stay in the ComfyUI workspace.
 
 | Tool | Wraps | What it does |
 |---|---|---|
-| `server_info()` | `comfy env` | Is a local ComfyUI running, where, and which workspace. **Call first.** |
+| `server_info()` | `comfy env` + `comfy outdated` | Is a local ComfyUI running, where, and which workspace. **Call first.** Also attaches a `freshness` block (`comfy outdated`): installed-vs-latest for ComfyUI core and each custom node pack, so a stale install is flagged before it masquerades as a missing model/node. On a comfy-cli without the `outdated` verb (or a network failure) the block degrades to `freshness: {"error": …}` — the tool itself still succeeds. |
 | `auth_status()` | `comfy cloud whoami` | Comfy Cloud credential status for partner-API nodes (read-only, never returns secrets). Adds a local `registration_env_key_present` bool for the `COMFY_API_KEY` registration-env slot whoami can't see. |
 | `which()` | `comfy which` | Which ComfyUI install/workspace comfy-cli currently targets (a lighter answer than `server_info`). |
 | `get_logs(tail=200)` | `comfy logs --tail <tail>` | Tail the background ComfyUI's captured log (`<workspace>/user/comfyui_<port>.log`) — closes the debugging loop after a detached `launch_comfyui`. Returns `{lines, path, truncated}`; a missing log file returns `{"error": "no_log_file", …}` rather than raising. |

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -1192,11 +1192,15 @@ def _freshness_report() -> Any:
     raising, so the probe can never take ``server_info`` down with it.
     ``OSError`` is caught for the same reason: a spawn failure on this second
     subprocess (the env probe already succeeded) is still just the freshness
-    probe failing, never grounds to fail ``server_info``.
+    probe failing, never grounds to fail ``server_info``. ``UnicodeDecodeError``
+    is caught too: ``_run_comfy_raw`` decodes the child's stdout with strict
+    ``encoding="utf-8"`` (no ``errors="replace"``), so non-UTF-8 bytes in a
+    pack name/path from the user's live custom-node install can raise it here,
+    same as the other probe failures above.
     """
     try:
         return _run_comfy("outdated", timeout=15.0)
-    except (ComfyCliError, OSError) as exc:
+    except (ComfyCliError, OSError, UnicodeDecodeError) as exc:
         return {"error": str(exc)}
 
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -1007,6 +1007,24 @@ def _check_comfy_cli_version() -> dict:
     return report
 
 
+def _freshness_report() -> Any:
+    """Best-effort installed-vs-latest report via ``comfy outdated``.
+
+    Returns the ``comfy outdated`` payload (``core`` install status, one row per
+    custom node ``packs`` entry, ``checked_at``) on success. On ANY
+    :class:`ComfyCliError` — the verb missing on an older comfy-cli, the network
+    lookup down, a timeout — returns ``{"error": "<reason>"}`` instead of
+    raising, so the probe can never take ``server_info`` down with it.
+    ``OSError`` is caught for the same reason: a spawn failure on this second
+    subprocess (the env probe already succeeded) is still just the freshness
+    probe failing, never grounds to fail ``server_info``.
+    """
+    try:
+        return _run_comfy("outdated", timeout=15.0)
+    except (ComfyCliError, OSError) as exc:
+        return {"error": str(exc)}
+
+
 @mcp.tool()
 def server_info() -> Any:
     """Report the local ComfyUI / comfy-cli environment and verify compatibility.
@@ -1023,15 +1041,27 @@ def server_info() -> Any:
     rather than deep inside a later tool. On success it attaches a
     ``compatibility`` block (detected version, floor, envelope schema, warnings)
     alongside the ``comfy env`` data.
+
+    Also attaches a ``freshness`` block (``comfy outdated``): ``core``
+    (installed vs latest ComfyUI, with an ``outdated`` bool) and ``packs`` (one
+    row per installed custom node pack). If ``freshness.core.outdated`` is true
+    or any pack row has ``outdated: true``, the install is STALE — when a model,
+    node, or template seems missing, tell the user to update FIRST
+    (``comfy update comfy`` for core, ``comfy node update <pack>`` for a pack)
+    before concluding the catalog lacks it; silent staleness is the usual
+    culprit. The probe is best-effort: on a comfy-cli without the ``outdated``
+    verb, a network failure, or a timeout, ``freshness`` degrades to
+    ``{"error": "<reason>"}`` — ``server_info`` itself still succeeds.
     """
     envelope, _stdout, args, returncode, stderr = _run_comfy_raw("env", timeout=60.0)
     # _unwrap_envelope has already raised if envelope was None, so it is non-None here.
     data = _unwrap_envelope(envelope, args, returncode, stderr)
     compat = _check_comfy_cli_version()
     compat["envelope_schema"] = _envelope_schema(envelope)
+    freshness = _freshness_report()
     if isinstance(data, dict):
-        return {**data, "compatibility": compat}
-    return {"env": data, "compatibility": compat}
+        return {**data, "compatibility": compat, "freshness": freshness}
+    return {"env": data, "compatibility": compat, "freshness": freshness}
 
 
 # comfy-cli error codes worth a short bounded retry from ``run_workflow`` —

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -288,3 +288,153 @@ def test_server_info_wraps_non_dict_env_data(patched_env, monkeypatch):
 
     assert result["env"] == "raw"
     assert result["compatibility"]["envelope_schema"] == "envelope/1"
+
+
+# --- server_info freshness block (`comfy outdated`) --------------------------
+
+
+_ENV_ENVELOPE = {
+    "schema": "envelope/1",
+    "type": "envelope",
+    "ok": True,
+    "data": {"running": True, "url": "http://127.0.0.1:8188"},
+}
+
+_OUTDATED_DATA = {
+    "core": {
+        "installed": "v0.3.40",
+        "commit": "abc1234",
+        "latest": "v0.3.41",
+        "outdated": True,
+    },
+    "packs": [
+        {
+            "name": "comfyui-seedream",
+            "source": "registry",
+            "installed": "1.0.0",
+            "latest": "1.2.0",
+            "outdated": True,
+        }
+    ],
+    "checked_at": "2026-07-22T00:00:00Z",
+}
+
+
+@pytest.fixture
+def patched_env_then_outdated(monkeypatch):
+    """Patch comfy-cli so ``server_info``'s two runs each see their own reply.
+
+    ``server_info`` shells out twice — ``comfy env`` then ``comfy outdated`` —
+    so unlike ``patched_env`` (same envelope every call) this queues ONE reply
+    per call: each entry is a ``CompletedProcess``-shaping tuple
+    ``(returncode, stdout, stderr)`` or an exception instance to raise.
+    """
+
+    def setup(replies: list) -> list[dict]:
+        calls: list[dict] = []
+
+        def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
+            calls.append({"cmd": cmd, "timeout": timeout})
+            reply = replies[len(calls) - 1]
+            if isinstance(reply, BaseException):
+                raise reply
+            returncode, stdout, stderr = reply
+            return subprocess.CompletedProcess(
+                cmd, returncode, stdout=stdout, stderr=stderr
+            )
+
+        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+        monkeypatch.setattr(server.subprocess, "run", fake)
+        monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.12.0")
+        monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", None)
+        return calls
+
+    return setup
+
+
+def test_server_info_attaches_freshness_block(patched_env_then_outdated):
+    """The `comfy outdated` payload passes through as the `freshness` key."""
+    import json
+
+    outdated_envelope = {
+        "schema": "envelope/1",
+        "type": "envelope",
+        "ok": True,
+        "data": _OUTDATED_DATA,
+    }
+    calls = patched_env_then_outdated(
+        [(0, json.dumps(_ENV_ENVELOPE), ""), (0, json.dumps(outdated_envelope), "")]
+    )
+
+    result = server.server_info()
+
+    assert result["running"] is True  # comfy env data preserved
+    assert result["freshness"] == _OUTDATED_DATA  # verbatim passthrough
+    assert result["freshness"]["core"]["outdated"] is True
+    # Second spawn is `comfy --json --where local outdated` with the 15s budget.
+    assert calls[1]["cmd"][4:] == ["outdated"]
+    assert calls[1]["timeout"] == 15.0
+
+
+def test_server_info_freshness_degrades_on_missing_verb(patched_env_then_outdated):
+    """An older comfy-cli without `outdated` -> freshness.error, tool still succeeds."""
+    import json
+
+    patched_env_then_outdated(
+        [
+            (0, json.dumps(_ENV_ENVELOPE), ""),
+            (2, "", "Usage: comfy [OPTIONS] COMMAND\nNo such command 'outdated'."),
+        ]
+    )
+
+    result = server.server_info()
+
+    assert result["running"] is True  # env data intact — the probe never breaks it
+    assert "compatibility" in result
+    assert set(result["freshness"]) == {"error"}
+    assert "No such command 'outdated'" in result["freshness"]["error"]
+
+
+def test_server_info_freshness_degrades_on_error_envelope(patched_env_then_outdated):
+    """A structured `comfy outdated` failure (e.g. network) -> freshness.error."""
+    import json
+
+    error_envelope = {
+        "schema": "envelope/1",
+        "type": "envelope",
+        "ok": False,
+        "error": {"code": "network_error", "message": "registry lookup failed"},
+    }
+    patched_env_then_outdated(
+        [(0, json.dumps(_ENV_ENVELOPE), ""), (1, json.dumps(error_envelope), "")]
+    )
+
+    result = server.server_info()
+
+    assert result["running"] is True
+    assert "registry lookup failed" in result["freshness"]["error"]
+
+
+def test_server_info_freshness_degrades_on_timeout(patched_env_then_outdated):
+    """A hung `comfy outdated` -> freshness.error, not a server_info timeout raise."""
+    import json
+
+    patched_env_then_outdated(
+        [
+            (0, json.dumps(_ENV_ENVELOPE), ""),
+            subprocess.TimeoutExpired(cmd=["comfy", "outdated"], timeout=15.0),
+        ]
+    )
+
+    result = server.server_info()
+
+    assert result["running"] is True
+    assert "timed out" in result["freshness"]["error"]
+
+
+def test_server_info_docstring_teaches_freshness_and_update_commands():
+    """The tool docstring documents `freshness` + the exact update commands."""
+    doc = server.server_info.__doc__ or ""
+    assert "freshness" in doc
+    assert "comfy update comfy" in doc
+    assert "comfy node update" in doc

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -432,6 +432,30 @@ def test_server_info_freshness_degrades_on_timeout(patched_env_then_outdated):
     assert "timed out" in result["freshness"]["error"]
 
 
+def test_server_info_freshness_degrades_on_decode_error(patched_env_then_outdated):
+    """Non-UTF-8 bytes from `comfy outdated` -> freshness.error, not a raise.
+
+    `_run_comfy_raw` decodes the child's stdout with strict `encoding="utf-8"`
+    (no `errors="replace"`), so a pack name/path with non-UTF-8 bytes in the
+    user's live custom-node install can make `subprocess.run` itself raise
+    `UnicodeDecodeError` — a `ValueError` subclass, not `OSError`/`ComfyCliError`.
+    """
+    import json
+
+    patched_env_then_outdated(
+        [
+            (0, json.dumps(_ENV_ENVELOPE), ""),
+            UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"),
+        ]
+    )
+
+    result = server.server_info()
+
+    assert result["running"] is True  # env data intact — the probe never breaks it
+    assert set(result["freshness"]) == {"error"}
+    assert "invalid start byte" in result["freshness"]["error"]
+
+
 def test_server_info_docstring_teaches_freshness_and_update_commands():
     """The tool docstring documents `freshness` + the exact update commands."""
     doc = server.server_info.__doc__ or ""


### PR DESCRIPTION
## ELI-5

When your local ComfyUI or a custom node pack falls behind, things quietly "go missing" — a model or node an agent expects isn't there, and the agent blames the catalog instead of the real culprit: a stale install. comfy-cli just grew a `comfy outdated` verb that reports installed-vs-latest for core and every node pack. This PR makes `server_info` (the "call me first" tool) run that check and attach the result as a `freshness` block, and teaches agents: if something looks outdated, tell the user to update (`comfy update comfy` / `comfy node update <pack>`) before concluding a model/node doesn't exist. If comfy-cli doesn't have the verb yet (or the network is down), `server_info` still works — `freshness` just carries an error note instead.

## Summary

Attach a best-effort `freshness` block (`comfy outdated`) to `server_info`, so silent install staleness is visible at the MCP layer.

## Changes

- **`_freshness_report()`** — thin `_run_comfy("outdated", timeout=15.0)` passthrough. On any `ComfyCliError` (verb missing on an older comfy-cli, network lookup down, timeout) — or an `OSError` on the spawn — it returns `{"error": "<reason>"}` instead of raising, so the probe can never take `server_info` down with it.
- **`server_info`** — attaches the report as a `"freshness"` key alongside the existing `compatibility` block (both dict and non-dict `comfy env` payload shapes). Docstring documents the block and instructs agents to surface `comfy update comfy` / `comfy node update <pack>` when `freshness.core.outdated` or any pack row is outdated, before blaming the catalog.
- **README** — `server_info` tool-table row now covers the `freshness` block + its graceful degradation; the comfy-cli version note explains the block needs the first release after 1.12.0 that ships `comfy outdated`.
- **Tests** (existing subprocess-mock pattern, in `test_compat.py` next to the other `server_info` integration tests): outdated payload passthrough (+ exact `comfy --json --where local outdated` argv and 15s budget), missing-verb → `freshness.error` with the tool still succeeding, structured error envelope → `freshness.error`, probe timeout → `freshness.error`, and docstring-contains-`freshness`/update-commands.

## Acceptance

- Stale install → `server_info` returns a `freshness` block flagging it (`core.outdated` / pack rows, verbatim from `comfy outdated`). ✅
- comfy-cli without the verb → `server_info` still succeeds with `freshness.error` populated. ✅ (Note: comfy-cli **below the existing 1.12.0 floor** is still refused by the pre-existing version guard on the first call — that gate predates this PR and is unchanged; the criterion applies to ≥ 1.12.0 installs that predate the `outdated` verb.)

## Testing

- [x] `pytest -q` — 232 passed, 1 skipped (5 new tests).
- [x] `ruff check .` and `ruff format --check .` clean.

## Judgment calls

- **No hard version bump.** `comfy outdated` merged to comfy-cli `main` today (comfy-cli #561) and is in **no tagged release yet** (newest is v1.12.0, which predates it). Bumping the enforced `>= 1.12.0` floor to an unreleased version would break every current install for a diagnostic nicety — and would contradict the acceptance criterion that `server_info` must still succeed without the verb. The README instead documents that `freshness` needs the first release after 1.12.0 shipping the verb and degrades gracefully until then. Happy to bump the pin in a follow-up once that release exists.
- **`OSError` added to the catch** alongside `ComfyCliError`: a spawn failure on this second subprocess is still "the freshness probe failed," and the invariant is that `server_info` never fails because of it.
- **15s probe budget as specified** — worst case adds 15s to `server_info` (on top of the env call's 60s budget); still comfortably under a typical MCP client's ~120s tool budget.
