### PR TITLE
docs: document COMFY_LOCAL_URL for a local ComfyUI on a non-default address

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,21 @@ address. Seeing `:8189` there (and the server reported running) confirms the ove
 
 **Requires a comfy-cli newer than 1.12.0.** `COMFY_LOCAL_URL` landed after the 1.12.0 release and
 is not in a published version yet — install comfy-cli from `main` to use it. On 1.12.0 or older the
-variable is simply ignored (no error) and every tool keeps targeting `127.0.0.1:8188`, so
-`server_info` still reporting `:8188` is the symptom of too old a comfy-cli.
+variable is simply ignored (no error) and every tool keeps targeting `127.0.0.1:8188`.
+
+**Still reporting `:8188`?** Three causes, all silent, in the order worth checking:
+
+1. **The value never reached comfy-cli** — it's in the wrong `env` block, or the client wasn't
+   restarted after the edit. The workspace/Python fields `server_info` reports confirm which
+   comfy-cli install you're actually talking to.
+2. **The value is malformed** — comfy-cli ignores it and falls back to `127.0.0.1:8188`, emitting
+   only a one-line stderr warning that this server's success path discards, so a typo
+   (`https://…` — only `http` is accepted; a non-numeric port; a port outside 1–65535) looks
+   exactly like the other two causes from the MCP side. Confirm by running
+   `COMFY_LOCAL_URL=<your value> comfy env` in a terminal and reading stderr; see
+   **Accepted values** above.
+3. **comfy-cli is too old** — it predates the variable and ignored it. `server_info`'s
+   `compatibility.comfy_cli_version` reports the detected version.
 
 **Precedence** (comfy-cli resolves this, first match wins): an explicit `--host`/`--port` flag →
 `COMFY_LOCAL_URL` → a comfy-cli-launched background server → `127.0.0.1:8188`.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Cloud MCP** — comfy-cli is the engine.
 
 - [Prerequisites](#prerequisites)
 - [Partner-API nodes](#partner-api-nodes)
+- [Driving a remote ComfyUI](#driving-a-remote-comfyui)
+- [Targeting a non-default ComfyUI address](#targeting-a-non-default-comfyui-address)
 - [Install](#install)
 - [Configure your AI client](#configure-your-ai-client)
 - [Quickstart](#quickstart)
@@ -72,7 +74,7 @@ Cloud MCP** — comfy-cli is the engine.
   `server_info`. Nothing here starts ComfyUI implicitly.
 
 <details>
-<summary><strong>Optional environment variables</strong> (<code>COMFY_BIN</code>, <code>COMFY_API_KEY</code>, <code>COMFYUI_URL</code>)</summary>
+<summary><strong>Optional environment variables</strong> (<code>COMFY_BIN</code>, <code>COMFY_API_KEY</code>, <code>COMFYUI_URL</code>, <code>COMFY_LOCAL_URL</code>)</summary>
 
 <br>
 
@@ -93,6 +95,11 @@ Cloud MCP** — comfy-cli is the engine.
   pair — to point the **run / job** tools at a ComfyUI running elsewhere, e.g. a GPU box reachable
   over a private network (Tailscale). See **[Driving a remote ComfyUI](#driving-a-remote-comfyui)**
   for what is and isn't remoted. Unset ⇒ local behavior is unchanged.
+- **`COMFY_LOCAL_URL` (optional — a local ComfyUI on a non-default port).** For a ComfyUI on
+  *this* machine that isn't on `127.0.0.1:8188` (e.g. `:8189` because Docker Desktop's ComfyUI
+  holds `:8188`). Read by comfy-cli, not by this server — it rides the environment passthrough,
+  so setting it in the client `env` block re-points every tool. See
+  **[Targeting a non-default ComfyUI address](#targeting-a-non-default-comfyui-address)**.
 
 </details>
 
@@ -151,6 +158,55 @@ reports the configured target under a `comfy_target` block.
 - The remote ComfyUI must be reachable and **unauthenticated** on that network (the private network
   is the boundary); the server does not authenticate to it. `server_info` does not live-probe the
   remote — reachability surfaces on the first run/job call.
+
+## Targeting a non-default ComfyUI address
+
+The section above drives a ComfyUI on **another machine**. This one is for a ComfyUI on **this**
+machine that simply isn't on the default `127.0.0.1:8188` — most often a port clash, e.g. Docker
+Desktop's ComfyUI already holds `:8188` so yours came up on `:8189`.
+
+That address is resolved by **comfy-cli**, not by this server. Every tool shells out to `comfy`
+with the server's full environment, so a `COMFY_LOCAL_URL` set in your MCP client's `env` block
+reaches comfy-cli and re-points *every* local-targeting verb. Nothing to change here — set it
+alongside `COMFY_BIN` in the client registration:
+
+```json
+{
+  "mcpServers": {
+    "comfy-local": {
+      "command": "comfy-local-mcp",
+      "env": {
+        "COMFY_BIN": "/path/to/venv/bin/comfy",
+        "COMFY_LOCAL_URL": "http://127.0.0.1:8189"
+      }
+    }
+  }
+}
+```
+
+**Accepted values.** `http://host:port`, `host:port`, or `http://host` (port defaults to `8188`;
+the scheme is optional and, if present, must be `http`). IPv6 literals are bracketed:
+`http://[::1]:8189`. A malformed value is ignored with a one-line stderr warning rather than
+breaking the call.
+
+**Verify it took effect — call `server_info` first.** `server_info` wraps `comfy env`, which
+resolves the local address by the same rules, so the server URL it reports *is* the resolved
+address. Seeing `:8189` there (and the server reported running) confirms the override is live.
+
+**Requires a comfy-cli newer than 1.12.0.** `COMFY_LOCAL_URL` landed after the 1.12.0 release and
+is not in a published version yet — install comfy-cli from `main` to use it. On 1.12.0 or older the
+variable is simply ignored (no error) and every tool keeps targeting `127.0.0.1:8188`, so
+`server_info` still reporting `:8188` is the symptom of too old a comfy-cli.
+
+**Precedence** (comfy-cli resolves this, first match wins): an explicit `--host`/`--port` flag →
+`COMFY_LOCAL_URL` → a comfy-cli-launched background server → `127.0.0.1:8188`.
+
+> **Use this *or* `COMFYUI_URL`, not both.** [`COMFYUI_URL`/`COMFYUI_HOST`](#driving-a-remote-comfyui)
+> makes this server forward explicit `--host`/`--port` flags for `comfy run` / `comfy jobs`, and an
+> explicit flag **outranks** `COMFY_LOCAL_URL` — so with both set the run/job tools would follow
+> `COMFYUI_URL` while every other verb followed `COMFY_LOCAL_URL`. For a non-default address on
+> *this* machine prefer `COMFY_LOCAL_URL` alone: it also covers the verbs that accept no
+> `--host`/`--port` (`comfy env`, templates, models, download), which `COMFYUI_URL` cannot reach.
 
 ## Install
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -5,8 +5,13 @@ target (``--where local``, defaulting to ComfyUI on ``127.0.0.1:8188``), asks
 for JSON, parses comfy-cli's versioned ``envelope/1`` result, and returns its
 ``data``. The run/queue tools can be pointed at a ComfyUI running ELSEWHERE by
 setting ``COMFYUI_URL`` / ``COMFYUI_HOST`` (see ``_comfy_target``), which
-forwards ``--host`` / ``--port`` to comfy-cli. There is deliberately no HTTP
-client and no code shared with the Comfy Cloud MCP — comfy-cli is the engine.
+forwards ``--host`` / ``--port`` to comfy-cli. A LOCAL ComfyUI on a non-default
+address (e.g. ``:8189``) instead needs no code here at all: ``COMFY_LOCAL_URL``
+rides the environment passthrough (see ``_comfy_env``) and is resolved by
+comfy-cli, which ranks a ``--host``/``--port`` flag above ``COMFY_LOCAL_URL``,
+that above a background record, and ``127.0.0.1:8188`` last. There is
+deliberately no HTTP client and no code shared with the Comfy Cloud MCP —
+comfy-cli is the engine.
 
 Tools so far: the run -> get-output core loop plus job management
 (``job_status`` / ``wait_for_job`` / ``watch_job`` / ``get_execution_error`` /
@@ -85,7 +90,11 @@ Everything targets the LOCAL server only — there is no cloud access here.
 
 mcp = FastMCP("comfy-local-mcp", instructions=INSTRUCTIONS)
 
-# Allow overriding the binary (e.g. a venv path) without touching code.
+# Allow overriding the binary (e.g. a venv path) without touching code. The
+# companion address override needs no constant here: a LOCAL ComfyUI on a
+# non-default address is selected with ``COMFY_LOCAL_URL``, which comfy-cli
+# reads straight off the environment ``_comfy_env`` forwards (precedence:
+# comfy-cli flags > env > background record > ``127.0.0.1:8188``).
 COMFY_BIN = os.environ.get("COMFY_BIN", "comfy")
 
 # Optional: point the run/queue tools at a ComfyUI running ELSEWHERE (e.g. a GPU
@@ -217,8 +226,12 @@ def _comfy_env() -> dict[str, str]:
     """Child-process environment for every comfy-cli spawn.
 
     Single source of truth so the two spawn sites (``_run_comfy`` /
-    ``_run_comfy_streaming``) cannot drift. Injected keys are placed AFTER
-    ``os.environ`` so they win over any inherited values:
+    ``_run_comfy_streaming``) cannot drift. The inherited ``os.environ`` is
+    forwarded WHOLESALE on purpose — that passthrough is what lets a variable
+    set in the MCP client's ``env`` block configure comfy-cli without any code
+    here, e.g. ``COMFY_LOCAL_URL`` to target a local ComfyUI on a non-default
+    address (``:8189``) or ``COMFY_API_KEY`` for partner-API nodes. Injected
+    keys are placed AFTER ``os.environ`` so they win over any inherited values:
 
     - ``COMFY_WHERE=local`` — belt-and-suspenders pin so we never touch cloud.
     - ``COMFY_NO_WATCH=1`` — suppress comfy-cli's file watcher for agentic
@@ -1211,6 +1224,14 @@ def server_info() -> Any:
     Wraps ``comfy env``. Returns whether a local ComfyUI server is running and
     its URL, plus the selected workspace and Python info. Call this first to
     confirm a local ComfyUI is up before running a workflow.
+
+    The reported server URL is the address comfy-cli RESOLVED, not a fixed
+    default: ``COMFY_LOCAL_URL`` wins, else a background record, else
+    ``127.0.0.1:8188`` (``comfy env`` itself takes no ``--host``). So this is
+    also the right first call to verify a ``COMFY_LOCAL_URL`` override took
+    effect. A URL still reading ``:8188`` after setting it means the value did
+    not reach comfy-cli, or the comfy-cli on ``PATH`` predates the variable and
+    ignored it.
 
     Also the compatibility gate for the unpinned comfy-cli this server shells
     out to: it asserts comfy-cli's envelope schema major matches the

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -1229,9 +1229,15 @@ def server_info() -> Any:
     default: ``COMFY_LOCAL_URL`` wins, else a background record, else
     ``127.0.0.1:8188`` (``comfy env`` itself takes no ``--host``). So this is
     also the right first call to verify a ``COMFY_LOCAL_URL`` override took
-    effect. A URL still reading ``:8188`` after setting it means the value did
-    not reach comfy-cli, or the comfy-cli on ``PATH`` predates the variable and
-    ignored it.
+    effect. A URL still reading ``:8188`` after setting it has three causes,
+    all silent and indistinguishable from here: the value did not reach
+    comfy-cli, the comfy-cli on ``PATH`` predates the variable and ignored it,
+    or the value was MALFORMED — comfy-cli then falls back to the default and
+    emits only a one-line stderr warning, which the success path of this
+    wrapper discards. Do not send the user straight to reinstalling comfy-cli:
+    have them re-check the value's syntax (see the README's *Accepted values*)
+    and, to see the dropped warning, run ``COMFY_LOCAL_URL=<value> comfy env``
+    in a terminal.
 
     Also the compatibility gate for the unpinned comfy-cli this server shells
     out to: it asserts comfy-cli's envelope schema major matches the


### PR DESCRIPTION
## ELI-5

Your ComfyUI isn't always on `127.0.0.1:8188` — Docker Desktop's ComfyUI often grabs that port, so yours ends up on `:8189`. comfy-cli now has an env var for that (`COMFY_LOCAL_URL`), and this server already hands its whole environment to comfy-cli, so it works today with **no code change**. It just wasn't written down anywhere. This PR writes it down.

## Summary

Docs-only. Documents `COMFY_LOCAL_URL` as the way to point comfy-local-mcp at a **local** ComfyUI on a non-default address, and explains how it differs from (and must not be combined with) the existing `COMFYUI_URL` remote-target support.

No behavior change — `git diff` touches one Markdown file and four docstrings/comments.

## Changes

- **README** — new `## Targeting a non-default ComfyUI address` section covering:
  - a sample `mcp.json` carrying both `COMFY_BIN` and `COMFY_LOCAL_URL`;
  - accepted value formats (`http://host:port`, `host:port`, `http://host`; IPv6 bracketed);
  - resolution precedence (`--host`/`--port` flag → `COMFY_LOCAL_URL` → background record → `127.0.0.1:8188`);
  - how to confirm it took effect with `server_info`, and what a stale `:8188` reading means;
  - the comfy-cli version floor;
  - a callout on **not** setting this together with `COMFYUI_URL`.
  - Also added to the optional-env-vars `<details>` list and the table of contents (plus the pre-existing "Driving a remote ComfyUI" section, which was missing from the ToC — see judgment calls).
- **`server.py`** — module docstring, the `COMFY_BIN` comment, and the `_comfy_env` docstring now note that the address override rides the wholesale environment passthrough.
- **`server_info` docstring** — the reported server URL is the address comfy-cli *resolved*, so it is the right first call to verify the override.

## Motivation

`COMFYUI_URL`/`COMFYUI_HOST` (#61) solves a **different** problem — a ComfyUI on another machine — and it does so by forwarding `--host`/`--port` flags, which only `comfy run` and `comfy jobs` accept (`_TARGET_AWARE_SUBCOMMANDS`). It deliberately cannot reach `comfy env`, templates, models, or download.

`COMFY_LOCAL_URL` works one layer down, inside comfy-cli's own address resolution, so it covers *every* local-targeting verb — including `comfy env`, which is exactly why `server_info` can be used to confirm it. The two are complementary, and the interaction is a genuine footgun (an explicit flag outranks the env var), so the new section documents it explicitly.

## Testing

- [x] Existing tests pass (`pytest`) — **263 passed, 1 skipped** (the skip is the e2e smoke test, which needs a live ComfyUI)
- [x] Lint passes (`ruff check .`) — All checks passed
- [x] Format check passes (`ruff format --check .`) — 14 files already formatted
- [x] Tested manually — see the verification notes below

### Verification of the factual claims

Because this PR asserts both that a capability **exists** and that it is **absent from released comfy-cli**, both were checked against comfy-cli itself rather than assumed:

| Claim | How it was checked | Result |
|---|---|---|
| `COMFY_LOCAL_URL` exists | cloned `Comfy-Org/comfy-cli` `main`, grepped | present — `comfy_cli/local_address.py`, `host_port.py`, `target.py`, `env_checker.py`, tests, README |
| `comfy env` honors it (so `server_info` can confirm) | comfy-cli `env_checker._resolved_local_address()` + `tests/comfy_cli/test_local_address.py` (`comfy env --json` server.url honors `COMFY_LOCAL_URL`) | confirmed |
| Not in a published release | `local_address.py` 404s at tag `v1.12.0`; `target.py@v1.12.0` has 0 occurrences | confirmed absent from v1.12.0 |
| When it landed | `feat: honor COMFY_LOCAL_URL env var for the local ComfyUI address (#571)`, 2026-07-23 | after the v1.12.0 release (2026-07-07) |
| The env var actually reaches comfy-cli | `_comfy_env()` returns `{**os.environ, …}`; injected keys are `COMFY_WHERE` / `COMFY_NO_WATCH` / `PYTHONUTF8` / `PYTHONIOENCODING` — `COMFY_LOCAL_URL` is not among them, so it passes through untouched | confirmed |
| `COMFYUI_URL` can't reach `comfy env` et al. | this repo's `_TARGET_AWARE_SUBCOMMANDS = frozenset({"run", "jobs"})` | confirmed |

> Worth flagging: a GitHub **code search** for `COMFY_LOCAL_URL` in comfy-cli returned **0 results** (stale index). Taking that at face value would have produced the exact opposite — and wrong — PR ("this variable doesn't exist"). The clone-and-grep is what got the right answer.

## Additional Notes

### ⚠️ The documented flow needs a comfy-cli that isn't released yet

`COMFY_LOCAL_URL` merged to comfy-cli `main` on 2026-07-23 (#571) and is **not** in any published release — the latest is v1.12.0 (2026-07-07), which predates it. This repo's own floor is already comfy-cli ≥ 1.12.0.

So the acceptance criterion — *"a reader following the README can point comfy-local-mcp at `:8189` via mcp.json alone and confirm it with `server_info`"* — is satisfied **by the documentation**, but a reader who installs comfy-cli from PyPI today cannot exercise it until the next comfy-cli release. On an older comfy-cli the variable is silently ignored (no error) and everything keeps targeting `:8188`. The README states this plainly and names the symptom, rather than implying it works everywhere. **No end-to-end run against a live ComfyUI on `:8189` was performed** — that needs the unreleased comfy-cli plus a running server.

If the version wording should instead name the eventual release (e.g. "1.13.0") once comfy-cli cuts it, that is a one-line follow-up.

### Judgment calls

1. **Placed as its own section rather than folding into "Driving a remote ComfyUI."** They solve different problems through different mechanisms with different verb coverage, and conflating them is what makes the precedence footgun invisible. The new section opens by contrasting the two and cross-links both ways.
2. **Did not add `COMFY_LOCAL_URL` to the three per-client examples** (Claude Code / Desktop / Cursor). Those show `COMFY_BIN` + `COMFY_API_KEY` only; `COMFYUI_URL` is likewise documented in its own section rather than in every snippet. Followed that precedent instead of growing all three examples.
3. **Added the pre-existing "Driving a remote ComfyUI" heading to the ToC** alongside the new one. Strictly out of scope, but a ToC that lists the new section while skipping the sibling directly above it reads as an oversight. One line; happy to drop it.
4. **No tracker reference in the title/body**, per `AGENTS.md` destined-public hygiene ("no internal-tracker references in commits or PR titles/bodies"). Note this differs from recent merged PRs here (#61, #63) which do carry them — I followed the written rule; the branch name carries the reference either way.
5. **The ticket's stated premise was stale** — it cited `server.py:84` and `:255` as the two env-passthrough sites. On current `main` those merged into a single `_comfy_env()` helper, and the file has since gained `COMFYUI_URL` support (#61) that the ticket predates. The intent was applied at the right places on `main`; the ticket's conclusion (no code change needed) still holds.
