### PR TITLE
feat: partner_generate — thin passthrough to `comfy generate` (partner-API, spend-gated) (BE-4105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ the originals stay in the ComfyUI workspace.
 
 ## Tools
 
-35 tools, grouped below by what they do. Every tool runs `comfy` with the global
+36 tools, grouped below by what they do. Every tool runs `comfy` with the global
 `--json --where local` flags, unwraps comfy-cli's `envelope/1`, and returns its `data`.
 
 ### Run and monitor
@@ -290,6 +290,7 @@ the originals stay in the ComfyUI workspace.
 |---|---|---|
 | `run_workflow(workflow_path, wait=True, timeout_seconds=600.0)` | `comfy run --workflow <path> [--wait]` | Run a workflow JSON; `wait=False` submits async and returns a `prompt_id`. |
 | `generate_image(prompt, checkpoint=None, wait=True, timeout_seconds=600.0)` | `comfy generate --prompt <prompt> [--checkpoint <ckpt>]` | Text prompt → image in one call — comfy-cli owns the graph/checkpoint injection, so no hand-assembled workflow needed. Same envelope shape as `run_workflow` (`prompt_id` + outputs); the fast on-ramp. |
+| `partner_generate(model, params=None, wait=True, timeout_seconds=600.0)` | `comfy generate <model> [--<param>=<value> …]` | Run a partner / hosted-API model (Flux, Ideogram, Veo, Kling, …) via comfy-cli's partner-API proxy. **Spends Comfy credits.** Never sends `--yes`; because the MCP runs in `--json` mode, comfy-cli's spend gate **fails closed** (errors, spends nothing) unless the user granted standing consent with `comfy generate consent always`. `wait=False` submits with `--async`. |
 | `job_status(prompt_id)` | `comfy jobs status <prompt_id>` | Poll a submitted job's status + outputs. |
 | `wait_for_job(prompt_id, timeout_seconds=25.0)` | `comfy jobs status <prompt_id>` (polled) | Bounded wait until a job reaches a terminal status; returns a `{"timed_out": True, …}` payload on expiry. Chain several. |
 | `watch_job(prompt_id, timeout_seconds=600.0)` | `comfy jobs watch <prompt_id>` (streamed) | Tail an async-submitted job's live execution, streaming progress notifications; bounded, returns a `{"timed_out": True, …}` payload on expiry. Streaming counterpart to `wait_for_job`. |

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -1461,6 +1461,62 @@ async def generate_image(
 
 
 @mcp.tool()
+def partner_generate(
+    model: str,
+    params: dict[str, str] | None = None,
+    wait: bool = True,
+    timeout_seconds: float = 600.0,
+) -> Any:
+    """Run a partner / hosted-API model (Flux, Ideogram, Veo, Kling, …) via
+    comfy-cli's partner-API proxy. **This spends Comfy credits.**
+
+    Wraps ``comfy generate <model> [--<param>=<value> …]`` — a pure passthrough
+    to that verb through ``_run_comfy`` (per the thin-wrapper rule; the proxy
+    call, credential resolution, and the model catalog all live in comfy-cli,
+    not here). Same partner mechanism the cloud MCP's ``partner_generate`` uses.
+
+    Spend gate — this tool never spends on its own: because the MCP always
+    drives comfy-cli in ``--json`` mode, comfy-cli's spend interlock
+    **fails closed** (errors, spends nothing) unless the user has already
+    granted standing consent with ``comfy generate consent always`` (persisted
+    ``spend.auto_confirm`` in comfy-cli config). This tool deliberately does
+    **not** send ``--yes``: spend consent is never inferred from an agent host's
+    "always allow this tool" permission. A denied call surfaces as an error and
+    costs nothing.
+
+    Args:
+        model: A model alias (e.g. ``flux-pro``, ``ideogram-edit``, ``dalle``).
+            List what's available with comfy-cli's ``comfy generate list``; see
+            a model's inputs with ``comfy generate schema <model>``.
+        params: Model-specific inputs as ``{name: value}``, forwarded verbatim
+            as ``--name=value`` (values are strings; comfy-cli coerces each per
+            the model's schema). The ``=`` form keeps a value that begins with
+            ``-`` from being misread as a flag.
+        wait: ``True`` (default) blocks until the partner job finishes and
+            returns its outputs; ``False`` submits with ``--async`` and returns
+            a job reference immediately.
+        timeout_seconds: Upper bound on the ``wait=True`` call. Very long
+            generations can still exceed an MCP client's own tool timeout.
+
+    Everything targets the LOCAL stack (``--where local`` is injected by
+    ``_run_comfy``); there is no direct cloud reachability here.
+    """
+    # A model that begins with ``-`` would be read as an option, not the
+    # positional alias comfy-cli's ``generate`` expects — reject it up front
+    # rather than shell out to a misparsed command.
+    if not model or model.startswith("-"):
+        raise ComfyCliError(
+            "partner_generate: `model` must be a model alias "
+            "(e.g. flux-pro), not empty and not a flag."
+        )
+    param_args = [f"--{key}={value}" for key, value in (params or {}).items()]
+    if wait:
+        return _run_comfy("generate", model, *param_args, timeout=timeout_seconds)
+    # Fire-and-return: comfy-cli's --async submits and prints the job reference.
+    return _run_comfy("generate", model, *param_args, "--async", timeout=60.0)
+
+
+@mcp.tool()
 def job_status(prompt_id: str) -> Any:
     """Check a submitted job's status (queued / running / completed / error).
 

--- a/tests/test_partner_generate.py
+++ b/tests/test_partner_generate.py
@@ -1,0 +1,97 @@
+# Tests for the ``partner_generate`` tool — the thin passthrough to
+# ``comfy generate <model>`` (partner / hosted-API proxy, spends credits).
+# comfy-cli is mocked: no real proxy call, no real spend. The tool uses the
+# plain ``_run_comfy`` path (no streaming), so these just assert the command
+# mapping and the spend-safety invariants.
+from __future__ import annotations
+
+import pytest
+
+from comfy_local_mcp import server
+
+
+def _patch_run_comfy(monkeypatch):
+    """Record the args/timeout of the (mocked) ``_run_comfy`` call."""
+    seen: dict = {}
+
+    def fake_run_comfy(*args, timeout=None):
+        seen["args"] = args
+        seen["timeout"] = timeout
+        return {"prompt_id": "p1", "outputs": ["/x.png"]}
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run_comfy)
+    return seen
+
+
+def test_partner_generate_wait_true_maps_command(monkeypatch):
+    """wait=True → `comfy generate <model>` with the long timeout, no --async."""
+    seen = _patch_run_comfy(monkeypatch)
+
+    result = server.partner_generate("flux-pro")
+
+    assert result == {"prompt_id": "p1", "outputs": ["/x.png"]}
+    assert seen["args"] == ("generate", "flux-pro")  # no --async, no params
+    assert seen["timeout"] == 600.0
+
+
+def test_partner_generate_forwards_params_as_equals(monkeypatch):
+    """params → `--key=value`, in insertion order, after the model."""
+    seen = _patch_run_comfy(monkeypatch)
+
+    server.partner_generate(
+        "ideogram-edit", params={"prompt": "a cat", "aspect_ratio": "16:9"}
+    )
+
+    assert seen["args"] == (
+        "generate",
+        "ideogram-edit",
+        "--prompt=a cat",
+        "--aspect_ratio=16:9",
+    )
+
+
+def test_partner_generate_wait_false_uses_async(monkeypatch):
+    """wait=False submits with --async and the short fire-and-return timeout."""
+    seen = _patch_run_comfy(monkeypatch)
+
+    server.partner_generate("dalle", params={"prompt": "x"}, wait=False)
+
+    assert seen["args"] == ("generate", "dalle", "--prompt=x", "--async")
+    assert seen["timeout"] == 60.0
+
+
+def test_partner_generate_param_value_leading_dash_kept(monkeypatch):
+    """A value starting with `-` survives via the `--key=value` form."""
+    seen = _patch_run_comfy(monkeypatch)
+
+    server.partner_generate("flux-pro", params={"seed": "-1"})
+
+    assert seen["args"] == ("generate", "flux-pro", "--seed=-1")
+
+
+def test_partner_generate_never_sends_yes(monkeypatch):
+    """Spend-safety invariant: this tool never sends --yes/-y — consent is the
+    engine's job, never inferred from tool permission."""
+    seen = _patch_run_comfy(monkeypatch)
+
+    server.partner_generate("flux-pro", params={"prompt": "x"}, wait=False)
+
+    assert "--yes" not in seen["args"]
+    assert "-y" not in seen["args"]
+
+
+@pytest.mark.parametrize("bad_model", ["", "-flux", "--flux"])
+def test_partner_generate_rejects_flag_like_or_empty_model(monkeypatch, bad_model):
+    """An empty or flag-like model is rejected before any shell-out."""
+    called = False
+
+    def must_not_run(*args, timeout=None):
+        nonlocal called
+        called = True
+        return {}
+
+    monkeypatch.setattr(server, "_run_comfy", must_not_run)
+
+    with pytest.raises(server.ComfyCliError):
+        server.partner_generate(bad_model)
+    assert called is False  # no command was run for rejected input


### PR DESCRIPTION
## ELI-5

The local MCP server lets an agent drive your own ComfyUI. Until now it could only run local models. This adds one tool — `partner_generate` — so an agent can also run the paid partner models (Flux, Ideogram, Veo, Kling, …) that go through Comfy's hosted API. The catch with paid models is they spend your credits, so this tool is built to never spend without your say-so: it can't silently run up a bill, and if you haven't already told comfy-cli "yes, always," the call errors instead of charging you.

## What this does

Adds a thin `partner_generate` MCP tool over comfy-cli's `comfy generate <model>` partner-API proxy — a pure passthrough via `_run_comfy` per the thin-wrapper rule: no partner logic in the MCP, no HTTP client, no code copied from the cloud MCP.

- `partner_generate(model, params=None, wait=True, timeout_seconds=600.0)`
- `model` — a model alias (e.g. `flux-pro`); discover with `comfy generate list`, inspect inputs with `comfy generate schema <model>`.
- `params` — model-specific inputs, forwarded verbatim as `--name=value` (the `=` form keeps a value starting with `-` from being read as a flag).
- `wait=True` blocks until the job finishes and returns outputs; `wait=False` submits with `--async` and returns a job reference.

## Spend safety

This is the tool half of the partner-generation queue; the money interlock lives in comfy-cli (already merged). Because the MCP always runs comfy-cli in `--json` mode, comfy-cli's spend gate **fails closed** — a partner call errors and spends nothing unless the user granted standing consent (`comfy generate consent always`). This tool deliberately never sends `--yes`, so a spend is never inferred from an agent host's "always allow this tool." Per-call in-agent confirmation (MCP elicitation) is a separate follow-up.

## Testing

- `tests/test_partner_generate.py` — 8 cases, comfy-cli mocked (no real proxy, no real spend): command mapping, `--name=value` param forwarding, `--async` on `wait=False`, the never-sends-`--yes` invariant, and rejection of empty/flag-like `model` (with no shell-out).
- Full suite: **271 passed**. `ruff check` clean; `ruff format --check` clean.

## Note

Runtime requires a comfy-cli that carries the spend-gated model-alias `comfy generate`; the comfy-cli pin bump for this repo is tracked separately.