### PR TITLE
feat(partner_generate): confirm the credit spend per call via MCP elicitation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,17 @@ Hard guardrails — a PR that breaks any of these should be rejected:
   — none of which apply here. This repo is local-only, single-process, and has no
   filesystem/multi-tenancy concerns to design around.
 
+The one thing that legitimately lives here rather than in comfy-cli is **MCP
+protocol surface** — capabilities that only exist between this server and its
+client, and that comfy-cli has no way to express. Today that is the per-call
+spend confirmation on `partner_generate`: comfy-cli owns the credit-spend
+interlock and the durable "always proceed" (`comfy generate consent always`),
+and this server only raises the confirmation over MCP **elicitation** — the
+protocol's equivalent of the CLI's y/N prompt — then forwards the answer as
+`--yes`. It stores no consent of its own. Adding *product* behavior here is
+still a guardrail breach; adapting comfy-cli's contract to an MCP primitive is
+this repo's job.
+
 The local differentiator: discovery tools (`search_nodes`, `get_node`,
 `search_models`) read the **user's live install** — custom nodes included — via
 comfy-cli, not a bundled static catalog.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Cloud MCP** — comfy-cli is the engine.
 
 - [Prerequisites](#prerequisites)
 - [Partner-API nodes](#partner-api-nodes)
+- [Spending credits on partner models](#spending-credits-on-partner-models)
 - [Driving a remote ComfyUI](#driving-a-remote-comfyui)
 - [Targeting a non-default ComfyUI address](#targeting-a-non-default-comfyui-address)
 - [Install](#install)
@@ -120,6 +121,45 @@ in the client registration `env` block (shown in every example below). If a run 
 `partner_node_requires_credential`, the error now carries comfy-cli's hint verbatim, including
 the `comfy auth set comfy-cloud-api-key --key …` fallback and the list of offending nodes; the
 server also retries a transient credential failure briefly before surfacing it.
+
+## Spending credits on partner models
+
+Everything else this server does runs on **your** machine and is free. `partner_generate` is the
+exception: it wraps `comfy generate <model>`, which calls a hosted partner API and **spends your
+Comfy credits**. So every call is confirmed with you first.
+
+**On a client that supports [MCP elicitation](https://modelcontextprotocol.io/specification/server/elicitation)**
+(Claude Code and Claude Desktop do), the call raises a confirmation prompt naming the model and
+saying that it spends credits:
+
+- **Approve** → the server forwards comfy-cli's `--yes` and the generation runs.
+- **Decline** (or dismiss it) → the tool returns an error, and comfy-cli is never started. No
+  credits are spent.
+
+**Don't want to be asked every time?** Persist it in comfy-cli, not here:
+
+```bash
+comfy generate consent always   # spend without prompting
+comfy generate consent show     # what is it set to?
+comfy generate consent ask      # back to confirming each call
+```
+
+The server reads that setting per call and skips its own prompt when it is on — the durable
+"always proceed" lives in comfy-cli's config, and this server keeps no spend state of its own.
+
+**On a client that cannot elicit**, there is no prompt to raise, so consent has to be explicit in
+the call: `confirm_spend=True` forwards `--yes`. Without it comfy-cli's gate fails closed (an MCP
+server has no terminal to prompt at) and the call errors having spent nothing. On a client that
+*can* elicit you are asked anyway — `confirm_spend=True` is not a way around the prompt.
+
+Two things the server deliberately will **not** do:
+
+- **Treat tool permission as spend consent.** Your agent host's "always allow this tool" toggle
+  authorizes *calling* `partner_generate`; it never authorizes spending your money, and is never
+  read as consent. Only the prompt you answered, or the comfy-cli setting you persisted, is.
+- **Run against a comfy-cli with no spend gate.** The fail-closed guarantee is the engine's, so if
+  `comfy generate consent` is missing the tool refuses up front rather than spending on the
+  assumption something would have stopped it. `pip install -U comfy-cli` to fix.
 
 ## Driving a remote ComfyUI
 
@@ -359,7 +399,7 @@ the originals stay in the ComfyUI workspace.
 |---|---|---|
 | `run_workflow(workflow_path, wait=True, timeout_seconds=600.0)` | `comfy run --workflow <path> [--wait]` | Run a workflow JSON; `wait=False` submits async and returns a `prompt_id`. |
 | `generate_image(prompt, checkpoint=None, wait=True, timeout_seconds=600.0)` | `comfy generate --prompt <prompt> [--checkpoint <ckpt>]` | Text prompt → image in one call — comfy-cli owns the graph/checkpoint injection, so no hand-assembled workflow needed. Same envelope shape as `run_workflow` (`prompt_id` + outputs); the fast on-ramp. |
-| `partner_generate(model, params=None, confirm_spend=False, download=None, timeout_seconds=600.0)` | `comfy generate <model> [--param=value…] [--download=<path>] [--timeout=<s>] [--yes]` | Run a hosted **partner** model (Flux / Ideogram / DALL·E / Recraft / …). **Spends Comfy credits**, unlike the local `run_workflow` / `generate_image` paths. comfy-cli owns the spend interlock and fails closed with no TTY, so the call errors unless `confirm_spend=True` forwards its `--yes`; the tool refuses outright against a comfy-cli too old to have that interlock (probed via `comfy generate consent`). `params` are the model's own schema-driven inputs, forwarded verbatim (discover them with `comfy generate schema <model>` / `comfy generate list`). `timeout_seconds` becomes comfy-cli's own `--timeout` so the engine — not a parent kill — owns the deadline on a job the partner may already have charged for. |
+| `partner_generate(model, params=None, confirm_spend=False, download=None, timeout_seconds=600.0)` | `comfy generate <model> [--param=value…] [--download=<path>] [--timeout=<s>] [--yes]` | Run a hosted **partner** model (Flux / Ideogram / DALL·E / Recraft / …). **Spends Comfy credits**, unlike the local `run_workflow` / `generate_image` paths. Every call confirms the spend with you first — see [Spending credits](#spending-credits-on-partner-models) below. `params` are the model's own schema-driven inputs, forwarded verbatim (discover them with `comfy generate schema <model>` / `comfy generate list`). `timeout_seconds` becomes comfy-cli's own `--timeout` so the engine — not a parent kill — owns the deadline on a job the partner may already have charged for. |
 | `job_status(prompt_id)` | `comfy jobs status <prompt_id>` | Poll a submitted job's status + outputs. |
 | `wait_for_job(prompt_id, timeout_seconds=25.0)` | `comfy jobs status <prompt_id>` (polled) | Bounded wait until a job reaches a terminal status; returns a `{"timed_out": True, …}` payload on expiry. Chain several. |
 | `watch_job(prompt_id, timeout_seconds=600.0)` | `comfy jobs watch <prompt_id>` (streamed) | Tail an async-submitted job's live execution, streaming progress notifications; bounded, returns a `{"timed_out": True, …}` payload on expiry. Streaming counterpart to `wait_for_job`. |

--- a/README.md
+++ b/README.md
@@ -124,9 +124,16 @@ server also retries a transient credential failure briefly before surfacing it.
 
 ## Spending credits on partner models
 
-Everything else this server does runs on **your** machine and is free. `partner_generate` is the
-exception: it wraps `comfy generate <model>`, which calls a hosted partner API and **spends your
-Comfy credits**. So every call is confirmed with you first.
+`partner_generate` is the one tool whose *whole purpose* is to spend: it wraps `comfy generate
+<model>`, which calls a hosted partner API and **spends your Comfy credits**. So every call is
+confirmed with you first.
+
+The other tools execute on **your** machine, and on their own they cost nothing — but that is a
+property of the tool, not a guarantee about the workflow you hand it. A workflow run through
+`run_workflow` / `generate_image` can itself contain the partner-API nodes described just above
+(Seedream, Veo, Kling, …), or any other node that bills a hosted service, and **those still spend
+your credits** — they bill through the workflow, below this server, with no confirmation prompt.
+Check what a workflow contains before running one you did not build.
 
 **On a client that supports [MCP elicitation](https://modelcontextprotocol.io/specification/server/elicitation)**
 (Claude Code and Claude Desktop do), the call raises a confirmation prompt naming the model and
@@ -135,6 +142,8 @@ saying that it spends credits:
 - **Approve** → the server forwards comfy-cli's `--yes` and the generation runs.
 - **Decline** (or dismiss it) → the tool returns an error, and comfy-cli is never started. No
   credits are spent.
+- **Leave it unanswered** → after five minutes the prompt lapses into a refusal, so a forgotten
+  call never sits pending forever. Nothing is spent; call the tool again to get a fresh prompt.
 
 **Don't want to be asked every time?** Persist it in comfy-cli, not here:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,15 @@ requires-python = ">=3.10"
 license = "Apache-2.0"
 authors = [{ name = "Comfy Org" }]
 dependencies = [
-    "mcp>=1.2.0",
+    # >= 1.10 for elicitation (`Context.elicit`, used by `partner_generate` to
+    # confirm a credit spend per call); >= 1.14 because earlier FastMCP builds
+    # crash at import on this server's `ctx: Context | None` tool parameters
+    # (`issubclass() arg 1 must be a class`). Verified by running the suite
+    # against each release; the floor was previously understated at 1.2.0.
+    "mcp>=1.14.0",
+    # Already an mcp dependency; declared explicitly because this server now
+    # imports it directly for the elicitation response schema.
+    "pydantic>=2",
 ]
 # comfy-cli is intentionally NOT a declared dependency: this server shells out
 # to whatever `comfy` binary PATH/COMFY_BIN resolves to (which may differ from a

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -1850,10 +1850,16 @@ async def _elicit_spend_consent(ctx: Context, model: str) -> bool:
             "Nothing was spent."
         ) from exc
     except Exception as exc:
+        # Name the way out. Because an errored capability probe now routes here
+        # rather than to `confirm_spend`, a client this server cannot prompt
+        # would otherwise dead-end with no route to a generation it is entitled
+        # to run — and the user's own durable consent is exactly that route.
         raise ComfyCliError(
             "could not confirm the credit spend with the user: the client "
             f"failed to answer the confirmation prompt ({exc}). Nothing was "
-            "spent."
+            "spent. If this client cannot show prompts, record your consent "
+            "with comfy-cli directly — `comfy generate consent always` — and "
+            "this tool will honor it without asking."
         ) from exc
     # Every read is a `getattr`: a non-conforming client can return an object
     # with no `.action`/`.data`, and an AttributeError here would escape as an

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -39,6 +39,7 @@ against a real comfy-cli install and a running local ComfyUI.
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
 import math
 import os
@@ -241,6 +242,39 @@ def _in_pipe_pool(func, *args):
     can never saturate the pool other `to_thread` callers rely on.
     """
     return asyncio.get_running_loop().run_in_executor(_PIPE_EXECUTOR, func, *args)
+
+
+# Dedicated, bounded thread pool for `partner_generate`'s blocking `comfy
+# generate` run.
+#
+# That run is the longest blocking call in this server — up to
+# `_MAX_GENERATE_TIMEOUT` (an hour) parked in `subprocess.run`. Cancelling the
+# awaiting coroutine (an MCP cancellation, a client disconnect) does NOT
+# interrupt the OS thread, so on asyncio's shared *default* executor a handful
+# of abandoned partner runs could occupy that pool for an hour and starve every
+# other `to_thread` caller in the process. Confining them here caps the blast
+# radius to partner generation itself, exactly as `_PIPE_EXECUTOR` does for the
+# streaming pipe reads.
+#
+# Sized like the pipe pool. Saturating it queues further partner runs rather
+# than growing threads without bound — deliberate backpressure on a paid,
+# hour-long call, and far beyond any realistic concurrent use of one local
+# server.
+_GENERATE_POOL_MAX_WORKERS = min(32, (os.cpu_count() or 1) + 4)
+_GENERATE_EXECUTOR = ThreadPoolExecutor(
+    max_workers=_GENERATE_POOL_MAX_WORKERS,
+    thread_name_prefix="comfy-generate",
+)
+
+
+def _in_generate_pool(func, *args, **kwargs):
+    """Off-load the blocking `comfy generate` run to the dedicated pool.
+
+    Mirrors :func:`asyncio.to_thread` but targets :data:`_GENERATE_EXECUTOR`.
+    ``run_in_executor`` takes no keyword arguments, so they are bound here.
+    """
+    call = functools.partial(func, *args, **kwargs)
+    return asyncio.get_running_loop().run_in_executor(_GENERATE_EXECUTOR, call)
 
 
 # Bound how long cleanup will block joining the parked stderr reader. `proc.kill`
@@ -1626,7 +1660,9 @@ def _require_spend_gate() -> None:
         return
     try:
         _run_comfy("generate", "consent", "show", timeout=30.0, plain_ok=True)
-    except ComfyCliError as exc:
+    # Broad on purpose: the probe must fail CLOSED with THIS explanation, not
+    # leak a raw OSError/UnicodeDecodeError from a present-but-unusable binary.
+    except Exception as exc:
         raise ComfyCliError(
             "this comfy-cli has no `comfy generate` spend gate, so a generation "
             "would spend Comfy credits with no consent interlock — refusing. "
@@ -1653,6 +1689,13 @@ def _engine_auto_confirms() -> bool:
     answer would keep prompting after the user turned the setting on, or worse,
     keep NOT prompting after they turned it off.
 
+    The trailing ``--json`` is REQUIRED and is not the global one: ``comfy
+    generate`` is registered with ``allow_extra_args``/``ignore_unknown_options``
+    so the argv tail after the target reaches the subcommand's own meta-flag
+    parser, and ``consent`` only prints JSON when IT sees ``--json``. Without it
+    the command prints rich human text and this parse fails — which is why the
+    global ``--json`` (which must still precede the subcommand) is not enough.
+
     Best-effort, and every failure answers ``False``: an unreadable setting must
     fall through to ASKING the user, never to assuming they already said yes.
     :func:`_require_spend_gate` — not this — is what refuses a comfy-cli with no
@@ -1662,7 +1705,13 @@ def _engine_auto_confirms() -> bool:
         _, stdout, _, returncode, _ = _run_comfy_raw(
             "generate", "consent", "show", "--json", timeout=30.0
         )
-    except ComfyCliError:
+    # Broad on purpose, to keep the "every failure answers False" contract
+    # above literally true: a present-but-non-executable binary
+    # (`PermissionError`/`OSError`) or invalid-UTF-8 child output
+    # (`UnicodeDecodeError`) escapes `_run_comfy_raw` uncaught, and crashing
+    # `partner_generate` is strictly worse than falling back to asking.
+    # `False` is the safe direction — it can only ever cause a prompt.
+    except Exception:
         return False
     if returncode != 0:
         return False
@@ -1699,15 +1748,22 @@ class SpendApproval(BaseModel):
     )
 
 
-def _client_supports_elicitation(ctx: Context | None) -> bool:
-    """True when the connected MCP client advertised the elicitation capability.
+def _client_elicitation_support(ctx: Context | None) -> bool | None:
+    """Whether the connected MCP client advertised the elicitation capability.
 
-    Elicitation is optional in MCP, so the prompt can only be raised on a client
-    that declared it at handshake. Anything else — no context (a direct call, or
-    a host that injects none), a session predating elicitation, a capability
-    probe that raises — answers ``False`` so the caller falls back to the
-    explicit ``confirm_spend`` argument instead of hanging on a request the
-    client will never answer.
+    Tri-state, because "the client said no" and "we could not find out" must not
+    be answered the same way on the money path:
+
+    - ``False`` — DEFINITELY not capable: no context (a direct call, or a host
+      that injects none), no ``elicit``, or a session predating elicitation.
+      The caller falls back to the explicit ``confirm_spend`` argument rather
+      than hanging on a request the client will never answer.
+    - ``True`` — the client declared the capability at handshake.
+    - ``None`` — UNKNOWN: the capability probe itself raised. Answering ``False``
+      here would silently downgrade a genuinely capable client to the fallback
+      path, so a caller-supplied ``confirm_spend=True`` would spend credits with
+      no human prompt — the one outcome this tool exists to prevent. The caller
+      treats ``None`` as "ask anyway" (see :func:`_resolve_spend_consent`).
     """
     if ctx is None or not callable(getattr(ctx, "elicit", None)):
         return False
@@ -1724,7 +1780,44 @@ def _client_supports_elicitation(ctx: Context | None) -> bool:
             check(types.ClientCapabilities(elicitation=types.ElicitationCapability()))
         )
     except Exception:
-        return False
+        return None
+
+
+# How long the user gets to answer the spend prompt before it lapses into a
+# refusal. `timeout_seconds` bounds only the generation that follows, so without
+# this a client that advertises elicitation but never answers leaves the request
+# pending forever and stuck calls accumulate with nothing to reclaim them.
+# Generous, because a human has to notice the prompt and decide.
+_SPEND_ELICIT_TIMEOUT = 300.0
+
+# Cap on how much of a caller-supplied model name is echoed into the prompt.
+_ELICIT_MODEL_DISPLAY_MAX = 80
+
+
+def _display_model(model: str) -> str:
+    """Render a caller-supplied model name safely inside the elicitation prompt.
+
+    The prompt quotes the model in a markdown code span, and the name arrives
+    from the CALLER — an agent that may be relaying untrusted text. Backticks or
+    newlines in it would close that span on a client that renders markdown,
+    letting the name inject its own content: hiding the "SPENDS credits" warning
+    or appending a reassuring "this is free". That redresses the very prompt the
+    user is answering, so it is neutralized before display.
+
+    Display only — argv still carries the model verbatim, so a name comfy-cli
+    would accept is never mangled into one it would not.
+    """
+    cleaned = "".join(
+        " " if ch.isspace() or not ch.isprintable() else ch for ch in model
+    )
+    # The span delimiter itself: without a backtick the rest of markdown is
+    # inert inside the code span, so this is the only character that must go.
+    cleaned = " ".join(cleaned.replace("`", "'").split())
+    if len(cleaned) > _ELICIT_MODEL_DISPLAY_MAX:
+        cleaned = cleaned[:_ELICIT_MODEL_DISPLAY_MAX] + "…"
+    # `partner_generate` rejects an empty model before reaching here; the
+    # fallback only covers a name that was ENTIRELY unprintable.
+    return cleaned or "<unnamed model>"
 
 
 async def _elicit_spend_consent(ctx: Context, model: str) -> bool:
@@ -1732,25 +1825,42 @@ async def _elicit_spend_consent(ctx: Context, model: str) -> bool:
 
     The MCP-native spend confirmation: one prompt per call, answered by the
     human, never remembered. A decline, a cancel, an accept that did not
-    actually say yes, and a client that errors on the request all answer
-    ``False`` — the caller then spends nothing.
+    actually say yes, a client that errors on the request, a client that answers
+    with something malformed, and a prompt left unanswered past
+    :data:`_SPEND_ELICIT_TIMEOUT` all fail closed — the caller spends nothing.
     """
     try:
-        result = await ctx.elicit(
-            message=(
-                f"Run the hosted partner model `{model}`? This SPENDS Comfy "
-                "credits from the account this machine is signed into. "
-                "Running a workflow on the local ComfyUI is free."
+        result = await asyncio.wait_for(
+            ctx.elicit(
+                message=(
+                    f"Run the hosted partner model `{_display_model(model)}`? "
+                    "This SPENDS Comfy credits from the account this machine is "
+                    "signed into. Running a workflow on the local ComfyUI is free."
+                ),
+                schema=SpendApproval,
             ),
-            schema=SpendApproval,
+            timeout=_SPEND_ELICIT_TIMEOUT,
         )
+    except (asyncio.TimeoutError, TimeoutError) as exc:
+        # Ordered before the catch-all: on 3.11+ these are the same class, but
+        # an unanswered prompt deserves its own message.
+        raise ComfyCliError(
+            "spend not confirmed: the confirmation prompt went unanswered for "
+            f"{_SPEND_ELICIT_TIMEOUT:.0f}s, so it was treated as a refusal. "
+            "Nothing was spent."
+        ) from exc
     except Exception as exc:
         raise ComfyCliError(
             "could not confirm the credit spend with the user: the client "
             f"failed to answer the confirmation prompt ({exc}). Nothing was "
             "spent."
         ) from exc
-    return result.action == "accept" and getattr(result.data, "approve", False) is True
+    # Every read is a `getattr`: a non-conforming client can return an object
+    # with no `.action`/`.data`, and an AttributeError here would escape as an
+    # uncaught crash instead of the refusal this contract promises.
+    if getattr(result, "action", None) != "accept":
+        return False
+    return getattr(getattr(result, "data", None), "approve", False) is True
 
 
 async def _resolve_spend_consent(
@@ -1767,10 +1877,12 @@ async def _resolve_spend_consent(
     1. **The engine's durable always-proceed** (``spend.auto_confirm``) wins. The
        user pre-authorized spending in comfy-cli's own config, so there is
        nothing to ask and no ``--yes`` to add: the engine consents to itself.
-    2. **Elicitation**, when the client supports it — the per-call human
-       confirmation this tool is built around. Approve forwards ``--yes``;
-       decline raises here, so the refusal is enforced BEFORE comfy-cli runs
-       rather than relying on the engine to fail closed afterwards.
+    2. **Elicitation**, unless the client is KNOWN not to support it — the
+       per-call human confirmation this tool is built around. Approve forwards
+       ``--yes``; decline raises here, so the refusal is enforced BEFORE
+       comfy-cli runs rather than relying on the engine to fail closed
+       afterwards. A capability probe that could not answer counts as "ask":
+       being wrong that way costs a prompt, the other way costs money.
     3. **The explicit ``confirm_spend`` argument**, only as the fallback for a
        client that cannot elicit. Left ``False`` (the default) nothing is
        forwarded and comfy-cli's own gate fails closed.
@@ -1784,7 +1896,12 @@ async def _resolve_spend_consent(
     """
     if await asyncio.to_thread(_engine_auto_confirms):
         return False
-    if _client_supports_elicitation(ctx):
+    # `None` is the probe's "could not tell" and is treated as CAPABLE, so an
+    # errored probe cannot quietly demote a real client onto the `confirm_spend`
+    # fallback and spend without asking. Trying to elicit is the safe way to be
+    # wrong: on a client that truly cannot answer, `_elicit_spend_consent`
+    # raises (or lapses at `_SPEND_ELICIT_TIMEOUT`) having spent nothing.
+    if _client_elicitation_support(ctx) is not False:
         if await _elicit_spend_consent(ctx, model):
             return True
         raise ComfyCliError(
@@ -1961,7 +2078,11 @@ async def partner_generate(
     # `_run_comfy` blocks for as long as the generation takes (up to an hour),
     # so it runs off the event loop — this tool is async for the elicitation
     # round-trip above and must not wedge the server while a partner model runs.
-    return await asyncio.to_thread(
+    # Its OWN pool, not the shared `to_thread` one: cancelling this await does
+    # not interrupt the thread, so an abandoned run stays parked until comfy-cli
+    # returns and would otherwise sit on the default executor for up to an hour.
+    # See `_GENERATE_EXECUTOR`.
+    return await _in_generate_pool(
         _run_comfy,
         *args,
         timeout=timeout_seconds + _GENERATE_TIMEOUT_GRACE,

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -23,7 +23,10 @@ detached launch's captured output, and the
 ``comfy which``) that lets an agent learn the CLI's own contract and selection.
 ``partner_generate`` (``comfy generate <model>``) reaches the hosted PARTNER
 models; it spends credits, so comfy-cli's own consent interlock gates it and
-this wrapper only passes that consent through (``--yes``) when asked to.
+this wrapper only passes that consent through (``--yes``) when the USER granted
+it for that call — asked per call over MCP elicitation, or pre-authorized in
+comfy-cli's own config. The durable "always proceed" stays engine-side, so this
+server holds no spend state of its own.
 
 Requires comfy-cli >= 1.12.0 (the ``comfy logs`` verb + the ``envelope/1``
 contract): :func:`_run_comfy` guards this once, up front, with an actionable
@@ -48,7 +51,9 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from urllib.parse import urlparse
 
+from mcp import types
 from mcp.server.fastmcp import Context, FastMCP, Image
+from pydantic import BaseModel, Field
 
 # Rides every client handshake — teach an agent the canonical flows up front so
 # it does not have to rediscover them tool-by-tool. Keep this short.
@@ -90,9 +95,14 @@ This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
   `get_logs` — it tails the captured ComfyUI log (invisible otherwise).
 - Hosted PARTNER models (Flux / Ideogram / DALL·E / …) run via `partner_generate`,
   which SPENDS the user's Comfy credits — local `run_workflow` / `generate_image`
-  runs are free. comfy-cli gates the spend and fails closed, so the call errors
-  unless you pass `confirm_spend=True`. Set that ONLY when the user has actually
-  agreed to spend credits for that call — never just to clear the error.
+  runs are free. Every call confirms the spend with the USER first: on a client
+  that supports MCP elicitation you will be shown a confirmation prompt, and a
+  decline cancels the call without spending. On a client that cannot elicit,
+  comfy-cli's gate fails closed and the call errors unless you pass
+  `confirm_spend=True` — set that ONLY when the user has actually agreed to
+  spend credits for that call, never just to clear the error, and never because
+  the host granted blanket permission to call the tool. A user who prefers not
+  to be asked persists it engine-side with `comfy generate consent always`.
 
 Everything targets the LOCAL server only — there is no cloud access here.
 """
@@ -1627,6 +1637,163 @@ def _require_spend_gate() -> None:
     _spend_gate_probed = True
 
 
+def _engine_auto_confirms() -> bool:
+    """True when comfy-cli's persisted ``spend.auto_confirm`` is on.
+
+    The DURABLE "always proceed" for credit spending lives in comfy-cli's own
+    config (``comfy generate consent always``), not here — this server stays
+    stateless and remembers nothing between calls. When the user has set it, the
+    engine consents to its own spending call and there is nothing left to ask,
+    so :func:`partner_generate` skips the per-call prompt and forwards no
+    ``--yes``: the consent is the engine's, and it stays the engine's.
+
+    ``comfy generate consent show --json`` prints the setting as a JSON object
+    (a pretty-printed one, so it is read from the whole of stdout rather than
+    the line-oriented envelope parser). Read fresh on every call — a latched
+    answer would keep prompting after the user turned the setting on, or worse,
+    keep NOT prompting after they turned it off.
+
+    Best-effort, and every failure answers ``False``: an unreadable setting must
+    fall through to ASKING the user, never to assuming they already said yes.
+    :func:`_require_spend_gate` — not this — is what refuses a comfy-cli with no
+    interlock at all, so a ``False`` here is never mistaken for "no gate".
+    """
+    try:
+        _, stdout, _, returncode, _ = _run_comfy_raw(
+            "generate", "consent", "show", "--json", timeout=30.0
+        )
+    except ComfyCliError:
+        return False
+    if returncode != 0:
+        return False
+    try:
+        payload = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    # Tolerate comfy-cli one day wrapping this verb in an `envelope/1` the way
+    # the other verbs are: read the setting out of `data` when it does.
+    if isinstance(payload, dict) and payload.get("type") == "envelope":
+        payload = payload.get("data")
+    # `is True` on purpose: only a real JSON `true` authorizes spending. A
+    # string, a 1, or a missing key is not consent.
+    return isinstance(payload, dict) and payload.get("spend_auto_confirm") is True
+
+
+class SpendApproval(BaseModel):
+    """What the client returns from the per-call spend-confirmation prompt.
+
+    Deliberately one boolean rather than a bare accept/decline: consent has to
+    be an AFFIRMATIVE answer to the question "spend credits?", so a client (or
+    an agent host) that accepts the elicitation without actually answering it
+    lands on the ``False`` default and is treated as a refusal.
+    """
+
+    approve: bool = Field(
+        default=False,
+        title="Spend Comfy credits on this generation?",
+        description=(
+            "Yes runs the hosted partner model and spends credits from the "
+            "Comfy account this machine is signed into. No cancels it and "
+            "spends nothing."
+        ),
+    )
+
+
+def _client_supports_elicitation(ctx: Context | None) -> bool:
+    """True when the connected MCP client advertised the elicitation capability.
+
+    Elicitation is optional in MCP, so the prompt can only be raised on a client
+    that declared it at handshake. Anything else — no context (a direct call, or
+    a host that injects none), a session predating elicitation, a capability
+    probe that raises — answers ``False`` so the caller falls back to the
+    explicit ``confirm_spend`` argument instead of hanging on a request the
+    client will never answer.
+    """
+    if ctx is None or not callable(getattr(ctx, "elicit", None)):
+        return False
+    try:
+        session = ctx.session
+    except (AttributeError, ValueError):
+        # `Context.session` raises ValueError outside a live request.
+        return False
+    check = getattr(session, "check_client_capability", None)
+    if check is None:
+        return False
+    try:
+        return bool(
+            check(types.ClientCapabilities(elicitation=types.ElicitationCapability()))
+        )
+    except Exception:
+        return False
+
+
+async def _elicit_spend_consent(ctx: Context, model: str) -> bool:
+    """Ask the USER to approve this one credit-spending call. True = approved.
+
+    The MCP-native spend confirmation: one prompt per call, answered by the
+    human, never remembered. A decline, a cancel, an accept that did not
+    actually say yes, and a client that errors on the request all answer
+    ``False`` — the caller then spends nothing.
+    """
+    try:
+        result = await ctx.elicit(
+            message=(
+                f"Run the hosted partner model `{model}`? This SPENDS Comfy "
+                "credits from the account this machine is signed into. "
+                "Running a workflow on the local ComfyUI is free."
+            ),
+            schema=SpendApproval,
+        )
+    except Exception as exc:
+        raise ComfyCliError(
+            "could not confirm the credit spend with the user: the client "
+            f"failed to answer the confirmation prompt ({exc}). Nothing was "
+            "spent."
+        ) from exc
+    return result.action == "accept" and getattr(result.data, "approve", False) is True
+
+
+async def _resolve_spend_consent(
+    model: str, confirm_spend: bool, ctx: Context | None
+) -> bool:
+    """Decide whether this call may spend, and whether to forward ``--yes``.
+
+    Returns True to forward ``--yes`` (comfy-cli's explicit non-interactive
+    consent) and False to forward nothing. Raises :class:`ComfyCliError` — with
+    no child process ever spawned — when consent was actively refused.
+
+    The precedence, and the reason for it:
+
+    1. **The engine's durable always-proceed** (``spend.auto_confirm``) wins. The
+       user pre-authorized spending in comfy-cli's own config, so there is
+       nothing to ask and no ``--yes`` to add: the engine consents to itself.
+    2. **Elicitation**, when the client supports it — the per-call human
+       confirmation this tool is built around. Approve forwards ``--yes``;
+       decline raises here, so the refusal is enforced BEFORE comfy-cli runs
+       rather than relying on the engine to fail closed afterwards.
+    3. **The explicit ``confirm_spend`` argument**, only as the fallback for a
+       client that cannot elicit. Left ``False`` (the default) nothing is
+       forwarded and comfy-cli's own gate fails closed.
+
+    Note what is NOT in that list: the agent host's permission to CALL this
+    tool. Spend consent and tool permission are different questions, and an
+    "always allow this tool" toggle answers only the second — so on an
+    elicitation-capable client the prompt is raised even when the caller passed
+    ``confirm_spend=True``. Otherwise a host-level convenience setting would
+    quietly become standing authority over the user's credits.
+    """
+    if await asyncio.to_thread(_engine_auto_confirms):
+        return False
+    if _client_supports_elicitation(ctx):
+        if await _elicit_spend_consent(ctx, model):
+            return True
+        raise ComfyCliError(
+            f"spend not confirmed: the user declined to spend Comfy credits on "
+            f"`{model}`. Nothing was spent and no generation was started."
+        )
+    return confirm_spend
+
+
 def _generate_param_args(params: dict[str, Any]) -> list[str]:
     """Marshal per-model ``params`` into ``comfy generate`` ``--name=value`` tokens.
 
@@ -1692,12 +1859,13 @@ def _generate_param_args(params: dict[str, Any]) -> list[str]:
 
 
 @mcp.tool()
-def partner_generate(
+async def partner_generate(
     model: str,
     params: dict[str, Any] | None = None,
     confirm_spend: bool = False,
     download: str | None = None,
     timeout_seconds: float = 600.0,
+    ctx: Context | None = None,
 ) -> Any:
     """Run a hosted PARTNER model (Flux / Ideogram / DALL·E / Recraft / …) — SPENDS CREDITS.
 
@@ -1708,17 +1876,32 @@ def partner_generate(
 
     SPEND CONSENT — read before calling. comfy-cli puts the credit-spending call
     behind a consent interlock, and this wrapper does not implement, weaken, or
-    reimplement it: the engine decides. An MCP server has no interactive
-    terminal, so there is no prompt to answer — with ``confirm_spend=False``
-    (the default) comfy-cli fails CLOSED and this raises :class:`ComfyCliError`
-    having spent nothing. Because that guarantee is the engine's, this refuses to
-    run at all against a comfy-cli that predates the gate (see
-    :func:`_require_spend_gate`). ``confirm_spend=True`` forwards ``--yes``, comfy-cli's
-    explicit non-interactive consent. Only set it when the USER has actually
-    agreed to spend credits on this call — never merely to clear the error you
-    just hit. (A user who ran ``comfy generate consent always`` has
-    pre-authorized spending in comfy-cli's own config; that is their choice and
-    it applies here too.)
+    reimplement it: the engine decides whether a call may spend, and this only
+    reports the consent it was actually given. Where that consent comes from,
+    in precedence order (see :func:`_resolve_spend_consent`):
+
+    - The user's DURABLE always-proceed in comfy-cli's own config
+      (``comfy generate consent always``). It stays engine-side — this server
+      remembers nothing between calls — so when it is set there is nothing to
+      ask and no ``--yes`` to send; the engine consents to itself.
+    - A PER-CALL confirmation raised on the client through MCP **elicitation**,
+      the same primitive an interactive terminal's y/N prompt serves. Approve
+      and ``--yes`` is forwarded; decline and this raises :class:`ComfyCliError`
+      without ever starting comfy-cli, so nothing is spent.
+    - ``confirm_spend=True``, the fallback for a client that cannot elicit: it
+      forwards ``--yes`` directly. Set it ONLY when the user has actually agreed
+      to spend credits on this call — never merely to clear the error you just
+      hit. On a client that CAN elicit the user is asked anyway, so it is not a
+      way around the prompt.
+
+    Spend consent is not tool permission: a host's "always allow this tool"
+    setting authorizes CALLING this tool, never spending the user's money, and
+    is never read as consent here.
+
+    With none of the three, comfy-cli fails CLOSED (an MCP server has no TTY for
+    its own prompt) and this raises having spent nothing. Because that
+    fail-closed guarantee is the engine's, this refuses to run at all against a
+    comfy-cli that predates the gate (see :func:`_require_spend_gate`).
 
     ``params`` carries the model's OWN inputs (``prompt``, ``aspect_ratio``,
     ``seed``, …). These are schema-driven per model and are forwarded verbatim;
@@ -1769,12 +1952,20 @@ def partner_generate(
     # This is also what makes `timeout_seconds` real: comfy-cli's own default is
     # 300s, so before this a caller asking for longer silently got five minutes.
     args.append(f"--timeout={timeout_seconds}")
-    if confirm_spend:
+    # Prove the engine's interlock exists BEFORE asking the user to approve a
+    # spend — there is no point prompting for a call this would refuse anyway.
+    await asyncio.to_thread(_require_spend_gate)
+    if await _resolve_spend_consent(model, confirm_spend, ctx):
         # comfy-cli's non-interactive spend consent; a bare boolean meta flag.
         args.append("--yes")
-    _require_spend_gate()
-    return _run_comfy(
-        *args, timeout=timeout_seconds + _GENERATE_TIMEOUT_GRACE, plain_ok=True
+    # `_run_comfy` blocks for as long as the generation takes (up to an hour),
+    # so it runs off the event loop — this tool is async for the elicitation
+    # round-trip above and must not wedge the server while a partner model runs.
+    return await asyncio.to_thread(
+        _run_comfy,
+        *args,
+        timeout=timeout_seconds + _GENERATE_TIMEOUT_GRACE,
+        plain_ok=True,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,20 @@ def _skip_spend_gate_probe(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _skip_engine_auto_confirm_probe(monkeypatch):
+    """Answer ``partner_generate``'s per-call ``spend.auto_confirm`` read as OFF.
+
+    Third once-per-call shell-out on the spending path (``comfy generate consent
+    show --json``); it would consume the stubbed ``subprocess.run`` and shift the
+    exact-argv assertions the same way the two guards above would. ``False`` is
+    also the default posture under test — the engine has no durable
+    always-proceed, so consent has to come from the call itself. The dedicated
+    auto-confirm tests (`test_partner_generate.py`) restore the real function.
+    """
+    monkeypatch.setattr(server, "_engine_auto_confirms", lambda: False)
+
+
+@pytest.fixture(autouse=True)
 def _clear_comfyui_target_env(monkeypatch):
     """Default every test to the LOCAL target (no configured remote ComfyUI).
 

--- a/tests/test_partner_generate.py
+++ b/tests/test_partner_generate.py
@@ -413,6 +413,49 @@ def test_engine_auto_confirms_is_false_when_the_probe_cannot_run(monkeypatch):
     assert _real_engine_auto_confirms() is False
 
 
+@pytest.mark.parametrize(
+    "exc",
+    [
+        PermissionError(13, "Permission denied"),  # `comfy` present, not executable
+        OSError(8, "Exec format error"),  # wrong-arch binary
+        UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"),
+    ],
+)
+def test_engine_auto_confirms_is_false_when_the_probe_blows_up(monkeypatch, exc):
+    """The docstring promises EVERY failure answers False — including non-CLI ones.
+
+    `_run_comfy_raw` converts a timeout and a missing binary into `ComfyCliError`,
+    but a present-but-unusable one (`PermissionError`/`OSError`) and invalid-UTF-8
+    child output (`UnicodeDecodeError`) escape it raw. Crashing `partner_generate`
+    on those is strictly worse than falling back to asking the user.
+    """
+
+    def boom(*args, **kwargs):  # noqa: ARG001
+        raise exc
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", boom)
+
+    assert _real_engine_auto_confirms() is False
+
+
+def test_engine_auto_confirms_asks_comfy_cli_for_json_explicitly(monkeypatch):
+    """The trailing `--json` is load-bearing and must not be "cleaned up" away.
+
+    `comfy generate` takes `allow_extra_args`, so the tail after the target
+    reaches `consent`'s OWN meta-flag parser — and it prints JSON only when IT
+    sees `--json`. The global `--json` before the subcommand does not reach it,
+    so dropping this flag would make the command print rich human text, fail the
+    parse, and silently turn `comfy generate consent always` into a dead setting.
+    """
+    calls = _patched_consent_show(monkeypatch, 0, '{"spend_auto_confirm": true}')
+
+    assert _real_engine_auto_confirms() is True
+    # The global flag precedes the subcommand; the subcommand's own flag trails it.
+    assert calls[0][:2] == [server.COMFY_BIN, "--json"]
+    assert calls[0][-1] == "--json"
+
+
 def test_engine_auto_confirms_unwraps_a_future_envelope(monkeypatch):
     """If comfy-cli ever wraps this verb in an `envelope/1`, read `data`."""
     _patched_consent_show(
@@ -663,12 +706,12 @@ def test_partner_generate_checks_the_gate_before_prompting_the_user(monkeypatch)
         _FakeCtx(supports_elicitation=False),  # client never advertised it
     ],
 )
-def test_client_supports_elicitation_is_false_without_a_capable_client(ctx):
+def test_client_elicitation_support_is_false_without_a_capable_client(ctx):
     """Only a client that advertised elicitation is sent a prompt."""
-    assert server._client_supports_elicitation(ctx) is False
+    assert server._client_elicitation_support(ctx) is False
 
 
-def test_client_supports_elicitation_is_false_outside_a_live_request():
+def test_client_elicitation_support_is_false_outside_a_live_request():
     """`Context.session` raises outside a request — that is "cannot ask", not a crash."""
 
     class _NoSessionCtx:
@@ -679,12 +722,127 @@ def test_client_supports_elicitation_is_false_outside_a_live_request():
         def session(self):
             raise ValueError("Context is not available outside of a request")
 
-    assert server._client_supports_elicitation(_NoSessionCtx()) is False
+    assert server._client_elicitation_support(_NoSessionCtx()) is False
 
 
-def test_client_supports_elicitation_is_true_for_a_capable_client():
+def test_client_elicitation_support_is_true_for_a_capable_client():
     """The positive case, so the two guards above can't pass by always saying no."""
-    assert server._client_supports_elicitation(_FakeCtx()) is True
+    assert server._client_elicitation_support(_FakeCtx()) is True
+
+
+def test_client_elicitation_support_is_unknown_when_the_probe_raises():
+    """A probe that ERRORS is `None` — "could not tell", not "cannot ask"."""
+
+    class _BrokenProbeCtx(_FakeCtx):
+        def __init__(self):
+            super().__init__()
+            self.session = _BrokenSession()
+
+    class _BrokenSession:
+        def check_client_capability(self, capability):  # noqa: ARG002
+            raise RuntimeError("capability table is corrupt")
+
+    assert server._client_elicitation_support(_BrokenProbeCtx()) is None
+
+
+def test_an_errored_capability_probe_still_asks_before_spending(patched_plain_run):
+    """A probe error must not silently promote `confirm_spend` into a free pass.
+
+    The failure this locks out: an elicitation-CAPABLE client whose probe merely
+    errored gets treated as incapable, so `confirm_spend=True` forwards `--yes`
+    and spends credits with no human prompt — exactly the "tool permission
+    became spend consent" outcome this tool exists to prevent. Unknown means
+    ASK.
+    """
+    calls = patched_plain_run(0, stdout="done")
+
+    class _BrokenSession:
+        def check_client_capability(self, capability):  # noqa: ARG002
+            raise RuntimeError("capability table is corrupt")
+
+    ctx = _FakeCtx(action="decline")
+    ctx.session = _BrokenSession()
+
+    with pytest.raises(server.ComfyCliError, match="spend not confirmed"):
+        _generate("flux-pro", confirm_spend=True, ctx=ctx)
+
+    assert len(ctx.elicitations) == 1  # asked, despite the broken probe
+    assert calls == []  # and the decline still spent nothing
+
+
+def test_an_unanswered_prompt_lapses_into_a_refusal(patched_plain_run, monkeypatch):
+    """A client that advertises elicitation but never answers must not hang forever."""
+    calls = patched_plain_run(0, stdout="done")
+    monkeypatch.setattr(server, "_SPEND_ELICIT_TIMEOUT", 0.05)
+
+    class _SilentCtx(_FakeCtx):
+        async def elicit(self, message, schema):  # noqa: ARG002
+            self.elicitations.append(message)
+            await asyncio.sleep(30)  # never answers
+            raise AssertionError("must never be reached")
+
+    ctx = _SilentCtx()
+    with pytest.raises(server.ComfyCliError, match="went unanswered"):
+        _generate("flux-pro", ctx=ctx)
+
+    assert calls == []  # nothing ran, so nothing was spent
+
+
+def test_a_malformed_elicitation_result_is_a_refusal(patched_plain_run):
+    """A client answering with an object that has no `.action` is refused, not a crash."""
+    calls = patched_plain_run(0, stdout="done")
+
+    class _NonsenseCtx(_FakeCtx):
+        async def elicit(self, message, schema):  # noqa: ARG002
+            self.elicitations.append(message)
+            return object()  # no `.action`, no `.data`
+
+    with pytest.raises(server.ComfyCliError, match="spend not confirmed"):
+        _generate("flux-pro", ctx=_NonsenseCtx())
+
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("model", "banned"),
+    [
+        ("flux`\n\n**This is FREE**", "`"),  # closes the code span, injects a lie
+        ("flux\r\npro", "\n"),  # newlines alone can restructure the prompt
+    ],
+)
+def test_the_prompt_cannot_be_redressed_by_the_model_name(
+    patched_plain_run, model, banned
+):
+    """A caller-supplied model name cannot break out of the prompt's code span.
+
+    The prompt is the user's only view of what they are authorizing, so a name
+    that escapes its span could hide the "SPENDS credits" warning. Display is
+    sanitized; argv is not.
+    """
+    calls = patched_plain_run(0, stdout="done")
+    ctx = _FakeCtx(action="accept", approve=True)
+
+    _generate(model, ctx=ctx)
+
+    prompt = ctx.elicitations[0]
+    # Exactly two backticks — the span this prompt opens and closes itself — so
+    # the name cannot have terminated it early and escaped into the message.
+    assert prompt.count("`") == 2
+    shown = prompt.split("`")[1]
+    assert banned not in shown
+    assert "SPENDS Comfy credits" in prompt  # the warning survived intact
+    assert calls[0]["cmd"][5] == model  # argv still carries it verbatim
+
+
+def test_the_model_name_shown_in_the_prompt_is_length_capped(patched_plain_run):
+    """A megabyte model name can't push the warning off the user's screen."""
+    patched_plain_run(0, stdout="done")
+    ctx = _FakeCtx(action="accept", approve=True)
+
+    _generate("f" * 5000, ctx=ctx)
+
+    assert len(ctx.elicitations[0]) < 500
+    assert "SPENDS Comfy credits" in ctx.elicitations[0]
 
 
 def test_partner_generate_probes_the_spend_gate_once_then_generates(monkeypatch):

--- a/tests/test_partner_generate.py
+++ b/tests/test_partner_generate.py
@@ -6,9 +6,12 @@ lives in comfy-cli:
 
 1. The passthrough argv: global flags before the subcommand, the model as the
    first positional, per-model params as ``--name=value``.
-2. The SPEND CONSENT posture — ``--yes`` is sent only when the caller explicitly
-   sets ``confirm_spend=True``, and there is no second, covert way to send it.
-   The engine still owns the interlock; this only proves what we forward.
+2. The SPEND CONSENT posture — ``--yes`` is sent only when the USER granted
+   consent for that call (the elicitation prompt, or the explicit
+   ``confirm_spend`` fallback on a client that cannot elicit), the engine's
+   durable always-proceed is honored without one, and there is no second, covert
+   way to send it. The engine still owns the interlock; this only proves what we
+   forward, and that a decline spawns no child at all.
 3. The no-envelope result contract: ``comfy generate`` prints human text and
    exits 0 without an ``envelope/1``, so success is synthesized (``plain_ok``)
    while a non-zero exit — the engine's fail-closed consent refusal — raises.
@@ -18,11 +21,60 @@ comfy-cli is mocked throughout: no real ComfyUI, and no real credit spend.
 
 from __future__ import annotations
 
+import asyncio
 import subprocess
 
 import pytest
+from mcp.server.elicitation import (
+    AcceptedElicitation,
+    CancelledElicitation,
+    DeclinedElicitation,
+)
 
 from comfy_local_mcp import server
+
+
+def _generate(*args, **kwargs):
+    """Drive the async ``partner_generate`` tool from a sync test.
+
+    Matches the ``asyncio.run`` convention the other async tools' tests use
+    (`test_wrapper.py`); the tool went async in order to raise the per-call
+    spend-confirmation elicitation.
+    """
+    return asyncio.run(server.partner_generate(*args, **kwargs))
+
+
+class _FakeSession:
+    """Stand-in for the MCP ``ServerSession`` capability probe."""
+
+    def __init__(self, supports_elicitation: bool):
+        self._supports = supports_elicitation
+
+    def check_client_capability(self, capability):
+        return self._supports and capability.elicitation is not None
+
+
+class _FakeCtx:
+    """A fake FastMCP ``Context`` that answers the elicitation with ``action``.
+
+    Records every elicitation raised so a test can assert the prompt happened
+    (and what it said), and can be told to have no elicitation capability at all
+    — the two clients the consent path has to tell apart.
+    """
+
+    def __init__(self, action="accept", approve=True, supports_elicitation=True):
+        self.session = _FakeSession(supports_elicitation)
+        self._action = action
+        self._approve = approve
+        self.elicitations: list[str] = []
+
+    async def elicit(self, message, schema):
+        self.elicitations.append(message)
+        if self._action == "accept":
+            return AcceptedElicitation(data=schema(approve=self._approve))
+        if self._action == "decline":
+            return DeclinedElicitation()
+        return CancelledElicitation()
 
 
 def _fake_run_plain(returncode: int, stdout: str = "", stderr: str = ""):
@@ -62,7 +114,7 @@ def test_partner_generate_argv_is_a_local_json_passthrough(patched_plain_run):
     """`comfy --json --where local generate <model> --param=value` (flags first)."""
     calls = patched_plain_run(0, stdout="Saved image to /tmp/out.png")
 
-    server.partner_generate("flux-pro", params={"prompt": "a red fox"})
+    _generate("flux-pro", params={"prompt": "a red fox"})
 
     cmd = calls[0]["cmd"]
     assert cmd[0] == server.COMFY_BIN
@@ -75,7 +127,7 @@ def test_partner_generate_marshals_param_types(patched_plain_run):
     """Params render in the spellings comfy-cli's schema parser accepts."""
     calls = patched_plain_run(0, stdout="done")
 
-    server.partner_generate(
+    _generate(
         "flux-pro",
         params={
             "prompt": "a cat",
@@ -107,7 +159,7 @@ def test_partner_generate_param_value_with_leading_dash_stays_a_value(
     """`--name=value` keeps a dash-leading value from being read as the next flag."""
     calls = patched_plain_run(0, stdout="done")
 
-    server.partner_generate("flux-pro", params={"prompt": "--not-a-flag, just text"})
+    _generate("flux-pro", params={"prompt": "--not-a-flag, just text"})
 
     assert calls[0]["cmd"][4:] == [
         "generate",
@@ -121,7 +173,7 @@ def test_partner_generate_forwards_download_path(patched_plain_run):
     """`download` forwards comfy-cli's `--download`, in the `=value` form."""
     calls = patched_plain_run(0, stdout="done")
 
-    server.partner_generate("flux-pro", download="/tmp/out.png")
+    _generate("flux-pro", download="/tmp/out.png")
 
     assert calls[0]["cmd"][4:] == [
         "generate",
@@ -135,7 +187,7 @@ def test_partner_generate_omits_params_when_none(patched_plain_run):
     """No params -> a bare `generate <model>`, not an empty flag token."""
     calls = patched_plain_run(0, stdout="done")
 
-    server.partner_generate("flux-pro")
+    _generate("flux-pro")
 
     assert calls[0]["cmd"][4:] == ["generate", "flux-pro", "--timeout=600.0"]
 
@@ -147,16 +199,20 @@ def test_partner_generate_withholds_consent_by_default(patched_plain_run):
     """The default sends NO `--yes`: comfy-cli's gate is left to fail closed."""
     calls = patched_plain_run(0, stdout="done")
 
-    server.partner_generate("flux-pro", params={"prompt": "a cat"})
+    _generate("flux-pro", params={"prompt": "a cat"})
 
     assert "--yes" not in calls[0]["cmd"]
 
 
 def test_partner_generate_forwards_consent_when_confirmed(patched_plain_run):
-    """`confirm_spend=True` forwards `--yes`, comfy-cli's non-interactive consent."""
+    """`confirm_spend=True` forwards `--yes` on a client that cannot elicit.
+
+    The fallback path: with no elicitation-capable client there is no prompt to
+    raise, so the explicit argument is the only consent available.
+    """
     calls = patched_plain_run(0, stdout="done")
 
-    server.partner_generate("flux-pro", params={"prompt": "a cat"}, confirm_spend=True)
+    _generate("flux-pro", params={"prompt": "a cat"}, confirm_spend=True)
 
     assert calls[0]["cmd"][4:] == [
         "generate",
@@ -165,6 +221,208 @@ def test_partner_generate_forwards_consent_when_confirmed(patched_plain_run):
         "--timeout=600.0",
         "--yes",
     ]
+
+
+# --- per-call spend elicitation ---------------------------------------------
+
+
+def test_partner_generate_elicits_and_forwards_consent_on_approval(patched_plain_run):
+    """An elicitation-capable client is PROMPTED, and approval forwards `--yes`."""
+    calls = patched_plain_run(0, stdout="done")
+    ctx = _FakeCtx(action="accept", approve=True)
+
+    _generate("flux-pro", params={"prompt": "a cat"}, ctx=ctx)
+
+    assert len(ctx.elicitations) == 1  # the user was actually asked
+    assert "flux-pro" in ctx.elicitations[0]
+    assert "credits" in ctx.elicitations[0]  # and told what it costs
+    assert calls[0]["cmd"][4:] == [
+        "generate",
+        "flux-pro",
+        "--prompt=a cat",
+        "--timeout=600.0",
+        "--yes",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("action", "approve"),
+    [
+        ("decline", False),  # the user said no
+        ("cancel", False),  # the user dismissed the prompt
+        ("accept", False),  # accepted the form without answering yes
+    ],
+)
+def test_partner_generate_spends_nothing_when_the_user_does_not_approve(
+    patched_plain_run, action, approve
+):
+    """Decline -> no spend AND no `--yes`: comfy-cli is never even invoked.
+
+    Refusing here rather than letting the engine fail closed matters because the
+    engine's gate is not the only thing that could let the call through — a
+    `spend.auto_confirm` flipped on between the read and the run would spend the
+    user's credits right after they said no. No child, no spend.
+    """
+    calls = patched_plain_run(0, stdout="done")
+    ctx = _FakeCtx(action=action, approve=approve)
+
+    with pytest.raises(server.ComfyCliError, match="spend not confirmed"):
+        _generate("flux-pro", params={"prompt": "a cat"}, ctx=ctx)
+
+    assert len(ctx.elicitations) == 1
+    assert calls == []  # nothing ran, so nothing was spent
+
+
+def test_partner_generate_elicits_even_when_confirm_spend_is_set(patched_plain_run):
+    """`confirm_spend=True` is NOT a way around the per-call prompt.
+
+    The design rule this locks in: spend consent != tool permission. An agent
+    host that grants blanket "always allow this tool" (and a caller that sets
+    the argument off the back of it) must not be able to turn that into standing
+    authority over the user's credits — on a client that can ask, the user is
+    asked, and a decline still spends nothing.
+    """
+    calls = patched_plain_run(0, stdout="done")
+    ctx = _FakeCtx(action="decline")
+
+    with pytest.raises(server.ComfyCliError, match="spend not confirmed"):
+        _generate("flux-pro", confirm_spend=True, ctx=ctx)
+
+    assert len(ctx.elicitations) == 1
+    assert calls == []
+
+
+def test_partner_generate_does_not_elicit_without_client_support(patched_plain_run):
+    """A client that never advertised elicitation is not sent a prompt it can't answer."""
+    calls = patched_plain_run(0, stdout="done")
+    ctx = _FakeCtx(supports_elicitation=False)
+
+    _generate("flux-pro", confirm_spend=True, ctx=ctx)
+
+    assert ctx.elicitations == []  # no prompt raised at a client that can't show one
+    assert "--yes" in calls[0]["cmd"]  # the explicit argument still carries consent
+
+
+def test_partner_generate_surfaces_a_broken_elicitation_without_spending(
+    patched_plain_run,
+):
+    """A client that ERRORS on the prompt is not silently treated as approval."""
+    calls = patched_plain_run(0, stdout="done")
+
+    class _BrokenCtx(_FakeCtx):
+        async def elicit(self, message, schema):  # noqa: ARG002
+            raise RuntimeError("client closed the connection")
+
+    with pytest.raises(
+        server.ComfyCliError, match="could not confirm the credit spend"
+    ):
+        _generate("flux-pro", ctx=_BrokenCtx())
+
+    assert calls == []
+
+
+def test_partner_generate_honors_the_engines_durable_always_proceed(monkeypatch):
+    """`spend.auto_confirm` -> no prompt, and no `--yes`: the engine consents itself.
+
+    The durable "always proceed" is the user's own choice, persisted in
+    comfy-cli's config — this server keeps no such state. Honoring it is what
+    keeps `comfy generate consent always` meaningful through the MCP, instead of
+    the wrapper re-asking a question the user already answered for good.
+    """
+    monkeypatch.setattr(server, "_engine_auto_confirms", lambda: True)
+    calls = []
+
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+    ctx = _FakeCtx(action="decline")
+
+    _generate("flux-pro", ctx=ctx)
+
+    assert ctx.elicitations == []  # nothing left to ask
+    assert "--yes" not in calls[0]  # consent is the engine's, not ours to assert
+
+
+# --- reading the engine's durable always-proceed ----------------------------
+
+
+# Captured at import, BEFORE conftest's autouse stub replaces it with a
+# constant "off" — the tests below exercise the real probe.
+_real_engine_auto_confirms = server._engine_auto_confirms
+
+
+def _patched_consent_show(monkeypatch, returncode: int, stdout: str) -> list[list[str]]:
+    """Stub `comfy generate consent show --json` with a canned exit + stdout."""
+    calls: list[list[str]] = []
+
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+    return calls
+
+
+def test_engine_auto_confirms_reads_the_json_consent_payload(monkeypatch):
+    """comfy-cli pretty-prints the setting, so it is read from the WHOLE stdout.
+
+    `output.print_json` uses `indent=2`, so no single line parses — the
+    line-oriented envelope scanner would see nothing and report "off" for a user
+    who had turned it on.
+    """
+    calls = _patched_consent_show(
+        monkeypatch, 0, '{\n  "spend_auto_confirm": true,\n  "action": "show"\n}\n'
+    )
+
+    assert _real_engine_auto_confirms() is True
+    assert calls[0][4:] == ["generate", "consent", "show", "--json"]
+
+
+@pytest.mark.parametrize(
+    ("returncode", "stdout"),
+    [
+        (0, '{"spend_auto_confirm": false, "action": "show"}'),  # explicitly off
+        (0, '{"spend_auto_confirm": "true"}'),  # a string is not a JSON true
+        (0, '{"action": "show"}'),  # key absent
+        (0, "spend.auto_confirm: true"),  # human text, not JSON
+        (0, ""),  # nothing at all
+        (1, '{"spend_auto_confirm": true}'),  # a failed read authorizes nothing
+    ],
+)
+def test_engine_auto_confirms_is_false_for_anything_unreadable(
+    monkeypatch, returncode, stdout
+):
+    """Only a real JSON `true` from a clean exit counts as pre-authorization.
+
+    Every other answer falls through to ASKING the user — the failure direction
+    that costs a prompt, not the one that costs money.
+    """
+    _patched_consent_show(monkeypatch, returncode, stdout)
+
+    assert _real_engine_auto_confirms() is False
+
+
+def test_engine_auto_confirms_is_false_when_the_probe_cannot_run(monkeypatch):
+    """No `comfy` on PATH -> a ComfyCliError, absorbed as "not pre-authorized"."""
+    monkeypatch.setattr(server.shutil, "which", lambda _: None)
+
+    assert _real_engine_auto_confirms() is False
+
+
+def test_engine_auto_confirms_unwraps_a_future_envelope(monkeypatch):
+    """If comfy-cli ever wraps this verb in an `envelope/1`, read `data`."""
+    _patched_consent_show(
+        monkeypatch,
+        0,
+        '{"schema": "envelope/1", "type": "envelope", "ok": true, '
+        '"data": {"spend_auto_confirm": true}}',
+    )
+
+    assert _real_engine_auto_confirms() is True
 
 
 def test_partner_generate_consent_refusal_raises_and_surfaces_the_reason(
@@ -186,7 +444,7 @@ def test_partner_generate_consent_refusal_raises_and_surfaces_the_reason(
     )
 
     with pytest.raises(server.ComfyCliError) as excinfo:
-        server.partner_generate("flux-pro", params={"prompt": "a cat"})
+        _generate("flux-pro", params={"prompt": "a cat"})
 
     assert "spends Comfy credits" in str(excinfo.value)  # the reason survives
     assert "--yes" in str(excinfo.value)  # and so does the way forward
@@ -204,7 +462,7 @@ def test_partner_generate_refuses_run_level_flags_as_params(patched_plain_run, n
     calls = patched_plain_run(0, stdout="done")
 
     with pytest.raises(server.ComfyCliError, match="run-level"):
-        server.partner_generate("flux-pro", params={name: True})
+        _generate("flux-pro", params={name: True})
 
     assert calls == []  # refused before comfy-cli was ever invoked
 
@@ -218,7 +476,7 @@ def test_partner_generate_rejects_option_like_model(patched_plain_run, model):
     calls = patched_plain_run(0, stdout="done")
 
     with pytest.raises(server.ComfyCliError, match="invalid model"):
-        server.partner_generate(model)
+        _generate(model)
 
     assert calls == []  # never reached comfy-cli
 
@@ -235,7 +493,7 @@ def test_partner_generate_rejects_reserved_subactions(patched_plain_run, target)
     calls = patched_plain_run(0, stdout="done")
 
     with pytest.raises(server.ComfyCliError, match="sub-action"):
-        server.partner_generate(target)
+        _generate(target)
 
     assert calls == []
 
@@ -245,7 +503,7 @@ def test_partner_generate_rejects_option_like_param_name(patched_plain_run):
     calls = patched_plain_run(0, stdout="done")
 
     with pytest.raises(server.ComfyCliError, match="invalid parameter name"):
-        server.partner_generate("flux-pro", params={"--prompt": "a cat"})
+        _generate("flux-pro", params={"--prompt": "a cat"})
 
     assert calls == []
 
@@ -263,7 +521,7 @@ def test_partner_generate_rejects_param_names_that_smuggle_a_value(
     calls = patched_plain_run(0, stdout="done")
 
     with pytest.raises(server.ComfyCliError, match="cannot contain"):
-        server.partner_generate("flux-pro", params={"output-prefix=/tmp/x": "v"})
+        _generate("flux-pro", params={"output-prefix=/tmp/x": "v"})
 
     assert calls == []
 
@@ -286,7 +544,7 @@ def test_partner_generate_rejects_embedded_nul(patched_plain_run, kwargs, match)
     calls = patched_plain_run(0, stdout="done")
 
     with pytest.raises(server.ComfyCliError, match=match):
-        server.partner_generate(**kwargs)
+        _generate(**kwargs)
 
     assert calls == []
 
@@ -296,7 +554,7 @@ def test_partner_generate_rejects_an_empty_download_path(patched_plain_run):
     calls = patched_plain_run(0, stdout="done")
 
     with pytest.raises(server.ComfyCliError, match="invalid download"):
-        server.partner_generate("flux-pro", download="")
+        _generate("flux-pro", download="")
 
     assert calls == []
 
@@ -305,7 +563,7 @@ def test_partner_generate_clamps_timeout(patched_plain_run):
     """An absurd timeout is clamped, so no `comfy generate` child runs forever."""
     calls = patched_plain_run(0, stdout="done")
 
-    server.partner_generate("flux-pro", timeout_seconds=float("inf"))
+    _generate("flux-pro", timeout_seconds=float("inf"))
 
     assert f"--timeout={server._MAX_GENERATE_TIMEOUT}" in calls[0]["cmd"]
     assert (
@@ -324,7 +582,7 @@ def test_partner_generate_lets_the_engine_own_the_deadline(patched_plain_run):
     """
     calls = patched_plain_run(0, stdout="done")
 
-    server.partner_generate("flux-pro", timeout_seconds=900.0)
+    _generate("flux-pro", timeout_seconds=900.0)
 
     assert "--timeout=900.0" in calls[0]["cmd"]
     assert calls[0]["timeout"] == 900.0 + server._GENERATE_TIMEOUT_GRACE
@@ -342,7 +600,7 @@ def test_partner_generate_rejects_a_non_positive_or_nan_timeout(patched_plain_ru
     calls = patched_plain_run(0, stdout="done")
 
     with pytest.raises(server.ComfyCliError, match="timeout_seconds"):
-        server.partner_generate("flux-pro", timeout_seconds=bad)
+        _generate("flux-pro", timeout_seconds=bad)
 
     assert calls == []
 
@@ -370,11 +628,63 @@ def test_partner_generate_refuses_when_comfy_cli_has_no_spend_gate(monkeypatch):
     monkeypatch.setattr(server.subprocess, "run", fake)
 
     with pytest.raises(server.ComfyCliError, match="no `comfy generate` spend gate"):
-        server.partner_generate("flux-pro", params={"prompt": "a cat"})
+        _generate("flux-pro", params={"prompt": "a cat"})
 
     assert len(calls) == 1  # only the probe ran
     assert calls[0][4:] == ["generate", "consent", "show"]  # never the generation
     assert server._spend_gate_probed is False  # a failed probe is not latched
+
+
+def test_partner_generate_checks_the_gate_before_prompting_the_user(monkeypatch):
+    """The gate probe runs BEFORE the elicitation, not after.
+
+    Prompting first would ask the user to authorize a spend this call was always
+    going to refuse — a confirmation dialog whose only outcome is an error.
+    """
+    monkeypatch.setattr(server, "_spend_gate_probed", False)
+
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="no such model")
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+    ctx = _FakeCtx(action="accept", approve=True)
+
+    with pytest.raises(server.ComfyCliError, match="no `comfy generate` spend gate"):
+        _generate("flux-pro", ctx=ctx)
+
+    assert ctx.elicitations == []  # the user was never asked a pointless question
+
+
+@pytest.mark.parametrize(
+    "ctx",
+    [
+        None,  # no context at all (a direct call)
+        _FakeCtx(supports_elicitation=False),  # client never advertised it
+    ],
+)
+def test_client_supports_elicitation_is_false_without_a_capable_client(ctx):
+    """Only a client that advertised elicitation is sent a prompt."""
+    assert server._client_supports_elicitation(ctx) is False
+
+
+def test_client_supports_elicitation_is_false_outside_a_live_request():
+    """`Context.session` raises outside a request — that is "cannot ask", not a crash."""
+
+    class _NoSessionCtx:
+        async def elicit(self, message, schema):  # noqa: ARG002
+            raise AssertionError("must never be reached")
+
+        @property
+        def session(self):
+            raise ValueError("Context is not available outside of a request")
+
+    assert server._client_supports_elicitation(_NoSessionCtx()) is False
+
+
+def test_client_supports_elicitation_is_true_for_a_capable_client():
+    """The positive case, so the two guards above can't pass by always saying no."""
+    assert server._client_supports_elicitation(_FakeCtx()) is True
 
 
 def test_partner_generate_probes_the_spend_gate_once_then_generates(monkeypatch):
@@ -389,8 +699,8 @@ def test_partner_generate_probes_the_spend_gate_once_then_generates(monkeypatch)
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
     monkeypatch.setattr(server.subprocess, "run", fake)
 
-    server.partner_generate("flux-pro", confirm_spend=True)
-    server.partner_generate("flux-pro", confirm_spend=True)
+    _generate("flux-pro", confirm_spend=True)
+    _generate("flux-pro", confirm_spend=True)
 
     assert [c[4:6] for c in calls] == [
         ["generate", "consent"],  # probed once...
@@ -410,9 +720,7 @@ def test_partner_generate_synthesizes_success_without_an_envelope(patched_plain_
     """
     patched_plain_run(0, stdout="Generated 1 image -> /tmp/out.png")
 
-    result = server.partner_generate(
-        "flux-pro", params={"prompt": "a cat"}, confirm_spend=True
-    )
+    result = _generate("flux-pro", params={"prompt": "a cat"}, confirm_spend=True)
 
     assert result["ok"] is True
     assert result["action"] == "generate flux-pro"  # stops before the flags
@@ -440,7 +748,7 @@ def test_partner_generate_prefers_a_real_envelope_when_comfy_cli_emits_one(
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
     monkeypatch.setattr(server.subprocess, "run", fake)
 
-    result = server.partner_generate("flux-pro", confirm_spend=True)
+    result = _generate("flux-pro", confirm_spend=True)
 
     assert result == {"images": ["/tmp/out.png"]}
 
@@ -461,7 +769,7 @@ def test_partner_generate_error_envelope_raises_with_code(monkeypatch):
     monkeypatch.setattr(server.subprocess, "run", fake)
 
     with pytest.raises(server.ComfyCliError, match="unknown_model"):
-        server.partner_generate("nope-not-a-model", confirm_spend=True)
+        _generate("nope-not-a-model", confirm_spend=True)
 
 
 def test_instructions_warn_that_partner_generate_spends_credits():
@@ -471,3 +779,18 @@ def test_instructions_warn_that_partner_generate_spends_credits():
     assert "partner_generate" in instructions
     assert "confirm_spend" in instructions
     assert "credits" in instructions
+    assert "elicitation" in instructions  # and that the user is asked per call
+
+
+def test_partner_generate_takes_an_injected_context():
+    """FastMCP must recognise `ctx` — or the spend prompt silently never fires.
+
+    The elicitation path is reachable only if the server injects the request
+    context; a rename or a retype would quietly degrade every call to the
+    `confirm_spend` fallback with nothing failing loudly. `ctx` also has to stay
+    OUT of the tool's public input schema, so a caller can't pass one.
+    """
+    tool = server.mcp._tool_manager.get_tool("partner_generate")
+
+    assert tool.context_kwarg == "ctx"
+    assert "ctx" not in tool.parameters["properties"]


### PR DESCRIPTION
## ELI-5

`partner_generate` is the one tool in this server that spends your money — it runs a hosted model on Comfy's partner APIs and burns Comfy credits. Everything else runs on your own machine for free.

Before this PR, the only way it knew you'd agreed was a `confirm_spend=True` argument that the **agent** filled in. If your MCP host had "always allow this tool" switched on, the agent could set that flag and generate away — a convenience toggle quietly becoming permission to spend your money.

Now the server asks **you**, every call, using MCP elicitation (the protocol's version of a y/N prompt): *"Run `flux-pro`? This spends Comfy credits."* Approve and it runs. Decline and it stops right there — comfy-cli is never even started, so there is nothing that could have spent anything. If you'd rather not be asked each time, you tell **comfy-cli** that (`comfy generate consent always`), not this server — the server keeps no memory of your answers.

## Summary

Adds a per-call spend confirmation to `partner_generate` over MCP **elicitation**, and pins the design rule that **spend consent ≠ tool permission**: `--yes` is forwarded only for consent the *user* actually gave (the prompt, or comfy-cli's own persisted setting), never inferred from the host's permission to call the tool.

## Changes

- **`partner_generate` elicits per call.** On an elicitation-capable client the tool prompts with the model name and a plain "this spends credits" warning.
  - **Approve** → `--yes` is forwarded to `comfy generate`.
  - **Decline / cancel / accept-without-answering** → raises `ComfyCliError`, and **no child process is spawned at all**. Refusing here rather than letting the engine fail closed matters: an engine-side `spend.auto_confirm` flipped on between the read and the run would otherwise spend right after the user said no.
- **`confirm_spend=True` no longer skips the prompt.** On a client that can elicit, the user is asked anyway. The argument stays as the fallback for clients that *cannot* elicit (unchanged behavior there), so this is additive rather than a removal.
- **The durable "always proceed" stays engine-side.** `_engine_auto_confirms()` reads comfy-cli's persisted `spend.auto_confirm` (`comfy generate consent show --json`) fresh on every call; when it is on, the tool skips its prompt *and* forwards no `--yes` — the engine consents to itself. This server stores no spend state.
- **Ordering:** the spend-gate probe runs *before* the prompt, so the user is never asked to authorize a call that was going to be refused for a missing interlock.
- **`partner_generate` is now `async`** (needed for the elicitation round-trip); the blocking comfy-cli calls move off the event loop via `asyncio.to_thread`, where before they blocked whatever thread FastMCP gave them.
- **Dependency floor correction:** `mcp>=1.2.0` → `mcp>=1.14.0`, plus an explicit `pydantic>=2` (imported directly now for the elicitation schema). See "Judgment calls".
- Docs: new **Spending credits on partner models** README section, updated handshake `INSTRUCTIONS`, and an AGENTS.md note that MCP-protocol surfaces (like elicitation) are the one thing that legitimately lives here rather than in comfy-cli.

## Motivation

The partner tool reaches hosted models that charge the user's Comfy account. comfy-cli owns the interlock and fails closed, but an MCP server has no TTY, so the only consent signal reaching it was an argument the calling agent set for itself. An agent host's generic "always allow this tool" setting is about *invoking* a tool; treating it as authority to spend money is how a convenience toggle becomes a surprise invoice. Elicitation is the protocol-native way to put a human back in that loop, per call.

## Testing

- [x] Existing tests pass (`pytest`) — **329 passed, 1 skipped** (e2e skipped: no live ComfyUI)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually (below)

**Cross-version:** the full suite is green on Python 3.11 and 3.14, and on `mcp` 1.14.0 (the new declared floor) as well as 1.28.1.

**New coverage** (in `tests/test_partner_generate.py`): approve forwards `--yes`; decline/cancel/accept-without-approving each raise and spawn **zero** subprocesses; `confirm_spend=True` still gets prompted and still spends nothing on a decline; a client without the capability is never sent a prompt; a client that *errors* on the prompt is not read as approval; engine auto-confirm suppresses both the prompt and `--yes`; the `spend_auto_confirm` reader is exercised across true/false/string-`"true"`/missing-key/human-text/empty/non-zero-exit/future-envelope inputs; the gate probe precedes the prompt; and FastMCP actually injects `ctx` (a rename or retype would silently degrade every call to the fallback with nothing failing loudly).

**Manual verification against a real comfy-cli** (`Comfy-Org/comfy-cli@f132a08`, `main`), run with a throwaway `HOME` so no real config was touched. This checks the contract the auto-confirm reader depends on, since I asserted a positive claim about comfy-cli's output shape:

| Command | Result |
|---|---|
| `comfy --json --where local generate consent show --json` | exit 0, stdout `{\n  "spend_auto_confirm": false,\n  "action": "show"\n}` |
| `… generate consent always --json` then `show --json` | exit 0, `"spend_auto_confirm": true` |
| `… generate consent show` (the gate-probe form) | exit 0, human text on stderr |
| same probe against an **older** comfy-cli build | exit 1, `Unknown model: 'consent'` — the fail-closed refusal path |

…and the reader itself end-to-end via `COMFY_BIN`: `_engine_auto_confirms()` returned `True` with the config set to `always` and `False` after `ask`; `_require_spend_gate()` passed against the gated build. Note this confirmed a real trap — comfy-cli pretty-prints that JSON with `indent=2`, so the repo's line-oriented envelope scanner finds nothing; the reader parses the whole of stdout instead. Had it used the line scanner, a user who had turned `always` on would have been prompted forever.

## Judgment calls

1. **`confirm_spend=True` no longer bypasses the prompt on an elicitation-capable client.** This is a behavior change to a shipped argument, made deliberately: leaving the bypass in place would leave the exact loophole this ticket exists to close, since an agent can set the argument off the back of a blanket host permission. On clients that cannot elicit — where there is no prompt to bypass — the argument behaves exactly as before.
2. **Honoring engine-side `spend.auto_confirm` costs one extra local subprocess per generation** (a config read, no network, no spend) and is deliberately *not* cached: a latched answer would keep prompting after the user turned it on, or keep *not* prompting after they turned it off. Against a multi-second-to-multi-minute partner generation the cost is noise.
3. **The `mcp` floor bump is a correction, not an upgrade.** The declared `>=1.2.0` was already wrong before this PR — FastMCP builds below 1.14 crash at import on this server's existing `ctx: Context | None` tool parameters (`issubclass() arg 1 must be a class`). I bisected releases against the suite: 1.10 first has `Context.elicit`, 1.14 is the first that imports this server at all. Flagging it because it is the one change here outside the ticket's stated scope; happy to split it out if preferred.
4. **The elicitation schema is one boolean, not a bare accept/decline.** Consent should be an affirmative answer to "spend credits?", so a client (or agent host) that auto-accepts a form without answering it lands on the `False` default and is treated as a refusal. The trade-off is a client that accepts with empty content gets a spurious decline — annoying, but it fails toward "ask again" rather than toward "charge them".

## Negative-claim check

Per the falsification rule: this diff adds a `raise` path, but it does **not** deny a product capability — it enforces a refusal the *user* just issued, and the capability stays reachable by approving the next prompt or by persisting consent in comfy-cli. No "not supported" / "unavailable" / dead-end claims were added, and no test was flipped to assert a capability's absence. The one positive claim the change depends on (comfy-cli's `consent show --json` payload shape) was verified live rather than assumed — see the table above.

## Additional Notes

- **Not covered:** there is no e2e/live test of the elicitation round-trip against a real MCP client; the tests drive a fake `Context`. The `ctx`-injection test is the guard against the most likely silent-wiring regression, but an actual client handshake is untested here.
- `search_templates` and the other discovery tools are untouched; nothing about the local (free) generation paths changes.
