### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfy-local-mcp"
-version = "0.2.0"
+version = "0.3.0"
 description = "Local MCP server for ComfyUI — a thin wrapper over comfy-cli."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/comfy_local_mcp/__init__.py
+++ b/src/comfy_local_mcp/__init__.py
@@ -1,3 +1,3 @@
 """comfy-local-mcp: a thin MCP wrapper over comfy-cli."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
## ELI5
comfy-local-mcp has shipped a batch of new tools and knobs since the 0.2.0 tag two weeks ago, but the package still calls itself 0.2.0. This bumps the label to 0.3.0 so we can cut a fresh tagged release — a fixed point to install, pin in the evals sandbox image, and run the eval suite against.

## Summary
1. Bump `version` in `pyproject.toml` 0.2.0 -> 0.3.0
2. Bump `__version__` in `src/comfy_local_mcp/__init__.py` to match

## Context
Everything merged since `v0.2.0` (2026-07-18) rides under this version:
1. `partner_generate` — partner-API generation passthrough, with per-call credit-spend confirmation via MCP elicitation (#67, #68)
2. `run_template` — thin passthrough to `comfy run-template` (#69)
3. `COMFYUI_URL` — configurable remote ComfyUI host for the run/queue tools, incl. Tailscale targets (#61); unblocks the evals sandbox re-pin (Comfy-Org/evals#41)
4. `COMFY_LOCAL_URL` — documented path for a local ComfyUI on a non-default address (#65)
5. `server_info` freshness block (#64)

Once merged, tag the merge commit `v0.3.0` and publish the release (manual tag flow).

## Test plan
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — 16 files already formatted
- [x] `pytest -m 'not e2e'` — 381 passed, 1 deselected
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
