### PR TITLE
fix(get_queue): drop cloud-tracked rows from the local jobs listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ the originals stay in the ComfyUI workspace.
 | `watch_job(prompt_id, timeout_seconds=600.0)` | `comfy jobs watch <prompt_id>` (streamed) | Tail an async-submitted job's live execution, streaming progress notifications; bounded, returns a `{"timed_out": True, …}` payload on expiry. Streaming counterpart to `wait_for_job`. |
 | `get_execution_error(prompt_id)` | `comfy jobs status <prompt_id>` | Compact failure verdict for a failed run — the failing node, `exception_type`/`exception_message`, and a bounded traceback tail — so an agent can self-repair; returns `error: None` on a healthy prompt. |
 | `cancel_job(prompt_id)` | `comfy jobs cancel <prompt_id>` | Cancel a queued or running job. |
-| `get_queue()` | `comfy jobs ls` | List known jobs with status (pending/running/completed). |
+| `get_queue()` | `comfy jobs ls` | List known **local** jobs with status (pending/running/completed); cloud-tracked rows are filtered out. |
 | `fetch_outputs(prompt_id, out_dir, url_only=False, inline_images=False)` | `comfy download <prompt_id> --where local -o <out_dir> [--url-only]` | Write a finished local job's outputs into `out_dir`; `url_only=True` emits the output URLs without copying bytes; `inline_images=True` also returns the copied images as inline MCP image content so the agent can see them without a second read. |
 
 ### Diagnostics

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -2655,6 +2655,39 @@ def cancel_job(prompt_id: str) -> Any:
     return _run_comfy("jobs", "cancel", prompt_id, timeout=60.0)
 
 
+def _drop_cloud_jobs(data: Any) -> Any:
+    """Return ``comfy jobs ls`` data with cloud-tracked rows removed.
+
+    comfy-cli merges its on-disk job state files into ``jobs ls`` without
+    scoping them to the requested ``--where``, so a listing this server asked
+    for as ``--where local`` can still carry rows from a prior CLOUD run. This
+    server is local-only, so those rows are noise at best and misleading at
+    worst — drop them here rather than let the caller reason about jobs it
+    cannot act on. Once comfy-cli scopes the merge itself this becomes a no-op.
+
+    Deliberately defensive: this filter never raises and never reshapes a
+    payload it does not recognize. Only a ``dict`` carrying a ``list`` of jobs
+    is touched, only rows POSITIVELY marked ``"cloud"`` are dropped (a row with
+    no ``where`` is a legacy local row and is kept), and the input object is
+    returned unchanged when nothing was dropped.
+    """
+    if not isinstance(data, dict):
+        return data
+    jobs = data.get("jobs")
+    if not isinstance(jobs, list):
+        return data
+    kept = [
+        row
+        for row in jobs
+        if not (isinstance(row, dict) and row.get("where") == "cloud")
+    ]
+    if len(kept) == len(jobs):
+        return data
+    # Shallow copy: the caller's ``count`` must match the rows we return, and
+    # mutating comfy-cli's parsed payload in place is not this helper's call.
+    return {**data, "jobs": kept, "count": len(kept)}
+
+
 @mcp.tool()
 def get_queue() -> Any:
     """List known LOCAL jobs with their status (pending / running / completed).
@@ -2663,8 +2696,14 @@ def get_queue() -> Any:
     running ComfyUI server's queue, so this returns both jobs still in the queue
     and recently completed ones — call it to find a ``prompt_id`` to inspect with
     ``job_status`` or cancel with ``cancel_job``.
+
+    LOCAL ONLY: jobs comfy-cli tracks in its state store from a CLOUD run are
+    filtered out of the listing, because this server drives the user's local
+    ComfyUI and nothing else. Passing a cloud job's ``prompt_id`` to
+    ``job_status`` / ``cancel_job`` would route locally regardless, so listing
+    those ids here would only invite calls that cannot work.
     """
-    return _run_comfy("jobs", "ls", timeout=60.0)
+    return _drop_cloud_jobs(_run_comfy("jobs", "ls", timeout=60.0))
 
 
 # Image suffixes we return inline from ``fetch_outputs`` — kept to the formats

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -385,6 +385,98 @@ def test_get_queue_error_envelope_raises(patched_run):
         server.get_queue()
 
 
+def test_get_queue_drops_cloud_rows(patched_run):
+    """Cloud-tracked rows are filtered out — this server is local-only.
+
+    comfy-cli merges its on-disk job state into `jobs ls` without scoping it to
+    the `--where local` this server always passes, so a listing can carry rows
+    from a prior cloud run.
+    """
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": True,
+            "data": {
+                "host": "127.0.0.1",
+                "port": 8188,
+                "where": "local",
+                "count": 3,
+                "jobs": [
+                    {"prompt_id": "a", "status": "running", "where": "local"},
+                    {"prompt_id": "b", "status": "completed", "where": "cloud"},
+                    {"prompt_id": "c", "status": "completed", "where": "local"},
+                ],
+            },
+        }
+    )
+
+    result = server.get_queue()
+
+    assert [job["prompt_id"] for job in result["jobs"]] == ["a", "c"]
+    assert result["count"] == 2
+    assert result["where"] == "local"  # rest of the payload is untouched
+
+
+def test_get_queue_keeps_rows_without_a_where(patched_run):
+    """A row with no `where` is a legacy LOCAL row — kept, not dropped."""
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": True,
+            "data": {
+                "count": 2,
+                "jobs": [
+                    {"prompt_id": "a", "status": "running"},
+                    {"prompt_id": "b", "status": "completed", "where": None},
+                ],
+            },
+        }
+    )
+
+    assert [job["prompt_id"] for job in server.get_queue()["jobs"]] == ["a", "b"]
+
+
+def test_get_queue_keeps_rows_that_are_not_dicts(patched_run):
+    """An unknown ROW shape passes through — only positively-cloud rows drop."""
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": True,
+            "data": {
+                "count": 3,
+                "jobs": ["a-bare-id", None, {"prompt_id": "b", "where": "cloud"}],
+            },
+        }
+    )
+
+    result = server.get_queue()
+
+    assert result["jobs"] == ["a-bare-id", None]
+    assert result["count"] == 2
+
+
+def test_get_queue_passes_through_foreign_payload_shapes(patched_run):
+    """An unrecognized payload (older/newer comfy-cli) is returned untouched."""
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": True,
+            "data": [{"prompt_id": "a", "where": "cloud"}],  # a bare list
+        }
+    )
+
+    assert server.get_queue() == [{"prompt_id": "a", "where": "cloud"}]
+
+
+def test_get_queue_passes_through_payload_without_jobs(patched_run):
+    """A dict with no `jobs` list is returned untouched (no `count` invented)."""
+    patched_run(
+        {"type": "envelope", "ok": True, "data": {"host": "127.0.0.1", "port": 8188}}
+    )
+
+    assert server.get_queue() == {"host": "127.0.0.1", "port": 8188}
+
+
 def test_upload_file_passes_paths_and_overwrite(patched_run):
     """upload_file forwards every path and appends --overwrite when asked."""
     calls = patched_run({"type": "envelope", "ok": True, "data": {"uploaded": 2}})


### PR DESCRIPTION
## ELI-5

`get_queue` says it lists your **local** ComfyUI jobs — but comfy-cli also folds in
its saved job files from earlier runs, including ones that ran in the **cloud**. So
an agent asking "what's in my local queue?" could get back jobs it can't inspect or
cancel from this server at all. This PR drops those cloud rows on the way out.

## Summary

`get_queue` returned `comfy jobs ls` verbatim. comfy-cli merges its on-disk job
state files into that listing without scoping them to the requested `--where`, so a
listing this server always asks for as `--where local` can still carry rows from a
prior cloud run. This filters them out.

The filter is **deliberately redundant defense**: an engine-side scoping fix is
tracked separately, but this server does not pin comfy-cli (compatibility is
runtime-asserted via `server_info`), so it must behave sanely against released CLIs
that predate that fix. Once the engine scopes the merge, this becomes a no-op.

## Changes

- `server.py`: new `_drop_cloud_jobs(data)` helper, applied to `get_queue`'s
  unwrapped envelope data. It drops only rows positively marked `where == "cloud"`
  and recomputes `count`.
- `get_queue` docstring: documents the local-only filter and why listing cloud ids
  here would only invite calls that cannot work.
- `README.md`: tool table row updated to match.
- `tests/test_wrapper.py`: 5 new cases (cloud rows dropped + count recomputed; a row
  with no `where` kept; a non-dict row kept; a bare-list payload passed through; a
  dict with no `jobs` passed through).

Defensive by construction — no new exception path:

- only a `dict` whose `jobs` is a `list` is touched; anything else is returned as-is,
- a row that is not a dict passes through (unknown shapes are not judged),
- a missing/`None` `where` counts as **local** (legacy rows are kept),
- when nothing is dropped the **original object** is returned unchanged, so a payload
  with no `count` never gets one invented.

## Motivation

Agents driving a local-only MCP were getting stale cloud entries in the queue
listing and had no way to act on them — `job_status` / `cancel_job` / `watch_job`
all run `--where local` and would route to the local ComfyUI regardless.

## Testing

- [x] Existing tests pass (`pytest` — 386 passed, 1 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually against a real released comfy-cli (below)

### Live verification (released comfy-cli 1.12.0, isolated HOME, telemetry off)

Seeded one `where: "cloud"` and one `where: "local"` job state file, then ran the
exact command `get_queue` issues:

```
$ comfy --json --where local jobs ls
... "count": 2, "jobs": [ {"prompt_id": "localjob456", ..., "where": "local"},
                          {"prompt_id": "cloudjob123", ..., "where": "cloud"} ]
```

The cloud row really does come back on a released CLI. End-to-end through the tool:

```
main behavior (raw _run_comfy):  count 2 — localjob456, cloudjob123
this branch  (get_queue):        count 1 — localjob456
```

And the falsification for the capability this PR hides — is a cloud row usable via
*any* path this server offers? No:

- every subprocess invocation hardcodes `comfy --json --where local` (plus a
  `COMFY_WHERE=local` env pin), so no tool can target cloud jobs;
- of the 37 registered tools, only `auth_status` (`comfy cloud whoami`) touches
  cloud at all, and it reports auth identity, not jobs;
- attempted directly: `job_status("cloudjob123")` → `ComfyCliError
  [server_not_running]` against `127.0.0.1:8188`; with a local server up, comfy-cli's
  local status path queries only the local `/queue` and `/history`, so a cloud
  prompt_id yields `prompt_not_found`. Nothing is lost by hiding these rows.

## Additional Notes

- **Judgment call — no tracker reference in the title/body**, per this repo's
  AGENTS.md "destined-public hygiene" rule; the branch name carries the link.
- **Known upstream nuance (not fixable here):** comfy-cli truncates rows to
  `--limit` *before* this filter runs, so on a state store with many cloud jobs the
  filtered listing can be shorter than the CLI's limit. Fixing that requires the
  engine-side `--where` scoping; a thin wrapper cannot recover rows the CLI already
  dropped.
- The helper lives next to `get_queue` rather than with the generic helpers, since it
  encodes one command's payload shape.
