### PR TITLE
fix: explain the macOS Full Disk Access fix instead of relaying a raw PermissionError

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ local differentiator from the cloud MCP's equivalents. The graph-wiring verbs (`
 **Symptom.** Setup fails with a raw Python startup crash naming a file under `~/Documents`,
 `~/Desktop` or `~/Downloads` — most often the ComfyUI venv's `pyvenv.cfg`:
 
-```
+```text
 Fatal Python error: init_import_site: Failed to import the site module
 PermissionError: [Errno 1] Operation not permitted: '/Users/you/Documents/ComfyUI/venv/pyvenv.cfg'
 ```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Cloud MCP** — comfy-cli is the engine.
 - [Configure your AI client](#configure-your-ai-client)
 - [Quickstart](#quickstart)
 - [Tools](#tools)
+- [Troubleshooting](#troubleshooting)
 - [Smoke test](#smoke-test)
 - [Contributing](#contributing)
 - [License](#license)
@@ -315,6 +316,11 @@ server. Pick your client.
 > [partner-API nodes](#partner-api-nodes) (Seedream / Veo / Kling / Gemini / …); drop it
 > otherwise.
 
+> **On macOS, keep ComfyUI out of `~/Documents`, `~/Desktop` and `~/Downloads`** — or grant your
+> client Full Disk Access. macOS blocks apps (and everything they launch) from reading those
+> folders, so an install there fails with `Operation not permitted` before anything runs. See
+> [Troubleshooting](#troubleshooting).
+
 ### Claude Code
 
 One command registers the server:
@@ -490,6 +496,38 @@ Node introspection (`search_nodes` / `get_node` / `list_nodes` / `nodes_upstream
 read the **user's live install** (custom nodes included), not a static catalog — that's the
 local differentiator from the cloud MCP's equivalents. The graph-wiring verbs (`upstream` /
 `downstream` / `path`) are what an agent authoring a workflow uses to find compatible nodes.
+
+## Troubleshooting
+
+### macOS: `PermissionError: [Errno 1] Operation not permitted` / `Fatal Python error`
+
+**Symptom.** Setup fails with a raw Python startup crash naming a file under `~/Documents`,
+`~/Desktop` or `~/Downloads` — most often the ComfyUI venv's `pyvenv.cfg`:
+
+```
+Fatal Python error: init_import_site: Failed to import the site module
+PermissionError: [Errno 1] Operation not permitted: '/Users/you/Documents/ComfyUI/venv/pyvenv.cfg'
+```
+
+**Cause.** macOS protects those three folders with TCC (Transparency, Consent & Control). An app
+without **Full Disk Access** cannot read them — and neither can the processes it spawns. So when
+your ComfyUI install (and its `venv`) lives under one of them, the `comfy` binary your MCP client
+launches dies before it executes a single line. Nothing is wrong with ComfyUI, comfy-cli, or this
+server: it is a macOS privacy setting.
+
+**Fix — either one works:**
+
+1. **Grant your MCP client Full Disk Access.** System Settings → Privacy & Security → Full Disk
+   Access → add the app (Claude Desktop, Cursor, or the terminal you launch the client from), then
+   **quit and reopen it** so the new permission takes effect.
+2. **Or move the ComfyUI folder somewhere unprotected** — e.g. `~/ComfyUI` — and re-point comfy-cli
+   at it with `comfy set-default <path>`. Update `COMFY_BIN` in your client config too if it names
+   a path inside the old location.
+
+Where it can, the server says this for you: a tool call blocked this way returns the guidance above
+instead of the raw traceback. The one case it cannot catch is **its own** interpreter startup (this
+server installed under a protected folder) — Python dies before any of its code runs, so that one
+surfaces as the raw traceback in your client's MCP logs. Same fix.
 
 ## Smoke test
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -374,20 +374,26 @@ def _comfy_env() -> dict[str, str]:
 _MACOS_PROTECTED_DIRS = ("Documents", "Desktop", "Downloads")
 
 # The denied path as CPython prints it in the OSError above. CPython's format is
-# ``[Errno 1] <strerror>: '<path>'`` and macOS can localize ``<strerror>``, so
-# match on the errno marker first and fall back to the English phrase for a
-# denial reported without one.
+# ``[Errno 1] <strerror>: <repr(path)>`` and macOS can localize ``<strerror>``,
+# so match on the errno marker first and fall back to the English phrase for a
+# denial reported without one. `repr` quotes with `'` unless the path itself
+# contains one (then `"`), so accept either; the capture stops at a newline and
+# is bounded well past macOS's PATH_MAX so a garbled stderr line cannot drag an
+# unbounded blob into the message.
 _TCC_PATH_RE = re.compile(
-    r"(?:\[Errno 1\][^:\n]*|Operation not permitted):[ \t]*'([^'\n]*)'"
+    r"(?:\[Errno 1\][^:\n]*|Operation not permitted):[ \t]*"
+    r"b?(?:'([^'\n]{0,1024})'|\"([^\"\n]{0,1024})\")"
 )
 
-# Substrings that mark a TCC denial in captured stderr. `init_import_site` is
-# the venv-startup form above; the errno markers cover a denial raised once the
-# interpreter is already up. `[errno 1]` is there because the strerror text next
-# to it comes from libc and macOS translates it under a non-English
+# EPERM as it reaches us in text. `[errno 1]` is here because the strerror text
+# next to it comes from libc and macOS translates it under a non-English
 # `LC_MESSAGES` — the bracketed errno is what stays constant. It cannot collide
 # with another errno: the closing bracket rules out `[Errno 13]` and friends.
-_TCC_SIGNATURES = ("operation not permitted", "[errno 1]", "init_import_site")
+_EPERM_MARKERS = ("operation not permitted", "[errno 1]")
+
+# CPython's own marker for "the interpreter died before `site` was imported",
+# which is the shape a venv under a protected folder takes.
+_STARTUP_CRASH_MARKER = "init_import_site"
 
 
 def _is_macos() -> bool:
@@ -395,14 +401,22 @@ def _is_macos() -> bool:
     return sys.platform == "darwin"
 
 
-def _macos_protected_dir(path: str | None) -> str | None:
-    """Name of the protected home folder ``path`` sits under, else ``None``."""
+def _macos_protected_dir(path: str | bytes | None) -> str | None:
+    """Name of the protected home folder ``path`` sits under, else ``None``.
+
+    Compared case-insensitively: macOS volumes are case-insensitive by default,
+    so ``~/downloads/ComfyUI`` is the very same TCC-protected folder as
+    ``~/Downloads/ComfyUI`` and must be named as such rather than silently
+    falling through to the generic wording.
+    """
     if not path:
         return None
-    resolved = os.path.abspath(os.path.expanduser(path))
+    # An OSError raised on a bytes path carries a bytes `filename`; decode it
+    # rather than let a str/bytes comparison raise TypeError below.
+    resolved = os.path.abspath(os.path.expanduser(os.fsdecode(path))).lower()
     home = os.path.expanduser("~")
     for name in _MACOS_PROTECTED_DIRS:
-        root = os.path.join(home, name)
+        root = os.path.join(home, name).lower()
         if resolved == root or resolved.startswith(root + os.sep):
             return name
     return None
@@ -414,28 +428,46 @@ def _looks_like_tcc_denial(text: str | None) -> bool:
     macOS-only by design: EPERM ("operation not permitted") means something
     else entirely on Linux, and the guidance below is System-Settings-specific,
     so a non-macOS failure must keep its original message.
+
+    EPERM alone is NOT enough even on macOS — SIP, the app sandbox and signalling
+    a protected process all raise it, and rewriting one of those with Full Disk
+    Access guidance would send the user off fixing the wrong thing. Require
+    corroboration: either CPython's startup-crash marker (the venv-under-a-
+    protected-folder shape this exists for) or a denied path that really does
+    resolve under one of the three folders. Anything else keeps its own message.
     """
     if not text or not _is_macos():
         return False
     lowered = text.lower()
-    return any(signature in lowered for signature in _TCC_SIGNATURES)
+    if not any(marker in lowered for marker in _EPERM_MARKERS):
+        return False
+    return (
+        _STARTUP_CRASH_MARKER in lowered
+        or _macos_protected_dir(_tcc_path_from(text)) is not None
+    )
 
 
 def _tcc_path_from(text: str | None) -> str | None:
     """The denied path CPython named in ``text``, when it named one."""
     match = _TCC_PATH_RE.search(text or "")
-    return match.group(1) if match else None
+    if match is None:
+        return None
+    # Exactly one of the two quote-style alternatives captured.
+    return match.group(1) if match.group(1) is not None else match.group(2)
 
 
-def _tcc_guidance(path: str | None = None) -> str:
+def _tcc_guidance(path: str | bytes | None = None) -> str:
     """Actionable fix for a macOS protected-folder denial, as one message.
 
     ``path`` is the denied file when we know it (parsed out of the child's
     stderr, or an unreadable ``COMFY_BIN``); naming its protected folder makes
     the message concrete. Without one — or with one outside the protected set —
     the wording stays general rather than asserting a location we haven't
-    verified.
+    verified. A ``bytes`` path (what an ``OSError`` from a bytes-path syscall
+    carries) is decoded, so it reads as a path rather than as ``b'...'``.
     """
+    if path is not None:
+        path = os.fsdecode(path)
     folder = _macos_protected_dir(path)
     if folder:
         where = (
@@ -479,26 +511,57 @@ class ComfyCliError(RuntimeError):
         self.code = code
 
 
+def _comfy_bin_candidates() -> list[str]:
+    """Every filesystem location ``COMFY_BIN`` could name, as ``which`` would look.
+
+    A ``COMFY_BIN`` carrying a directory separator names exactly one file. A bare
+    name (the default, ``comfy``) is resolved against ``PATH`` — NOT against the
+    current working directory, which is what a plain ``os.stat(COMFY_BIN)`` would
+    do and which would miss a `comfy` that lives on ``PATH`` inside a protected
+    folder: precisely the install this diagnostic exists for.
+    """
+    if os.path.dirname(COMFY_BIN):
+        return [COMFY_BIN]
+    return [os.path.join(entry, COMFY_BIN) for entry in os.get_exec_path() if entry]
+
+
+def _tcc_blocked_comfy_bin() -> str | None:
+    """The candidate ``comfy`` path macOS is denying us, if that's what's wrong.
+
+    Only a candidate that BOTH sits under a protected folder and refuses to be
+    stat'ed counts. The protected-folder test is what keeps an ordinary EACCES —
+    a restrictive mode or ACL on a ``COMFY_BIN`` somewhere else entirely — from
+    being mislabelled as a Full Disk Access problem it isn't.
+    """
+    for candidate in _comfy_bin_candidates():
+        if _macos_protected_dir(candidate) is None:
+            continue
+        try:
+            os.stat(candidate)
+        except PermissionError:
+            return candidate
+        except OSError:
+            continue  # absent, a broken link, an unresolvable name — not ours
+    return None
+
+
 def _require_comfy_bin() -> None:
     """Resolve the ``comfy`` binary, raising an actionable error when it can't be.
 
     Shared by both spawn sites (:func:`_run_comfy_raw` / :func:`_run_comfy_streaming`)
-    so their missing-binary behavior cannot drift. On macOS a ``COMFY_BIN`` that
-    exists but cannot even be stat'ed is a protected-folder denial, not a missing
-    install — ``shutil.which`` reports both as ``None``, so say which one it is
-    instead of the misleading "not found on PATH".
+    so their missing-binary behavior cannot drift. On macOS a ``comfy`` that exists
+    but cannot even be stat'ed is a protected-folder denial, not a missing install
+    — ``shutil.which`` reports both as ``None``, so say which one it is instead of
+    the misleading "not found on PATH".
     """
     if shutil.which(COMFY_BIN) is not None:
         return
     if _is_macos():
-        try:
-            os.stat(COMFY_BIN)
-        except PermissionError:
+        blocked = _tcc_blocked_comfy_bin()
+        if blocked is not None:
             raise ComfyCliError(
-                f"`{COMFY_BIN}` could not be read.\n\n{_tcc_guidance(COMFY_BIN)}"
-            ) from None
-        except OSError:
-            pass  # genuinely absent (or an unresolvable name) -> the message below
+                f"`{COMFY_BIN}` could not be read.\n\n{_tcc_guidance(blocked)}"
+            )
     raise ComfyCliError(
         f"`{COMFY_BIN}` not found on PATH. Install comfy-cli "
         "(`pip install comfy-cli`) or set the COMFY_BIN env var."
@@ -554,6 +617,21 @@ def _check_comfy_version() -> None:
         # the same 30s wait; fail OPEN for the rest of the process.
         _version_checked = True
         return
+    except PermissionError as exc:
+        # The spawn ITSELF was denied (not the child exiting non-zero) — e.g. a
+        # `comfy` launcher whose interpreter sits in a protected folder. Without
+        # this branch the generic handler below fails open and the raw EPERM
+        # escapes from the real spawn a moment later, unexplained. Must precede
+        # the OSError handler: PermissionError is a subclass of it.
+        denied = getattr(exc, "filename", None) or _tcc_path_from(str(exc))
+        if _is_macos() and (
+            _looks_like_tcc_denial(str(exc)) or _macos_protected_dir(denied) is not None
+        ):
+            raise ComfyCliError(
+                f"`{COMFY_BIN}` could not be started.\n\n{_tcc_guidance(denied)}\n\n"
+                f"Original error: {exc}"
+            ) from exc
+        return  # any other permission problem: fail OPEN, exactly as before
     except (OSError, subprocess.SubprocessError):
         # A transient spawn failure fails OPEN for THIS call but is NOT latched —
         # a later call re-checks rather than permanently disabling the guard.
@@ -3683,9 +3761,14 @@ def main() -> None:
     try:
         mcp.run()
     except PermissionError as exc:
-        if not _looks_like_tcc_denial(str(exc)):
-            raise
+        # Prefer the exception's structured `filename` over re-parsing its text:
+        # it is the authoritative path, and it is present for errnos the text
+        # signature alone would not claim (TCC can surface as EACCES too).
         path = getattr(exc, "filename", None) or _tcc_path_from(str(exc))
+        if not _is_macos() or not (
+            _looks_like_tcc_denial(str(exc)) or _macos_protected_dir(path) is not None
+        ):
+            raise
         print(
             f"comfy-local-mcp: {exc}\n\n{_tcc_guidance(path)}",
             file=sys.stderr,

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -373,13 +373,21 @@ def _comfy_env() -> dict[str, str]:
 # Python traceback the user can do nothing with.
 _MACOS_PROTECTED_DIRS = ("Documents", "Desktop", "Downloads")
 
-# The denied path as CPython prints it in the OSError above.
-_TCC_PATH_RE = re.compile(r"Operation not permitted:\s*'([^']*)'")
+# The denied path as CPython prints it in the OSError above. CPython's format is
+# ``[Errno 1] <strerror>: '<path>'`` and macOS can localize ``<strerror>``, so
+# match on the errno marker first and fall back to the English phrase for a
+# denial reported without one.
+_TCC_PATH_RE = re.compile(
+    r"(?:\[Errno 1\][^:\n]*|Operation not permitted):[ \t]*'([^'\n]*)'"
+)
 
 # Substrings that mark a TCC denial in captured stderr. `init_import_site` is
-# the venv-startup form above; the bare errno text covers a denial raised once
-# the interpreter is already up.
-_TCC_SIGNATURES = ("operation not permitted", "init_import_site")
+# the venv-startup form above; the errno markers cover a denial raised once the
+# interpreter is already up. `[errno 1]` is there because the strerror text next
+# to it comes from libc and macOS translates it under a non-English
+# `LC_MESSAGES` — the bracketed errno is what stays constant. It cannot collide
+# with another errno: the closing bracket rules out `[Errno 13]` and friends.
+_TCC_SIGNATURES = ("operation not permitted", "[errno 1]", "init_import_site")
 
 
 def _is_macos() -> bool:

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -47,6 +47,7 @@ import re
 import shutil
 import signal
 import subprocess
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
@@ -356,6 +357,104 @@ def _comfy_env() -> dict[str, str]:
     }
 
 
+# --- macOS protected-folder (TCC) diagnostics --------------------------------
+#
+# macOS gates ~/Documents, ~/Desktop and ~/Downloads behind TCC (Transparency,
+# Consent & Control). An app without Full Disk Access cannot read them, and
+# neither can the processes it spawns — so when a ComfyUI install (and its
+# venv) lives under one of those folders, the `comfy` binary an MCP client
+# spawns dies during interpreter startup:
+#
+#     Fatal Python error: init_import_site: Failed to import the site module
+#     PermissionError: [Errno 1] Operation not permitted: '.../venv/pyvenv.cfg'
+#
+# That is a macOS privacy setting, not a ComfyUI/comfy-cli fault, so the helpers
+# below detect the signature and answer with the fix instead of relaying a raw
+# Python traceback the user can do nothing with.
+_MACOS_PROTECTED_DIRS = ("Documents", "Desktop", "Downloads")
+
+# The denied path as CPython prints it in the OSError above.
+_TCC_PATH_RE = re.compile(r"Operation not permitted:\s*'([^']*)'")
+
+# Substrings that mark a TCC denial in captured stderr. `init_import_site` is
+# the venv-startup form above; the bare errno text covers a denial raised once
+# the interpreter is already up.
+_TCC_SIGNATURES = ("operation not permitted", "init_import_site")
+
+
+def _is_macos() -> bool:
+    """True on macOS. Read at call time so tests can patch ``sys.platform``."""
+    return sys.platform == "darwin"
+
+
+def _macos_protected_dir(path: str | None) -> str | None:
+    """Name of the protected home folder ``path`` sits under, else ``None``."""
+    if not path:
+        return None
+    resolved = os.path.abspath(os.path.expanduser(path))
+    home = os.path.expanduser("~")
+    for name in _MACOS_PROTECTED_DIRS:
+        root = os.path.join(home, name)
+        if resolved == root or resolved.startswith(root + os.sep):
+            return name
+    return None
+
+
+def _looks_like_tcc_denial(text: str | None) -> bool:
+    """True if ``text`` carries the macOS protected-folder denial signature.
+
+    macOS-only by design: EPERM ("operation not permitted") means something
+    else entirely on Linux, and the guidance below is System-Settings-specific,
+    so a non-macOS failure must keep its original message.
+    """
+    if not text or not _is_macos():
+        return False
+    lowered = text.lower()
+    return any(signature in lowered for signature in _TCC_SIGNATURES)
+
+
+def _tcc_path_from(text: str | None) -> str | None:
+    """The denied path CPython named in ``text``, when it named one."""
+    match = _TCC_PATH_RE.search(text or "")
+    return match.group(1) if match else None
+
+
+def _tcc_guidance(path: str | None = None) -> str:
+    """Actionable fix for a macOS protected-folder denial, as one message.
+
+    ``path`` is the denied file when we know it (parsed out of the child's
+    stderr, or an unreadable ``COMFY_BIN``); naming its protected folder makes
+    the message concrete. Without one — or with one outside the protected set —
+    the wording stays general rather than asserting a location we haven't
+    verified.
+    """
+    folder = _macos_protected_dir(path)
+    if folder:
+        where = (
+            f"{path} is under ~/{folder}, which macOS protects (TCC): an app — "
+            "and every process it spawns — cannot read it unless that app has "
+            "Full Disk Access."
+        )
+    else:
+        where = (
+            "macOS protects ~/Documents, ~/Desktop and ~/Downloads (TCC): an "
+            "app — and every process it spawns — cannot read them unless that "
+            "app has Full Disk Access, so a ComfyUI install or venv under one "
+            "of them is unreadable from here."
+        )
+    return (
+        f"macOS denied access to a protected folder. {where}\n"
+        "Fix it either way:\n"
+        "  1. Grant your MCP client Full Disk Access — System Settings > "
+        "Privacy & Security > Full Disk Access > add the app (Claude Desktop, "
+        "Cursor, or the terminal you launch the client from) — then quit and "
+        "reopen it.\n"
+        "  2. Or move the ComfyUI folder somewhere unprotected (e.g. ~/ComfyUI) "
+        "and re-point comfy-cli at it with `comfy set-default <path>`.\n"
+        "This is a macOS privacy setting, not a ComfyUI or comfy-cli fault."
+    )
+
+
 class ComfyCliError(RuntimeError):
     """comfy-cli was missing, timed out, or returned an error envelope.
 
@@ -370,6 +469,32 @@ class ComfyCliError(RuntimeError):
     def __init__(self, *args: object, code: str | None = None) -> None:
         super().__init__(*args)
         self.code = code
+
+
+def _require_comfy_bin() -> None:
+    """Resolve the ``comfy`` binary, raising an actionable error when it can't be.
+
+    Shared by both spawn sites (:func:`_run_comfy_raw` / :func:`_run_comfy_streaming`)
+    so their missing-binary behavior cannot drift. On macOS a ``COMFY_BIN`` that
+    exists but cannot even be stat'ed is a protected-folder denial, not a missing
+    install — ``shutil.which`` reports both as ``None``, so say which one it is
+    instead of the misleading "not found on PATH".
+    """
+    if shutil.which(COMFY_BIN) is not None:
+        return
+    if _is_macos():
+        try:
+            os.stat(COMFY_BIN)
+        except PermissionError:
+            raise ComfyCliError(
+                f"`{COMFY_BIN}` could not be read.\n\n{_tcc_guidance(COMFY_BIN)}"
+            ) from None
+        except OSError:
+            pass  # genuinely absent (or an unresolvable name) -> the message below
+    raise ComfyCliError(
+        f"`{COMFY_BIN}` not found on PATH. Install comfy-cli "
+        "(`pip install comfy-cli`) or set the COMFY_BIN env var."
+    )
 
 
 def _parse_version(text: str) -> tuple[int, int, int] | None:
@@ -425,6 +550,18 @@ def _check_comfy_version() -> None:
         # A transient spawn failure fails OPEN for THIS call but is NOT latched —
         # a later call re-checks rather than permanently disabling the guard.
         return
+    if proc.returncode != 0 and _looks_like_tcc_denial(proc.stderr):
+        # comfy-cli's own interpreter could not start because macOS denied it
+        # its venv — the reported failure for a ComfyUI install under
+        # ~/Documents. This guard runs before the first tool call of the
+        # process, so catching it here is what turns the raw `Fatal Python
+        # error` traceback into the fix. Deliberately NOT memoized: granting
+        # Full Disk Access and retrying in the same process must re-check.
+        raise ComfyCliError(
+            f"`{COMFY_BIN}` could not start.\n\n"
+            f"{_tcc_guidance(_tcc_path_from(proc.stderr))}\n\n"
+            f"Original error: {_tail(proc.stderr)}"
+        )
     version = _parse_version(f"{proc.stdout}\n{proc.stderr}")
     if version is not None and version < _MIN_COMFY_CLI:
         # Deliberately do NOT memoize a too-old verdict: if the user upgrades and
@@ -601,11 +738,7 @@ def _run_comfy_raw(
     ``stdout`` (e.g. the lifecycle-success synthesizer), while :func:`_run_comfy`
     just unwraps it down to ``data``.
     """
-    if shutil.which(COMFY_BIN) is None:
-        raise ComfyCliError(
-            f"`{COMFY_BIN}` not found on PATH. Install comfy-cli "
-            "(`pip install comfy-cli`) or set the COMFY_BIN env var."
-        )
+    _require_comfy_bin()
     _check_comfy_version()
     # Forward --host/--port into the subcommand when a remote ComfyUI is
     # configured (no-op for the local default; see _with_target). Reassigning
@@ -789,6 +922,15 @@ def _unwrap_envelope(
     with no declared schema is assumed compatible.
     """
     if envelope is None:
+        if _looks_like_tcc_denial(stderr):
+            # comfy-cli emitted no envelope because macOS denied it a protected
+            # folder (see the TCC block above) — a permission problem the user
+            # can fix, not the opaque "returned no JSON" this would otherwise be.
+            raise ComfyCliError(
+                f"comfy-cli could not run (exit {returncode}).\n\n"
+                f"{_tcc_guidance(_tcc_path_from(stderr))}\n\n"
+                f"Original error: {_tail(stderr)}"
+            )
         raise ComfyCliError(
             f"comfy-cli returned no JSON (exit {returncode}). "
             f"stderr: {stderr.strip()[:500]}"
@@ -1029,11 +1171,7 @@ async def _run_comfy_streaming(
     ``{"timed_out": True, "status": <progress snapshot>}`` payload (mirroring
     :func:`wait_for_job`) rather than surface the deadline as an error.
     """
-    if shutil.which(COMFY_BIN) is None:
-        raise ComfyCliError(
-            f"`{COMFY_BIN}` not found on PATH. Install comfy-cli "
-            "(`pip install comfy-cli`) or set the COMFY_BIN env var."
-        )
+    _require_comfy_bin()
     # `_check_comfy_version` runs a synchronous `comfy --version` (up to 30s on
     # the first call per process); offload it so the async event loop is never
     # blocked while it runs.
@@ -3519,8 +3657,33 @@ def vary_workflow(
 
 
 def main() -> None:
-    """Entry point: serve the MCP over stdio."""
-    mcp.run()
+    """Entry point: serve the MCP over stdio.
+
+    A macOS protected-folder denial hit during startup (a config, log, or module
+    the server itself reads from under ~/Documents, say) arrives as a bare
+    :class:`PermissionError` that the MCP client would surface as a raw Python
+    traceback. Translate it into the same actionable guidance the tool paths
+    give, on stderr — where MCP clients collect server logs — and exit non-zero.
+    Anything else propagates unchanged.
+
+    One case is beyond reach on purpose: if THIS server's own interpreter cannot
+    read its venv, CPython dies in ``init_import_site`` before any of our code
+    runs. That failure is only catchable from the parent side, which is exactly
+    what the ``comfy``-binary guards in :func:`_check_comfy_version` and
+    :func:`_require_comfy_bin` do for the child process we spawn.
+    """
+    try:
+        mcp.run()
+    except PermissionError as exc:
+        if not _looks_like_tcc_denial(str(exc)):
+            raise
+        path = getattr(exc, "filename", None) or _tcc_path_from(str(exc))
+        print(
+            f"comfy-local-mcp: {exc}\n\n{_tcc_guidance(path)}",
+            file=sys.stderr,
+            flush=True,
+        )
+        raise SystemExit(1) from exc
 
 
 if __name__ == "__main__":

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -95,6 +95,23 @@ def test_denial_signature_is_macos_only(on_macos, monkeypatch):
     assert server._looks_like_tcc_denial(_FATAL_STDERR) is False
 
 
+def test_denial_survives_a_localized_strerror(on_macos):
+    """`Operation not permitted` is libc text macOS translates; `[Errno 1]` isn't."""
+    localized = (
+        "Fatal Python error: init_import_site: Failed to import the site module\n"
+        f"PermissionError: [Errno 1] Opération non permise: '{_DENIED_PATH}'\n"
+    )
+    assert server._looks_like_tcc_denial(localized) is True
+    # …and the path still resolves, so the message names the folder.
+    assert server._tcc_path_from(localized) == _DENIED_PATH
+    assert "~/Documents" in server._tcc_guidance(server._tcc_path_from(localized))
+    # A different errno must not be swept in by the `[Errno 1]` marker.
+    assert (
+        server._looks_like_tcc_denial("PermissionError: [Errno 13] Accès refusé")
+        is False
+    )
+
+
 def test_denied_path_is_parsed_out_of_the_traceback():
     assert server._tcc_path_from(_FATAL_STDERR) == _DENIED_PATH
     assert server._tcc_path_from("no path here") is None

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,291 @@
+"""macOS protected-folder (TCC) diagnostics.
+
+A ComfyUI install under ~/Documents, ~/Desktop or ~/Downloads is unreadable by
+an MCP client that lacks Full Disk Access — and by every process it spawns. The
+`comfy` binary then dies inside CPython's own startup:
+
+    Fatal Python error: init_import_site: Failed to import the site module
+    PermissionError: [Errno 1] Operation not permitted: '.../venv/pyvenv.cfg'
+
+These tests lock in that we recognize that signature wherever it can reach us
+and answer with the fix (Full Disk Access, or move the folder) instead of
+relaying the raw traceback — and, just as importantly, that we do NOT rewrite
+unrelated failures or non-macOS ones.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+
+import pytest
+
+from comfy_local_mcp import server
+
+# The child's stderr when its venv sits in a TCC-protected folder.
+_DENIED_PATH = os.path.join(
+    os.path.expanduser("~"), "Documents", "ComfyUI", "venv", "pyvenv.cfg"
+)
+_FATAL_STDERR = (
+    "Fatal Python error: init_import_site: Failed to import the site module\n"
+    "Python runtime state: core initialized\n"
+    "Traceback (most recent call last):\n"
+    '  File "<frozen site>", line 762, in <module>\n'
+    f"PermissionError: [Errno 1] Operation not permitted: '{_DENIED_PATH}'\n"
+)
+
+
+@pytest.fixture
+def on_macos(monkeypatch):
+    """Run the body as if on macOS (the diagnostics are macOS-only by design)."""
+    monkeypatch.setattr(server.sys, "platform", "darwin")
+
+
+@pytest.fixture
+def on_linux(monkeypatch):
+    monkeypatch.setattr(server.sys, "platform", "linux")
+
+
+def _assert_actionable(message: str) -> None:
+    """Every rewritten message must carry both escape hatches."""
+    assert "Full Disk Access" in message
+    assert "System Settings" in message
+    assert "comfy set-default" in message
+
+
+# --- path classification -----------------------------------------------------
+
+
+@pytest.mark.parametrize("folder", ["Documents", "Desktop", "Downloads"])
+def test_protected_dir_detects_each_folder(folder):
+    path = os.path.join(os.path.expanduser("~"), folder, "ComfyUI", "venv", "bin")
+    assert server._macos_protected_dir(path) == folder
+
+
+def test_protected_dir_ignores_unprotected_and_prefix_collisions():
+    home = os.path.expanduser("~")
+    assert server._macos_protected_dir(os.path.join(home, "ComfyUI")) is None
+    # "~/DocumentsArchive" merely starts with "~/Documents" — not the same folder.
+    assert server._macos_protected_dir(os.path.join(home, "DocumentsArchive")) is None
+    assert server._macos_protected_dir("/opt/comfy/venv") is None
+    assert server._macos_protected_dir(None) is None
+
+
+def test_guidance_names_the_folder_when_the_path_is_known(on_macos):
+    message = server._tcc_guidance(_DENIED_PATH)
+    assert "~/Documents" in message
+    assert _DENIED_PATH in message
+    _assert_actionable(message)
+
+
+def test_guidance_stays_general_without_a_path(on_macos):
+    message = server._tcc_guidance(None)
+    # No location is asserted as fact; all three protected folders are listed.
+    for folder in ("~/Documents", "~/Desktop", "~/Downloads"):
+        assert folder in message
+    _assert_actionable(message)
+
+
+def test_denial_signature_is_macos_only(on_macos, monkeypatch):
+    assert server._looks_like_tcc_denial(_FATAL_STDERR) is True
+    assert server._looks_like_tcc_denial("connection refused") is False
+    assert server._looks_like_tcc_denial("") is False
+    monkeypatch.setattr(server.sys, "platform", "linux")
+    assert server._looks_like_tcc_denial(_FATAL_STDERR) is False
+
+
+def test_denied_path_is_parsed_out_of_the_traceback():
+    assert server._tcc_path_from(_FATAL_STDERR) == _DENIED_PATH
+    assert server._tcc_path_from("no path here") is None
+
+
+# --- binary resolution -------------------------------------------------------
+
+
+def test_unreadable_comfy_bin_reports_the_permission_not_a_missing_install(
+    on_macos, monkeypatch
+):
+    """`shutil.which` returns None for BOTH cases — say which one it is."""
+    monkeypatch.setattr(server.shutil, "which", lambda _: None)
+    monkeypatch.setattr(
+        server.os, "stat", lambda _: (_ for _ in ()).throw(PermissionError(1, "EPERM"))
+    )
+    monkeypatch.setattr(server, "COMFY_BIN", _DENIED_PATH)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._require_comfy_bin()
+
+    message = str(excinfo.value)
+    assert "not found on PATH" not in message
+    _assert_actionable(message)
+
+
+def test_genuinely_missing_comfy_bin_keeps_the_install_message(on_macos, monkeypatch):
+    monkeypatch.setattr(server.shutil, "which", lambda _: None)
+    monkeypatch.setattr(
+        server.os, "stat", lambda _: (_ for _ in ()).throw(FileNotFoundError())
+    )
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._require_comfy_bin()
+
+    assert "not found on PATH" in str(excinfo.value)
+    assert "Full Disk Access" not in str(excinfo.value)
+
+
+def test_resolvable_comfy_bin_passes(on_macos, monkeypatch):
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    server._require_comfy_bin()  # no raise
+
+
+# --- the version guard (first shell-out of the process) ----------------------
+
+
+def _patch_version_probe(monkeypatch, returncode: int, stderr: str) -> None:
+    """Re-enable the memoized version guard and make `comfy --version` fail."""
+    monkeypatch.setattr(server, "_version_checked", False)
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+
+    def fake_run(cmd, **kwargs):  # noqa: ARG001
+        return subprocess.CompletedProcess(cmd, returncode, stdout="", stderr=stderr)
+
+    monkeypatch.setattr(server.subprocess, "run", fake_run)
+
+
+def test_version_guard_translates_the_fatal_startup_error(on_macos, monkeypatch):
+    """The earliest catchable point: `comfy --version` before the first tool call."""
+    _patch_version_probe(monkeypatch, 1, _FATAL_STDERR)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._check_comfy_version()
+
+    message = str(excinfo.value)
+    _assert_actionable(message)
+    assert "~/Documents" in message
+    # The raw error is preserved, just demoted below the fix.
+    assert "init_import_site" in message
+    # Not memoized: granting access and retrying in-process must re-check.
+    assert server._version_checked is False
+
+
+def test_version_guard_leaves_a_non_macos_failure_alone(on_linux, monkeypatch):
+    """EPERM means something else on Linux — no macOS guidance there."""
+    _patch_version_probe(monkeypatch, 1, _FATAL_STDERR)
+    server._check_comfy_version()  # fails open, exactly as before
+    assert server._version_checked is True
+
+
+def test_version_guard_ignores_a_healthy_comfy_cli(on_macos, monkeypatch):
+    """A supported comfy-cli passes through untouched."""
+    monkeypatch.setattr(server, "_version_checked", False)
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(
+        server.subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(  # noqa: ARG005
+            cmd, 0, stdout="comfy-cli, version 1.12.0\n", stderr=""
+        ),
+    )
+    server._check_comfy_version()
+    assert server._version_checked is True
+
+
+# --- the envelope path (a denial that reaches us mid-run) --------------------
+
+
+def _patch_failing_run(monkeypatch, stderr: str) -> None:
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+
+    def fake_run(cmd, **kwargs):  # noqa: ARG001
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr=stderr)
+
+    monkeypatch.setattr(server.subprocess, "run", fake_run)
+
+
+def test_tool_call_surfaces_the_fix_instead_of_returned_no_json(on_macos, monkeypatch):
+    _patch_failing_run(monkeypatch, _FATAL_STDERR)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("env", timeout=1.0)
+
+    message = str(excinfo.value)
+    assert "returned no JSON" not in message
+    _assert_actionable(message)
+    assert "init_import_site" in message
+
+
+def test_an_unrelated_failure_keeps_its_original_message(on_macos, monkeypatch):
+    _patch_failing_run(monkeypatch, "Traceback: ConnectionRefusedError")
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("env", timeout=1.0)
+
+    assert "returned no JSON" in str(excinfo.value)
+    assert "Full Disk Access" not in str(excinfo.value)
+
+
+def test_a_real_error_envelope_is_untouched(on_macos, monkeypatch):
+    """An envelope means comfy-cli ran — its own error must not be reinterpreted."""
+    envelope = json.dumps(
+        {
+            "schema": "envelope/1",
+            "type": "envelope",
+            "ok": False,
+            "error": {"code": "workflow_unknown_nodes", "message": "nope"},
+        }
+    )
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(
+        server.subprocess,
+        "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(  # noqa: ARG005
+            cmd, 1, stdout=envelope, stderr=_FATAL_STDERR
+        ),
+    )
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("validate", timeout=1.0)
+
+    assert excinfo.value.code == "workflow_unknown_nodes"
+    assert "Full Disk Access" not in str(excinfo.value)
+
+
+# --- process startup ---------------------------------------------------------
+
+
+def test_main_reports_a_startup_denial_instead_of_a_traceback(
+    on_macos, monkeypatch, capsys
+):
+    def boom():
+        raise PermissionError(1, "Operation not permitted", _DENIED_PATH)
+
+    monkeypatch.setattr(server.mcp, "run", boom)
+
+    with pytest.raises(SystemExit) as excinfo:
+        server.main()
+
+    assert excinfo.value.code == 1
+    message = capsys.readouterr().err
+    _assert_actionable(message)
+    assert "~/Documents" in message
+
+
+def test_main_propagates_an_unrelated_permission_error(on_macos, monkeypatch):
+    def boom():
+        raise PermissionError(13, "Permission denied", "/etc/shadow")
+
+    monkeypatch.setattr(server.mcp, "run", boom)
+
+    with pytest.raises(PermissionError):
+        server.main()
+
+
+def test_main_propagates_on_non_macos(on_linux, monkeypatch):
+    def boom():
+        raise PermissionError(1, "Operation not permitted", _DENIED_PATH)
+
+    monkeypatch.setattr(server.mcp, "run", boom)
+
+    with pytest.raises(PermissionError):
+        server.main()

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -72,6 +72,18 @@ def test_protected_dir_ignores_unprotected_and_prefix_collisions():
     assert server._macos_protected_dir(None) is None
 
 
+def test_protected_dir_matches_case_insensitively():
+    """macOS volumes are case-insensitive by default: ~/downloads IS ~/Downloads."""
+    path = os.path.join(os.path.expanduser("~"), "downloads", "ComfyUI")
+    assert server._macos_protected_dir(path) == "Downloads"
+
+
+def test_protected_dir_accepts_a_bytes_path():
+    """An OSError from a bytes-path syscall carries a bytes `filename`."""
+    path = os.path.join(os.path.expanduser("~"), "Documents", "ComfyUI")
+    assert server._macos_protected_dir(os.fsencode(path)) == "Documents"
+
+
 def test_guidance_names_the_folder_when_the_path_is_known(on_macos):
     message = server._tcc_guidance(_DENIED_PATH)
     assert "~/Documents" in message
@@ -112,9 +124,33 @@ def test_denial_survives_a_localized_strerror(on_macos):
     )
 
 
+def test_eperm_alone_is_not_enough_to_claim_tcc(on_macos):
+    """macOS raises EPERM for SIP, sandboxing and more — don't rewrite those.
+
+    Without either corroborating signal (the startup-crash marker, or a denied
+    path that really is under a protected folder) the original message stands.
+    """
+    sip = "OSError: [Errno 1] Operation not permitted: '/usr/lib/dyld'"
+    assert server._looks_like_tcc_denial(sip) is False
+    assert server._looks_like_tcc_denial("Operation not permitted") is False
+    # …but a denied path inside a protected folder needs no startup marker.
+    mid_run = f"OSError: [Errno 1] Operation not permitted: '{_DENIED_PATH}'"
+    assert server._looks_like_tcc_denial(mid_run) is True
+
+
 def test_denied_path_is_parsed_out_of_the_traceback():
     assert server._tcc_path_from(_FATAL_STDERR) == _DENIED_PATH
     assert server._tcc_path_from("no path here") is None
+
+
+def test_denied_path_is_parsed_when_repr_used_double_quotes(on_macos):
+    """`repr` switches to double quotes for a path containing an apostrophe."""
+    path = os.path.join(
+        os.path.expanduser("~"), "Documents", "Conan's App", "venv", "pyvenv.cfg"
+    )
+    text = f'PermissionError: [Errno 1] Operation not permitted: "{path}"'
+    assert server._tcc_path_from(text) == path
+    assert server._looks_like_tcc_denial(text) is True
 
 
 # --- binary resolution -------------------------------------------------------
@@ -138,7 +174,56 @@ def test_unreadable_comfy_bin_reports_the_permission_not_a_missing_install(
     _assert_actionable(message)
 
 
+def test_bare_comfy_bin_is_resolved_against_path_not_the_cwd(on_macos, monkeypatch):
+    """The default `COMFY_BIN` is a bare name: a plain stat() would check $PWD.
+
+    A `comfy` installed on PATH *inside* a protected folder is exactly the case
+    this feature exists for, so it must be found by walking PATH.
+    """
+    protected_bin_dir = os.path.join(
+        os.path.expanduser("~"), "Documents", "ComfyUI", "venv", "bin"
+    )
+    monkeypatch.setattr(server, "COMFY_BIN", "comfy")
+    monkeypatch.setattr(server.shutil, "which", lambda _: None)
+    monkeypatch.setattr(
+        server.os, "get_exec_path", lambda: ["/usr/bin", protected_bin_dir]
+    )
+
+    def fake_stat(path):
+        if path == os.path.join(protected_bin_dir, "comfy"):
+            raise PermissionError(1, "Operation not permitted", path)
+        raise FileNotFoundError()
+
+    monkeypatch.setattr(server.os, "stat", fake_stat)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._require_comfy_bin()
+
+    message = str(excinfo.value)
+    assert "not found on PATH" not in message
+    assert "~/Documents" in message
+    _assert_actionable(message)
+
+
+def test_an_unprotected_permission_failure_is_not_called_tcc(on_macos, monkeypatch):
+    """A restrictive mode/ACL on a COMFY_BIN elsewhere is not a Full Disk Access
+    problem — mislabelling it sends the user off fixing the wrong setting."""
+    monkeypatch.setattr(server, "COMFY_BIN", "/opt/comfy/bin/comfy")
+    monkeypatch.setattr(server.shutil, "which", lambda _: None)
+    monkeypatch.setattr(
+        server.os,
+        "stat",
+        lambda p: (_ for _ in ()).throw(PermissionError(13, "Permission denied", p)),
+    )
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._require_comfy_bin()
+
+    assert "Full Disk Access" not in str(excinfo.value)
+
+
 def test_genuinely_missing_comfy_bin_keeps_the_install_message(on_macos, monkeypatch):
+    monkeypatch.setattr(server, "COMFY_BIN", _DENIED_PATH)
     monkeypatch.setattr(server.shutil, "which", lambda _: None)
     monkeypatch.setattr(
         server.os, "stat", lambda _: (_ for _ in ()).throw(FileNotFoundError())
@@ -184,6 +269,46 @@ def test_version_guard_translates_the_fatal_startup_error(on_macos, monkeypatch)
     assert "init_import_site" in message
     # Not memoized: granting access and retrying in-process must re-check.
     assert server._version_checked is False
+
+
+def test_version_guard_translates_a_denied_spawn(on_macos, monkeypatch):
+    """The probe can be denied at exec time, never reaching a returncode.
+
+    The generic OSError handler would fail open here and let the raw EPERM
+    escape unexplained from the real spawn a moment later.
+    """
+    monkeypatch.setattr(server, "_version_checked", False)
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(
+        server.subprocess,
+        "run",
+        lambda cmd, **kw: (_ for _ in ()).throw(  # noqa: ARG005
+            PermissionError(1, "Operation not permitted", _DENIED_PATH)
+        ),
+    )
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._check_comfy_version()
+
+    _assert_actionable(str(excinfo.value))
+    assert "~/Documents" in str(excinfo.value)
+    assert server._version_checked is False
+
+
+def test_version_guard_fails_open_on_an_unrelated_denied_spawn(on_macos, monkeypatch):
+    """A non-TCC permission failure keeps the pre-existing fail-OPEN behavior."""
+    monkeypatch.setattr(server, "_version_checked", False)
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(
+        server.subprocess,
+        "run",
+        lambda cmd, **kw: (_ for _ in ()).throw(  # noqa: ARG005
+            PermissionError(13, "Permission denied", "/opt/comfy/bin/comfy")
+        ),
+    )
+
+    server._check_comfy_version()  # no raise
+    assert server._version_checked is False  # not latched, exactly as before
 
 
 def test_version_guard_leaves_a_non_macos_failure_alone(on_linux, monkeypatch):
@@ -286,6 +411,22 @@ def test_main_reports_a_startup_denial_instead_of_a_traceback(
     message = capsys.readouterr().err
     _assert_actionable(message)
     assert "~/Documents" in message
+
+
+def test_main_handles_a_bytes_filename(on_macos, monkeypatch, capsys):
+    """A denial on a bytes path carries a bytes `filename` — decode, don't crash."""
+
+    def boom():
+        raise PermissionError(1, "Operation not permitted", os.fsencode(_DENIED_PATH))
+
+    monkeypatch.setattr(server.mcp, "run", boom)
+
+    with pytest.raises(SystemExit):
+        server.main()
+
+    message = capsys.readouterr().err
+    assert "~/Documents" in message
+    assert _DENIED_PATH in message  # decoded, not rendered as b'...'
 
 
 def test_main_propagates_an_unrelated_permission_error(on_macos, monkeypatch):


### PR DESCRIPTION
## ELI-5

macOS keeps `~/Documents`, `~/Desktop` and `~/Downloads` locked. An app that has not been given **Full Disk Access** cannot read them — and neither can anything that app starts. So if your ComfyUI (and its `venv`) lives in one of those folders, the `comfy` program your AI client launches dies before it does anything, and you got a wall of Python crash text that did not tell you what to do. Now you get told: give the app Full Disk Access, or move ComfyUI somewhere else.

## Summary

A user's setup failed with `Fatal Python error: init_import_site` / `PermissionError: [Errno 1] Operation not permitted: '<...>/ComfyUI/venv/pyvenv.cfg'` because their ComfyUI install lived under `~/Documents`. Granting the client Full Disk Access fixed it. That is a macOS privacy setting (TCC), not a ComfyUI or comfy-cli fault — but it is a likely recurrence, since those are common install locations. This PR documents the fix and makes the server say it wherever it can see the failure, instead of relaying a raw traceback.

## Changes

- **`_check_comfy_version`** — the first shell-out of the process, before any tool call: raises the actionable guidance when `comfy --version` dies with the TCC signature. Deliberately **not memoized**, so granting access and retrying in the same process re-checks rather than latching the failure.
- **`_unwrap_envelope`** — replaces the opaque `comfy-cli returned no JSON` when the child produced no envelope for this reason. Shared by the plain (`--json`) and streaming (`--json-stream`) paths, so both are covered by one change.
- **`_require_comfy_bin`** (new) — extracted from the two spawn sites (`_run_comfy_raw` / `_run_comfy_streaming`), which previously carried duplicate copies of the same check. It now distinguishes an **unreadable** `COMFY_BIN` from a **missing** one: `shutil.which` returns `None` for both, so the old message blamed a missing install for what was a permission problem.
- **`main`** — translates a `PermissionError` raised during server startup into the same guidance on stderr (where MCP clients collect server logs) and exits non-zero, instead of letting the client render a traceback.
- **`README.md`** — a `Troubleshooting` section with the symptom, the cause and both fixes (grant Full Disk Access; or move ComfyUI out of the protected folder and `comfy set-default <path>`), a table-of-contents entry, and a pointer note in **Configure your AI client**.
- **`tests/test_permissions.py`** — 20 new tests.

## Motivation

Acceptance criteria from the report, both met:

- Install/troubleshooting docs mention the Full Disk Access fix for this `PermissionError` → the README `Troubleshooting` section plus the pointer from the client-configuration section.
- Startup catches this `PermissionError` case and surfaces a friendly, actionable message instead of a raw traceback → the four call sites above.

## Testing

- [x] Existing tests pass (`pytest`) — **406 passed, 1 skipped** (386 before; the 20 new ones are `tests/test_permissions.py`)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — see below

**Manual verification on real macOS (darwin 25.4.0), with real subprocess spawns and no `subprocess` mocking**, since the mocked tests can only assert my own premise:

- A genuine executable that dies exactly like a TCC-blocked venv (the ticket's stderr verbatim, exit 1) → `server_info()` raised the full guidance, `not found on PATH` absent, the raw stderr preserved under `Original error:`, and `_version_checked` still `False` (a retry after granting access really does re-check).
- A genuine healthy comfy-cli stub (`--version` → `1.12.0`, envelope on stdout) through the **same** code path → `server_info()` returned `{'running': True, 'compatibility': {...}, 'freshness': {...}}` and the version guard memoized normally. Nothing about a working install changed.

I could not reproduce a live TCC denial here (this machine has no ComfyUI under a protected folder, and a `chmod`-based fake is not the same mechanism), so the signature match itself is exercised against the exact stderr from the report rather than against a live denial.

## Additional Notes

**No capability is denied by this change.** Every new `raise` sits on a path that already failed: `_unwrap_envelope(None, ...)` already raised, and both `shutil.which(...) is None` sites already raised — those are message rewrites, not new dead-ends. The one genuinely new raise is in `_check_comfy_version`, and it cannot cost anything that previously worked: it fires only when `comfy --version` **exits non-zero** with the TCC signature, and a binary whose interpreter cannot start for `--version` cannot serve any other invocation either. It just fails one call earlier, with a message that names the fix, and it is not memoized so the fix takes effect immediately.

Judgment calls worth a reviewer's eye:

- **Detection is deliberately macOS-only.** `_looks_like_tcc_denial` returns `False` off darwin — EPERM means something else on Linux and the guidance is System-Settings-specific, so a non-macOS failure keeps its original message. Tested both ways.
- **The signature is a substring match** (`operation not permitted` / `init_import_site`), so an unrelated macOS EPERM in comfy-cli's stderr would also get this guidance. I accepted that: it only fires on a path that had already failed with an unhelpful message, and the original stderr is preserved verbatim under `Original error:`, so the worst case is an accurate raw error plus a suggestion that does not apply. A real error envelope is never reinterpreted (test covers it).
- **`_tcc_guidance` will not assert a location it has not verified.** With a known denied path under a protected folder it names that folder; otherwise it lists all three generically rather than claiming the install is somewhere it may not be.
- **One case is structurally uncatchable and is documented rather than papered over:** if *this server's own* interpreter cannot read its venv, CPython dies in `init_import_site` before any code here runs. That failure is only catchable from the parent side — which is exactly what the `comfy`-binary guards do for the child we spawn. Both the `main` docstring and the README say so plainly, so nobody reads the README section as a promise the server always intercepts this.
- **`_detect_comfy_cli_version` was left alone** on purpose. It is a best-effort reporting helper for `server_info`'s compatibility block and returns `None` rather than raising; routing it through `_require_comfy_bin` would turn a nice-to-have into a hard failure. The TCC case never reaches it unhandled anyway, because `server_info` calls `_run_comfy` first.
- No change to the thin-wrapper architecture rule, the toolchain, or the tool set, so `AGENTS.md` needs no sync. No new dependencies; `sys` is stdlib.
