### PR TITLE
fix: surface stdout and stderr tails in envelope failure messages

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -895,9 +895,7 @@ def _run_comfy(*args: str, timeout: float | None = None, plain_ok: bool = False)
     # line on a successful run would be mis-unwrapped into a spurious "failed"
     # raise. A real error envelope still has `type==envelope`, so it flows to
     # `_unwrap_envelope` and raises as usual.
-    real_envelope = (
-        envelope if envelope and envelope.get("type") == "envelope" else None
-    )
+    real_envelope = _real_envelope(envelope)
     if plain_ok and real_envelope is None and returncode == 0:
         return _synthesize_plain_result(args, stdout, stderr)
     # Enforce the envelope contract on the normal path too: pass `real_envelope`
@@ -970,12 +968,20 @@ def _stream_tail(text: str | bytes | None, limit: int = 500) -> str:
     The *tail* is what's kept (not the head): a CLI traceback puts the
     exception — the part that says what actually went wrong — last.
     """
-    tail = _tail(text, limit=limit)
+    if limit <= 0:
+        # Mirror `_tail`'s own non-positive guard. It matters more here: we ask
+        # `_tail` for `limit + 1`, so a `limit` of 0 would slip past its check
+        # and the `[-limit:]` below would then be `[0:]` — the WHOLE capture,
+        # exactly the unbounded payload the limit exists to prevent.
+        return "<empty>"
+    # `_tail` clips silently, so ask it ONCE for one char more than the bound:
+    # an over-long answer is itself the evidence that something was dropped, and
+    # re-slicing it locally costs nothing (asking `_tail` twice would re-run the
+    # strip and any bytes-decode over the whole capture just to learn that).
+    tail = _tail(text, limit=limit + 1)
     if not tail:
         return "<empty>"
-    # `_tail` clips silently, so ask it for one char more than the bound: a
-    # longer answer means something was dropped and the marker is warranted.
-    return "..." + tail if len(_tail(text, limit=limit + 1)) > limit else tail
+    return "..." + tail[-limit:] if len(tail) > limit else tail
 
 
 def _kill_proc_tree(proc: subprocess.Popen) -> None:
@@ -1104,9 +1110,15 @@ def _unwrap_envelope(
         # own message only — `_stream_tail` already bounds its result, and
         # re-slicing its HEAD here would chop off the truncation marker plus the
         # very end of the tail, i.e. the part worth keeping.
-        message = err.get("message")
+        # Strip BEFORE the truthiness test: a whitespace-only `error.message`
+        # ("   ") is truthy, so it would keep the fallback from firing and render
+        # exactly the dangling-colon message this branch exists to prevent —
+        # `_stream_tail` already treats a whitespace-only capture as `<empty>`,
+        # so treat the envelope's own field the same way.
+        raw_message = err.get("message")
+        message = str(raw_message).strip() if raw_message else ""
         message = (
-            str(message)[:_MAX_ERROR_FIELD_CHARS]
+            message[:_MAX_ERROR_FIELD_CHARS]
             if message
             else _stream_tail(stderr, _MAX_ERROR_FIELD_CHARS)
         )
@@ -1210,6 +1222,24 @@ def _last_json_object(stdout: str) -> dict | None:
         elif best is None or best.get("type") != "envelope":
             best = obj  # fallback to any JSON object until an envelope appears
     return best
+
+
+def _real_envelope(obj: dict | None) -> dict | None:
+    """Keep ``obj`` only if it is a genuine ``type==envelope``; else ``None``.
+
+    The companion filter to :func:`_last_json_object`, which deliberately falls
+    back to ANY JSON object on stdout so a caller can still see what comfy-cli
+    printed. That fallback must never reach :func:`_unwrap_envelope` unfiltered:
+    a stray progress/custom-node line would then be unwrapped as if it were the
+    result — one carrying ``ok: true`` read as a successful run, and one without
+    it raising a bogus ``failed [unknown]`` that SUPPRESSES the no-envelope
+    branch and its stdout/stderr diagnostics, which is the only thing that
+    explains a mid-run crash. Every path into ``_unwrap_envelope`` filters here
+    first. An envelope declaring an incompatible ``schema`` still passes through
+    on purpose — that is a real envelope, and ``_unwrap_envelope`` owns refusing
+    it with the version error rather than a generic "returned no JSON".
+    """
+    return obj if obj and obj.get("type") == "envelope" else None
 
 
 def _parse_event(line: str) -> dict | None:
@@ -1403,8 +1433,14 @@ async def _run_comfy_streaming(
         # the EOF path, so comfy-cli died without an envelope and whatever plain
         # text it printed is the only diagnosis there is.
         stdout_text = "".join(lines)
+        # `_real_envelope` for the same reason `_run_comfy` applies it: reaching
+        # EOF means `_pump` never saw a terminal envelope, so `_last_json_object`
+        # here is usually its fallback — the last progress/custom-node event of a
+        # crashed run. Unwrapping that would discard the diagnostics just
+        # collected; filtering to None routes it to the no-envelope branch, which
+        # is what actually reports why comfy-cli died.
         return False, _unwrap_envelope(
-            _last_json_object(stdout_text),
+            _real_envelope(_last_json_object(stdout_text)),
             args,
             returncode,
             stderr,
@@ -1664,6 +1700,11 @@ def server_info() -> Any:
     same host.
     """
     envelope, stdout, args, returncode, stderr = _run_comfy_raw("env", timeout=60.0)
+    # `_run_comfy_raw` hands back `_last_json_object`'s answer unfiltered, so
+    # enforce the envelope contract here exactly as `_run_comfy` does: an
+    # incidental non-envelope JSON line from `comfy env` must raise "returned no
+    # JSON" (with both stream tails) rather than be reported as server info.
+    envelope = _real_envelope(envelope)
     # _unwrap_envelope raises if envelope is None, so it is non-None below.
     data = _unwrap_envelope(envelope, args, returncode, stderr, stdout=stdout)
     compat = _check_comfy_cli_version()

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -906,7 +906,7 @@ def _run_comfy(*args: str, timeout: float | None = None, plain_ok: bool = False)
     # response for a non-`plain_ok` tool; it raises the "returned no JSON" error
     # like any other missing envelope. A real error envelope still has
     # `type==envelope`, so it flows through and raises with its code as usual.
-    return _unwrap_envelope(real_envelope, args, returncode, stderr)
+    return _unwrap_envelope(real_envelope, args, returncode, stderr, stdout=stdout)
 
 
 def _envelope_schema(envelope: dict) -> str | None:
@@ -955,6 +955,29 @@ def _tail(text: str | bytes | None, limit: int = 500) -> str:
     return text.strip()[-limit:]
 
 
+def _stream_tail(text: str | bytes | None, limit: int = 500) -> str:
+    """Bounded tail of a captured stream, with explicit empty/truncation markers.
+
+    The error-message dressing over :func:`_tail`, for the messages a user
+    actually reads when comfy-cli fails:
+
+    - a blank/absent capture renders as ``<empty>`` rather than nothing, so a
+      message can never end in a dangling ``stderr:`` that is indistinguishable
+      from a capture we truncated away;
+    - a capture that WAS clipped is prefixed with ``...`` so the truncation is
+      visible instead of looking like the whole stream.
+
+    The *tail* is what's kept (not the head): a CLI traceback puts the
+    exception — the part that says what actually went wrong — last.
+    """
+    tail = _tail(text, limit=limit)
+    if not tail:
+        return "<empty>"
+    # `_tail` clips silently, so ask it for one char more than the bound: a
+    # longer answer means something was dropped and the marker is warranted.
+    return "..." + tail if len(_tail(text, limit=limit + 1)) > limit else tail
+
+
 def _kill_proc_tree(proc: subprocess.Popen) -> None:
     """Kill the child *and* any grandchildren it spawned.
 
@@ -993,13 +1016,25 @@ def _reap(proc: subprocess.Popen, timeout: float = 5.0) -> None:
 
 
 def _unwrap_envelope(
-    envelope: dict | None, args: tuple[str, ...], returncode: int | None, stderr: str
+    envelope: dict | None,
+    args: tuple[str, ...],
+    returncode: int | None,
+    stderr: str,
+    stdout: str = "",
 ) -> Any:
     """Unwrap comfy-cli's ``envelope/1`` result, raising on error/absence.
 
     Shared by the plain (`--json`) and streaming (`--json-stream`) paths so both
     have identical terminal behavior: return ``data`` on success, and raise a
     :class:`ComfyCliError` carrying the envelope's ``error.code`` on failure.
+
+    ``stdout`` is the RAW captured stdout the caller parsed ``envelope`` out of.
+    It is only read on the no-envelope path, where it is the whole point: a
+    comfy-cli that dies before emitting JSON usually prints its diagnosis as
+    plain text, and every caller parses stdout through :func:`_last_json_object`
+    — which drops that text on the floor. Passing it here is what keeps the
+    failure legible; it defaults to ``""`` (rendered ``<empty>``) so a caller
+    that genuinely has no stdout still produces a well-formed message.
 
     Also the envelope-version assertion: if comfy-cli declares an envelope
     ``schema`` whose major differs from :data:`ENVELOPE_SCHEMA_MAJOR`, the whole
@@ -1015,11 +1050,23 @@ def _unwrap_envelope(
             raise ComfyCliError(
                 f"comfy-cli could not run (exit {returncode}).\n\n"
                 f"{_tcc_guidance(_tcc_path_from(stderr))}\n\n"
-                f"Original error: {_tail(stderr)}"
+                # `_stream_tail` for the truncation marker: `_looks_like_tcc_denial`
+                # only fires on a non-empty stderr, so the `<empty>` half is
+                # unreachable here — but a long denial traceback still gets
+                # clipped, and silently is how you misread it as the whole thing.
+                # No stdout here on purpose: this branch has already identified
+                # the cause, so its curated guidance beats a second raw stream.
+                f"Original error: {_stream_tail(stderr)}"
             )
+        # Both streams, both explicitly marked when blank: comfy-cli splits its
+        # diagnostics unpredictably (a Python traceback lands on stderr, a
+        # Typer/click usage error or a plain-text status line on stdout), and
+        # `_last_json_object` has already discarded the stdout text by the time
+        # we get here. Rendering only stderr — and rendering an empty one as
+        # nothing at all — is what made this error opaque.
         raise ComfyCliError(
             f"comfy-cli returned no JSON (exit {returncode}). "
-            f"stderr: {stderr.strip()[:500]}"
+            f"stderr: {_stream_tail(stderr)} | stdout: {_stream_tail(stdout)}"
         )
     # A declared schema must be a recognized ``envelope/<N>`` whose major matches.
     # Absent schema -> assume compatible (older comfy-cli); declared-but-unparseable
@@ -1051,12 +1098,19 @@ def _unwrap_envelope(
         # credential) — dropping them was the exact workaround testers needed.
         # Each field is length-capped so a huge/malformed envelope can't bloat
         # the message propagated to the MCP client.
-        message = err.get("message") or stderr.strip()[:_MAX_ERROR_FIELD_CHARS]
-        parts = [
-            f"comfy {' '.join(args)} failed "
-            f"[{code or 'unknown'}]: "
-            f"{str(message)[:_MAX_ERROR_FIELD_CHARS]}"
-        ]
+        # The stderr fallback goes through `_stream_tail` so an envelope with an
+        # empty `error.message` AND an empty stderr can't render a bare trailing
+        # colon with nothing after it. Note the cap is applied to the envelope's
+        # own message only — `_stream_tail` already bounds its result, and
+        # re-slicing its HEAD here would chop off the truncation marker plus the
+        # very end of the tail, i.e. the part worth keeping.
+        message = err.get("message")
+        message = (
+            str(message)[:_MAX_ERROR_FIELD_CHARS]
+            if message
+            else _stream_tail(stderr, _MAX_ERROR_FIELD_CHARS)
+        )
+        parts = [f"comfy {' '.join(args)} failed [{code or 'unknown'}]: {message}"]
         hint = err.get("hint")
         if hint:
             parts.append(f"hint: {str(hint)[:_MAX_ERROR_FIELD_CHARS]}")
@@ -1345,8 +1399,16 @@ async def _run_comfy_streaming(
         # stderr is collectible for the error message.
         returncode = await _in_pipe_pool(proc.wait)
         stderr = (await stderr_future) if stderr_future is not None else ""
+        # Keep the joined stdout around rather than only its parsed JSON: this is
+        # the EOF path, so comfy-cli died without an envelope and whatever plain
+        # text it printed is the only diagnosis there is.
+        stdout_text = "".join(lines)
         return False, _unwrap_envelope(
-            _last_json_object("".join(lines)), args, returncode, stderr
+            _last_json_object(stdout_text),
+            args,
+            returncode,
+            stderr,
+            stdout=stdout_text,
         )
 
     try:
@@ -1403,7 +1465,8 @@ async def _run_comfy_streaming(
         # Envelope path: the authoritative result is already in `lines`, read
         # within the deadline. Give the child a brief grace to exit on a SEPARATE
         # budget; the `finally` kills a still-live one.
-        envelope = _last_json_object("".join(lines))
+        stdout_text = "".join(lines)
+        envelope = _last_json_object(stdout_text)
         child_reaped = True
         try:
             await asyncio.wait_for(
@@ -1431,7 +1494,9 @@ async def _run_comfy_streaming(
                 )
             except (asyncio.TimeoutError, TimeoutError):
                 stderr = ""
-        return _unwrap_envelope(envelope, args, proc.returncode, stderr)
+        return _unwrap_envelope(
+            envelope, args, proc.returncode, stderr, stdout=stdout_text
+        )
     finally:
         # Never leave a stray child or a dangling stderr reader on any exit path
         # (timeout, a report_progress error, or normal completion). Kill the
@@ -1598,9 +1663,9 @@ def server_info() -> Any:
     reachability is confirmed by the first run/queue call, which targets the
     same host.
     """
-    envelope, _stdout, args, returncode, stderr = _run_comfy_raw("env", timeout=60.0)
-    # _unwrap_envelope has already raised if envelope was None, so it is non-None here.
-    data = _unwrap_envelope(envelope, args, returncode, stderr)
+    envelope, stdout, args, returncode, stderr = _run_comfy_raw("env", timeout=60.0)
+    # _unwrap_envelope raises if envelope is None, so it is non-None below.
+    data = _unwrap_envelope(envelope, args, returncode, stderr, stdout=stdout)
     compat = _check_comfy_cli_version()
     compat["envelope_schema"] = _envelope_schema(envelope)
     freshness = _freshness_report()

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -279,6 +279,26 @@ def test_server_info_raises_on_version_below_floor(patched_env, monkeypatch):
         server.server_info()
 
 
+def test_server_info_rejects_a_stray_non_envelope_json(patched_env, monkeypatch):
+    """An incidental non-envelope JSON line from `comfy env` is not server info.
+
+    `_run_comfy_raw` hands back `_last_json_object`'s answer, which falls back to
+    ANY JSON object on stdout. `server_info` must apply the same `type==envelope`
+    contract `_run_comfy` does — otherwise a diagnostic line that happens to
+    carry `ok: true` would be reported as a valid environment report, and the
+    no-envelope diagnostics (both stream tails) would never be shown.
+    """
+    monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", None)
+    patched_env({"ok": True, "data": {"running": True}})
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.server_info()
+
+    msg = str(excinfo.value)
+    assert "returned no JSON" in msg
+    assert "stdout: " in msg  # the raw line is surfaced, not swallowed
+
+
 def test_server_info_wraps_non_dict_env_data(patched_env, monkeypatch):
     """If `comfy env` ever returns non-dict data, it is still returned with compat."""
     monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", None)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -22,7 +22,7 @@ import threading
 import time
 
 import pytest
-from conftest import _OK_STREAM, _RecordingCtx
+from conftest import _OK_STREAM, _FakeProc, _RecordingCtx
 
 from comfy_local_mcp import server
 
@@ -1029,6 +1029,128 @@ def test_plain_ok_still_honors_a_real_envelope(patched_run):
     patched_run({"type": "envelope", "ok": True, "data": {"pid": 7}})
 
     assert server._run_comfy("launch", "--background", plain_ok=True) == {"pid": 7}
+
+
+# --- envelope-failure messages must carry BOTH stream tails -----------------
+# A comfy-cli that dies without emitting an envelope used to raise a message
+# that showed only the HEAD of stderr and nothing at all about stdout — so a
+# plain-text diagnostic printed to stdout was lost, a traceback was clipped
+# right before the exception that explains it, and an empty stderr rendered as
+# a dangling `stderr: ` indistinguishable from truncation.
+
+
+def test_stream_tail_marks_empty_and_truncation():
+    """`_stream_tail` marks a blank capture and a clipped one, and keeps the END."""
+    assert server._stream_tail("") == "<empty>"
+    assert server._stream_tail(None) == "<empty>"
+    assert server._stream_tail("   \n  ") == "<empty>"  # whitespace-only is empty
+    # A capture that fits the bound is passed through verbatim — no marker.
+    assert server._stream_tail("  short  ") == "short"
+    assert server._stream_tail("x" * 500, limit=500) == "x" * 500  # exactly at bound
+    # One char over the bound: clipped, marked, and it is the TAIL that survives.
+    clipped = server._stream_tail("HEAD" + "x" * 600 + "FINAL_ERROR_LINE", limit=500)
+    assert clipped.startswith("...")
+    assert clipped.endswith("FINAL_ERROR_LINE")
+    assert "HEAD" not in clipped
+    assert len(clipped) == 503  # bounded: the marker plus exactly `limit` chars
+    # bytes are decoded defensively, same as `_tail`
+    assert server._stream_tail(b"cafe\xff") == "cafe\ufffd"
+
+
+def test_no_envelope_error_marks_both_empty_streams(patched_plain_run):
+    """Nothing on either stream still renders explicitly, never a dangling colon."""
+    patched_plain_run(1, stdout="", stderr="")
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("env")
+
+    msg = str(excinfo.value)
+    assert "exit 1" in msg
+    assert "stderr: <empty>" in msg
+    assert "stdout: <empty>" in msg
+
+
+def test_no_envelope_error_surfaces_plain_stdout_diagnostic(patched_plain_run):
+    """comfy-cli's plain-text stdout diagnosis survives `_last_json_object`."""
+    patched_plain_run(
+        1,
+        stdout="Traceback (most recent call last):\n  ...\nValueError: boom\n",
+        stderr="",
+    )
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("env")
+
+    msg = str(excinfo.value)
+    assert "ValueError: boom" in msg  # the whole point: stdout is no longer dropped
+    assert "stderr: <empty>" in msg
+
+
+def test_no_envelope_error_keeps_the_stderr_tail_not_the_head(patched_plain_run):
+    """A long traceback is clipped from the FRONT — the exception is at the END."""
+    patched_plain_run(1, stderr="HEAD_MARKER" + "x" * 600 + "FINAL_ERROR_LINE")
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("env")
+
+    msg = str(excinfo.value)
+    assert "FINAL_ERROR_LINE" in msg  # the useful end survived
+    assert "HEAD_MARKER" not in msg  # the useless start did not
+    assert "stderr: ..." in msg  # truncation is visibly marked
+
+
+def test_error_envelope_falls_back_to_marked_empty_not_bare_colon():
+    """`ok: false` with no message and no stderr must not end in a bare colon."""
+    envelope = {"type": "envelope", "ok": False, "error": {"code": "x"}}
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(envelope, ("env",), 1, "")
+
+    assert str(excinfo.value) == "comfy env failed [x]: <empty>"
+
+
+def test_error_envelope_stderr_fallback_keeps_its_tail():
+    """The stderr fallback on `ok: false` is bounded from the END, marker intact."""
+    stderr = "HEAD_MARKER" + "x" * 900 + "FINAL_ERROR_LINE"
+    envelope = {"type": "envelope", "ok": False, "error": {"code": "x"}}
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(envelope, ("env",), 1, stderr)
+
+    msg = str(excinfo.value)
+    assert msg.endswith("FINAL_ERROR_LINE")  # the cap must not re-clip the tail off
+    assert "HEAD_MARKER" not in msg
+    assert "[x]: ..." in msg
+
+
+def test_streaming_no_envelope_error_includes_both_stream_tails(monkeypatch):
+    """The streaming EOF path produces the same enriched message as `_run_comfy`."""
+    procs: list[_FakeProc] = []
+
+    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
+        proc = _FakeProc(
+            cmd,
+            "starting run...\ncomfy-cli crashed before emitting a result\n",
+            stderr_text="Traceback (most recent call last):\nRuntimeError: nope",
+            env=env,
+            encoding=encoding,
+        )
+        proc.returncode = 1
+        procs.append(proc)
+        return proc
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        asyncio.run(
+            server._run_comfy_streaming("run", "--workflow", "wf.json", timeout=5.0)
+        )
+
+    msg = str(excinfo.value)
+    assert "returned no JSON (exit 1)" in msg
+    assert "RuntimeError: nope" in msg  # stderr tail
+    assert "comfy-cli crashed before emitting a result" in msg  # stdout tail
 
 
 # --- download_model: no JSON envelope on a successful fetch (BE-3345) -------

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1055,6 +1055,11 @@ def test_stream_tail_marks_empty_and_truncation():
     assert len(clipped) == 503  # bounded: the marker plus exactly `limit` chars
     # bytes are decoded defensively, same as `_tail`
     assert server._stream_tail(b"cafe\xff") == "cafe\ufffd"
+    # A non-positive bound yields no tail rather than defeating itself: the
+    # single-pass implementation asks `_tail` for `limit + 1`, so a 0 would slip
+    # past its guard and `[-0:]` would return the whole capture unbounded.
+    assert server._stream_tail("x" * 100, limit=0) == "<empty>"
+    assert server._stream_tail("x" * 100, limit=-1) == "<empty>"
 
 
 def test_no_envelope_error_marks_both_empty_streams(patched_plain_run):
@@ -1151,6 +1156,88 @@ def test_streaming_no_envelope_error_includes_both_stream_tails(monkeypatch):
     assert "returned no JSON (exit 1)" in msg
     assert "RuntimeError: nope" in msg  # stderr tail
     assert "comfy-cli crashed before emitting a result" in msg  # stdout tail
+
+
+def test_streaming_eof_ignores_a_trailing_progress_event(monkeypatch):
+    """A crash whose last stdout line is a progress EVENT still reports both tails.
+
+    The streaming path reads NDJSON, so at EOF `_last_json_object`'s fallback is
+    typically the run's last progress/custom-node event — not a result. Unwrapping
+    it would swallow the diagnostics this branch exists to surface (and an event
+    carrying `ok: true` would be read as a successful run on a spend-capable
+    tool), so it is filtered to None and the no-envelope branch fires instead.
+    """
+
+    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
+        proc = _FakeProc(
+            cmd,
+            # An event that both parses AND claims success — the worst case.
+            '{"type": "progress", "ok": true, "data": {"value": 3}}\n'
+            "comfy-cli crashed mid-run\n",
+            stderr_text="RuntimeError: nope",
+            env=env,
+            encoding=encoding,
+        )
+        proc.returncode = 1
+        return proc
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        asyncio.run(
+            server._run_comfy_streaming("run", "--workflow", "wf.json", timeout=5.0)
+        )
+
+    msg = str(excinfo.value)
+    assert "returned no JSON (exit 1)" in msg  # not silently "succeeded"
+    assert "RuntimeError: nope" in msg
+    assert "comfy-cli crashed mid-run" in msg
+
+
+def test_streaming_eof_still_refuses_an_incompatible_envelope(monkeypatch):
+    """The filter keeps REAL envelopes: a bad `schema` still raises the version error.
+
+    `_pump` only stops on `envelope/1`, so an envelope declaring another major
+    reaches EOF. It is a genuine envelope, so it must flow through and be refused
+    with the incompatible-version message — not demoted to "returned no JSON".
+    """
+
+    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
+        proc = _FakeProc(
+            cmd,
+            '{"schema": "envelope/2", "type": "envelope", "ok": true, "data": {}}\n',
+            env=env,
+            encoding=encoding,
+        )
+        return proc
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+
+    with pytest.raises(server.ComfyCliError, match="incompatible comfy-cli envelope"):
+        asyncio.run(
+            server._run_comfy_streaming("run", "--workflow", "wf.json", timeout=5.0)
+        )
+
+
+def test_error_envelope_whitespace_message_falls_back_to_stderr():
+    """A whitespace-only `error.message` is truthy but renders as a dangling colon."""
+    envelope = {
+        "type": "envelope",
+        "ok": False,
+        "error": {"code": "x", "message": "   "},
+    }
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(envelope, ("env",), 1, "the real reason")
+
+    assert str(excinfo.value) == "comfy env failed [x]: the real reason"
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(envelope, ("env",), 1, "")
+
+    assert str(excinfo.value) == "comfy env failed [x]: <empty>"
 
 
 # --- download_model: no JSON envelope on a successful fetch (BE-3345) -------


### PR DESCRIPTION
## ELI-5

When the `comfy` command dies before printing its JSON result, this server raised an error that told you almost nothing — often literally `comfy-cli returned no JSON (exit 1). stderr:` with nothing after the colon. It was throwing away the part that explains the failure. Now the error carries the last 500 characters of *both* streams, says `<empty>` out loud when a stream really was empty, and marks with `...` when it clipped something.

## Summary

Enriches the failure messages `_unwrap_envelope` raises so a comfy-cli crash is diagnosable from the message alone.

Before, the no-envelope path rendered `stderr.strip()[:500]` and nothing else. Three separate ways that lost the diagnosis:

1. **stdout was never included.** Every call site parses stdout through `_last_json_object` and keeps only the parsed object, so any plain-text diagnostic comfy-cli printed to stdout (a Typer/click usage error, a status line, a traceback that went to stdout) was dropped on the floor.
2. **An empty stderr rendered as a dangling `stderr: `** — indistinguishable from a capture that had been truncated away.
3. **It sliced the HEAD.** Tracebacks put the exception last, so a `[:500]` slice clipped off precisely the line that says what went wrong.

The `ok: false` branch (envelope present, failure reported) had the same empty-fallback problem: `err.get("message") or stderr.strip()[...]` could render `comfy env failed [x]: ` with nothing after the colon.

## Changes

- **New `_stream_tail(text, limit=500)`** — the error-message dressing over the existing `_tail`. A blank/absent capture renders `<empty>`; a clipped one is prefixed `...` so truncation is visible; the END of the stream is what survives. It delegates to `_tail` for the bound and the defensive bytes decode, so there is one implementation of "bounded tail", not two.
- **`_unwrap_envelope` takes the raw `stdout`** (new trailing parameter, defaulting to `""`, so nothing that doesn't pass it breaks). Read only on the no-envelope path.
- **All four call sites pass it.** The ticket named two; there are four, and the two extra were quietly discarding stdout: the streaming *envelope* path (`_run_comfy_streaming`, which already joined the lines — now hoisted and reused, so no extra work) and `server_info`, which was destructuring it as `_stdout` and throwing it away.
- **`ok: false` stderr fallback goes through `_stream_tail`**, so a bare trailing colon is now unrepresentable.
- **The TCC (macOS Full Disk Access) branch** also uses `_stream_tail`, purely for the truncation marker on a long denial traceback. It deliberately does *not* append stdout — that branch has already identified the cause, and its curated guidance beats a second raw stream.

## Motivation

`comfy-cli returned no JSON (exit 1). stderr:` is an unactionable error. The information needed to debug it was captured and then discarded by the formatter.

## Testing

- [x] Existing tests pass (`pytest`) — **417 → 424 collected (+7 new); 423 passed, 1 skipped.** No existing test changed; the success paths are untouched and only error-message text moves.
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — drove both real code paths under a stubbed comfy-cli and read the actual raised strings, rather than trusting the assertions: streaming EOF path → `comfy-cli returned no JSON (exit 1). stderr: Traceback (most recent call last):\nRuntimeError: nope | stdout: starting run...\ncomfy-cli crashed before emitting a result`; plain path with a 600-char stderr → message ends `...xxxFINAL_ERROR_LINE | stdout: <empty>` and opens `stderr: ...`, confirming the tail (not the head) survived and the clip is marked.

New tests cover: `_stream_tail` unit behavior (empty / whitespace-only / exactly-at-bound / one-over / bytes); both streams empty; a plain-text stdout diagnostic surviving; tail-not-head on a >500-char stderr; `ok: false` with neither message nor stderr; the `ok: false` stderr fallback keeping its tail past the length cap; and the streaming path producing the same enriched shape.

## Additional Notes

**Judgment calls**

- **`_tail` was left alone.** The ticket's plan proposed adding a `_tail` helper, but one already exists (added for the timeout paths) with different, tested semantics: `""` for empty, no `...` marker. Changing it would have broken `test_tail_bounds_and_decodes` and altered two unrelated timeout messages, so `_stream_tail` wraps it instead. That also means `<empty>` is produced in exactly one place.
- **Where the length cap is applied in the `ok: false` branch changed.** It now caps the envelope's own `error.message` only. Applying `[:_MAX_ERROR_FIELD_CHARS]` on top of a `_stream_tail` result would head-slice a tail — chopping off the `...` marker plus the last 3 characters, i.e. the end worth keeping. `_stream_tail` already bounds its own output (≤ limit + 3), so the message stays bounded either way; `test_oversized_error_fields_are_length_capped` still passes unchanged.
- **Bound is `limit + 3` chars, not `limit`**, when the marker is present. Acceptance criterion says "≤~500 char", so this reads as within tolerance rather than a violation — flagging it since it is a deliberate reading.

**Acceptance criteria** — all four met. The one place a no-envelope failure does *not* render both tails is the TCC branch described above, which returns early with its own actionable guidance; it is guarded by `_looks_like_tcc_denial(stderr)`, which cannot match an empty stderr, so the defect this PR fixes is unreachable there by construction.

**Negative-claim falsification (regression case: the "SVG/3D aren't supported — STOP" dead-end)** — checked, **trigger does not fire, so no live falsification was required.** This diff denies no capability: it adds no "not supported"/"unavailable"/"STOP" string, adds no throw or deny path, and flips no test to assert a dead-end. Every `raise ComfyCliError` in the diff *replaces an existing raise on the same already-failing branch* — the control flow is byte-for-byte identical and only the message text changes. The two strings it does add, `<empty>` and `...`, describe a captured stream, not a product capability. The new tests assert richer messages on paths that already raised; none asserts the absence of a feature.
