### PR TITLE
fix: generate_image runs the local text-to-image template instead of the partner-only `comfy generate` verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Cloud MCP** — comfy-cli is the engine.
   `server_info`. Nothing here starts ComfyUI implicitly.
 
 <details>
-<summary><strong>Optional environment variables</strong> (<code>COMFY_BIN</code>, <code>COMFY_API_KEY</code>, <code>COMFYUI_URL</code>, <code>COMFY_LOCAL_URL</code>)</summary>
+<summary><strong>Optional environment variables</strong> (<code>COMFY_BIN</code>, <code>COMFY_API_KEY</code>, <code>COMFYUI_URL</code>, <code>COMFY_LOCAL_URL</code>, <code>COMFY_T2I_TEMPLATE</code>)</summary>
 
 <br>
 
@@ -102,6 +102,14 @@ Cloud MCP** — comfy-cli is the engine.
   holds `:8188`). Read by comfy-cli, not by this server — it rides the environment passthrough,
   so setting it in the client `env` block re-points every tool. See
   **[Targeting a non-default ComfyUI address](#targeting-a-non-default-comfyui-address)**.
+- **`COMFY_T2I_TEMPLATE` / `COMFY_T2I_PROMPT_SLOT` / `COMFY_T2I_CHECKPOINT_SLOT` (optional — retarget
+  `generate_image`).** `generate_image(prompt)` runs the gallery's `default` template (ComfyUI's own
+  basic SD1.5 text-to-image graph), filling its positive-prompt slot `6.text` and, when you pass
+  `checkpoint`, its `ckpt_name` slot. To point that on-ramp at a different local text-to-image graph,
+  set all three **together** — the slot keys describe one specific template, so changing the template
+  alone leaves the prompt address matching no slot. List a replacement's slots with
+  `comfy templates fetch <name> -o wf.json && comfy workflow slots wf.json`. For a one-off run of some
+  other template, prefer the `run_template` tool over these.
 
 </details>
 
@@ -219,7 +227,8 @@ reports the configured target under a `comfy_target` block.
   **local** ComfyUI process and stay local-only; they cannot start/stop or read logs from a remote
   box. Start ComfyUI on the remote host yourself.
 - **Output download** (`fetch_outputs` → `comfy download`) and `search_templates` / `search_models`
-  / `generate_image` / `partner_generate` — the underlying comfy-cli verbs take **no** `--host`/`--port`, so they run
+  / `generate_image` / `run_template` / `partner_generate` — this server forwards **no**
+  `--host`/`--port` to these verbs (most of them accept none at all), so they run
   against comfy-cli's local default. Against a remote target, prefer `run_workflow(wait=True)` /
   `job_status` (which return the remote job's `/view` output URLs) to retrieve results.
 - **Discovery / validation** (`search_nodes`, `get_node`, `validate_workflow`) — their comfy-cli
@@ -434,7 +443,7 @@ the originals stay in the ComfyUI workspace.
 | Tool | Wraps | What it does |
 |---|---|---|
 | `run_workflow(workflow_path, wait=True, timeout_seconds=600.0)` | `comfy run --workflow <path> [--wait]` | Run a workflow JSON; `wait=False` submits async and returns a `prompt_id`. |
-| `generate_image(prompt, checkpoint=None, wait=True, timeout_seconds=600.0)` | `comfy generate --prompt <prompt> [--checkpoint <ckpt>]` | Text prompt → image in one call — comfy-cli owns the graph/checkpoint injection, so no hand-assembled workflow needed. Same envelope shape as `run_workflow` (`prompt_id` + outputs); the fast on-ramp. |
+| `generate_image(prompt, checkpoint=None, wait=True, timeout_seconds=600.0)` | `comfy run-template default --param=6.text=<prompt> [--param=ckpt_name=<ckpt>]` | Text prompt → image in one call, with no hand-assembled workflow needed: it runs ComfyUI's own default SD1.5 text-to-image gallery template through the same verb (and the same local run path) as `run_template`. Free and fully local — nothing here spends credits. Retarget it with [`COMFY_T2I_TEMPLATE` and its slot-key companions](#prerequisites). Same envelope shape as `run_workflow` (`prompt_id` + outputs); the fast on-ramp. |
 | `partner_generate(model, params=None, confirm_spend=False, download=None, timeout_seconds=600.0)` | `comfy generate <model> [--param=value…] [--download=<path>] [--timeout=<s>] [--yes]` | Run a hosted **partner** model (Flux / Ideogram / DALL·E / Recraft / …). **Spends Comfy credits**, unlike the local `run_workflow` / `generate_image` paths. Every call confirms the spend with you first — see [Spending credits](#spending-credits-on-partner-models) below. `params` are the model's own schema-driven inputs, forwarded verbatim (discover them with `comfy generate schema <model>` / `comfy generate list`). `timeout_seconds` becomes comfy-cli's own `--timeout` so the engine — not a parent kill — owns the deadline on a job the partner may already have charged for. |
 | `run_template(name, params=None, confirm_spend=False, wait=True, timeout_seconds=600.0, ctx=None)` | `comfy run-template <name> [--param=KEY=VALUE…] [--timeout=<s>] [--allow-spend] [--async]` | One-command template run — fetch the gallery template, fill its parameterized slots, and run it on local ComfyUI (the one-shot alternative to `fetch_template` → `run_workflow`). `params` are `{slot: value}` (slot address `6.text` or name `prompt`), JSON-encoded so types round-trip. Most templates are free OSS graphs; one embedding partner (paid) nodes spends credits and fails closed unless `confirm_spend=True` unlocks it — and on an elicitation-capable client that asks **you** per call before anything runs (same posture as `partner_generate`; a default, free run is never prompted, and `comfy generate consent always` does not apply to this verb). No capability probe is needed here (unlike `partner_generate`): this verb's gate ships inside the verb itself, so a comfy-cli that has `run-template` has the gate. `wait=False` submits `--async` and returns a `prompt_id`. comfy-cli's `--timeout` for this verb is *per-event*, not a whole-run deadline, so `timeout_seconds` is forwarded only to tighten it below the engine's 120s default — prefer `wait=False` over a large `timeout_seconds` for long runs. |
 | `job_status(prompt_id)` | `comfy jobs status <prompt_id>` | Poll a submitted job's status + outputs. |

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -1828,7 +1828,9 @@ async def generate_image(
     prompt / checkpoint slot keys are overridable alongside it via
     ``COMFY_T2I_PROMPT_SLOT`` / ``COMFY_T2I_CHECKPOINT_SLOT``, and must be
     overridden together with the template since slot keys describe one specific
-    graph. Pass ``checkpoint`` to swap the template's checkpoint model (it must
+    graph; the two must name DIFFERENT slots (one key for both is refused rather
+    than silently dropping the prompt). Pass ``checkpoint`` to swap the
+    template's checkpoint model (it must
     already be installed locally — see ``search_models`` / ``download_model``);
     omit it to use the template's own default. The default template is a free,
     fully local OSS graph: nothing here spends Comfy credits, so no spend
@@ -1874,11 +1876,12 @@ async def generate_image(
             # (a plausible wrong image). Only reachable via a misconfigured
             # override pair; refuse it by name instead.
             raise ComfyCliError(
-                f"COMFY_T2I_PROMPT_SLOT and COMFY_T2I_CHECKPOINT_SLOT are both "
-                f"{prompt_slot!r} — the checkpoint would overwrite the prompt. "
-                "Point them at the two different slots of template "
-                f"{template!r} (list them with `comfy templates fetch "
-                f"{template} -o wf.json && comfy workflow slots wf.json`)."
+                f"generate_image's prompt slot and checkpoint slot both resolve "
+                f"to {prompt_slot!r} — the checkpoint would overwrite the "
+                "prompt. Set COMFY_T2I_PROMPT_SLOT / COMFY_T2I_CHECKPOINT_SLOT "
+                f"to the two different slots of template {template!r} (list "
+                f"them with `comfy templates fetch {template} -o wf.json && "
+                "comfy workflow slots wf.json`)."
             )
         params[checkpoint_slot] = checkpoint
     timeout_seconds = _bounded_timeout(timeout_seconds, _MAX_RUN_TEMPLATE_TIMEOUT)

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -81,6 +81,8 @@ This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
   For a one-shot run, `run_template(name, params=...)` does fetch + fill + run in a
   single call; a template that embeds partner (paid) nodes spends credits and is
   gated by the same `confirm_spend` flag as `partner_generate` (free templates ignore it).
+  For the quickest path from text to an image, `generate_image(prompt)` runs the
+  default local text-to-image template through that same verb — free, no API key.
 - When custom nodes or models may be missing, pre-flight with `validate_workflow`
   before running.
 - Manage in-flight work with `get_queue` (list jobs) and `cancel_job`.
@@ -1761,6 +1763,49 @@ async def run_workflow(
             await asyncio.sleep(backoff)
 
 
+# The gallery template `generate_image` runs: ComfyUI's own default graph — the
+# basic SD1.5 text-to-image workflow whose CheckpointLoaderSimple default is
+# `v1-5-pruned-emaonly-fp16.safetensors`. Free (core nodes only, no partner-API
+# node, no `API` gallery tag), so the run never trips comfy-cli's spend gate.
+_T2I_TEMPLATE = "default"
+
+# Slot keys for that template's prompt + checkpoint inputs. These VERSION WITH
+# `_T2I_TEMPLATE` — they are properties of that one graph, verified with
+# `comfy templates fetch default -o wf.json && comfy workflow slots wf.json`:
+#
+#   4.ckpt_name | ckpt_name       | CheckpointLoaderSimple
+#   6.text      | text (positive) | CLIPTextEncode
+#   7.text      | text (negative) | CLIPTextEncode
+#
+# The prompt MUST use the node-address form: `text` is carried by BOTH
+# CLIPTextEncode nodes, so the bare name is ambiguous and comfy-cli refuses it
+# (`workflow_slot_invalid`) rather than guessing which one is the positive
+# prompt. `ckpt_name` is unique in this graph, so the name form is used there —
+# it survives a template revision that renumbers nodes.
+_T2I_PROMPT_SLOT = "6.text"
+_T2I_CHECKPOINT_SLOT = "ckpt_name"
+
+
+def _t2i_config() -> tuple[str, str, str]:
+    """Resolve ``generate_image``'s (template, prompt slot, checkpoint slot).
+
+    Each is env-overridable so a user can point the on-ramp at a different local
+    text-to-image graph without a code change. All three move TOGETHER: the slot
+    keys describe one specific template, so overriding ``COMFY_T2I_TEMPLATE``
+    alone will almost certainly leave the prompt address matching no slot in the
+    new graph. List a replacement's slots with ``comfy templates fetch <name> -o
+    wf.json && comfy workflow slots wf.json``.
+
+    Read per call rather than latched at import so a test (or a client that
+    re-execs with different env) sees the current value.
+    """
+    return (
+        os.environ.get("COMFY_T2I_TEMPLATE") or _T2I_TEMPLATE,
+        os.environ.get("COMFY_T2I_PROMPT_SLOT") or _T2I_PROMPT_SLOT,
+        os.environ.get("COMFY_T2I_CHECKPOINT_SLOT") or _T2I_CHECKPOINT_SLOT,
+    )
+
+
 @mcp.tool()
 async def generate_image(
     prompt: str,
@@ -1771,22 +1816,33 @@ async def generate_image(
 ) -> Any:
     """Generate an image from a text prompt on the LOCAL ComfyUI — the fast on-ramp.
 
-    Wraps ``comfy generate --prompt <prompt>``: a single call that turns a text
-    prompt into an image, so an agent does not have to hand-assemble a workflow
-    graph. comfy-cli owns the text->workflow injection (which node/slot the
-    prompt fills, the default graph, checkpoint selection); this tool is a pure
-    passthrough to that verb. Returns the same envelope shape as
-    ``run_workflow`` (``prompt_id`` + outputs).
+    A single call that turns a text prompt into an image, so an agent does not
+    have to hand-assemble a workflow graph. It runs ComfyUI's default SD1.5
+    text-to-image gallery template through ``comfy run-template <name>
+    --param=KEY=VALUE`` — the same verb (and the same local run path) as
+    ``run_template``, with the prompt filled into the template's positive
+    CLIPTextEncode slot. Returns the same envelope shape as ``run_workflow``
+    (``prompt_id`` + outputs).
 
-    Pass ``checkpoint`` to pick a specific checkpoint model (forwarded to
-    ``comfy generate --checkpoint``); omit it to let comfy-cli choose a default.
+    The template is ``default`` unless ``COMFY_T2I_TEMPLATE`` overrides it; its
+    prompt / checkpoint slot keys are overridable alongside it via
+    ``COMFY_T2I_PROMPT_SLOT`` / ``COMFY_T2I_CHECKPOINT_SLOT``, and must be
+    overridden together with the template since slot keys describe one specific
+    graph. Pass ``checkpoint`` to swap the template's checkpoint model (it must
+    already be installed locally — see ``search_models`` / ``download_model``);
+    omit it to use the template's own default. The default template is a free,
+    fully local OSS graph: nothing here spends Comfy credits, so no spend
+    consent is passed and none is needed. (For hosted PARTNER models, which do
+    spend, use ``partner_generate``.)
+
     With ``wait=True`` (default) this waits until the generation finishes and
     streams live progress as MCP progress notifications (per-node execution +
     sampler step counts) so a long generation is not a silent block; with
     ``wait=False`` it submits and returns immediately with a ``prompt_id`` to
-    poll via ``job_status``. ``timeout_seconds`` only bounds the ``wait=True``
-    streaming path; the ``wait=False`` submit-and-return branch uses a fixed
-    short timeout, so callers should not expect it to govern that case.
+    poll via ``job_status`` / ``wait_for_job`` / ``watch_job``.
+    ``timeout_seconds`` only bounds the ``wait=True`` streaming path; the
+    ``wait=False`` submit-and-return branch uses a fixed short timeout, so
+    callers should not expect it to govern that case.
 
     This is the quickest path to an image. For full control — choosing a
     template, editing its graph, or running a hand-authored workflow — use the
@@ -1795,24 +1851,71 @@ async def generate_image(
     Everything targets the LOCAL server (``--where local`` is injected by
     ``_run_comfy``), so there is no cloud reachability here.
     """
-    # Pass the free-form text as ``--flag=value`` so a prompt (or checkpoint)
-    # that begins with ``-`` is read as the value rather than mis-parsed by
-    # comfy-cli as an option token. The leading-dash guards elsewhere reject
-    # such input, but a prompt legitimately can start with ``-``, so we keep it
-    # instead of rejecting it.
-    checkpoint_args = [f"--checkpoint={checkpoint}"] if checkpoint else []
-    if not wait:
-        # Fire-and-return: no stream to follow, so keep the plain --json path.
-        return _run_comfy(
-            "generate", f"--prompt={prompt}", *checkpoint_args, timeout=60.0
+    template, prompt_slot, checkpoint_slot = _t2i_config()
+    if not template or template.startswith("-"):
+        # A leading-dash name is read by comfy-cli as an option, not the template
+        # positional. Only reachable via a malformed COMFY_T2I_TEMPLATE, but a
+        # named error beats comfy-cli's "No such option".
+        raise ComfyCliError(
+            f"invalid COMFY_T2I_TEMPLATE: {template!r} — expected a gallery "
+            "template name (e.g. 'default'), not an empty or option-like value."
         )
-    return await _run_comfy_streaming(
-        "generate",
-        f"--prompt={prompt}",
-        *checkpoint_args,
-        "--wait",
-        ctx=ctx,
-        timeout=timeout_seconds,
+    _reject_nul("template name", template)
+    # The free-form prompt rides inside a single `--param=KEY=VALUE` token, so a
+    # prompt that begins with `-` (or contains `=`) is carried as the value
+    # rather than mis-parsed by comfy-cli as an option. `_run_template_param_args`
+    # owns that escaping, the JSON value rendering, and the key validation.
+    params: dict[str, Any] = {prompt_slot: prompt}
+    if checkpoint:
+        params[checkpoint_slot] = checkpoint
+    timeout_seconds = _bounded_timeout(timeout_seconds, _MAX_RUN_TEMPLATE_TIMEOUT)
+    args, budget = _run_template_argv(
+        template,
+        _run_template_param_args(params),
+        wait=wait,
+        timeout_seconds=timeout_seconds,
+    )
+    # No `--allow-spend`, and deliberately no `_require_spend_gate` probe: that
+    # gate is `comfy generate`-scoped, and this template is free. A
+    # `spend_consent_required` here would mean the constant above names a paid
+    # template — fix the constant, not the consent plumbing.
+    try:
+        if not wait:
+            # Fire-and-return: no stream to follow, so keep the plain --json
+            # path — off the event loop, in the same pool `run_template` uses.
+            args.append("--async")
+            return await _in_generate_pool(
+                _run_comfy, *args, timeout=budget + _RUN_TEMPLATE_TIMEOUT_GRACE
+            )
+        return await _run_comfy_streaming(*args, ctx=ctx, timeout=budget)
+    except ComfyCliError as exc:
+        hinted = _t2i_slot_hint(exc, template, prompt_slot, checkpoint_slot)
+        if hinted is exc:
+            # Not a slot failure — let the engine's own error through untouched,
+            # with its original traceback rather than a self-referential cause.
+            raise
+        raise hinted from exc
+
+
+def _t2i_slot_hint(
+    exc: ComfyCliError, template: str, prompt_slot: str, checkpoint_slot: str
+) -> ComfyCliError:
+    """Re-raise a slot-resolution failure with the knob that fixes it, else pass through.
+
+    The slot keys above are pinned to one revision of one template, so the day
+    the gallery renumbers that graph (or a ``COMFY_T2I_TEMPLATE`` override names
+    a graph with a different shape) comfy-cli answers ``workflow_slot_invalid``
+    with the template's real addresses — accurate, but it says nothing about
+    WHICH knob in this server produced the bad key. Name them.
+    """
+    if exc.code != "workflow_slot_invalid":
+        return exc
+    return ComfyCliError(
+        f"{exc}\n(generate_image filled template {template!r} using prompt slot "
+        f"{prompt_slot!r} and checkpoint slot {checkpoint_slot!r}; set "
+        "COMFY_T2I_TEMPLATE / COMFY_T2I_PROMPT_SLOT / COMFY_T2I_CHECKPOINT_SLOT "
+        "to match the addresses above, or use run_template directly)",
+        code=exc.code,
     )
 
 
@@ -2511,6 +2614,33 @@ def _run_template_param_args(params: dict[str, Any]) -> list[str]:
     return argv
 
 
+def _run_template_argv(
+    name: str, param_args: list[str], *, wait: bool, timeout_seconds: float
+) -> tuple[list[str], float]:
+    """Build the ``run-template`` argv (sans consent/``--async``) + the parent budget.
+
+    Shared by :func:`run_template` and :func:`generate_image` so the engine
+    deadline rule lives in exactly one place. ``wait``'s budget is the caller's
+    (already bounded) ``timeout_seconds``; a ``wait=False`` submit gets the fixed
+    short :data:`_RUN_TEMPLATE_ASYNC_TIMEOUT` instead, since the run outlives the
+    call.
+
+    Hand the engine a deadline it can act on. Unlike ``comfy generate --timeout``,
+    this one is PER-EVENT, not a whole-run bound, so the caller's total budget
+    cannot simply be forwarded; it is used only to LOWER the engine's bound when
+    that budget is smaller than comfy-cli's 120s default. Without it a short
+    budget is consumed entirely inside the engine's own 120s server probe and the
+    child is SIGKILLed with no diagnostic — e.g. ``wait=False`` had a 60s budget
+    against a 120s probe. Never RAISED above the default: that would blunt stall
+    detection on long runs. comfy-cli types this flag as an int, so a float is a
+    parse error.
+    """
+    budget = timeout_seconds if wait else _RUN_TEMPLATE_ASYNC_TIMEOUT
+    args = ["run-template", name, *param_args]
+    args.append(f"--timeout={max(1, int(min(budget, _RUN_TEMPLATE_EVENT_TIMEOUT)))}")
+    return args, budget
+
+
 @mcp.tool()
 async def run_template(
     name: str,
@@ -2598,18 +2728,14 @@ async def run_template(
         )
     _reject_nul("template name", name)
     timeout_seconds = _bounded_timeout(timeout_seconds, _MAX_RUN_TEMPLATE_TIMEOUT)
-    args = ["run-template", name, *_run_template_param_args(params or {})]
-    # Hand the engine a deadline it can act on. Unlike `comfy generate
-    # --timeout`, this one is PER-EVENT, not a whole-run bound, so the caller's
-    # total budget cannot simply be forwarded; it is used only to LOWER the
-    # engine's bound when that budget is smaller than comfy-cli's 120s default.
-    # Without it a short `timeout_seconds` is consumed entirely inside the
-    # engine's own 120s server probe and the child is SIGKILLed with no
-    # diagnostic — e.g. `wait=False` had a 60s budget against a 120s probe.
-    # Never RAISED above the default: that would blunt stall detection on long
-    # runs. comfy-cli types this flag as an int, so a float is a parse error.
-    budget = timeout_seconds if wait else _RUN_TEMPLATE_ASYNC_TIMEOUT
-    args.append(f"--timeout={max(1, int(min(budget, _RUN_TEMPLATE_EVENT_TIMEOUT)))}")
+    # argv + the engine deadline are built by the shared helper (see
+    # `_run_template_argv` for why `--timeout` is needed and never raised).
+    args, budget = _run_template_argv(
+        name,
+        _run_template_param_args(params or {}),
+        wait=wait,
+        timeout_seconds=timeout_seconds,
+    )
     if await _resolve_template_spend_consent(name, confirm_spend, ctx):
         # comfy-cli's paid-node consent for run-template; a bare boolean flag.
         args.append("--allow-spend")

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -1867,6 +1867,19 @@ async def generate_image(
     # owns that escaping, the JSON value rendering, and the key validation.
     params: dict[str, Any] = {prompt_slot: prompt}
     if checkpoint:
+        if checkpoint_slot == prompt_slot:
+            # Same key for both slots would have the checkpoint overwrite the
+            # prompt already stored under it, running the template's DEFAULT
+            # prompt with no error at all — the worst failure mode available
+            # (a plausible wrong image). Only reachable via a misconfigured
+            # override pair; refuse it by name instead.
+            raise ComfyCliError(
+                f"COMFY_T2I_PROMPT_SLOT and COMFY_T2I_CHECKPOINT_SLOT are both "
+                f"{prompt_slot!r} — the checkpoint would overwrite the prompt. "
+                "Point them at the two different slots of template "
+                f"{template!r} (list them with `comfy templates fetch "
+                f"{template} -o wf.json && comfy workflow slots wf.json`)."
+            )
         params[checkpoint_slot] = checkpoint
     timeout_seconds = _bounded_timeout(timeout_seconds, _MAX_RUN_TEMPLATE_TIMEOUT)
     args, budget = _run_template_argv(
@@ -1887,9 +1900,20 @@ async def generate_image(
             return await _in_generate_pool(
                 _run_comfy, *args, timeout=budget + _RUN_TEMPLATE_TIMEOUT_GRACE
             )
-        return await _run_comfy_streaming(*args, ctx=ctx, timeout=budget)
+        # Same grace as the submit path above (and as `run_template`): the child
+        # was handed `--timeout=min(budget, 120)`, so for a budget at or under
+        # comfy-cli's 120s cap the engine's deadline and the parent's kill land
+        # on the SAME instant. Without slack the parent can SIGKILL comfy-cli
+        # mid-write of its own structured timeout / `server_not_running` result,
+        # replacing an actionable error with a generic parent kill (and orphaning
+        # an already-enqueued run). The engine must be the side that gives up.
+        return await _run_comfy_streaming(
+            *args, ctx=ctx, timeout=budget + _RUN_TEMPLATE_TIMEOUT_GRACE
+        )
     except ComfyCliError as exc:
-        hinted = _t2i_slot_hint(exc, template, prompt_slot, checkpoint_slot)
+        hinted = _t2i_slot_hint(
+            exc, template, prompt_slot, checkpoint_slot if checkpoint else None
+        )
         if hinted is exc:
             # Not a slot failure — let the engine's own error through untouched,
             # with its original traceback rather than a self-referential cause.
@@ -1898,7 +1922,7 @@ async def generate_image(
 
 
 def _t2i_slot_hint(
-    exc: ComfyCliError, template: str, prompt_slot: str, checkpoint_slot: str
+    exc: ComfyCliError, template: str, prompt_slot: str, checkpoint_slot: str | None
 ) -> ComfyCliError:
     """Re-raise a slot-resolution failure with the knob that fixes it, else pass through.
 
@@ -1907,14 +1931,22 @@ def _t2i_slot_hint(
     a graph with a different shape) comfy-cli answers ``workflow_slot_invalid``
     with the template's real addresses — accurate, but it says nothing about
     WHICH knob in this server produced the bad key. Name them.
+
+    ``checkpoint_slot`` is None when the call passed no ``checkpoint``: that slot
+    was never sent, so naming it would implicate a knob that cannot be the cause
+    and send the reader after the wrong env var.
     """
     if exc.code != "workflow_slot_invalid":
         return exc
+    filled = f"prompt slot {prompt_slot!r}"
+    knobs = "COMFY_T2I_TEMPLATE / COMFY_T2I_PROMPT_SLOT"
+    if checkpoint_slot is not None:
+        filled += f" and checkpoint slot {checkpoint_slot!r}"
+        knobs += " / COMFY_T2I_CHECKPOINT_SLOT"
     return ComfyCliError(
-        f"{exc}\n(generate_image filled template {template!r} using prompt slot "
-        f"{prompt_slot!r} and checkpoint slot {checkpoint_slot!r}; set "
-        "COMFY_T2I_TEMPLATE / COMFY_T2I_PROMPT_SLOT / COMFY_T2I_CHECKPOINT_SLOT "
-        "to match the addresses above, or use run_template directly)",
+        f"{exc}\n(generate_image filled template {template!r} using {filled}; "
+        f"set {knobs} to match the addresses above, or use run_template "
+        "directly)",
         code=exc.code,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,23 @@ def _clear_comfyui_target_env(monkeypatch):
         monkeypatch.delenv(var, raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _clear_t2i_env(monkeypatch):
+    """Default every test to ``generate_image``'s built-in template + slot keys.
+
+    Same reason as the target env above: ``generate_image`` reads
+    ``COMFY_T2I_TEMPLATE`` / ``COMFY_T2I_PROMPT_SLOT`` /
+    ``COMFY_T2I_CHECKPOINT_SLOT`` per call, so an ambient value would perturb its
+    exact-argv assertions. The override test sets them explicitly.
+    """
+    for var in (
+        "COMFY_T2I_TEMPLATE",
+        "COMFY_T2I_PROMPT_SLOT",
+        "COMFY_T2I_CHECKPOINT_SLOT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
 class _FakeProc:
     """A minimal stand-in for ``subprocess.Popen`` over a canned NDJSON stream."""
 

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1,14 +1,26 @@
-"""End-to-end smoke test: a real no-model round-trip against a LIVE local ComfyUI.
+"""End-to-end smoke tests: real round-trips against a LIVE local ComfyUI.
 
 This is the manual validation ritual turned into a command. It drives the actual
-tools (no mocks): ``server_info`` -> ``run_workflow`` on a checkpoint-free
-``EmptyImage`` -> ``SaveImage`` graph (both ComfyUI core nodes) -> ``fetch_outputs``,
-then asserts a real PNG landed in a temp out_dir.
+tools (no mocks):
 
-**Gated.** It requires BOTH a live local ComfyUI answering on ``COMFYUI_URL`` (or
+1. ``server_info`` -> ``run_workflow`` on a checkpoint-free ``EmptyImage`` ->
+   ``SaveImage`` graph (both ComfyUI core nodes) -> ``fetch_outputs``, then
+   asserts a real PNG landed in a temp out_dir.
+2. ``generate_image(prompt=…, wait=True)`` — the text-prompt on-ramp — end to
+   end, likewise down to a real PNG. This one is a REGRESSION GUARD: the tool
+   used to wrap ``comfy generate``, a partner/cloud-only verb with no local mode
+   and no ``--prompt`` flag, so every call died in comfy-cli's argument parser
+   ("comfy-cli returned no JSON (exit 1)") and nothing was ever enqueued. No unit
+   test could catch that — mocks happily accept an argv the real CLI rejects —
+   so the only real defense is running it. Unlike case 1 it needs the default
+   template's SD1.5 checkpoint (``v1-5-pruned-emaonly-fp16.safetensors``)
+   installed locally; without it the run fails with comfy-cli's own missing-model
+   error rather than skipping.
+
+**Gated.** They require BOTH a live local ComfyUI answering on ``COMFYUI_URL`` (or
 ``http://127.0.0.1:8188``) AND the ``comfy`` binary on ``PATH`` (or ``COMFY_BIN``).
-CI runners have neither, so it SKIPS cleanly there — CI stays green via skip, not
-failure. Run it on a machine that has both with::
+CI runners have neither, so they SKIP cleanly there — CI stays green via skip, not
+failure. Run them on a machine that has both with::
 
     python -m pytest tests/e2e -m e2e      # or: scripts/smoke.sh
 """
@@ -116,3 +128,30 @@ def test_no_model_round_trip(tmp_path):
         if p.is_file() and p.read_bytes()[:8] == _PNG_MAGIC
     ]
     assert pngs, f"no valid PNG downloaded into {out_dir}"
+
+
+def test_generate_image_round_trip(tmp_path):
+    """generate_image(prompt, wait=True) enqueues a real job and yields a PNG.
+
+    The regression guard for the ``comfy generate`` era: a green run proves the
+    pinned comfy-cli actually PARSES the argv this tool emits and runs the
+    default text-to-image template to completion. Needs the template's SD1.5
+    checkpoint installed (see the module docstring).
+    """
+    # `generate_image` raises ComfyCliError on an error envelope, so simply
+    # returning is already the "non-error envelope" half of the assertion.
+    result = asyncio.run(
+        server.generate_image("a cat", wait=True, timeout_seconds=600.0)
+    )
+    prompt_id = _extract_prompt_id(result)
+    assert prompt_id, f"no prompt_id in generate_image result: {result!r}"
+
+    out_dir = tmp_path / "generate_out"
+    server.fetch_outputs(prompt_id, str(out_dir))
+
+    pngs = [
+        p
+        for p in out_dir.rglob("*")
+        if p.is_file() and p.read_bytes()[:8] == _PNG_MAGIC
+    ]
+    assert pngs, f"generate_image produced no valid PNG in {out_dir}"

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,18 +1,32 @@
-# Tests for the ``generate_image`` tool — the thin passthrough to
-# ``comfy generate`` (text prompt -> image). The streaming fakes and the
-# ``patched_stream`` fixture live in ``conftest.py`` and are shared with the
-# other streaming tools' tests.
+# Tests for the ``generate_image`` tool — the text-prompt on-ramp, which
+# delegates to ``comfy run-template <template> --param=KEY=VALUE`` (the same verb
+# ``run_template`` wraps) rather than the partner-only, credit-spending
+# ``comfy generate``. The streaming fakes and the ``patched_stream`` fixture live
+# in ``conftest.py`` and are shared with the other streaming tools' tests.
+#
+# What these lock in:
+#
+# 1. The argv shape: global flags first, then ``run-template <template>``, the
+#    prompt as a single ``--param=<slot>=<json>`` token, and the engine's
+#    per-event ``--timeout`` — with ``--async`` only on ``wait=False``.
+# 2. That the prompt rides INSIDE that token, so a prompt starting with ``-``
+#    can never be re-read as an option (the wf-006 class of bug).
+# 3. That nothing spend-related is forwarded — the default template is a free,
+#    fully local OSS graph.
+# 4. That ``COMFY_T2I_TEMPLATE`` (and its slot-key companions) actually retarget
+#    the call.
 from __future__ import annotations
 
 import asyncio
 
+import pytest
 from conftest import _OK_STREAM, _RecordingCtx
 
 from comfy_local_mcp import server
 
 
 def test_generate_image_streams_and_maps_command(patched_stream):
-    """wait=True drives `comfy --json-stream … generate --prompt … --wait`."""
+    """wait=True drives `comfy --json-stream … run-template default --param=…`."""
     procs = patched_stream(_OK_STREAM)
     ctx = _RecordingCtx()
 
@@ -24,40 +38,64 @@ def test_generate_image_streams_and_maps_command(patched_stream):
     cmd = procs[0].cmd
     assert cmd[0] == server.COMFY_BIN
     assert cmd[1:4] == ["--json-stream", "--where", "local"]  # global flags first
-    # No checkpoint given -> no --checkpoint token in the command. The prompt is
-    # passed as --prompt=<value> so a leading dash can't be misread as a flag.
-    assert cmd[4:] == ["generate", "--prompt=a red fox in snow", "--wait"]
+    # No checkpoint given -> no ckpt_name param. The prompt rides inside a single
+    # `--param=KEY=VALUE` token (JSON-encoded value), and the engine gets its
+    # per-event deadline — capped at comfy-cli's own 120s default, never raised.
+    assert cmd[4:] == [
+        "run-template",
+        "default",
+        '--param=6.text="a red fox in snow"',
+        "--timeout=120",
+    ]
+    # Nothing spend-related: the default template is a free local OSS graph.
+    assert "--allow-spend" not in cmd
+    # And no trace of the partner-only verb this tool used to (mis)invoke.
+    assert "generate" not in cmd
 
 
 def test_generate_image_forwards_checkpoint_when_streaming(patched_stream):
-    """A checkpoint is forwarded as `--checkpoint=<name>` before `--wait`."""
+    """A checkpoint fills the template's `ckpt_name` slot, after the prompt."""
     procs = patched_stream(_OK_STREAM)
 
     asyncio.run(server.generate_image("a cat", checkpoint="sd_xl.safetensors"))
 
     assert procs[0].cmd[4:] == [
-        "generate",
-        "--prompt=a cat",
-        "--checkpoint=sd_xl.safetensors",
-        "--wait",
+        "run-template",
+        "default",
+        '--param=6.text="a cat"',
+        '--param=ckpt_name="sd_xl.safetensors"',
+        "--timeout=120",
     ]
 
 
 def test_generate_image_leading_dash_prompt_is_not_parsed_as_flag(patched_stream):
-    """A prompt starting with `-` is kept as the value via `--prompt=<value>`."""
+    """A prompt starting with `-` is carried inside `--param=<slot>=<value>`."""
     procs = patched_stream(_OK_STREAM)
 
     asyncio.run(server.generate_image("--not-a-flag, just text"))
 
     assert procs[0].cmd[4:] == [
-        "generate",
-        "--prompt=--not-a-flag, just text",
-        "--wait",
+        "run-template",
+        "default",
+        '--param=6.text="--not-a-flag, just text"',
+        "--timeout=120",
     ]
+    # The whole prompt is one argv token, so comfy-cli's parser never sees a
+    # bare `--not-a-flag`.
+    assert not any(tok.startswith("--not-a-flag") for tok in procs[0].cmd)
+
+
+def test_generate_image_short_timeout_lowers_the_engine_deadline(patched_stream):
+    """A budget under comfy-cli's 120s default tightens `--timeout` to match."""
+    procs = patched_stream(_OK_STREAM)
+
+    asyncio.run(server.generate_image("a cat", timeout_seconds=45.0))
+
+    assert procs[0].cmd[-1] == "--timeout=45"
 
 
 def test_generate_image_wait_false_uses_plain_json_no_stream(monkeypatch):
-    """wait=False keeps the plain --json _run_comfy path (no streaming, no --wait)."""
+    """wait=False submits `--async` on the plain --json path (no streaming)."""
     seen: dict = {}
 
     def fake_run_comfy(*args, timeout=None):
@@ -74,12 +112,22 @@ def test_generate_image_wait_false_uses_plain_json_no_stream(monkeypatch):
     result = asyncio.run(server.generate_image("a red fox in snow", wait=False))
 
     assert result == {"prompt_id": "p1"}
-    assert seen["args"] == ("generate", "--prompt=a red fox in snow")  # no --wait
-    assert seen["timeout"] == 60.0
+    assert seen["args"] == (
+        "run-template",
+        "default",
+        '--param=6.text="a red fox in snow"',
+        "--timeout=60",
+        "--async",
+    )
+    # Submit budget is the fixed short one, plus the grace that lets comfy-cli
+    # report its own error instead of dying to the parent's signal.
+    assert seen["timeout"] == pytest.approx(
+        server._RUN_TEMPLATE_ASYNC_TIMEOUT + server._RUN_TEMPLATE_TIMEOUT_GRACE
+    )
 
 
 def test_generate_image_wait_false_forwards_checkpoint(monkeypatch):
-    """wait=False still forwards a checkpoint to `comfy generate --checkpoint`."""
+    """wait=False still fills the template's checkpoint slot."""
     seen: dict = {}
 
     def fake_run_comfy(*args, timeout=None):
@@ -94,7 +142,106 @@ def test_generate_image_wait_false_forwards_checkpoint(monkeypatch):
 
     assert server_result == {"prompt_id": "p2"}
     assert seen["args"] == (
-        "generate",
-        "--prompt=a dog",
-        "--checkpoint=dreamshaper.safetensors",
+        "run-template",
+        "default",
+        '--param=6.text="a dog"',
+        '--param=ckpt_name="dreamshaper.safetensors"',
+        "--timeout=60",
+        "--async",
     )
+
+
+def test_generate_image_env_overrides_template_and_slots(patched_stream, monkeypatch):
+    """COMFY_T2I_TEMPLATE (+ slot keys) retarget the run at another graph."""
+    procs = patched_stream(_OK_STREAM)
+    monkeypatch.setenv("COMFY_T2I_TEMPLATE", "image_flux2")
+    monkeypatch.setenv("COMFY_T2I_PROMPT_SLOT", "44.text")
+    monkeypatch.setenv("COMFY_T2I_CHECKPOINT_SLOT", "unet_name")
+
+    asyncio.run(server.generate_image("a cat", checkpoint="flux2.safetensors"))
+
+    assert procs[0].cmd[4:] == [
+        "run-template",
+        "image_flux2",
+        '--param=44.text="a cat"',
+        '--param=unet_name="flux2.safetensors"',
+        "--timeout=120",
+    ]
+
+
+def test_generate_image_env_template_override_alone_keeps_default_slots(
+    patched_stream, monkeypatch
+):
+    """Overriding only the template leaves the built-in slot keys in place."""
+    procs = patched_stream(_OK_STREAM)
+    monkeypatch.setenv("COMFY_T2I_TEMPLATE", "some_other_template")
+
+    asyncio.run(server.generate_image("a cat"))
+
+    assert procs[0].cmd[4:6] == ["run-template", "some_other_template"]
+    assert procs[0].cmd[6] == '--param=6.text="a cat"'
+
+
+def test_generate_image_rejects_option_like_template(monkeypatch):
+    """A malformed COMFY_T2I_TEMPLATE is refused by name, before any child spawns."""
+    monkeypatch.setenv("COMFY_T2I_TEMPLATE", "--json")
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+    monkeypatch.setattr(server, "_run_comfy_streaming", boom)
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        asyncio.run(server.generate_image("a cat"))
+
+    assert "COMFY_T2I_TEMPLATE" in str(exc.value)
+
+
+def test_generate_image_empty_env_falls_back_to_the_builtin_template(
+    patched_stream, monkeypatch
+):
+    """An empty COMFY_T2I_TEMPLATE is treated as unset, not as an invalid name."""
+    procs = patched_stream(_OK_STREAM)
+    monkeypatch.setenv("COMFY_T2I_TEMPLATE", "")
+
+    asyncio.run(server.generate_image("a cat"))
+
+    assert procs[0].cmd[4:6] == ["run-template", server._T2I_TEMPLATE]
+
+
+def test_generate_image_slot_error_names_the_env_knobs(monkeypatch):
+    """A `workflow_slot_invalid` from the engine gains a which-knob-to-set hint."""
+
+    def fake_run_comfy(*args, timeout=None):
+        raise server.ComfyCliError(
+            "--param key '6.text' matches no slot in this template",
+            code="workflow_slot_invalid",
+        )
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run_comfy)
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        asyncio.run(server.generate_image("a cat", wait=False))
+
+    message = str(exc.value)
+    assert "matches no slot" in message  # the engine's own diagnosis survives
+    assert "COMFY_T2I_PROMPT_SLOT" in message
+    assert exc.value.code == "workflow_slot_invalid"
+
+
+def test_generate_image_other_errors_pass_through_unchanged(monkeypatch):
+    """A non-slot failure is re-raised as-is, not dressed up with the slot hint."""
+
+    def fake_run_comfy(*args, timeout=None):
+        raise server.ComfyCliError("ComfyUI is not running", code="server_not_running")
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run_comfy)
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        asyncio.run(server.generate_image("a cat", wait=False))
+
+    assert str(exc.value) == "ComfyUI is not running"
+    assert "COMFY_T2I_PROMPT_SLOT" not in str(exc.value)
+    # Re-raised bare, so it carries no self-referential __cause__ chain.
+    assert exc.value.__cause__ is not exc.value

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -228,6 +228,88 @@ def test_generate_image_slot_error_names_the_env_knobs(monkeypatch):
     assert "matches no slot" in message  # the engine's own diagnosis survives
     assert "COMFY_T2I_PROMPT_SLOT" in message
     assert exc.value.code == "workflow_slot_invalid"
+    # No checkpoint was passed, so that slot was never sent — naming it here
+    # would send the reader after a knob that cannot be the cause.
+    assert "checkpoint slot" not in message
+    assert "COMFY_T2I_CHECKPOINT_SLOT" not in message
+
+
+def test_generate_image_slot_error_names_checkpoint_only_when_filled(monkeypatch):
+    """With a checkpoint actually filled, the hint names that knob too."""
+
+    def fake_run_comfy(*args, timeout=None):
+        raise server.ComfyCliError(
+            "--param key 'ckpt_name' matches no slot in this template",
+            code="workflow_slot_invalid",
+        )
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run_comfy)
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        asyncio.run(
+            server.generate_image("a cat", checkpoint="sd_xl.safetensors", wait=False)
+        )
+
+    message = str(exc.value)
+    assert "checkpoint slot 'ckpt_name'" in message
+    assert "COMFY_T2I_CHECKPOINT_SLOT" in message
+
+
+def test_generate_image_rejects_colliding_slot_overrides(monkeypatch):
+    """One key for both slots would silently drop the prompt — refuse it instead."""
+    monkeypatch.setenv("COMFY_T2I_PROMPT_SLOT", "6.text")
+    monkeypatch.setenv("COMFY_T2I_CHECKPOINT_SLOT", "6.text")
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+    monkeypatch.setattr(server, "_run_comfy_streaming", boom)
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        asyncio.run(server.generate_image("a cat", checkpoint="sd_xl.safetensors"))
+
+    message = str(exc.value)
+    assert "COMFY_T2I_PROMPT_SLOT" in message
+    assert "COMFY_T2I_CHECKPOINT_SLOT" in message
+
+
+def test_generate_image_colliding_slots_are_fine_without_a_checkpoint(
+    patched_stream, monkeypatch
+):
+    """Nothing overwrites the prompt when no checkpoint is passed, so the run proceeds."""
+    procs = patched_stream(_OK_STREAM)
+    monkeypatch.setenv("COMFY_T2I_PROMPT_SLOT", "6.text")
+    monkeypatch.setenv("COMFY_T2I_CHECKPOINT_SLOT", "6.text")
+
+    asyncio.run(server.generate_image("a cat"))
+
+    assert procs[0].cmd[4:] == [
+        "run-template",
+        "default",
+        '--param=6.text="a cat"',
+        "--timeout=120",
+    ]
+
+
+def test_generate_image_streaming_parent_deadline_has_the_engine_grace(monkeypatch):
+    """The parent outlives the deadline it hands the engine, so comfy-cli reports first."""
+    seen: dict = {}
+
+    async def fake_stream(*args, ctx=None, timeout=None, **kwargs):
+        seen["args"] = args
+        seen["timeout"] = timeout
+        return {"outputs": []}
+
+    monkeypatch.setattr(server, "_run_comfy_streaming", fake_stream)
+
+    # A budget at/under comfy-cli's 120s cap is the dangerous case: the child's
+    # `--timeout` equals the budget, so without grace both deadlines fire at the
+    # same instant and the parent's SIGKILL wins over the engine's own report.
+    asyncio.run(server.generate_image("a cat", timeout_seconds=45.0))
+
+    assert seen["args"][-1] == "--timeout=45"  # engine's deadline: the budget
+    assert seen["timeout"] == pytest.approx(45.0 + server._RUN_TEMPLATE_TIMEOUT_GRACE)
 
 
 def test_generate_image_other_errors_pass_through_unchanged(monkeypatch):


### PR DESCRIPTION
## ELI-5

`generate_image("a cat")` never worked. It called `comfy generate`, which is the **cloud/partner** verb — the one that runs Flux/DALL·E on Comfy's servers and spends your credits. It takes a *model name* as its first argument, not a `--prompt` flag. So the flag text landed where the model name goes, comfy-cli said "Unknown model: '--prompt=a cat'", and the tool blew up with `comfy-cli returned no JSON (exit 1)` every single time. Nothing was ever queued.

This rewires it to the verb that actually generates images locally: `comfy run-template`. It runs ComfyUI's own default SD1.5 text-to-image graph and drops your prompt into it. Free, fully local, no API key, no credits. The tool's inputs and outputs are unchanged — it just works now.

## What changed

`generate_image`'s public signature is untouched (`prompt, checkpoint=None, wait=True, timeout_seconds=600.0, ctx=None`). Its body now builds `comfy run-template <template> --param=KEY=VALUE …`, the same verb and the same local run path `run_template` wraps.

| | before | after |
|---|---|---|
| `wait=True` | `--json-stream … generate --prompt=<p> [--checkpoint=<c>] --wait` | `--json-stream … run-template default --param=6.text=<p> [--param=ckpt_name=<c>] --timeout=<n>` |
| `wait=False` | `--json … generate --prompt=<p>` | `--json … run-template default --param=6.text=<p> --timeout=60 --async` |

- **Template.** The gallery's `default` graph — ComfyUI's basic SD1.5 text-to-image workflow, the one whose `CheckpointLoaderSimple` default is `v1-5-pruned-emaonly-fp16.safetensors`. Core nodes only, no partner-API node, no `API` gallery tag, so it is free and can never trip comfy-cli's spend gate.
- **Spend consent: nothing forwarded.** No `--allow-spend`, and no `_require_spend_gate` probe — that gate is `comfy generate`-scoped. A `spend_consent_required` here would mean the template constant is wrong, not that the consent plumbing is missing.
- **Slot keys were read off the real template, not guessed** (see the evidence section). The prompt has to use the *address* form `6.text`: `text` is carried by BOTH `CLIPTextEncode` nodes (positive and negative), so the bare name resolves ambiguous. `ckpt_name` is unique, so the name form is used there — it survives a template revision that renumbers nodes.
- **Overrides.** `COMFY_T2I_TEMPLATE`, `COMFY_T2I_PROMPT_SLOT`, `COMFY_T2I_CHECKPOINT_SLOT`, read per call. They move together — slot keys describe one specific graph.
- **No duplicated marshalling.** `--param` escaping/rendering stays in `_run_template_param_args`; the engine-deadline rule (`--timeout` is PER-EVENT, only ever lowered, never raised) moved out of `run_template`'s body into a shared `_run_template_argv` helper so both callers read from one place. `run_template`'s emitted argv is byte-identical — its 40-odd existing tests prove it.
- **Error handling.** A `workflow_slot_invalid` from the engine is re-raised with the env knob that produced the bad key appended (the engine's own message and error code survive). Every other error is re-raised bare, with its original traceback.

Docs: the server `INSTRUCTIONS`, the README env-var section, and the README tool table all said or implied `comfy generate`; all three now describe the run-template delegation. The README's remote-targeting caveat gained `run_template` (it was already missing) and its reason clause was corrected — `comfy run-template` *does* accept `--host`/`--port`; this server simply forwards neither.

## Evidence — the premise, checked against a real comfy-cli, not assumed

Run against a checkout of comfy-cli `main` (`85b62da`, the commit that added `run-template`).

**1. `comfy generate` is partner-only, and the old call fails exactly as reported.**

```
$ comfy generate --help
comfy generate — call ComfyUI partner nodes
Usage: comfy generate <model> [--<param> value]... [--download PATH] [--async] [--yes] [--api-key KEY]
Generation spends Comfy credits: interactive runs confirm first …
```

No local mode, no bare `--prompt`, no `--checkpoint`, no `--wait`.

```
$ comfy --json --where local generate "--prompt=a cat"
Unknown model: '--prompt=a cat'.
Run `comfy generate list` to see available models.
exit 1        stdout: rich text (not JSON)        stderr: <empty>
```

That is the reported failure verbatim: rich text on stdout, exit 1, empty stderr → `ComfyCliError("comfy-cli returned no JSON (exit 1). stderr: ")`.

**2. The new argv parses and reaches the engine's own envelope.**

```
$ comfy --json --where local run-template default --param=6.text="a cat" --timeout=120
{"schema":"envelope/1","ok":false,"command":"run-template","error":{"code":"server_not_running",
 "message":"ComfyUI not running on specified address (127.0.0.1:8188)","hint":"run: comfy launch"}}
```

Same under `--json-stream` (the `wait=True` path). This machine has no local ComfyUI, so the run stops at the server probe — but the argument parser, the template resolution, and the envelope contract are all exercised, which is precisely what the old path could never get past.

**3. The slot keys — decided by comfy-cli's own resolver, over comfy-cli's own slot list.**

```
$ comfy templates fetch default -o wf.json && comfy workflow slots wf.json
4.ckpt_name | ckpt_name | CheckpointLoaderSimple | 'v1-5-pruned-emaonly-fp16.safetensors'
6.text      | text      | CLIPTextEncode        | 'beautiful scenery nature glass bottle…'   ← positive
7.text      | text      | CLIPTextEncode        | 'text, watermark'                          ← negative
…
```

Feeding candidate keys to comfy-cli's `_resolve_param_addresses` against that list:

| key | result |
|---|---|
| `prompt` | ❌ `workflow_slot_invalid` — *matches no slot in this template* |
| `text` | ❌ `workflow_slot_invalid` — *ambiguous: 2 slots share that name* |
| `6.text` | ✅ → `{'6.text': …}` |
| `ckpt_name` | ✅ → `{'4.ckpt_name': …}` |

## Judgment calls

1. **The prompt slot is `6.text`, not `prompt`.** The plan said to fill `prompt=<prompt>` always. That key does not exist in this template — the table above is comfy-cli refusing it. The plan also said to *determine* the slot key empirically and fall back to the `node.field` address form, which is what I did; I applied that same rule to the prompt slot, not just the checkpoint one.
2. **Two extra env vars beyond `COMFY_T2I_TEMPLATE`.** Slot keys are properties of one specific graph, so a template override without slot overrides is a guaranteed `workflow_slot_invalid`. `COMFY_T2I_PROMPT_SLOT` / `COMFY_T2I_CHECKPOINT_SLOT` make the documented override actually usable. Documented as "set all three together".
3. **`wait=False` uses run_template's timeout shape, not a bare `timeout=60.0`.** The plan's snippet omitted `--timeout`; `run_template`'s body carries a comment explaining that exact omission as a bug it already fixed (a 60s parent budget against comfy-cli's 120s server probe → SIGKILL with no diagnostic). I copied `run_template`'s flag usage, as the plan's own instruction to read its body first directs: `--timeout=60`, parent budget `60 + 30s` grace. It also runs in the same dedicated thread pool `run_template` uses instead of blocking the event loop, which the old code did.
4. **`generate_image` stayed where it is in the file** and forward-references the run-template helpers defined below it (legal at call time). Moving it next to `run_template` would have made the diff read as a delete-plus-add and reordered `tools/list`.

## Testing

`pytest -q` → **423 passed, 2 skipped**. `ruff check .` and `ruff format --check .` clean.

`tests/test_generate.py` rewritten: argv assertions for both wait paths and the checkpoint case, the leading-dash prompt (now proving it rides inside one `--param=…` token and that no bare `--not-a-flag` reaches argv), a short-timeout case that lowers the engine deadline, `COMFY_T2I_TEMPLATE` override (with and without the slot companions), empty-env fallback, malformed-template rejection, and both branches of the slot-error hint. Two new assertions guard the regression directly: `"--allow-spend" not in cmd` and `"generate" not in cmd`.

`tests/conftest.py` clears the three `COMFY_T2I_*` vars for every test, matching the existing `COMFYUI_URL` fixture, so an ambient value can't perturb argv assertions.

### Not verified here: the live e2e case

`tests/e2e/test_smoke.py` gains `test_generate_image_round_trip` — `generate_image("a cat", wait=True)` → non-error envelope → `fetch_outputs` → assert a real PNG. It is the reported-bug repro and the guard against ever again shipping a wrapper around an argv the pinned comfy-cli cannot parse, since a mock will happily accept one.

**It has not been run green.** This machine has no local ComfyUI and no SD1.5 checkpoint, and the pieces (ComfyUI + torch + a ~2 GB checkpoint) were more than this change warranted installing. It skips cleanly here and in CI (`2 skipped`), same as the existing smoke test. **Someone with a live install should run `scripts/smoke.sh` before merging** — that is the one acceptance criterion I could not close myself. What I *could* verify without it is in the Evidence section above: the argv parses, the template resolves, and the slot keys are the ones comfy-cli itself accepts.

Beyond the checkpoint download, the remaining risk is that `_T2I_PROMPT_SLOT = "6.text"` is pinned to node IDs in a template Comfy-Org can revise. If that graph is ever renumbered, the failure is loud (`workflow_slot_invalid`, listing the real addresses) rather than silent, the hint names the env var that fixes it, and the override is a config change rather than a release.
