### PR TITLE
fix(server_info): degrade freshness to a clean 'unsupported' on a comfy-cli without `comfy outdated`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Cloud MCP** — comfy-cli is the engine.
   every tool wraps; the server refuses to run against an older comfy-cli with an upgrade message.
   The `server_info` `freshness` block additionally needs the first comfy-cli release **after**
   1.12.0 that ships the `comfy outdated` verb; on a comfy-cli without it the block degrades to
-  `freshness: {"error": …}` and everything else works unchanged.
+  `freshness: {"error": "freshness unavailable: …", "unsupported": true}` — update checks are
+  skipped, nothing is broken, and everything else works unchanged.
 - **A ComfyUI workspace.** If you don't have one, `comfy-cli` can create it: `comfy install`
   sets up a ComfyUI workspace it will point at. (An existing ComfyUI checkout works too — see
   `comfy set-default <path>`.)
@@ -449,7 +450,7 @@ the originals stay in the ComfyUI workspace.
 
 | Tool | Wraps | What it does |
 |---|---|---|
-| `server_info()` | `comfy env` + `comfy outdated` | Is a local ComfyUI running, where, and which workspace. **Call first.** Also attaches a `freshness` block (`comfy outdated`): installed-vs-latest for ComfyUI core and each custom node pack, so a stale install is flagged before it masquerades as a missing model/node. On a comfy-cli without the `outdated` verb (or a network failure) the block degrades to `freshness: {"error": …}` — the tool itself still succeeds. Reports the configured remote under a `comfy_target` block when `COMFYUI_URL`/`COMFYUI_HOST` is set (see [Driving a remote ComfyUI](#driving-a-remote-comfyui)). |
+| `server_info()` | `comfy env` + `comfy outdated` | Is a local ComfyUI running, where, and which workspace. **Call first.** Also attaches a `freshness` block (`comfy outdated`): installed-vs-latest for ComfyUI core and each custom node pack, so a stale install is flagged before it masquerades as a missing model/node. On a comfy-cli without the `outdated` verb the block degrades to `freshness: {"error": "freshness unavailable: …", "unsupported": true}` (a benign capability gap — skip staleness advice, nothing is broken); on any other probe failure such as a network error it degrades to `freshness: {"error": …}` carrying the real reason. Either way the tool itself still succeeds. Reports the configured remote under a `comfy_target` block when `COMFYUI_URL`/`COMFYUI_HOST` is set (see [Driving a remote ComfyUI](#driving-a-remote-comfyui)). |
 | `auth_status()` | `comfy cloud whoami` | Comfy Cloud credential status for partner-API nodes (read-only, never returns secrets). Adds a local `registration_env_key_present` bool for the `COMFY_API_KEY` registration-env slot whoami can't see. |
 | `which()` | `comfy which` | Which ComfyUI install/workspace comfy-cli currently targets (a lighter answer than `server_info`). |
 | `get_logs(tail=200)` | `comfy logs --tail <tail>` | Tail the background ComfyUI's captured log (`<workspace>/user/comfyui_<port>.log`) — closes the debugging loop after a detached `launch_comfyui`. Returns `{lines, path, truncated}`; a missing log file returns `{"error": "no_log_file", …}` rather than raising. |

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -513,6 +513,12 @@ class ComfyCliError(RuntimeError):
     ``error.code`` — so a caller asking "did comfy-cli fail *before* it could
     report structurally?" must check this flag rather than ``code is None``.
     :func:`_is_missing_verb_error` is exactly that caller.
+
+    ``returncode`` is the child's exit status on that same no-envelope path
+    (``None`` elsewhere). It distinguishes *how* comfy-cli failed without an
+    envelope — a usage error the argument parser rejected before dispatch versus
+    a crash partway through a command it did accept — which the message text
+    alone cannot tell you.
     """
 
     def __init__(
@@ -520,10 +526,12 @@ class ComfyCliError(RuntimeError):
         *args: object,
         code: str | None = None,
         no_envelope: bool = False,
+        returncode: int | None = None,
     ) -> None:
         super().__init__(*args)
         self.code = code
         self.no_envelope = no_envelope
+        self.returncode = returncode
 
 
 def _comfy_bin_candidates() -> list[str]:
@@ -1079,6 +1087,7 @@ def _unwrap_envelope(
                 # the cause, so its curated guidance beats a second raw stream.
                 f"Original error: {_stream_tail(stderr)}",
                 no_envelope=True,
+                returncode=returncode,
             )
         # Both streams, both explicitly marked when blank: comfy-cli splits its
         # diagnostics unpredictably (a Python traceback lands on stderr, a
@@ -1090,6 +1099,7 @@ def _unwrap_envelope(
             f"comfy-cli returned no JSON (exit {returncode}). "
             f"stderr: {_stream_tail(stderr)} | stdout: {_stream_tail(stdout)}",
             no_envelope=True,
+            returncode=returncode,
         )
     # A declared schema must be a recognized ``envelope/<N>`` whose major matches.
     # Absent schema -> assume compatible (older comfy-cli); declared-but-unparseable
@@ -1642,6 +1652,11 @@ def _check_comfy_cli_version() -> dict:
     return report
 
 
+# `click.UsageError.exit_code` — the status Click exits with when its parser
+# rejects the command line (an unknown subcommand, a bad option) before
+# dispatching to any command body. Typer inherits it.
+_CLICK_USAGE_ERROR_EXIT = 2
+
 # Click/Typer's "No such command '<verb>'." usage error, made robust to the ways
 # that text arrives mangled. `\s+` between the words (not a literal space)
 # because rich renders Typer errors inside a bordered panel and wraps them at the
@@ -1650,14 +1665,18 @@ def _check_comfy_cli_version() -> dict:
 # `_normalize_cli_text` first. The verb follows within a few non-word characters
 # (the quotes/colon/period around it) and must END there: `\b` would treat the
 # hyphen in a DIFFERENT command like `outdated-notifier` as a word boundary and
-# match it, so `(?![\w-])` requires a real delimiter. See
+# match it, so `(?![\w-])` requires a real delimiter. At least one separator,
+# since Click always writes a space and a quote there. See
 # `_is_missing_verb_error`.
-_MISSING_VERB_RE_TEMPLATE = r"no\s+such\s+command\W{{0,8}}{verb}(?![\w-])"
+_MISSING_VERB_RE_TEMPLATE = r"no\s+such\s+command\W{{1,8}}{verb}(?![\w-])"
 
 # A CSI escape sequence (`\x1b[...m` and friends). Rich colourizes its error
 # panels, and those codes contain word characters (digits, `m`), so leaving them
 # in would let styling land between the matched words and defeat the pattern.
-_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+# The parameter-byte class is ECMA-48's full 0x30-0x3F range, not just `[0-9;]`:
+# colon-separated SGR (`\x1b[38:5:130m`, true-colour on many terminals) would
+# otherwise survive stripping and reintroduce the very problem.
+_ANSI_RE = re.compile(r"\x1b\[[0-9:;<=>?]*[ -/]*[@-~]")
 
 # Whitespace, the Unicode Box Drawing block (U+2500-U+257F), and ASCII `|` —
 # i.e. every character rich can use to frame and wrap an error panel.
@@ -1696,6 +1715,17 @@ def _is_missing_verb_error(exc: ComfyCliError, verb: str) -> bool:
     ``error.code`` also yields a null code, and gating on that would let exactly
     the relayed-message case above through.
 
+    ``exc.returncode == 2`` — Click's ``UsageError.exit_code``, i.e. the argument
+    parser rejected the command line before dispatching anything. On its own
+    ``no_envelope`` only says comfy-cli died before emitting JSON, which a verb
+    it DID accept can also do by crashing mid-run; if such a crash happened to
+    print our phrase, the degrade would swallow a genuine failure. Requiring the
+    usage-error status narrows it to "never dispatched". The trade is
+    deliberate and one-directional: a comfy-cli that someday reports an unknown
+    verb with a different exit status just falls through to the raw passthrough
+    below — the pre-existing behaviour, noisy but honest — whereas a wrong
+    ``unsupported`` actively tells the user nothing is broken.
+
     The phrase must also name ``verb`` itself, within a few punctuation
     characters (Click writes ``No such command 'outdated'.``) and ending at a
     real delimiter, so a different command that merely starts with the same
@@ -1703,7 +1733,7 @@ def _is_missing_verb_error(exc: ComfyCliError, verb: str) -> bool:
     anywhere in the message would fold in the same relayed stderr the first
     condition exists to exclude.
     """
-    if not exc.no_envelope:
+    if not exc.no_envelope or exc.returncode != _CLICK_USAGE_ERROR_EXIT:
         return False
     pattern = _MISSING_VERB_RE_TEMPLATE.format(verb=re.escape(verb))
     normalized = _normalize_cli_text(str(exc))

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -514,11 +514,14 @@ class ComfyCliError(RuntimeError):
     report structurally?" must check this flag rather than ``code is None``.
     :func:`_is_missing_verb_error` is exactly that caller.
 
-    ``returncode`` is the child's exit status on that same no-envelope path
-    (``None`` elsewhere). It distinguishes *how* comfy-cli failed without an
-    envelope — a usage error the argument parser rejected before dispatch versus
-    a crash partway through a command it did accept — which the message text
-    alone cannot tell you.
+    ``returncode`` is the child's exit status wherever :func:`_unwrap_envelope`
+    knows it — on the no-envelope path AND on an error envelope — so it is
+    genuinely independent of ``no_envelope`` rather than a proxy for it. It
+    distinguishes *how* comfy-cli failed: a usage error the argument parser
+    rejected before dispatch versus a failure partway through a command it did
+    accept, which the message text alone cannot tell you. It stays ``None`` for
+    the failures raised without ever reading a child's status (missing binary,
+    timeout).
     """
 
     def __init__(
@@ -1156,7 +1159,7 @@ def _unwrap_envelope(
         detail_str = _render_error_details(err.get("details"))
         if detail_str:
             parts.append(detail_str)
-        raise ComfyCliError("\n".join(parts), code=code)
+        raise ComfyCliError("\n".join(parts), code=code, returncode=returncode)
     return envelope.get("data")
 
 
@@ -1665,10 +1668,12 @@ _CLICK_USAGE_ERROR_EXIT = 2
 # `_normalize_cli_text` first. The verb follows within a few non-word characters
 # (the quotes/colon/period around it) and must END there: `\b` would treat the
 # hyphen in a DIFFERENT command like `outdated-notifier` as a word boundary and
-# match it, so `(?![\w-])` requires a real delimiter. At least one separator,
-# since Click always writes a space and a quote there. See
+# match it, so the lookahead rejects every character a command name could
+# continue with — `\w` plus the `.`, `:`, `/`, `-` that appear in namespaced or
+# hyphenated verbs — and `outdated.foo` no longer reads as `outdated`. At least
+# one separator, since Click always writes a space and a quote there. See
 # `_is_missing_verb_error`.
-_MISSING_VERB_RE_TEMPLATE = r"no\s+such\s+command\W{{1,8}}{verb}(?![\w-])"
+_MISSING_VERB_RE_TEMPLATE = r"no\s+such\s+command\W{{1,8}}{verb}(?![\w.:/-])"
 
 # A CSI escape sequence (`\x1b[...m` and friends). Rich colourizes its error
 # panels, and those codes contain word characters (digits, `m`), so leaving them
@@ -1725,6 +1730,22 @@ def _is_missing_verb_error(exc: ComfyCliError, verb: str) -> bool:
     verb with a different exit status just falls through to the raw passthrough
     below — the pre-existing behaviour, noisy but honest — whereas a wrong
     ``unsupported`` actively tells the user nothing is broken.
+
+    Two residuals are known and accepted, both bounded by the conditions above:
+
+    - Exit 2 is Click's status for ANY ``UsageError``, including one a command
+      body raises after dispatch, so it does not *strictly* prove the parser
+      rejected the verb. To reach a false ``unsupported`` through that door a
+      recognized ``comfy outdated`` would have to raise a usage error mid-run,
+      emit no envelope, AND print "no such command" naming ``outdated`` itself
+      with a closing delimiter — i.e. reproduce the parser's own message about
+      its own name. No further heuristic buys much here; the alternative is
+      pattern-matching Click's usage preamble, which a mid-run ``UsageError``
+      also prints.
+    - The message this reads is built from bounded stream tails, so a wide rich
+      panel could in principle push the phrase out of the slice. Click prints
+      the error line LAST and the tail is what's kept, so it lands inside; if it
+      ever did not, the miss fails toward the raw passthrough.
 
     The phrase must also name ``verb`` itself, within a few punctuation
     characters (Click writes ``No such command 'outdated'.``) and ending at a

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -504,11 +504,24 @@ class ComfyCliError(RuntimeError):
     itself (missing binary, timeout, no-JSON output), so callers can branch on a
     specific code without string-matching the message — e.g. ``get_logs``
     swallows ``no_log_file`` but re-raises the rest.
+
+    ``no_envelope`` is the stronger, unambiguous provenance signal: ``True`` only
+    when comfy-cli ran to completion and emitted NO envelope at all. A null
+    ``code`` does NOT imply that — a well-formed error envelope may simply omit
+    ``error.code`` — so a caller asking "did comfy-cli fail *before* it could
+    report structurally?" must check this flag rather than ``code is None``.
+    :func:`_is_missing_verb_error` is exactly that caller.
     """
 
-    def __init__(self, *args: object, code: str | None = None) -> None:
+    def __init__(
+        self,
+        *args: object,
+        code: str | None = None,
+        no_envelope: bool = False,
+    ) -> None:
         super().__init__(*args)
         self.code = code
+        self.no_envelope = no_envelope
 
 
 def _comfy_bin_candidates() -> list[str]:
@@ -1015,11 +1028,13 @@ def _unwrap_envelope(
             raise ComfyCliError(
                 f"comfy-cli could not run (exit {returncode}).\n\n"
                 f"{_tcc_guidance(_tcc_path_from(stderr))}\n\n"
-                f"Original error: {_tail(stderr)}"
+                f"Original error: {_tail(stderr)}",
+                no_envelope=True,
             )
         raise ComfyCliError(
             f"comfy-cli returned no JSON (exit {returncode}). "
-            f"stderr: {stderr.strip()[:500]}"
+            f"stderr: {stderr.strip()[:500]}",
+            no_envelope=True,
         )
     # A declared schema must be a recognized ``envelope/<N>`` whose major matches.
     # Absent schema -> assume compatible (older comfy-cli); declared-but-unparseable
@@ -1524,14 +1539,22 @@ def _check_comfy_cli_version() -> dict:
     return report
 
 
-# Click/Typer's "No such command '<verb>'." usage error, made robust to the two
-# ways that text arrives mangled. `\s+` between the words (not a literal space)
+# Click/Typer's "No such command '<verb>'." usage error, made robust to the ways
+# that text arrives mangled. `\s+` between the words (not a literal space)
 # because rich renders Typer errors inside a bordered panel and wraps them at the
 # terminal width, so a newline can land mid-phrase; the box-drawing characters
-# that wrapping introduces are stripped by `_normalize_cli_text` first. The verb
-# must follow within a few non-word characters (the quotes/colon/period around
-# it) — see `_is_missing_verb_error`.
-_MISSING_VERB_RE_TEMPLATE = r"no\s+such\s+command\W{{0,8}}{verb}\b"
+# and ANSI colour codes that wrapping and styling introduce are stripped by
+# `_normalize_cli_text` first. The verb follows within a few non-word characters
+# (the quotes/colon/period around it) and must END there: `\b` would treat the
+# hyphen in a DIFFERENT command like `outdated-notifier` as a word boundary and
+# match it, so `(?![\w-])` requires a real delimiter. See
+# `_is_missing_verb_error`.
+_MISSING_VERB_RE_TEMPLATE = r"no\s+such\s+command\W{{0,8}}{verb}(?![\w-])"
+
+# A CSI escape sequence (`\x1b[...m` and friends). Rich colourizes its error
+# panels, and those codes contain word characters (digits, `m`), so leaving them
+# in would let styling land between the matched words and defeat the pattern.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
 
 # Whitespace, the Unicode Box Drawing block (U+2500-U+257F), and ASCII `|` —
 # i.e. every character rich can use to frame and wrap an error panel.
@@ -1539,15 +1562,16 @@ _PANEL_NOISE_RE = re.compile(r"[\s─-╿|]+")
 
 
 def _normalize_cli_text(text: str) -> str:
-    """Lowercased text with panel borders and wrapping collapsed to single spaces.
+    """Lowercased text with ANSI, panel borders, and wrapping folded away.
 
     Typer renders errors inside a rich panel when rich is installed, so the raw
-    stderr of a usage error can read ``"│ No such command\\n│ 'outdated'. │"``.
-    Folding the border glyphs and any run of whitespace into one space puts that
-    back on a single line, so a phrase match cannot be defeated by the terminal
-    width the child happened to render at.
+    stderr of a usage error can read ``"│ No such command\\n│ 'outdated'. │"``,
+    optionally colourized. Dropping the escape sequences and folding the border
+    glyphs and any run of whitespace into one space puts that back on a single
+    plain line, so a phrase match cannot be defeated by the terminal width the
+    child happened to render at, or by whether it decided to emit colour.
     """
-    return _PANEL_NOISE_RE.sub(" ", text).strip().lower()
+    return _PANEL_NOISE_RE.sub(" ", _ANSI_RE.sub("", text)).strip().lower()
 
 
 def _is_missing_verb_error(exc: ComfyCliError, verb: str) -> bool:
@@ -1557,22 +1581,26 @@ def _is_missing_verb_error(exc: ComfyCliError, verb: str) -> bool:
     NOTHING is broken: a false positive here silently buries a real failure.
     Two independent conditions must both hold.
 
-    ``exc.code is None`` — an error envelope carries a structured ``error.code``
-    (see :class:`ComfyCliError`), and an envelope means comfy-cli *recognized*
-    the verb, ran it, and reported why it failed. A missing verb never gets that
-    far: Click aborts with a usage error and exit 2 before any envelope is
-    emitted, so the failure can only reach us via the wrapper-raised "returned
-    no JSON" path, where ``code`` is ``None``. This is what stops a relayed
+    ``exc.no_envelope`` — comfy-cli emitted no envelope at all. An envelope, even
+    a codeless one, means comfy-cli *recognized* the verb, ran it, and reported
+    why it failed. A missing verb never gets that far: Click aborts with a usage
+    error before any envelope is emitted, so the failure can only reach us via
+    the wrapper-raised "returned no JSON" path. This is what stops a relayed
     nested error — a git/pip call, a custom-node pack name, a registry response
     that happens to contain "no such command" — from being mistaken for the verb
-    itself being absent.
+    itself being absent. Note this is checked instead of ``exc.code is None``,
+    which looks equivalent but is not: an error envelope that merely omits
+    ``error.code`` also yields a null code, and gating on that would let exactly
+    the relayed-message case above through.
 
     The phrase must also name ``verb`` itself, within a few punctuation
-    characters (Click writes ``No such command 'outdated'.``). Matching the bare
-    phrase anywhere in the message would fold in the same relayed stderr the
-    first condition exists to exclude.
+    characters (Click writes ``No such command 'outdated'.``) and ending at a
+    real delimiter, so a different command that merely starts with the same
+    letters — ``outdated-notifier`` — does not match. Matching the bare phrase
+    anywhere in the message would fold in the same relayed stderr the first
+    condition exists to exclude.
     """
-    if exc.code is not None:
+    if not exc.no_envelope:
         return False
     pattern = _MISSING_VERB_RE_TEMPLATE.format(verb=re.escape(verb))
     normalized = _normalize_cli_text(str(exc))

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -1528,21 +1528,47 @@ def _freshness_report() -> Any:
     """Best-effort installed-vs-latest report via ``comfy outdated``.
 
     Returns the ``comfy outdated`` payload (``core`` install status, one row per
-    custom node ``packs`` entry, ``checked_at``) on success. On ANY
-    :class:`ComfyCliError` — the verb missing on an older comfy-cli, the network
-    lookup down, a timeout — returns ``{"error": "<reason>"}`` instead of
-    raising, so the probe can never take ``server_info`` down with it.
-    ``OSError`` is caught for the same reason: a spawn failure on this second
-    subprocess (the env probe already succeeded) is still just the freshness
-    probe failing, never grounds to fail ``server_info``. ``UnicodeDecodeError``
-    is caught too: ``_run_comfy_raw`` decodes the child's stdout with strict
-    ``encoding="utf-8"`` (no ``errors="replace"``), so non-UTF-8 bytes in a
-    pack name/path from the user's live custom-node install can raise it here,
-    same as the other probe failures above.
+    custom node ``packs`` entry, ``checked_at``) on success. It never raises, so
+    the probe can never take ``server_info`` down with it; it degrades to one of
+    two shapes instead.
+
+    The MISSING-VERB degrade is its own shape: ``comfy outdated`` does not exist
+    on any released comfy-cli (through 1.12.0), so on those installs this probe
+    fails every time — and Click/Typer's raw ``No such command 'outdated'.``
+    usage dump, relayed verbatim, reads like a broken MCP rather than the benign
+    capability gap it is. That case returns
+    ``{"error": "freshness unavailable: ...", "unsupported": True}``, with
+    ``unsupported`` machine-readable so a client can branch on it without
+    matching strings.
+
+    EVERY OTHER failure keeps the raw ``{"error": "<reason>"}`` passthrough — for
+    a network failure, a timeout, or a decode error the underlying reason IS the
+    diagnostic, so relaying it is the useful thing to do. ``OSError`` is caught
+    because a spawn failure on this second subprocess (the env probe already
+    succeeded) is still just the freshness probe failing, never grounds to fail
+    ``server_info``. ``UnicodeDecodeError`` is caught too: ``_run_comfy_raw``
+    decodes the child's stdout with strict ``encoding="utf-8"`` (no
+    ``errors="replace"``), so non-UTF-8 bytes in a pack name/path from the
+    user's live custom-node install can raise it here, same as the other probe
+    failures above.
     """
     try:
         return _run_comfy("outdated", timeout=15.0)
     except (ComfyCliError, OSError, UnicodeDecodeError) as exc:
+        # Click/Typer emits `No such command 'outdated'.` on stderr, which
+        # `_unwrap_envelope` embeds in the raised message via its stderr tail.
+        # Match on that phrase alone, NOT on a quoted `'outdated'`: rich-formatted
+        # Typer output can wrap lines inside its error panel, and any "no such
+        # command" raised from a `comfy outdated` invocation is unambiguous.
+        if isinstance(exc, ComfyCliError) and "no such command" in str(exc).lower():
+            return {
+                "error": (
+                    "freshness unavailable: the installed comfy-cli does not support "
+                    "'comfy outdated' (the verb ships in releases after 1.12.0). "
+                    "Workflows are unaffected; update checks were skipped."
+                ),
+                "unsupported": True,
+            }
         return {"error": str(exc)}
 
 
@@ -1584,9 +1610,16 @@ def server_info() -> Any:
     node, or template seems missing, tell the user to update FIRST
     (``comfy update comfy`` for core, ``comfy node update <pack>`` for a pack)
     before concluding the catalog lacks it; silent staleness is the usual
-    culprit. The probe is best-effort: on a comfy-cli without the ``outdated``
-    verb, a network failure, or a timeout, ``freshness`` degrades to
-    ``{"error": "<reason>"}`` — ``server_info`` itself still succeeds.
+    culprit. The probe is best-effort and degrades two ways — ``server_info``
+    itself still succeeds either way. On a comfy-cli that lacks the ``outdated``
+    verb (no release through 1.12.0 has it), ``freshness`` is
+    ``{"error": "freshness unavailable: ...", "unsupported": true}``:
+    ``unsupported: true`` means SKIP staleness advice entirely and do NOT tell
+    the user anything is broken — nothing failed, this comfy-cli just cannot
+    answer the question, and workflows are unaffected. On any other probe
+    failure (a network failure, a timeout, a decode error) ``freshness`` is
+    ``{"error": "<reason>"}`` with no ``unsupported`` key, and that reason is
+    the real diagnostic.
 
     Remote target: when a remote ComfyUI is configured (``COMFYUI_URL`` or
     ``COMFYUI_HOST`` — see :func:`_comfy_target`), a ``comfy_target`` block is

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -1524,6 +1524,61 @@ def _check_comfy_cli_version() -> dict:
     return report
 
 
+# Click/Typer's "No such command '<verb>'." usage error, made robust to the two
+# ways that text arrives mangled. `\s+` between the words (not a literal space)
+# because rich renders Typer errors inside a bordered panel and wraps them at the
+# terminal width, so a newline can land mid-phrase; the box-drawing characters
+# that wrapping introduces are stripped by `_normalize_cli_text` first. The verb
+# must follow within a few non-word characters (the quotes/colon/period around
+# it) — see `_is_missing_verb_error`.
+_MISSING_VERB_RE_TEMPLATE = r"no\s+such\s+command\W{{0,8}}{verb}\b"
+
+# Whitespace, the Unicode Box Drawing block (U+2500-U+257F), and ASCII `|` —
+# i.e. every character rich can use to frame and wrap an error panel.
+_PANEL_NOISE_RE = re.compile(r"[\s─-╿|]+")
+
+
+def _normalize_cli_text(text: str) -> str:
+    """Lowercased text with panel borders and wrapping collapsed to single spaces.
+
+    Typer renders errors inside a rich panel when rich is installed, so the raw
+    stderr of a usage error can read ``"│ No such command\\n│ 'outdated'. │"``.
+    Folding the border glyphs and any run of whitespace into one space puts that
+    back on a single line, so a phrase match cannot be defeated by the terminal
+    width the child happened to render at.
+    """
+    return _PANEL_NOISE_RE.sub(" ", text).strip().lower()
+
+
+def _is_missing_verb_error(exc: ComfyCliError, verb: str) -> bool:
+    """Is *exc* comfy-cli rejecting ``verb`` as unknown, rather than *running* it?
+
+    Deliberately narrow, because the caller's degrade tells the agent that
+    NOTHING is broken: a false positive here silently buries a real failure.
+    Two independent conditions must both hold.
+
+    ``exc.code is None`` — an error envelope carries a structured ``error.code``
+    (see :class:`ComfyCliError`), and an envelope means comfy-cli *recognized*
+    the verb, ran it, and reported why it failed. A missing verb never gets that
+    far: Click aborts with a usage error and exit 2 before any envelope is
+    emitted, so the failure can only reach us via the wrapper-raised "returned
+    no JSON" path, where ``code`` is ``None``. This is what stops a relayed
+    nested error — a git/pip call, a custom-node pack name, a registry response
+    that happens to contain "no such command" — from being mistaken for the verb
+    itself being absent.
+
+    The phrase must also name ``verb`` itself, within a few punctuation
+    characters (Click writes ``No such command 'outdated'.``). Matching the bare
+    phrase anywhere in the message would fold in the same relayed stderr the
+    first condition exists to exclude.
+    """
+    if exc.code is not None:
+        return False
+    pattern = _MISSING_VERB_RE_TEMPLATE.format(verb=re.escape(verb))
+    normalized = _normalize_cli_text(str(exc))
+    return re.search(pattern, normalized, re.IGNORECASE) is not None
+
+
 def _freshness_report() -> Any:
     """Best-effort installed-vs-latest report via ``comfy outdated``.
 
@@ -1539,7 +1594,10 @@ def _freshness_report() -> Any:
     capability gap it is. That case returns
     ``{"error": "freshness unavailable: ...", "unsupported": True}``, with
     ``unsupported`` machine-readable so a client can branch on it without
-    matching strings.
+    matching strings. :func:`_is_missing_verb_error` decides that case, and is
+    deliberately strict: this degrade asserts nothing is broken, so a failure
+    that merely *relays* a "no such command" from somewhere else must keep the
+    raw passthrough below rather than be waved through as a capability gap.
 
     EVERY OTHER failure keeps the raw ``{"error": "<reason>"}`` passthrough — for
     a network failure, a timeout, or a decode error the underlying reason IS the
@@ -1556,11 +1614,11 @@ def _freshness_report() -> Any:
         return _run_comfy("outdated", timeout=15.0)
     except (ComfyCliError, OSError, UnicodeDecodeError) as exc:
         # Click/Typer emits `No such command 'outdated'.` on stderr, which
-        # `_unwrap_envelope` embeds in the raised message via its stderr tail.
-        # Match on that phrase alone, NOT on a quoted `'outdated'`: rich-formatted
-        # Typer output can wrap lines inside its error panel, and any "no such
-        # command" raised from a `comfy outdated` invocation is unambiguous.
-        if isinstance(exc, ComfyCliError) and "no such command" in str(exc).lower():
+        # `_unwrap_envelope` embeds in the raised message. `_is_missing_verb_error`
+        # keeps that detection narrow — a relayed nested error that merely quotes
+        # the same phrase must NOT reach this degrade, which claims nothing is
+        # wrong.
+        if isinstance(exc, ComfyCliError) and _is_missing_verb_error(exc, "outdated"):
             return {
                 "error": (
                     "freshness unavailable: the installed comfy-cli does not support "

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -508,6 +508,63 @@ def test_server_info_freshness_relayed_phrase_is_not_unsupported(
     assert "freshness unavailable" not in result["freshness"]["error"]
 
 
+def test_server_info_freshness_envelope_at_exit_two_is_not_unsupported(
+    patched_env_then_outdated,
+):
+    """An error envelope at Click's usage-error status still proves the verb ran.
+
+    Pins the `no_envelope` half of the gate INDEPENDENTLY of the exit code:
+    every other envelope-present negative here exits 1, so the exit-code check
+    alone would reject them and the provenance condition would go untested. A
+    comfy-cli that HAS `outdated` can reject one of its options and report that
+    structurally at exit 2 — only the absence of an envelope means the parser
+    never dispatched.
+    """
+    import json
+
+    error_envelope = {
+        "schema": "envelope/1",
+        "type": "envelope",
+        "ok": False,
+        "error": {
+            "code": "bad_option",
+            "message": "No such command 'outdated' handler registered for --json",
+        },
+    }
+    patched_env_then_outdated(
+        [(0, json.dumps(_ENV_ENVELOPE), ""), (2, json.dumps(error_envelope), "")]
+    )
+
+    result = server.server_info()
+
+    assert "unsupported" not in result["freshness"]
+    assert "bad_option" in result["freshness"]["error"]
+
+
+def test_server_info_freshness_dotted_command_is_not_unsupported(
+    patched_env_then_outdated,
+):
+    """`No such command 'outdated.foo'` is a different command, not our verb.
+
+    The lookahead must reject every character a command name can continue with,
+    not just word characters and the hyphen — a `.` would otherwise let the
+    `outdated` prefix match and discard a real diagnostic.
+    """
+    import json
+
+    patched_env_then_outdated(
+        [
+            (0, json.dumps(_ENV_ENVELOPE), ""),
+            (2, "", "Error: No such command 'outdated.foo'."),
+        ]
+    )
+
+    result = server.server_info()
+
+    assert "unsupported" not in result["freshness"]
+    assert "outdated.foo" in result["freshness"]["error"]
+
+
 def test_server_info_freshness_midrun_crash_is_not_unsupported(
     patched_env_then_outdated,
 ):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -463,8 +463,8 @@ def test_server_info_freshness_relayed_phrase_is_not_unsupported(
     quotes a nested tool's own "no such command" (a git/pip call, a custom-node
     pack's install script, a relayed registry response). Classifying that as
     `unsupported` would tell the agent to skip staleness advice and reassure the
-    user that nothing is broken — masking a genuine failure. The envelope's
-    structured `error.code` proves the verb ran, so it must pass through.
+    user that nothing is broken — masking a genuine failure. The presence of an
+    envelope at all proves the verb ran, so it must pass through.
     """
     import json
 
@@ -486,6 +486,81 @@ def test_server_info_freshness_relayed_phrase_is_not_unsupported(
     assert "unsupported" not in result["freshness"]
     assert "pack_probe_failed" in result["freshness"]["error"]
     assert "freshness unavailable" not in result["freshness"]["error"]
+
+
+def test_server_info_freshness_codeless_envelope_is_not_unsupported(
+    patched_env_then_outdated,
+):
+    """An error envelope that OMITS `error.code` still proves the verb ran.
+
+    A null `code` is not evidence of a missing verb — `_unwrap_envelope` leaves
+    it `None` whenever an otherwise well-formed error envelope has no `code`
+    field. Gating on `code is None` would misread this genuine failure as the
+    benign capability gap; `no_envelope` is the signal that actually holds.
+    """
+    import json
+
+    codeless_envelope = {
+        "schema": "envelope/1",
+        "type": "envelope",
+        "ok": False,
+        "error": {"message": "No such command 'outdated' in the pack's hook script"},
+    }
+    patched_env_then_outdated(
+        [(0, json.dumps(_ENV_ENVELOPE), ""), (1, json.dumps(codeless_envelope), "")]
+    )
+
+    result = server.server_info()
+
+    assert "unsupported" not in result["freshness"]
+    assert "hook script" in result["freshness"]["error"]
+    assert "freshness unavailable" not in result["freshness"]["error"]
+
+
+def test_server_info_freshness_hyphenated_command_is_not_unsupported(
+    patched_env_then_outdated,
+):
+    """`No such command 'outdated-notifier'` is a DIFFERENT command, not our verb.
+
+    A trailing `\\b` would treat the hyphen as a word boundary and match the
+    `outdated` prefix, discarding a real diagnostic about some other command.
+    """
+    import json
+
+    patched_env_then_outdated(
+        [
+            (0, json.dumps(_ENV_ENVELOPE), ""),
+            (2, "", "Error: No such command 'outdated-notifier'."),
+        ]
+    )
+
+    result = server.server_info()
+
+    assert "unsupported" not in result["freshness"]
+    assert "outdated-notifier" in result["freshness"]["error"]
+
+
+def test_server_info_freshness_missing_verb_survives_ansi_colour(
+    patched_env_then_outdated,
+):
+    """Colourized rich output still degrades cleanly.
+
+    Rich styles its error panel with ANSI escapes, whose bytes include word
+    characters (digits, `m`). Left in place they land between the matched words
+    and defeat the pattern, leaking the raw usage dump.
+    """
+    import json
+
+    coloured = (
+        "\x1b[31mError\x1b[0m: \x1b[1mNo such\x1b[0m \x1b[1mcommand\x1b[0m "
+        "\x1b[33m'outdated'\x1b[0m."
+    )
+    patched_env_then_outdated([(0, json.dumps(_ENV_ENVELOPE), ""), (2, "", coloured)])
+
+    result = server.server_info()
+
+    assert result["freshness"]["unsupported"] is True
+    assert "freshness unavailable" in result["freshness"]["error"]
 
 
 def test_server_info_freshness_unknown_other_verb_is_not_unsupported(

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -508,6 +508,56 @@ def test_server_info_freshness_relayed_phrase_is_not_unsupported(
     assert "freshness unavailable" not in result["freshness"]["error"]
 
 
+def test_server_info_freshness_midrun_crash_is_not_unsupported(
+    patched_env_then_outdated,
+):
+    """A crash in a verb comfy-cli DID accept keeps its raw diagnostic.
+
+    Emitting no envelope only proves comfy-cli died before it could report
+    structurally — a recognized verb can do that too by crashing mid-run. Click
+    exits 2 only when its parser rejected the command line before dispatch, so a
+    no-envelope failure at any other status is a real failure, even when its
+    output happens to quote the missing-verb phrase.
+    """
+    import json
+
+    patched_env_then_outdated(
+        [
+            (0, json.dumps(_ENV_ENVELOPE), ""),
+            (1, "", "Traceback...\nRuntimeError: No such command 'outdated' in hook"),
+        ]
+    )
+
+    result = server.server_info()
+
+    assert "unsupported" not in result["freshness"]
+    assert "Traceback" in result["freshness"]["error"]
+    assert "freshness unavailable" not in result["freshness"]["error"]
+
+
+def test_server_info_freshness_missing_verb_survives_colon_sgr(
+    patched_env_then_outdated,
+):
+    """Colon-separated SGR (`\\x1b[38:5:130m`) is stripped like any other CSI.
+
+    ECMA-48 allows `:<=>` in CSI parameter bytes, and terminals do emit the
+    colon form for true-colour. A parameter class of only `[0-9;]` would leave
+    those bytes in place, defeating the match and leaking the raw usage dump.
+    """
+    import json
+
+    coloured = (
+        "\x1b[38:5:130mError\x1b[0m: No such \x1b[38:2:255:0:0mcommand\x1b[0m "
+        "'outdated'."
+    )
+    patched_env_then_outdated([(0, json.dumps(_ENV_ENVELOPE), ""), (2, "", coloured)])
+
+    result = server.server_info()
+
+    assert result["freshness"]["unsupported"] is True
+    assert "freshness unavailable" in result["freshness"]["error"]
+
+
 def test_server_info_freshness_missing_verb_on_stdout(patched_env_then_outdated):
     """The usage error degrades cleanly whichever stream Click wrote it to.
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -377,7 +377,14 @@ def test_server_info_attaches_freshness_block(patched_env_then_outdated):
 
 
 def test_server_info_freshness_degrades_on_missing_verb(patched_env_then_outdated):
-    """An older comfy-cli without `outdated` -> freshness.error, tool still succeeds."""
+    """A comfy-cli without `outdated` -> the purpose-built `unsupported` degrade.
+
+    Every released comfy-cli (through 1.12.0) lacks the verb, so this is the
+    COMMON path, not an edge case. It must read as a capability gap rather than
+    a failure of this server: no raw Click/Typer usage dump, no "returned no
+    JSON" wrapper text, and a machine-readable `unsupported` flag so a client
+    can branch without string-matching.
+    """
     import json
 
     patched_env_then_outdated(
@@ -391,8 +398,55 @@ def test_server_info_freshness_degrades_on_missing_verb(patched_env_then_outdate
 
     assert result["running"] is True  # env data intact — the probe never breaks it
     assert "compatibility" in result
-    assert set(result["freshness"]) == {"error"}
-    assert "No such command 'outdated'" in result["freshness"]["error"]
+    assert result["freshness"]["unsupported"] is True
+    assert "freshness unavailable" in result["freshness"]["error"]
+    # The raw wrapper/CLI text no longer leaks through.
+    assert "returned no JSON" not in result["freshness"]["error"]
+    assert "No such command" not in result["freshness"]["error"]
+    assert "Usage: comfy" not in result["freshness"]["error"]
+
+
+def test_server_info_freshness_missing_verb_match_is_case_insensitive(
+    patched_env_then_outdated,
+):
+    """`Error: no such command 'outdated'` (lowercase) also degrades cleanly."""
+    import json
+
+    patched_env_then_outdated(
+        [
+            (0, json.dumps(_ENV_ENVELOPE), ""),
+            (2, "", "Error: no such command 'outdated'"),
+        ]
+    )
+
+    result = server.server_info()
+
+    assert result["freshness"]["unsupported"] is True
+    assert "freshness unavailable" in result["freshness"]["error"]
+
+
+def test_server_info_freshness_passes_through_other_errors(patched_env_then_outdated):
+    """A NON-missing-verb spawn failure keeps the raw reason and no `unsupported`.
+
+    The special case above is deliberately narrow: for a network failure the raw
+    reason IS the diagnostic, so it must still reach the caller verbatim.
+    """
+    import json
+
+    patched_env_then_outdated(
+        [
+            (0, json.dumps(_ENV_ENVELOPE), ""),
+            (1, "", "network unreachable"),
+        ]
+    )
+
+    result = server.server_info()
+
+    assert result["running"] is True
+    assert set(result["freshness"]) == {"error"}  # no `unsupported` key
+    assert "unsupported" not in result["freshness"]
+    assert "network unreachable" in result["freshness"]["error"]
+    assert "freshness unavailable" not in result["freshness"]["error"]
 
 
 def test_server_info_freshness_degrades_on_error_envelope(patched_env_then_outdated):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -425,6 +425,88 @@ def test_server_info_freshness_missing_verb_match_is_case_insensitive(
     assert "freshness unavailable" in result["freshness"]["error"]
 
 
+def test_server_info_freshness_missing_verb_survives_panel_wrapping(
+    patched_env_then_outdated,
+):
+    """A rich panel that wraps the phrase mid-line still degrades cleanly.
+
+    Typer renders errors inside a bordered rich panel and wraps at the terminal
+    width, so `No such command` and `'outdated'` can land on separate lines with
+    box-drawing glyphs between them. Matching a literal one-line phrase would
+    miss this and leak the raw usage dump — the exact outcome this degrade
+    exists to prevent.
+    """
+    import json
+
+    wrapped_panel = (
+        "╭─ Error ─────────────────────────╮\n"
+        "│ No such command\n"
+        "│ 'outdated'.                     │\n"
+        "╰─────────────────────────────────╯"
+    )
+    patched_env_then_outdated(
+        [(0, json.dumps(_ENV_ENVELOPE), ""), (2, "", wrapped_panel)]
+    )
+
+    result = server.server_info()
+
+    assert result["freshness"]["unsupported"] is True
+    assert "freshness unavailable" in result["freshness"]["error"]
+
+
+def test_server_info_freshness_relayed_phrase_is_not_unsupported(
+    patched_env_then_outdated,
+):
+    """A REAL failure relaying "no such command" keeps its raw diagnostic.
+
+    A comfy-cli that HAS the verb can fail with an error envelope whose message
+    quotes a nested tool's own "no such command" (a git/pip call, a custom-node
+    pack's install script, a relayed registry response). Classifying that as
+    `unsupported` would tell the agent to skip staleness advice and reassure the
+    user that nothing is broken — masking a genuine failure. The envelope's
+    structured `error.code` proves the verb ran, so it must pass through.
+    """
+    import json
+
+    error_envelope = {
+        "schema": "envelope/1",
+        "type": "envelope",
+        "ok": False,
+        "error": {
+            "code": "pack_probe_failed",
+            "message": "git: 'no such command' while probing pack 'outdated-notifier'",
+        },
+    }
+    patched_env_then_outdated(
+        [(0, json.dumps(_ENV_ENVELOPE), ""), (1, json.dumps(error_envelope), "")]
+    )
+
+    result = server.server_info()
+
+    assert "unsupported" not in result["freshness"]
+    assert "pack_probe_failed" in result["freshness"]["error"]
+    assert "freshness unavailable" not in result["freshness"]["error"]
+
+
+def test_server_info_freshness_unknown_other_verb_is_not_unsupported(
+    patched_env_then_outdated,
+):
+    """ "No such command" naming a DIFFERENT verb is not our capability gap."""
+    import json
+
+    patched_env_then_outdated(
+        [
+            (0, json.dumps(_ENV_ENVELOPE), ""),
+            (2, "", "Error: No such command 'git-lfs'."),
+        ]
+    )
+
+    result = server.server_info()
+
+    assert "unsupported" not in result["freshness"]
+    assert "git-lfs" in result["freshness"]["error"]
+
+
 def test_server_info_freshness_passes_through_other_errors(patched_env_then_outdated):
     """A NON-missing-verb spawn failure keeps the raw reason and no `unsupported`.
 


### PR DESCRIPTION
## ELI-5

When you ask `server_info` "is my ComfyUI up to date?", it asks comfy-cli by running `comfy outdated`. That command only exists on comfy-cli's `main` branch — no released version has it — so on basically everyone's machine that question comes back as a scary-looking crash dump. Nothing was actually broken; comfy-cli just doesn't know that word yet. This PR replaces the crash dump with a plain sentence that says "I couldn't check for updates on this comfy-cli, and that's fine — your workflows are unaffected", plus a `unsupported: true` flag so an agent can tell "couldn't check" apart from "something failed" without reading the sentence.

## Summary

`server_info`'s best-effort `freshness` probe (`comfy outdated`) degraded to a raw comfy-cli error dump on every *released* comfy-cli, because the `outdated` verb only exists on comfy-cli `main` (added 2026-07-22, commit `9004f80`) and has never shipped in a tagged release. The failure was benign — `server_info` itself succeeded, exactly as designed — but the message read like a failure of the MCP:

```
{"error": "comfy-cli returned no JSON (exit 2). stderr: Usage: comfy [OPTIONS] COMMAND [ARGS]... ... No such command 'outdated'."}
```

This maps that one specific failure to a purpose-built degrade and leaves every other failure's raw reason untouched. Reported by QA.

## Changes

- `_freshness_report()`: inside the existing `except (ComfyCliError, OSError, UnicodeDecodeError)` handler, special-case the missing-verb failure — `isinstance(exc, ComfyCliError)` **and** a case-insensitive `"no such command"` substring match — and return `{"error": "freshness unavailable: the installed comfy-cli does not support 'comfy outdated' (the verb ships in releases after 1.12.0). Workflows are unaffected; update checks were skipped.", "unsupported": True}`. The `unsupported` flag is machine-readable so MCP clients/agents branch on it rather than string-matching the message.
- Every other exception in that handler keeps the existing `{"error": str(exc)}` passthrough — for a network failure, timeout, or decode error the raw reason IS the diagnostic, so relaying it verbatim is the useful behavior. The special case is deliberately narrow.
- Docstrings: `_freshness_report` now documents both degrade shapes; the `server_info` freshness paragraph describes both and tells the calling agent explicitly that `unsupported: true` means *skip staleness advice and do not tell the user anything is broken*.
- README: the two places that documented the old single `{"error": …}` degrade (the Prerequisites bullet and the tool table row) now describe both shapes — AGENTS.md requires docs stay in sync in the same PR. This was not in the ticket; it was found during self-review.

No new dependencies, no HTTP, no new comfy-cli invocation — the AGENTS.md thin-wrapper guardrails are untouched.

## Motivation

`server_info` is the "call this first" diagnostic. An agent that sees a raw `returned no JSON (exit 2)` dump in its very first tool result reasonably concludes the MCP is broken and starts debugging the install — when in reality the only thing that happened is that the user's comfy-cli predates a verb that has never been released. The degrade already existed (BE-3397's best-effort design worked correctly); only the message quality was wrong.

## Testing

- [x] Existing tests pass (`uv run pytest` — 418 passed, 1 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually (see falsification evidence below)

Test changes in `tests/test_compat.py`:

- `test_server_info_freshness_degrades_on_missing_verb` — reworked. It still simulates exit 2 with `Usage: comfy [OPTIONS] COMMAND\nNo such command 'outdated'.`, but now asserts `freshness.unsupported is True`, `"freshness unavailable" in freshness.error`, and that none of the raw wrapper/CLI text (`returned no JSON`, `No such command`, `Usage: comfy`) leaks through. It still asserts `server_info` succeeds and the `comfy env` data (`running`, `compatibility`) passes through.
- `test_server_info_freshness_passes_through_other_errors` — new. A NON-missing-verb second-spawn failure (exit 1, stderr `network unreachable`, no envelope) yields `freshness == {"error": "<raw ComfyCliError text>"}` with **no** `unsupported` key, proving the special case is narrow.
- `test_server_info_freshness_missing_verb_match_is_case_insensitive` — new. Lowercase `Error: no such command 'outdated'` also produces the `unsupported` shape.

The existing populated-freshness test (`test_server_info_attaches_freshness_block`) is untouched and still passes, so a comfy-cli that *does* have the verb behaves exactly as before.

## Negative-claim falsification

This diff's user-facing outcome denies a capability ("does not support `comfy outdated`"), so per the falsification discipline I went and empirically looked for the capability rather than trusting the ticket's premise. Evidence:

- **Present on `main`:** cloned `Comfy-Org/comfy-cli`; `comfy_cli/command/outdated.py` exists, `comfy_cli/cmdline.py:662` registers the `outdated` verb, and `comfy_cli/discovery.py:101` advertises it. Commit `9004f80` ("feat: add read-only `comfy outdated` verb", 2026-07-22).
- **Absent from the latest release:** `git ls-tree -r v1.12.0` returns no `outdated` path, and `git show v1.12.0:comfy_cli/cmdline.py | grep outdated` is empty. `v1.12.0` (2026-07-07) is the newest release per `gh release list`, and it postdates nothing relevant — the verb landed 15 days after it.
- **No alternative path in a released comfy-cli.** I checked whether any other released verb answers "installed vs latest" so the degrade could redirect there instead of dead-ending. It cannot: at `v1.12.0` the top-level commands are install/update/run/validate/upload/download/stop/launch/logs/setup/set-default/which/discover/env (no read-only freshness verb), and `comfy node show` accepts only `installed|enabled|not-installed|disabled|all|snapshot|snapshot-list` — there is no `updates` target. `comfy update` *performs* an update (mutating), so it is not a substitute for a read-only probe and would be a guardrail breach to call from `server_info` anyway.
- Note the denial here is **conditional on runtime evidence**, not a static premise: this branch only fires when comfy-cli itself answered "no such command" for this exact invocation. If a user's comfy-cli has the verb, the code never reaches it.

## Additional Notes — judgment calls

- **The message says "the verb ships in releases after 1.12.0", and as of today no such release exists yet.** That is accurate but forward-looking: a user who reads it and runs `pip install -U comfy-cli` today will still land on 1.12.0 and still see the degrade. I kept the ticket's prescribed wording verbatim rather than editorializing, since the exact string was specified and the tests assert on it. If you'd rather it said something like "not yet available in any released comfy-cli", that's a one-line change.
- **Detection matches `"no such command"` alone, not `'outdated'`.** Per the ticket: rich-formatted Typer output can wrap lines inside its error panel, so requiring the quoted verb would make the match fragile. Within an error raised from a `comfy outdated` invocation, the phrase is unambiguous. I checked the one nearby false-positive risk — the missing-binary path raises "`comfy` not found on PATH", which does not contain the phrase — and the TCC-denial path, which has its own distinct message. A false negative (unexpected phrasing) simply falls through to the pre-existing passthrough, i.e. today's behavior, so it cannot regress anything.
- **Riskiest line** is the `isinstance` + substring guard: a mislabel would tell an agent "skip staleness advice" when something genuinely failed. Blast radius is contained to the `freshness` block of one read-only diagnostic tool — `server_info` never fails on it, and nothing mutates.
- `_freshness_report` has exactly one call site (`server_info`), so there are no other consumers to update.
