### PR TITLE
fix: redact credentials from every comfy-cli stream tail we surface

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -696,6 +696,77 @@ def _redact_url(url: str) -> str:
     return url
 
 
+# The secret-bearing shapes masked out of any comfy-cli output we echo back.
+# Deliberately STRUCTURED patterns rather than an entropy heuristic: these
+# messages exist to diagnose a crash, so mangling a traceback is a real cost —
+# under-redacting a shape we don't recognize beats over-redacting prose.
+#
+# A credential is only ever masked in a position where it cannot be anything
+# else: after a URL scheme separator, as the value of a known secret query
+# param, as the value of a `--key`-family CLI flag, or after a `Bearer` scheme
+# keyword. None of them can fire on ordinary traceback text.
+#
+# Every pattern starts with a LITERAL (`://`, `?`/`&`, `--`, `bearer`) so the
+# engine can skip ahead to a candidate instead of re-scanning from each
+# position. That matters: an earlier draft anchored the first pattern on the
+# scheme (`[A-Za-z][A-Za-z0-9+.-]*://`), whose leading character class re-scans
+# forward from every offset — quadratic, and it hangs for minutes on a
+# multi-megabyte alphanumeric capture. The scheme is not needed anyway: `://`
+# effectively only occurs in a URL, and the replacement puts it back verbatim.
+_URL_USERINFO_RE = re.compile(r"://[^/\s@]+@")
+_SECRET_QUERY_PARAM_RE = re.compile(
+    r"([?&](?:token|sig|signature|key|api[_-]?key|access[_-]?token"
+    r"|x-amz-signature)=)[^&\s\"'<>]+",
+    re.IGNORECASE,
+)
+# `(?!-)` keeps `--key --verbose` (a flag missing its value) from swallowing the
+# NEXT flag; the separator excludes newlines so a dangling `--key` at end of line
+# can't eat the first word of the following traceback frame.
+_SECRET_FLAG_RE = re.compile(
+    r"(--(?:key|token|api[_-]?key|access[_-]?token)(?:=|[ \t]+))(?!-)\S+",
+    re.IGNORECASE,
+)
+# 16+ chars so a prose "bearer <word>" can't trip it; `Basic`/`Token`/a bare
+# `Authorization:` value are deliberately NOT matched — those keywords are common
+# English ("Basic authentication", "authorization: failed") and masking them
+# would eat the diagnosis instead of a secret.
+_BEARER_TOKEN_RE = re.compile(r"(\bbearer[ \t]+)[A-Za-z0-9._\-+/=]{16,}", re.IGNORECASE)
+
+# How far past a tail's bound :func:`_tail` scans for credentials to mask. Any
+# credential shorter than this that reaches into the kept tail begins inside the
+# window, and signed URLs — the longest shape here — run well under 2k chars.
+_REDACT_LOOKBACK = 4096
+
+
+def _redact_secrets(text: str) -> str:
+    """Mask credential-shaped substrings anywhere in ``text``.
+
+    comfy-cli output reaches the MCP client (an LLM context) and the host logs
+    verbatim through :class:`ComfyCliError`, and a crashing comfy-cli can print
+    secrets: a signed model-download URL carrying a token, or an API key echoed
+    back as part of an argv/usage error. Everything we surface from a captured
+    stream goes through here first.
+
+    Distinct from :func:`_redact_url`, which takes a *whole* URL and masks its
+    netloc by offset arithmetic — over free text that handles only one
+    well-formed URL and is confused by a stray ``@`` in surrounding prose. This
+    one scans arbitrary text and masks every occurrence:
+
+    - URL userinfo (``scheme://user:pass@host`` -> ``scheme://***@host``);
+    - the value of a secret-bearing query param (``?token=…`` -> ``?token=***``);
+    - the value of a ``--key`` / ``--api-key`` / ``--token`` CLI flag, since
+      comfy-cli usage errors echo argv (cf. the ``comfy auth set
+      comfy-cloud-api-key --key …`` hint text this server already forwards);
+    - a ``Bearer <token>`` authorization value.
+
+    Text with none of those shapes — a plain traceback — comes back byte-for-byte.
+    """
+    text = _URL_USERINFO_RE.sub("://***@", text)
+    text = _SECRET_QUERY_PARAM_RE.sub(r"\1***", text)
+    text = _SECRET_FLAG_RE.sub(r"\1***", text)
+    return _BEARER_TOKEN_RE.sub(r"\1***", text)
+
+
 def _strip_brackets(host: str) -> str:
     """Strip surrounding ``[...]`` from a bracketed IPv6 host for consistency.
 
@@ -938,6 +1009,12 @@ def _tail(text: str | bytes | None, limit: int = 500) -> str:
     Windows ``run()`` re-communicates after the kill and returns ``str``), so
     callers can hand us either. The ``limit`` hard-bounds the result so a chatty
     child cannot inflate an error payload.
+
+    Every tail is passed through :func:`_redact_secrets` before it is returned:
+    this helper is the single chokepoint through which captured comfy-cli output
+    reaches a :class:`ComfyCliError` message, so masking here covers every call
+    site (including :func:`_stream_tail`, which is built on it) and any future
+    one, instead of relying on each message to remember.
     """
     if not text or limit <= 0:
         # ``[-0:]`` is ``[0:]`` (the whole string), so a non-positive limit would
@@ -950,7 +1027,14 @@ def _tail(text: str | bytes | None, limit: int = 500) -> str:
         # enough to yield ``limit`` decoded chars (a leading byte may be dropped,
         # which ``errors="replace"`` handles cleanly).
         text = text[-4 * limit :].decode("utf-8", errors="replace")
-    return text.strip()[-limit:]
+    # Redact BEFORE the tail slice, not after: a credential straddling the
+    # truncation boundary would otherwise lose the `://` that identifies its
+    # userinfo and slip through unmasked. Scan a window that reaches
+    # `_REDACT_LOOKBACK` chars PAST the bound rather than the whole capture, so
+    # the cost stays proportional to what we keep even for a multi-megabyte str
+    # (the bytes branch above is already bounded); any credential shorter than
+    # the lookback that reaches into the kept tail starts inside the window.
+    return _redact_secrets(text.strip()[-(limit + _REDACT_LOOKBACK) :])[-limit:]
 
 
 def _stream_tail(text: str | bytes | None, limit: int = 500) -> str:
@@ -967,6 +1051,12 @@ def _stream_tail(text: str | bytes | None, limit: int = 500) -> str:
 
     The *tail* is what's kept (not the head): a CLI traceback puts the
     exception — the part that says what actually went wrong — last.
+
+    Credential masking comes from :func:`_tail` underneath, so the truncation
+    test below measures the REDACTED length. A mask can shift that length either
+    way, so on a capture carrying a credential right at the bound the ``...``
+    marker can be one off in either direction — cosmetic, and only on the
+    already-masked case. The result stays bounded and never leaks.
     """
     if limit <= 0:
         # Mirror `_tail`'s own non-positive guard. It matters more here: we ask

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -2817,3 +2817,241 @@ def test_get_logs_caps_oversized_line(patched_run):
     # TOTAL length (content + marker) never exceeds the hard cap.
     assert len(lines[1]) <= server._MAX_LOG_LINE_CHARS
     assert lines[1].endswith(server._TRACEBACK_TRUNCATION_MARKER)
+
+
+# --- credential redaction on every surfaced stream tail ---------------------
+# comfy-cli can print secrets when it crashes — a signed model-download URL
+# carrying a token, or an API key echoed back as part of an argv/usage error —
+# and those tails are interpolated straight into `ComfyCliError` messages that
+# reach the MCP client (an LLM context) and the host logs. Every tail is masked;
+# a tail with no credential shape in it must survive byte-for-byte, because
+# mangling a traceback defeats the point of surfacing it at all.
+
+_SIGNED_URL = "https://cdn.example/models/f.safetensors?token=abc123&expires=99"
+_USERINFO_URL = "https://user:tok@host/f.safetensors"
+
+
+def test_redact_secrets_masks_url_userinfo_including_multiple_urls():
+    """Every `scheme://user:pass@host` is masked — not just the first (what `_redact_url` can't do)."""
+    assert server._redact_secrets(_USERINFO_URL) == "https://***@host/f.safetensors"
+    two = f"tried {_USERINFO_URL} then http://svc:pw2@mirror/g.bin"
+    masked = server._redact_secrets(two)
+    assert masked == "tried https://***@host/f.safetensors then http://***@mirror/g.bin"
+    assert "tok" not in masked
+    assert "pw2" not in masked
+    # A password-less userinfo (`scheme://token@host`) is masked the same way.
+    assert server._redact_secrets("https://deadbeefcafe@h/x") == "https://***@h/x"
+
+
+def test_redact_secrets_masks_secret_query_params():
+    """A signed URL's token/signature values are masked, the rest of the URL kept."""
+    masked = server._redact_secrets(_SIGNED_URL)
+    assert masked == "https://cdn.example/models/f.safetensors?token=***&expires=99"
+    for param in (
+        "sig",
+        "signature",
+        "key",
+        "api_key",
+        "access_token",
+        "X-Amz-Signature",
+    ):
+        out = server._redact_secrets(f"https://h/o?{param}=SUPERSECRET&x=1")
+        assert "SUPERSECRET" not in out
+        assert f"{param}=***" in out
+        assert "x=1" in out  # a non-secret param is untouched
+
+
+def test_redact_secrets_masks_cli_flag_values():
+    """comfy-cli usage errors echo argv — the `--key`-family value must not survive."""
+    argv = "comfy auth set comfy-cloud-api-key --key sk-real-secret"
+    assert server._redact_secrets(argv) == (
+        "comfy auth set comfy-cloud-api-key --key ***"
+    )
+    for flag in ("--api-key", "--api_key", "--token", "--access-token", "--KEY"):
+        out = server._redact_secrets(f"usage: comfy {flag} sk-real-secret --json")
+        assert "sk-real-secret" not in out
+        assert f"{flag} ***" in out
+        assert "--json" in out  # the following flag is not swallowed
+    # `=` form too, and a value-less flag must not eat the NEXT flag.
+    assert server._redact_secrets("--key=sk-real-secret") == "--key=***"
+    assert server._redact_secrets("--key --verbose") == "--key --verbose"
+
+
+def test_redact_secrets_masks_bearer_tokens_but_not_prose():
+    """A `Bearer <token>` value is masked; a short prose word after `bearer` is not."""
+    out = server._redact_secrets("Authorization: Bearer abcdefghij0123456789")
+    assert out == "Authorization: Bearer ***"
+    assert server._redact_secrets("the bearer token was absent") == (
+        "the bearer token was absent"
+    )
+
+
+def test_redact_secrets_leaves_a_plain_traceback_byte_for_byte():
+    """The over-redaction guard: text with no credential shape is returned unchanged."""
+    traceback = (
+        "Traceback (most recent call last):\n"
+        '  File "/opt/comfy/cli.py", line 42, in run\n'
+        "    raise ValueError('boom')\n"
+        "ValueError: boom\n"
+        "note: user@example.com filed this; see key: value, a@b, http://plain/host\n"
+    )
+    assert server._redact_secrets(traceback) == traceback
+
+
+# One test per call site: a future tail interpolation added without redaction
+# should show up as a gap here rather than as a leaked credential in production.
+
+
+def test_sync_timeout_tails_are_redacted(monkeypatch):
+    """Site 1 — `_run_comfy_raw`'s TimeoutExpired tails (stderr AND stdout)."""
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(
+        server.subprocess,
+        "run",
+        _timeout_run(
+            stderr=f"downloading {_USERINFO_URL}".encode(),
+            stdout=b"usage: comfy auth set comfy-cloud-api-key --key sk-real-secret",
+        ),
+    )
+    with pytest.raises(server.ComfyCliError) as exc:
+        server._run_comfy("discover", timeout=60.0)
+    msg = str(exc.value)
+    assert "tok" not in msg
+    assert "***@host" in msg
+    assert "sk-real-secret" not in msg
+    assert "--key ***" in msg
+
+
+def test_no_envelope_error_tails_are_redacted(patched_plain_run):
+    """Site 2 — the `_unwrap_envelope` no-envelope branch, both halves."""
+    patched_plain_run(
+        1,
+        stdout="usage: comfy auth set comfy-cloud-api-key --key sk-real-secret",
+        stderr=f"failed to fetch {_SIGNED_URL}",
+    )
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("env")
+
+    msg = str(excinfo.value)
+    assert "abc123" not in msg
+    assert "token=***" in msg
+    assert "expires=99" in msg  # the diagnosis around it survives
+    assert "sk-real-secret" not in msg
+    assert "--key ***" in msg
+
+
+def test_error_envelope_stderr_fallback_is_redacted():
+    """Site 3 — the `ok: false` stderr fallback when the envelope carries no message."""
+    envelope = {"type": "envelope", "ok": False, "error": {"code": "x"}}
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(
+            envelope, ("env",), 1, f"download failed: {_USERINFO_URL}"
+        )
+
+    msg = str(excinfo.value)
+    assert "tok@" not in msg
+    assert msg.endswith("download failed: https://***@host/f.safetensors")
+
+
+def test_streaming_timeout_tails_are_redacted(monkeypatch):
+    """Site 4 — `_run_comfy_streaming`'s timeout, stderr tail AND joined stdout tail."""
+    line = json.dumps({"type": "log", "message": f"GET {_SIGNED_URL}"})
+
+    def fake_popen(cmd, stdout, stderr, text, env, **kwargs):  # noqa: ARG001
+        return _BlockingProcWithStderr(cmd, [line + "\n"], f"pulling {_USERINFO_URL}")
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        asyncio.run(
+            server._run_comfy_streaming(
+                "run", "--workflow", "wf.json", timeout=0.25, ctx=_RecordingCtx()
+            )
+        )
+    msg = str(exc.value)
+    assert "tok@" not in msg  # stderr tail masked
+    assert "***@host" in msg
+    assert "abc123" not in msg  # stdout (NDJSON) tail masked
+    assert "token=***" in msg
+
+
+# The two macOS-denial branches interpolate a tail too. They are not in the
+# ticket's four, but they share the same chokepoint — assert it, so the
+# chokepoint's coverage is what's locked in rather than four hand-wired sites.
+
+_TCC_STDERR = (
+    "Fatal Python error: init_import_site: Failed to import the site module\n"
+    "PermissionError: [Errno 1] Operation not permitted: "
+    "'/Users/x/Documents/ComfyUI/venv/pyvenv.cfg'\n"
+    f"while fetching {_USERINFO_URL}\n"
+)
+
+
+def test_tcc_no_envelope_original_error_tail_is_redacted(monkeypatch):
+    """The macOS-denial branch of `_unwrap_envelope` masks its `Original error:` tail."""
+    monkeypatch.setattr(server.sys, "platform", "darwin")
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        server._unwrap_envelope(None, ("env",), 1, _TCC_STDERR)
+
+    msg = str(exc.value)
+    assert "Full Disk Access" in msg  # still the curated guidance
+    assert "tok@" not in msg
+    assert "***@host" in msg
+
+
+def test_version_guard_tcc_original_error_tail_is_redacted(monkeypatch):
+    """The version guard's macOS-denial branch masks its `Original error:` tail."""
+    monkeypatch.setattr(server, "_version_checked", False)
+    monkeypatch.setattr(server.sys, "platform", "darwin")
+
+    def fake(cmd, **kwargs):  # noqa: ARG001
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr=_TCC_STDERR)
+
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        server._check_comfy_version()
+
+    msg = str(exc.value)
+    assert "tok@" not in msg
+    assert "***@host" in msg
+
+
+def test_redact_secrets_stays_linear_on_a_large_capture():
+    """Every pattern leads with a literal, so a huge capture can't wedge the scan.
+
+    Anchoring the userinfo pattern on the URL *scheme* instead of `://` makes it
+    re-scan from every offset — quadratic, and it hangs for minutes on a
+    multi-megabyte alphanumeric stderr. Guard the shape, not a wall-clock number.
+    """
+    started = time.monotonic()
+    assert server._redact_secrets("a" * 2_000_000) == "a" * 2_000_000
+    assert time.monotonic() - started < 5.0
+
+
+def test_tail_masks_a_credential_that_straddles_the_truncation_boundary():
+    """Redaction runs on a window PAST the bound, so a clipped URL is still masked."""
+    capture = "x" * 400 + _USERINFO_URL + "y" * 477
+    # The raw 500-char tail begins in the MIDDLE of the userinfo — the `://` that
+    # identifies it has been clipped away, so redacting the clipped tail alone
+    # would leave the password in the message.
+    assert capture[-500:].startswith(":tok@host")
+    tail = server._tail(capture, limit=500)
+
+    assert len(tail) == 500
+    assert "tok" not in tail
+    assert "*@host/f.safetensors" in tail
+
+
+def test_tail_bound_survives_a_capture_larger_than_the_redaction_window():
+    """A capture far bigger than the lookback window is still bounded and scanned."""
+    capture = "z" * (server._REDACT_LOOKBACK * 3) + _SIGNED_URL
+    tail = server._tail(capture, limit=500)
+
+    assert len(tail) == 500
+    assert "abc123" not in tail
+    assert "token=***" in tail


### PR DESCRIPTION
**STACKED — merging lands on `matt/be-4575-envelope-error-tails` (owned by mattmillerai, PR #73), NOT `main`.** Do not merge this before #73; GitHub will retarget it to `main` once #73 lands.

## ELI-5

When comfy-cli crashes, we paste the last bit of what it printed into our error message so you can see what went wrong. Trouble is, comfy-cli sometimes prints secrets on its way down — a download link with a token baked into it, or your API key echoed back in a "you used this flag wrong" message. That error message goes straight to the MCP client (an LLM's context) and into the host's logs. This change runs every one of those pasted-in snippets through a masker first, so `?token=abc123` shows up as `?token=***` and `https://user:tok@host` shows up as `https://***@host`. A normal traceback with no secrets in it comes through completely untouched — that's the whole point of showing it.

## What changed

- **`_redact_secrets(text)`** — a new pure string function next to the existing `_redact_url`. It scans arbitrary text (not a single well-formed URL) and masks *every* occurrence of four structured shapes: URL userinfo (`scheme://user:pass@host` → `scheme://***@host`), secret-bearing query params (`token`, `sig`, `signature`, `key`, `api_key`, `access_token`, `X-Amz-Signature`), the value of a `--key` / `--api-key` / `--token` / `--access-token` CLI flag (comfy-cli usage errors echo argv), and a `Bearer <token>` value.
- **Applied at the chokepoint**: `_tail` now redacts before it returns. That is the single function through which every captured comfy-cli stream reaches a `ComfyCliError` message, so `_stream_tail` (built on it) and all six current call sites are covered by one edit — and so is any tail added later.
- Tests: unit coverage per shape, an explicit over-redaction guard, one test per call site, plus two properties (boundary-straddling credential, linear scan on a large capture).

`pytest` 441 passed / 1 skipped, `ruff check` and `ruff format --check` clean.

## Why it is stacked

The four sites this touches are the four sites #73 reworks, and one of them (the stdout half of the no-envelope message) only exists on #73's branch. Building on `main` would conflict with #73 across the whole diff and would silently skip that site. Base is `matt/be-4575-envelope-error-tails`; the diff shown here is the net change on top of it.

## Judgment calls

- **Chokepoint over four call-site wrappers.** The plan said "route every stream tail through it" at four named sites. There are actually **six** tail interpolations into error messages, not four: the two macOS-denial `Original error:` tails (the version guard's, and `_unwrap_envelope`'s TCC branch) were not in the list. Wrapping four call sites by hand would have left two live leak paths and would have re-created the "add a call site, forget the redaction" failure mode the plan is trying to close. Redacting inside `_tail` covers all six and any future one. Every one of the four named sites still gets its own test, so a regression at any of them is caught by name.
- **No entropy heuristic.** The plan allowed a high-entropy bearer-ish rule "only if it can be done without false positives." I implemented the *structured* half (`Bearer <16+ chars>`) and skipped the generic entropy scan. `Basic`, `Token`, and a bare `Authorization:` value are also deliberately not matched — those keywords are common English ("Basic authentication", "authorization: failed"), and masking them would eat the diagnosis rather than a secret.
- **`error.message` / `error.hint` / `error.details` are NOT redacted, on purpose.** They are comfy-cli's own structured fields, not stream tails, and the `hint` is specifically the actionable `comfy auth set comfy-cloud-api-key --key <your-key>` fallback text this server forwards — running it through the flag masker would turn the fix instruction into `--key ***`. Flagging it as a known adjacent surface rather than silently widening scope; if we want it, it wants its own decision about the hint.
- **`_redact_url` left alone.** It still handles the `COMFYUI_URL` config errors, where the input genuinely is one whole URL and offset arithmetic is correct. Not merged with the new function.

## Things worth a reviewer's eye

- **A ReDoS I introduced and removed.** The first draft anchored the userinfo pattern on the URL scheme (`[A-Za-z][A-Za-z0-9+.-]*://`). That leading character class re-scans forward from every offset — quadratic. On a 1 MB alphanumeric stderr it did not finish in two minutes. It is now anchored on the literal `://`, which is linear (5 MB in ~2 ms); every other pattern also leads with a literal (`?`/`&`, `--`, `bearer`). `test_redact_secrets_stays_linear_on_a_large_capture` guards it.
- **Redaction runs before the tail slice, over a bounded window.** A credential clipped mid-URL loses the `://` that identifies it, so masking the already-clipped tail would leak it. `_tail` therefore scans the last `limit + _REDACT_LOOKBACK` (4096) chars and then slices — bounded, so a multi-megabyte capture is not scanned end to end, while any credential shorter than the lookback that reaches into the kept tail starts inside the window. Both properties have tests.
- **One cosmetic consequence**, documented in `_stream_tail`'s docstring: it detects truncation by asking `_tail` for `limit + 1`, and that length is now measured *after* masking. On a capture carrying a credential right at the bound, the `...` marker can be one off in either direction. The result stays bounded and never leaks; it only affects captures that were masked anyway.
- **Negative-claim falsification: not applicable.** This diff denies no capability — it adds masking to existing error text. It introduces no "not supported"/"unavailable"/dead-end path and flips no test to assert one, so the falsification trigger does not fire.

## Testing

```
pytest -q                # 441 passed, 1 skipped
ruff check .             # All checks passed!
ruff format --check .    # 17 files already formatted
```
