### PR TITLE
feat: add an opt-in local rotating failure log for comfy-cli failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Cloud MCP** — comfy-cli is the engine.
 - [Quickstart](#quickstart)
 - [Tools](#tools)
 - [Troubleshooting](#troubleshooting)
+- [Failure log (opt-in)](#failure-log-opt-in)
 - [Smoke test](#smoke-test)
 - [Contributing](#contributing)
 - [License](#license)
@@ -537,6 +538,49 @@ Where it can, the server says this for you: a tool call blocked this way returns
 instead of the raw traceback. The one case it cannot catch is **its own** interpreter startup (this
 server installed under a protected folder) — Python dies before any of its code runs, so that one
 surfaces as the raw traceback in your client's MCP logs. Same fix.
+
+## Failure log (opt-in)
+
+When you're diagnosing a flaky setup, an MCP client's transcript is a poor record: it scrolls, it
+truncates, and the interesting failures (a missing `comfy` binary, a crash before any JSON, a
+timeout) are exactly the ones that leave the least behind. Set **`COMFY_LOCAL_MCP_DEBUG_LOG`** and
+the server appends one JSON object per comfy-cli **failure** to a local file you can `jq`, grep, or
+zip up and attach to a bug report.
+
+| Value | Behavior |
+| --- | --- |
+| unset, empty, or `0` | **Off (the default).** Nothing is created and no log file is opened. |
+| `1` | On, at the default path for your OS (below). |
+| anything else | On, and the value is used as the log file path (parent directories are created). |
+
+Default paths — the same per-OS local-state convention comfy-cli itself uses:
+
+| OS | Path |
+| --- | --- |
+| macOS | `~/Library/Application Support/comfy-local-mcp/failures.jsonl` |
+| Windows | `~/AppData/Local/comfy-local-mcp/failures.jsonl` |
+| Linux / other | `~/.config/comfy-local-mcp/failures.jsonl` |
+
+Each line records the failure `kind` (`error_envelope`, `no_json`, `timeout`, `binary_missing`,
+`schema_mismatch`), a UTC `ts`, the comfy-cli `args`, its `exit_code` and the envelope's
+`error_code`, the message you saw in your client, and up to 4,000 characters of `stdout_tail` /
+`stderr_tail` — deliberately more output than an error message can carry:
+
+```console
+$ COMFY_LOCAL_MCP_DEBUG_LOG=1 …            # in your MCP client config's env block
+$ jq -r 'select(.kind == "timeout") | .ts + "  " + (.args | join(" "))' \
+    ~/Library/Application\ Support/comfy-local-mcp/failures.jsonl
+```
+
+The file rotates itself: 1 MiB per file with two older generations kept (`failures.jsonl.1`,
+`failures.jsonl.2`), so it stops growing at roughly 3 MiB no matter how long you leave it on.
+Successful calls are never recorded, and nothing is ever transmitted anywhere — the log is local,
+full stop.
+
+> **Privacy — review before sharing.** The log contains local file paths and comfy-cli's own
+> command output, which can include the workflow or prompt text comfy-cli echoed back. Credentials
+> in a URL argument are masked (`user:pass@` userinfo, and the whole query string, are stripped),
+> but read a file over before you attach it to an issue.
 
 ## Smoke test
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import json
+import logging
 import math
 import os
 import re
@@ -48,8 +49,11 @@ import shutil
 import signal
 import subprocess
 import sys
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from logging.handlers import RotatingFileHandler
 from typing import Any
 from urllib.parse import urlparse
 
@@ -122,6 +126,76 @@ mcp = FastMCP("comfy-local-mcp", instructions=INSTRUCTIONS)
 # reads straight off the environment ``_comfy_env`` forwards (precedence:
 # comfy-cli flags > env > background record > ``127.0.0.1:8188``).
 COMFY_BIN = os.environ.get("COMFY_BIN", "comfy")
+
+# --- opt-in local failure log -------------------------------------------------
+# `COMFY_LOCAL_MCP_DEBUG_LOG` turns on a rotating, local-only JSONL record of
+# every comfy-cli failure this server surfaces, so a tester can zip up a durable
+# diagnostic trail instead of scraping an MCP client's transcript after the fact.
+# Failure-only (a successful call writes nothing), local-only (nothing is
+# transmitted anywhere), and OFF by default — while disabled there are ZERO
+# filesystem effects: no directory is created and no handler is ever opened.
+#
+#   unset / "" / "0"  -> disabled (the default)
+#   "1"               -> enabled at the per-OS default path
+#   anything else     -> enabled, and the value IS the log file path
+_FAILURE_LOG_ENV = "COMFY_LOCAL_MCP_DEBUG_LOG"
+
+# Chars kept per stream tail, deliberately far larger than the
+# `_MAX_ERROR_FIELD_CHARS` cap an error *message* carries: preserving more output
+# than the message can is this log's whole reason to exist.
+_FAILURE_LOG_TAIL_CHARS = 4000
+
+# Cap on the recorded `message` (the sentence the MCP client displayed) so a
+# pathological envelope cannot write an unbounded line.
+_FAILURE_LOG_MESSAGE_CHARS = 2000
+
+# Rotation, via the stdlib handler: 1 MiB per file plus two older generations,
+# so the log is self-limiting at ~3 MiB no matter how long a tester leaves it on.
+_FAILURE_LOG_MAX_BYTES = 1_048_576
+_FAILURE_LOG_BACKUPS = 2
+
+# A dedicated logger with `propagate = False`. Non-propagation is not cosmetic:
+# this is an MCP **stdio** server, so stdout is the protocol transport, and a
+# record reaching a default root handler could corrupt the session.
+_FAILURE_LOGGER_NAME = "comfy_local_mcp.failures"
+
+
+def _default_failure_log_path() -> str:
+    """Per-OS default path for the failure log. Creates nothing.
+
+    Mirrors comfy-cli's own local-state convention (its ``constants.py``
+    ``DEFAULT_CONFIG``) with a ``comfy-local-mcp`` leaf, hand-rolled rather than
+    imported: comfy-cli is the *engine* this server shells out to, not a Python
+    dependency of it (``mcp`` is the only one), so there is nothing to import.
+
+    Deliberately NOT under the ComfyUI workspace: resolving that requires
+    *running* comfy-cli, and this log's prime scenarios — a missing binary, a
+    crash before any JSON, a timeout — are exactly when comfy-cli cannot answer.
+    """
+    home = os.path.expanduser("~")
+    if sys.platform == "darwin":
+        base = os.path.join(home, "Library", "Application Support")
+    elif sys.platform == "win32":
+        base = os.path.join(home, "AppData", "Local")
+    else:
+        base = os.path.join(home, ".config")
+    return os.path.join(base, "comfy-local-mcp", "failures.jsonl")
+
+
+def _resolve_failure_log_path(value: str | None) -> str | None:
+    """The log path ``COMFY_LOCAL_MCP_DEBUG_LOG=<value>`` selects, else ``None``."""
+    value = (value or "").strip()
+    if not value or value == "0":
+        return None
+    if value == "1":
+        return _default_failure_log_path()
+    return value
+
+
+# Single source of truth for "is the failure log on, and where" — ``None`` means
+# disabled. One global rather than a separate enabled flag plus a path, so the
+# two can never disagree (enabled-with-no-path would be a live tripwire).
+_FAILURE_LOG_PATH = _resolve_failure_log_path(os.environ.get(_FAILURE_LOG_ENV))
 
 # Optional: point the run/queue tools at a ComfyUI running ELSEWHERE (e.g. a GPU
 # box reachable over a private network / tailnet) instead of the implicit local
@@ -561,13 +635,17 @@ def _require_comfy_bin() -> None:
     if _is_macos():
         blocked = _tcc_blocked_comfy_bin()
         if blocked is not None:
-            raise ComfyCliError(
-                f"`{COMFY_BIN}` could not be read.\n\n{_tcc_guidance(blocked)}"
-            )
-    raise ComfyCliError(
+            message = f"`{COMFY_BIN}` could not be read.\n\n{_tcc_guidance(blocked)}"
+            # `args=()` on both raises: no comfy-cli invocation ever happened, so
+            # there is no argv to record — the failure IS that there is no binary.
+            _log_failure("binary_missing", (), message=message)
+            raise ComfyCliError(message)
+    message = (
         f"`{COMFY_BIN}` not found on PATH. Install comfy-cli "
         "(`pip install comfy-cli`) or set the COMFY_BIN env var."
     )
+    _log_failure("binary_missing", (), message=message)
+    raise ComfyCliError(message)
 
 
 def _parse_version(text: str) -> tuple[int, int, int] | None:
@@ -858,11 +936,22 @@ def _run_comfy_raw(
         # (capture_output=True) to the exception — surface it so a crashed,
         # wedged comfy-cli (e.g. a traceback on stderr) is not indistinguishable
         # from a genuinely slow one. See BE-3343.
-        raise ComfyCliError(
+        message = (
             f"comfy-cli timed out after {timeout}s: {' '.join(cmd)}. "
             f"stderr tail: {_tail(exc.stderr) or '<empty>'}; "
             f"stdout tail: {_tail(exc.stdout) or '<empty>'}"
-        ) from exc
+        )
+        # `exit_code=None`: the child was killed at the deadline, so it never
+        # reported one. The log keeps a longer slice of both streams than the
+        # message above does — see `_FAILURE_LOG_TAIL_CHARS`.
+        _log_failure(
+            "timeout",
+            args,
+            message=message,
+            stdout=exc.stdout,
+            stderr=exc.stderr,
+        )
+        raise ComfyCliError(message) from exc
 
     return (
         _last_json_object(proc.stdout),
@@ -986,6 +1075,162 @@ def _stream_tail(text: str | bytes | None, limit: int = 500) -> str:
     return "..." + tail[-limit:] if len(tail) > limit else tail
 
 
+def _scrub_arg(arg: str) -> str:
+    """A comfy-cli argv token, safe to record in the failure log.
+
+    A URL argument gets two treatments and everything else passes through
+    verbatim (an arg is usually a path or a subcommand, and mangling those would
+    defeat the log):
+
+    - :func:`_redact_url` masks ``user:pass@`` userinfo, exactly as it does for
+      the config values the error messages echo;
+    - the query string and fragment are dropped entirely. That mirrors
+      comfy-cli's own ``tracking.py`` scrubber, which exists because a CivitAI
+      model URL carries its credential as ``?token=…`` — a secret no amount of
+      userinfo masking would catch.
+    """
+    if not arg.lower().startswith(("http://", "https://")):
+        return arg
+    scrubbed = _redact_url(arg)
+    # Cut at whichever of `?` / `#` comes first: a fragment can precede a
+    # (meaningless, but present) query, and slicing on each in turn would leave
+    # the earlier delimiter's contents behind.
+    cut = min(
+        (i for i in (scrubbed.find("?"), scrubbed.find("#")) if i != -1),
+        default=-1,
+    )
+    return scrubbed if cut == -1 else scrubbed[:cut]
+
+
+# A URL anywhere in a recorded `message`. Anchored on the literal scheme so the
+# engine can skip ahead to a candidate rather than re-scan from every offset,
+# and `\S+` is a possessive-free single-pass match — no backtracking risk on a
+# multi-KB message.
+_MESSAGE_URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+
+
+def _scrub_message(message: str) -> str:
+    """Apply :func:`_scrub_arg`'s URL scrubbing to every URL inside ``message``.
+
+    Scrubbing ``args`` alone would be theatre: the error-envelope message this log
+    records is built by :func:`_unwrap_envelope` as ``comfy <args> failed …``, so
+    the RAW argv — including a signed ``?token=…`` model URL — is echoed right
+    back into it. That string is already what the MCP client sees (unchanged
+    here), but this log PERSISTS it to disk for a tester to zip up and share, so
+    the same masking has to reach it.
+
+    Only URL-shaped substrings are touched; the surrounding prose (the point of
+    keeping ``message`` at all) is preserved byte-for-byte.
+    """
+    return _MESSAGE_URL_RE.sub(lambda match: _scrub_arg(match.group(0)), message)
+
+
+# The path the currently-open rotating handler writes to; ``None`` until the
+# first failure is logged. Keyed on the path rather than a bare "set up yet?"
+# flag so the handler is rebuilt if `_FAILURE_LOG_PATH` is ever repointed, and
+# so nothing here touches the filesystem while the log is disabled.
+_failure_handler_path: str | None = None
+
+# Serializes the setup below. Tool calls reach `_run_comfy` from several worker
+# pools (`_in_pipe_pool` / `_in_generate_pool`), so two threads can fail at once
+# and race here. `logging` makes *emitting* thread-safe but not this
+# check-then-swap: interleaved remove-all/add passes can leave the logger holding
+# BOTH handlers, which would duplicate every subsequent line for the life of the
+# process. Only the (once-per-path) setup takes the lock; the common case is the
+# unguarded `!=` comparison plus a normal `.info()`.
+_failure_handler_lock = threading.Lock()
+
+
+def _failure_logger(path: str) -> logging.Logger:
+    """The dedicated failure logger, opening its rotating handler on first use.
+
+    Created lazily — the handler opens the file, so building it eagerly at import
+    would give a disabled log a filesystem footprint. ``path`` is passed in
+    rather than read from the global so this can never be reached without one.
+    """
+    global _failure_handler_path
+    logger = logging.getLogger(_FAILURE_LOGGER_NAME)
+    if _failure_handler_path != path:
+        with _failure_handler_lock:
+            # Re-check under the lock: the thread that lost the race must not
+            # tear down and rebuild the handler the winner just installed.
+            if _failure_handler_path != path:
+                for existing in list(logger.handlers):
+                    logger.removeHandler(existing)
+                    existing.close()
+                # Cleared BEFORE the (fallible) setup below, so a handler that
+                # fails to open cannot leave the global claiming a path nothing
+                # is actually writing to.
+                _failure_handler_path = None
+                parent = os.path.dirname(path)
+                if parent:
+                    os.makedirs(parent, exist_ok=True)
+                handler = RotatingFileHandler(
+                    path,
+                    maxBytes=_FAILURE_LOG_MAX_BYTES,
+                    backupCount=_FAILURE_LOG_BACKUPS,
+                    encoding="utf-8",
+                )
+                # Bare `%(message)s`: every line must be pure JSON, so `jq` can
+                # read the file directly with no level/timestamp prefix to strip
+                # first (the record carries its own `ts`).
+                handler.setFormatter(logging.Formatter("%(message)s"))
+                logger.addHandler(handler)
+                logger.setLevel(logging.INFO)
+                logger.propagate = False
+                _failure_handler_path = path
+    return logger
+
+
+def _log_failure(
+    kind: str,
+    args: tuple[str, ...] | list[str],
+    exit_code: int | None = None,
+    error_code: str | None = None,
+    message: str = "",
+    stdout: str | bytes | None = None,
+    stderr: str | bytes | None = None,
+    streaming: bool = False,
+) -> None:
+    """Append one JSONL record for a comfy-cli failure, if the log is enabled.
+
+    Called immediately before each raise, so every line recorded corresponds to a
+    failure a caller actually saw. ``kind`` is one of ``error_envelope`` /
+    ``no_json`` / ``timeout`` / ``binary_missing`` / ``schema_mismatch``.
+
+    The record is STRUCTURED, not just the formatted sentence, so the log is
+    ``jq``/grep-able without parsing prose — ``message`` is kept alongside it so
+    QA can correlate a line with what the MCP client displayed. Stream tails go
+    through :func:`_stream_tail` (tail-not-head, ``<empty>`` marker, ``...``
+    truncation prefix) for consistency with those messages.
+
+    Best-effort by construction: a disabled log returns before touching
+    anything, and ANY error while writing is swallowed — a diagnostic aid must
+    never mask, replace, or delay the real error.
+    """
+    path = _FAILURE_LOG_PATH
+    if path is None:
+        return
+    try:
+        entry = {
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "kind": kind,
+            "args": [_scrub_arg(arg) for arg in args],
+            "exit_code": exit_code,
+            "error_code": error_code,
+            # Cap first, then scrub: bounding the work keeps the regex pass off a
+            # pathological multi-MB message, and a URL that survives the cap is
+            # still scrubbed in full.
+            "message": _scrub_message(message[:_FAILURE_LOG_MESSAGE_CHARS]),
+            "stdout_tail": _stream_tail(stdout, _FAILURE_LOG_TAIL_CHARS),
+            "stderr_tail": _stream_tail(stderr, _FAILURE_LOG_TAIL_CHARS),
+            "streaming": streaming,
+        }
+        _failure_logger(path).info(json.dumps(entry, ensure_ascii=False))
+    except Exception:
+        pass  # diagnostics are best-effort; never mask the real error
+
+
 def _kill_proc_tree(proc: subprocess.Popen) -> None:
     """Kill the child *and* any grandchildren it spawned.
 
@@ -1029,6 +1274,7 @@ def _unwrap_envelope(
     returncode: int | None,
     stderr: str,
     stdout: str = "",
+    streaming: bool = False,
 ) -> Any:
     """Unwrap comfy-cli's ``envelope/1`` result, raising on error/absence.
 
@@ -1044,6 +1290,11 @@ def _unwrap_envelope(
     failure legible; it defaults to ``""`` (rendered ``<empty>``) so a caller
     that genuinely has no stdout still produces a well-formed message.
 
+    ``streaming`` only tags the failure-log record (:func:`_log_failure`) with
+    which spawn path produced it — ``_run_comfy`` (``--json``) or
+    ``_run_comfy_streaming`` (``--json-stream``) — since this function is shared
+    by both and the raised error is otherwise identical either way.
+
     Also the envelope-version assertion: if comfy-cli declares an envelope
     ``schema`` whose major differs from :data:`ENVELOPE_SCHEMA_MAJOR`, the whole
     result shape is presumed incompatible and we refuse it with a clear error
@@ -1055,7 +1306,7 @@ def _unwrap_envelope(
             # comfy-cli emitted no envelope because macOS denied it a protected
             # folder (see the TCC block above) — a permission problem the user
             # can fix, not the opaque "returned no JSON" this would otherwise be.
-            raise ComfyCliError(
+            message = (
                 f"comfy-cli could not run (exit {returncode}).\n\n"
                 f"{_tcc_guidance(_tcc_path_from(stderr))}\n\n"
                 # `_stream_tail` for the truncation marker: `_looks_like_tcc_denial`
@@ -1066,27 +1317,61 @@ def _unwrap_envelope(
                 # the cause, so its curated guidance beats a second raw stream.
                 f"Original error: {_stream_tail(stderr)}"
             )
+            # Still `no_json` — a TCC denial is the *reason* comfy-cli emitted no
+            # envelope, not a different kind of failure. Unlike the message, the
+            # record keeps the raw stdout too: a diagnostic trail is read after
+            # the fact, when a curated guidance string is no longer enough.
+            _log_failure(
+                "no_json",
+                args,
+                exit_code=returncode,
+                message=message,
+                stdout=stdout,
+                stderr=stderr,
+                streaming=streaming,
+            )
+            raise ComfyCliError(message)
         # Both streams, both explicitly marked when blank: comfy-cli splits its
         # diagnostics unpredictably (a Python traceback lands on stderr, a
         # Typer/click usage error or a plain-text status line on stdout), and
         # `_last_json_object` has already discarded the stdout text by the time
         # we get here. Rendering only stderr — and rendering an empty one as
         # nothing at all — is what made this error opaque.
-        raise ComfyCliError(
+        message = (
             f"comfy-cli returned no JSON (exit {returncode}). "
             f"stderr: {_stream_tail(stderr)} | stdout: {_stream_tail(stdout)}"
         )
+        _log_failure(
+            "no_json",
+            args,
+            exit_code=returncode,
+            message=message,
+            stdout=stdout,
+            stderr=stderr,
+            streaming=streaming,
+        )
+        raise ComfyCliError(message)
     # A declared schema must be a recognized ``envelope/<N>`` whose major matches.
     # Absent schema -> assume compatible (older comfy-cli); declared-but-unparseable
     # or a different major -> refuse loudly rather than fail open on a shape we
     # can't vouch for.
     schema = _envelope_schema(envelope)
     if schema is not None and _envelope_major(envelope) != ENVELOPE_SCHEMA_MAJOR:
-        raise ComfyCliError(
+        message = (
             f"incompatible comfy-cli envelope schema {schema!r}: "
             f"this server speaks envelope/{ENVELOPE_SCHEMA_MAJOR}. "
             "Upgrade or pin comfy-cli to a version whose envelope contract matches."
         )
+        _log_failure(
+            "schema_mismatch",
+            args,
+            exit_code=returncode,
+            message=message,
+            stdout=stdout,
+            stderr=stderr,
+            streaming=streaming,
+        )
+        raise ComfyCliError(message)
     if not envelope.get("ok", False):
         # A malformed envelope may set `error` to a non-dict (e.g. a bare
         # string); fall back to `{}` so `.get()` below can't raise AttributeError.
@@ -1131,7 +1416,21 @@ def _unwrap_envelope(
         detail_str = _render_error_details(err.get("details"))
         if detail_str:
             parts.append(detail_str)
-        raise ComfyCliError("\n".join(parts), code=code)
+        text = "\n".join(parts)
+        # `error_code` carries the envelope's own `error.code` as a first-class
+        # field, so a tester can `jq 'select(.error_code == "…")'` a run's
+        # failures instead of string-matching the rendered sentence.
+        _log_failure(
+            "error_envelope",
+            args,
+            exit_code=returncode,
+            error_code=code,
+            message=text,
+            stdout=stdout,
+            stderr=stderr,
+            streaming=streaming,
+        )
+        raise ComfyCliError(text, code=code)
     return envelope.get("data")
 
 
@@ -1447,6 +1746,7 @@ async def _run_comfy_streaming(
             returncode,
             stderr,
             stdout=stdout_text,
+            streaming=True,
         )
 
     try:
@@ -1477,10 +1777,14 @@ async def _run_comfy_streaming(
             if proc.poll() is None:
                 _kill_proc_tree(proc)
                 await _in_pipe_pool(_reap, proc)
-            stderr_tail = ""
+            # Keep the drained text itself, not only its 500-char message tail:
+            # the failure log records a much longer slice (`_stream_tail` at
+            # `_FAILURE_LOG_TAIL_CHARS`), and pre-truncating here would silently
+            # cap it back down to the message's bound.
+            stderr_text = ""
             if stderr_future is not None:
                 try:
-                    stderr_tail = _tail(await asyncio.wait_for(stderr_future, 2.0))
+                    stderr_text = await asyncio.wait_for(stderr_future, 2.0) or ""
                 except (Exception, asyncio.CancelledError):
                     # Diagnostics are best-effort: never let gathering the tail
                     # mask the timeout itself. CancelledError is a BaseException
@@ -1488,17 +1792,27 @@ async def _run_comfy_streaming(
                     # outer wait_for cancels _drain while it awaits stderr_future,
                     # which cancels the future too — so awaiting it below re-raises
                     # CancelledError. Swallow it so we still raise ComfyCliError.
-                    stderr_tail = ""
-            raise ComfyCliError(
+                    stderr_text = ""
+            # Slice to the last lines before joining so a chatty child's full
+            # stdout history isn't copied just to keep the 500-char tail.
+            timeout_stdout = "".join(lines[-500:])
+            message = (
                 f"comfy-cli timed out after {timeout}s: {' '.join(cmd)}. "
                 f"Progress so far: {tracker.snapshot()}. The run may still be "
                 "going — check `job_status`, or for long generations submit "
                 "with `wait=False` and poll `wait_for_job` / `watch_job`. "
-                f"stderr tail: {stderr_tail or '<empty>'}; "
-                # Slice to the last lines before joining so a chatty child's full
-                # stdout history isn't copied just to keep the 500-char tail.
-                f"stdout tail: {_tail(''.join(lines[-500:])) or '<empty>'}"
-            ) from exc
+                f"stderr tail: {_tail(stderr_text) or '<empty>'}; "
+                f"stdout tail: {_tail(timeout_stdout) or '<empty>'}"
+            )
+            _log_failure(
+                "timeout",
+                args,
+                message=message,
+                stdout=timeout_stdout,
+                stderr=stderr_text,
+                streaming=True,
+            )
+            raise ComfyCliError(message) from exc
 
         # Envelope path: the authoritative result is already in `lines`, read
         # within the deadline. Give the child a brief grace to exit on a SEPARATE
@@ -1533,7 +1847,12 @@ async def _run_comfy_streaming(
             except (asyncio.TimeoutError, TimeoutError):
                 stderr = ""
         return _unwrap_envelope(
-            envelope, args, proc.returncode, stderr, stdout=stdout_text
+            envelope,
+            args,
+            proc.returncode,
+            stderr,
+            stdout=stdout_text,
+            streaming=True,
         )
     finally:
         # Never leave a stray child or a dangling stderr reader on any exit path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 
 import pytest
 
@@ -69,6 +70,29 @@ def _clear_comfyui_target_env(monkeypatch):
     """
     for var in ("COMFYUI_URL", "COMFYUI_HOST", "COMFYUI_PORT"):
         monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_failure_log(monkeypatch):
+    """Default every test to the opt-in failure log being OFF, and never leak it.
+
+    ``server._FAILURE_LOG_PATH`` is resolved from ``COMFY_LOCAL_MCP_DEBUG_LOG`` at
+    import, so a developer who has the var exported would otherwise have the whole
+    suite writing real records into their app-support directory — and the
+    "disabled by default" tests would fail for an environmental reason. Pin it off
+    here (`test_failure_log.py` enables it explicitly per test).
+
+    The teardown closes any handler a test opened, so no test leaves a file handle
+    on a ``tmp_path`` that pytest is about to remove, and no record written by one
+    test can land in the next one's log.
+    """
+    monkeypatch.setattr(server, "_FAILURE_LOG_PATH", None)
+    monkeypatch.setattr(server, "_failure_handler_path", None)
+    yield
+    logger = logging.getLogger(server._FAILURE_LOGGER_NAME)
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        handler.close()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_failure_log.py
+++ b/tests/test_failure_log.py
@@ -1,0 +1,490 @@
+"""Tests for the opt-in local rotating failure log (``COMFY_LOCAL_MCP_DEBUG_LOG``).
+
+The log exists to give a tester a durable, zippable diagnostic trail for
+comfy-cli failures, so these tests hold its three defining properties:
+
+1. **Opt-in.** With the env var unset there are ZERO filesystem effects — no
+   directory, no handler, no file — even when comfy-cli fails.
+2. **Failure-only.** A successful call writes nothing, and neither does a
+   pre-flight validation raise (which never spawned comfy-cli at all).
+3. **Structured + scrubbed.** Every line is pure JSON with the failure's
+   ``kind`` / ``args`` / ``exit_code`` / ``error_code`` / stream tails, and a URL
+   argument is logged with its userinfo masked and its query string dropped.
+
+Like the rest of the suite these mock comfy-cli; nothing here needs a real
+``comfy`` binary.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import threading
+
+import pytest
+from conftest import _FakeProc
+
+from comfy_local_mcp import server
+
+# A failing envelope/1 result, the most common recorded failure.
+_ERROR_ENVELOPE = json.dumps(
+    {
+        "schema": "envelope/1",
+        "type": "envelope",
+        "ok": False,
+        "error": {"code": "credential_missing", "message": "no API key configured"},
+    }
+)
+
+
+@pytest.fixture
+def log_path(monkeypatch, tmp_path):
+    """Enable the failure log at a path under ``tmp_path`` and return that path.
+
+    The parent directory deliberately does NOT exist: creating it lazily, on the
+    first write, is part of the contract.
+    """
+    path = tmp_path / "state" / "failures.jsonl"
+    monkeypatch.setattr(server, "_FAILURE_LOG_PATH", str(path))
+    return path
+
+
+@pytest.fixture
+def fake_comfy(monkeypatch):
+    """Patch ``shutil.which`` + ``subprocess.run`` for one canned comfy-cli result.
+
+    ``setup(stdout=…, stderr=…, returncode=…, raises=…)`` — ``raises`` makes the
+    fake raise instead of returning (used for ``subprocess.TimeoutExpired``).
+    """
+
+    def setup(stdout="", stderr="", returncode=0, raises=None):
+        def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
+            if raises is not None:
+                raise raises
+            return subprocess.CompletedProcess(
+                cmd, returncode, stdout=stdout, stderr=stderr
+            )
+
+        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+        monkeypatch.setattr(server.subprocess, "run", fake)
+
+    return setup
+
+
+def _entries(path) -> list[dict]:
+    """Every JSONL record written to ``path``, parsed.
+
+    Parsing each line as JSON is itself an assertion: the log must be
+    ``jq``-able, so a level/timestamp prefix leaking in would fail here.
+    """
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+# --- the opt-in switch -------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [None, "", "   ", "0"])
+def test_env_var_unset_empty_or_zero_disables(value):
+    """Unset, blank, or an explicit ``0`` all mean disabled."""
+    assert server._resolve_failure_log_path(value) is None
+
+
+def test_env_var_one_selects_the_per_os_default(monkeypatch, tmp_path):
+    """``1`` means "on, at the default path" — it is never taken as a literal path."""
+    default = str(tmp_path / "default.jsonl")
+    monkeypatch.setattr(server, "_default_failure_log_path", lambda: default)
+
+    assert server._resolve_failure_log_path("1") == default
+
+
+def test_env_var_any_other_value_is_the_log_path(tmp_path):
+    """Any other value IS the path, so a tester can point it at a scratch file."""
+    target = str(tmp_path / "x.jsonl")
+
+    assert server._resolve_failure_log_path(target) == target
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected"),
+    [
+        ("darwin", ("Library", "Application Support", "comfy-local-mcp")),
+        ("win32", ("AppData", "Local", "comfy-local-mcp")),
+        ("linux", (".config", "comfy-local-mcp")),
+    ],
+)
+def test_default_path_mirrors_comfy_cli_app_dirs(monkeypatch, platform, expected):
+    """The default path follows comfy-cli's per-OS local-state convention."""
+    monkeypatch.setattr(server.sys, "platform", platform)
+    monkeypatch.setattr(server.os.path, "expanduser", lambda _: "/home/u")
+
+    path = server._default_failure_log_path()
+
+    assert path.endswith("failures.jsonl")
+    for segment in expected:
+        assert segment in path
+    # Never inside the ComfyUI workspace: resolving that needs a working
+    # comfy-cli, which is precisely what has failed when this log matters.
+    assert path.startswith("/home/u")
+
+
+def test_disabled_by_default_writes_nothing_and_creates_no_dir(
+    monkeypatch, tmp_path, fake_comfy
+):
+    """With the log off, a failing call leaves ZERO filesystem traces.
+
+    The default path is pointed into ``tmp_path`` so "nothing was created" is
+    actually observable — otherwise a stray write would land in the real user
+    app-support directory and the assertion could not see it.
+    """
+    default = tmp_path / "default" / "failures.jsonl"
+    monkeypatch.setattr(server, "_default_failure_log_path", lambda: str(default))
+    # The autouse `_isolate_failure_log` fixture already pins this to the
+    # disabled state; restate it here so the test reads as its own premise.
+    monkeypatch.setattr(server, "_FAILURE_LOG_PATH", None)
+    fake_comfy(stdout=_ERROR_ENVELOPE)
+
+    with pytest.raises(server.ComfyCliError):
+        server._run_comfy("run", "wf.json")
+
+    assert not default.exists()
+    assert not default.parent.exists()
+    # No handler was opened either — the memo is untouched.
+    assert server._failure_handler_path is None
+
+
+def test_enabled_path_from_env_var_value_is_written(
+    monkeypatch, tmp_path, fake_comfy, capsys
+):
+    """``COMFY_LOCAL_MCP_DEBUG_LOG=<path>`` writes to exactly that file."""
+    target = tmp_path / "nested" / "chosen.jsonl"
+    monkeypatch.setattr(
+        server, "_FAILURE_LOG_PATH", server._resolve_failure_log_path(str(target))
+    )
+    fake_comfy(stdout=_ERROR_ENVELOPE)
+
+    with pytest.raises(server.ComfyCliError):
+        server._run_comfy("run", "wf.json")
+
+    assert len(_entries(target)) == 1
+    # This is an MCP *stdio* server: stdout is the protocol transport, so the
+    # dedicated logger must never reach a default stream handler.
+    assert capsys.readouterr().out == ""
+
+
+# --- what a record contains --------------------------------------------------
+
+
+def test_error_envelope_is_recorded(log_path, fake_comfy):
+    """An error envelope logs one line with its code, argv, and empty-stream markers."""
+    fake_comfy(stdout=_ERROR_ENVELOPE)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("run", "wf.json")
+
+    (entry,) = _entries(log_path)
+    assert entry["kind"] == "error_envelope"
+    assert entry["args"] == ["run", "wf.json"]
+    assert entry["error_code"] == "credential_missing"
+    assert entry["exit_code"] == 0
+    assert entry["streaming"] is False
+    # `message` is kept alongside the structured fields so QA can correlate a
+    # line with what the MCP client actually displayed.
+    assert entry["message"] == str(excinfo.value)
+    assert entry["stderr_tail"] == "<empty>"
+    assert "credential_missing" in entry["stdout_tail"]
+    assert entry["ts"].endswith("+00:00")
+
+
+@pytest.mark.parametrize("blank", ["", "   ", None, b""])
+def test_blank_streams_are_marked_not_dropped(blank):
+    """A blank/absent capture records ``<empty>``, never an empty string.
+
+    Same ``_stream_tail`` marker the error messages use, so a record can never
+    show a stream that looks absent when it was actually truncated away.
+    """
+    assert server._stream_tail(blank, server._FAILURE_LOG_TAIL_CHARS) == "<empty>"
+
+
+def test_concurrent_first_failures_write_one_line_each(log_path, fake_comfy):
+    """Two threads failing at once must not install duplicate handlers.
+
+    The handler is built lazily on the first write, so concurrent first failures
+    race on that setup — an interleaving that left both threads' handlers attached
+    would duplicate every subsequent line for the life of the process.
+    """
+    fake_comfy(stdout=_ERROR_ENVELOPE)
+    barrier = threading.Barrier(4)
+
+    def fail():
+        barrier.wait()
+        with pytest.raises(server.ComfyCliError):
+            server._run_comfy("run", "wf.json")
+
+    threads = [threading.Thread(target=fail) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(_entries(log_path)) == 4
+    assert len(server.logging.getLogger(server._FAILURE_LOGGER_NAME).handlers) == 1
+
+
+def test_no_json_exit_is_recorded_with_both_tails(log_path, fake_comfy):
+    """A comfy-cli that dies before emitting JSON logs both streams and its exit code."""
+    fake_comfy(stdout="usage: comfy [OPTIONS]", stderr="Traceback: boom", returncode=2)
+
+    with pytest.raises(server.ComfyCliError):
+        server._run_comfy("jobs", "status", "abc")
+
+    (entry,) = _entries(log_path)
+    assert entry["kind"] == "no_json"
+    assert entry["exit_code"] == 2
+    assert entry["error_code"] is None
+    assert "usage: comfy" in entry["stdout_tail"]
+    assert "Traceback: boom" in entry["stderr_tail"]
+
+
+def test_timeout_is_recorded(log_path, fake_comfy):
+    """A killed child logs ``timeout`` with no exit code (it never reported one)."""
+    fake_comfy(
+        raises=subprocess.TimeoutExpired(
+            cmd=["comfy"], timeout=1.0, output=b"partial stdout", stderr=b"partial err"
+        )
+    )
+
+    with pytest.raises(server.ComfyCliError):
+        server._run_comfy("run", "wf.json", timeout=1.0)
+
+    (entry,) = _entries(log_path)
+    assert entry["kind"] == "timeout"
+    assert entry["exit_code"] is None
+    assert "partial stdout" in entry["stdout_tail"]
+    assert "partial err" in entry["stderr_tail"]
+
+
+def test_binary_missing_is_recorded_with_no_args(monkeypatch, log_path):
+    """No binary means no invocation, so ``args`` is empty by construction."""
+    monkeypatch.setattr(server.shutil, "which", lambda _: None)
+    monkeypatch.setattr(server, "_is_macos", lambda: False)
+
+    with pytest.raises(server.ComfyCliError):
+        server._run_comfy("run", "wf.json")
+
+    (entry,) = _entries(log_path)
+    assert entry["kind"] == "binary_missing"
+    assert entry["args"] == []
+    assert "not found on PATH" in entry["message"]
+
+
+def test_schema_mismatch_is_recorded(log_path, fake_comfy):
+    """A future envelope major is refused loudly — and recorded as its own kind."""
+    fake_comfy(
+        stdout=json.dumps(
+            {"schema": "envelope/2", "type": "envelope", "ok": True, "data": {}}
+        )
+    )
+
+    with pytest.raises(server.ComfyCliError):
+        server._run_comfy("run", "wf.json")
+
+    (entry,) = _entries(log_path)
+    assert entry["kind"] == "schema_mismatch"
+    assert "envelope/2" in entry["message"]
+
+
+def test_tail_cap_is_larger_than_the_message_cap():
+    """The log keeps MORE output than an error message can — its reason to exist."""
+    assert server._FAILURE_LOG_TAIL_CHARS > server._MAX_ERROR_FIELD_CHARS
+
+
+def test_long_stream_is_tail_truncated_with_a_marker(log_path, fake_comfy):
+    """An oversized capture is clipped to the tail and marked, never silently."""
+    noise = "x" * (server._FAILURE_LOG_TAIL_CHARS * 2)
+    fake_comfy(stdout="no json here", stderr=noise + "THE-REAL-ERROR", returncode=1)
+
+    with pytest.raises(server.ComfyCliError):
+        server._run_comfy("run", "wf.json")
+
+    (entry,) = _entries(log_path)
+    tail = entry["stderr_tail"]
+    # The `...` marker is additive to the bound, exactly as in the error messages
+    # `_stream_tail` was written for — the payload itself stays capped.
+    assert len(tail) == server._FAILURE_LOG_TAIL_CHARS + len("...")
+    assert tail.startswith("...")  # truncation is visible
+    assert tail.endswith("THE-REAL-ERROR")  # the tail, not the head, is kept
+
+
+def test_streaming_failure_is_flagged(log_path, monkeypatch):
+    """The ``streaming`` flag distinguishes the ``--json-stream`` spawn path."""
+    procs: list[_FakeProc] = []
+
+    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
+        proc = _FakeProc(cmd, _ERROR_ENVELOPE + "\n", env=env, encoding=encoding)
+        procs.append(proc)
+        return proc
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+
+    with pytest.raises(server.ComfyCliError):
+        server.asyncio.run(server._run_comfy_streaming("run", "wf.json"))
+
+    (entry,) = _entries(log_path)
+    assert entry["kind"] == "error_envelope"
+    assert entry["streaming"] is True
+
+
+# --- failure-only ------------------------------------------------------------
+
+
+def test_successful_call_logs_nothing(log_path, fake_comfy):
+    """Failure-only: a healthy call must not leave a line (or a file) behind."""
+    fake_comfy(
+        stdout=json.dumps(
+            {"schema": "envelope/1", "type": "envelope", "ok": True, "data": {"x": 1}}
+        )
+    )
+
+    assert server._run_comfy("jobs", "status", "abc") == {"x": 1}
+
+    assert not log_path.exists()
+
+
+def test_preflight_validation_raise_logs_nothing(log_path, fake_comfy):
+    """A guard that rejects an argument never spawned comfy-cli — not our gap.
+
+    comfy-cli is stubbed to FAIL, so a spawn would certainly write a record: the
+    empty log is evidence the leading-dash guard short-circuited before it.
+    """
+    fake_comfy(stdout=_ERROR_ENVELOPE)
+
+    with pytest.raises(server.ComfyCliError):
+        server.get_execution_error("-x")
+
+    assert not log_path.exists()
+
+
+# --- redaction ---------------------------------------------------------------
+
+
+def test_scrub_arg_masks_userinfo_and_strips_query(log_path, fake_comfy):
+    """A URL arg is logged with userinfo masked and query/fragment dropped.
+
+    Also covers the ``message`` field, which :func:`_unwrap_envelope` builds as
+    ``comfy <args> failed …`` — i.e. it echoes the RAW argv, so scrubbing only
+    the ``args`` list would leave the credential in the very next key.
+    """
+    url = "https://user:tok@host/x?token=abc#frag"
+    fake_comfy(stdout=_ERROR_ENVELOPE)
+
+    with pytest.raises(server.ComfyCliError):
+        server._run_comfy("model", "download", "--url", url)
+
+    (entry,) = _entries(log_path)
+    assert entry["args"] == ["model", "download", "--url", "https://***@host/x"]
+    assert entry["message"].startswith(
+        "comfy model download --url https://***@host/x failed"
+    )
+    line = log_path.read_text()
+    assert "tok" not in line
+    assert "token=abc" not in line
+
+
+def test_scrub_message_masks_urls_but_keeps_prose():
+    """Only URL-shaped substrings are rewritten; the surrounding prose survives."""
+    text = "comfy model download --url https://u:p@h/m.safetensors?token=s failed"
+    assert server._scrub_message(text) == (
+        "comfy model download --url https://***@h/m.safetensors failed"
+    )
+    plain = "comfy run wf.json failed [bad_workflow]: node 3 has no input"
+    assert server._scrub_message(plain) == plain
+
+
+@pytest.mark.parametrize(
+    ("arg", "expected"),
+    [
+        # Non-URL args pass through verbatim — mangling a path or a subcommand
+        # would defeat the log.
+        ("run", "run"),
+        ("/Users/me/wf.json", "/Users/me/wf.json"),
+        ("user:pass@notaurl", "user:pass@notaurl"),
+        # Query stripped even with no credential in it (mirrors comfy-cli's own
+        # scrubber: a CivitAI URL carries its token as `?token=…`).
+        ("https://h/m.safetensors?token=abc", "https://h/m.safetensors"),
+        ("http://h/p#f", "http://h/p"),
+        # A fragment BEFORE a query still cuts at the first delimiter.
+        ("https://h/p#f?q=1", "https://h/p"),
+        # Userinfo masked with no query present, and the scheme is case-blind.
+        ("https://u:p@h/path", "https://***@h/path"),
+        ("HTTPS://u:p@h/path", "HTTPS://***@h/path"),
+        # A bare host URL is untouched.
+        ("https://h/path", "https://h/path"),
+    ],
+)
+def test_scrub_arg_cases(arg, expected):
+    assert server._scrub_arg(arg) == expected
+
+
+# --- best-effort + rotation --------------------------------------------------
+
+
+def test_unwritable_log_never_masks_the_real_error(monkeypatch, tmp_path, fake_comfy):
+    """A log that cannot be opened is swallowed; the ComfyCliError is unchanged."""
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("i am a file")
+    # Parent is a regular file, so `os.makedirs` inside the handler setup raises.
+    monkeypatch.setattr(server, "_FAILURE_LOG_PATH", str(blocker / "failures.jsonl"))
+    fake_comfy(stdout=_ERROR_ENVELOPE)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("run", "wf.json")
+
+    assert excinfo.value.code == "credential_missing"
+    assert "no API key configured" in str(excinfo.value)
+    # The failed setup must not leave the memo claiming a path nothing writes to,
+    # or the next failure would skip setup and silently drop its record.
+    assert server._failure_handler_path is None
+
+
+def test_log_path_that_is_a_directory_is_swallowed(monkeypatch, tmp_path, fake_comfy):
+    """Same best-effort contract when the path itself is an existing directory."""
+    monkeypatch.setattr(server, "_FAILURE_LOG_PATH", str(tmp_path))
+    fake_comfy(stdout=_ERROR_ENVELOPE)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("run", "wf.json")
+
+    assert excinfo.value.code == "credential_missing"
+
+
+def test_handler_is_configured_for_rotation(log_path, fake_comfy):
+    """Smoke-check the stdlib handler's configuration (rotation itself is its own)."""
+    fake_comfy(stdout=_ERROR_ENVELOPE)
+
+    with pytest.raises(server.ComfyCliError):
+        server._run_comfy("run", "wf.json")
+
+    logger = server.logging.getLogger(server._FAILURE_LOGGER_NAME)
+    (handler,) = logger.handlers
+    assert isinstance(handler, server.RotatingFileHandler)
+    assert handler.maxBytes == server._FAILURE_LOG_MAX_BYTES == 1_048_576
+    assert handler.backupCount == server._FAILURE_LOG_BACKUPS == 2
+    assert handler.encoding == "utf-8"
+    # Bare `%(message)s`: lines must be pure JSON for `jq`.
+    assert handler.formatter._fmt == "%(message)s"
+    # Never up to the root logger — stdout is the MCP transport.
+    assert logger.propagate is False
+
+
+def test_rotation_produces_a_backup_file(monkeypatch, log_path, fake_comfy):
+    """Past ``maxBytes`` the handler rolls over, so the log is self-limiting."""
+    monkeypatch.setattr(server, "_FAILURE_LOG_MAX_BYTES", 200)
+    fake_comfy(stdout=_ERROR_ENVELOPE)
+
+    for _ in range(5):
+        with pytest.raises(server.ComfyCliError):
+            server._run_comfy("run", "wf.json")
+
+    assert log_path.exists()
+    assert log_path.with_suffix(log_path.suffix + ".1").exists()


### PR DESCRIPTION
## ELI-5

When comfy-cli breaks, the only record is whatever your AI client happened to print — and it scrolls away. Flip one environment variable on and this server starts keeping a little notebook of every comfy-cli failure on your own machine: what it ran, what exit code came back, and the last chunk of what comfy-cli printed. Zip the notebook up and attach it to a bug report. It's off unless you turn it on, it only writes down failures, and it never sends anything anywhere.

## Summary

Adds `COMFY_LOCAL_MCP_DEBUG_LOG`, an opt-in, local-only, failure-only rotating JSONL log of every comfy-cli failure the server surfaces. Off by default with **zero filesystem effects** — no directory created, no handler opened. Stdlib only; no new dependencies.

| `COMFY_LOCAL_MCP_DEBUG_LOG` | Behavior |
| --- | --- |
| unset / empty / `0` | off (default) |
| `1` | on, at the per-OS default path |
| anything else | on, and the value is the log file path |

Default paths mirror comfy-cli's own local-state convention (`constants.py` `DEFAULT_CONFIG`) with a `comfy-local-mcp` leaf — hand-rolled across three `sys.platform` branches, since comfy-cli is the *engine* this server shells out to and not a Python dependency (`mcp` is the only one): `~/Library/Application Support/comfy-local-mcp/failures.jsonl` (macOS), `~/AppData/Local/…` (Windows), `~/.config/…` (Linux). Deliberately **not** in the ComfyUI workspace — resolving that requires running comfy-cli, and this log's prime scenarios (missing binary, pre-JSON crash, timeout) are exactly when comfy-cli can't answer.

## Changes

- **`_log_failure(...)`** writes one JSON object per failure: `ts` (UTC, seconds), `kind`, scrubbed `args`, `exit_code`, `error_code`, `message`, `stdout_tail`, `stderr_tail`, `streaming`. Structured fields rather than just the formatted sentence, so the log is `jq`/grep-able without parsing prose; `message` is kept too so QA can correlate a line with what the client displayed.
- **Hook points** — log-then-raise at every path that raises *after* invoking comfy-cli: `_unwrap_envelope`'s error-envelope (`error_envelope`, carrying the envelope's `error.code`), no-envelope (`no_json`), and schema-mismatch (`schema_mismatch`) branches; `_run_comfy_raw`'s `TimeoutExpired` handler and `_run_comfy_streaming`'s timeout raise (`timeout`, `exit_code=None`); both `_require_comfy_bin` raises (`binary_missing`, `args=()`). `_unwrap_envelope` is shared by the plain and streaming spawns, so it takes a `streaming` flag purely to tag which one produced the record.
- **Pre-flight validation raises are deliberately NOT logged** (leading-dash guards, bounds checks) — they never spawned comfy-cli, so they aren't the diagnostic gap. There's a test asserting this with comfy-cli stubbed to fail, so a spawn would definitely have written a line.
- **Rotation** via `logging.handlers.RotatingFileHandler` (1 MiB × 3 generations) on a dedicated logger with `propagate = False` and a bare `%(message)s` formatter — lines stay pure JSON, and nothing can reach stdout, which is the MCP **stdio** transport. The handler opens lazily on the first write.
- **Scrubbing** — `_scrub_arg` applies the existing `_redact_url` (masks `user:pass@`) and additionally drops the query string + fragment, mirroring comfy-cli's `tracking.py` scrubber (a CivitAI model URL carries its credential as `?token=…`). Non-URL args pass through verbatim.
- **README** — a "Failure log (opt-in)" section: the env var, the three default paths, the field list, rotation sizes, a `jq` example, and the privacy note.

## Motivation

Gives testers a durable, zippable local diagnostic trail for comfy-cli failures, in exactly the cases where nothing else survives. Opt-in, local-only, failure-only: a successful call never writes, and nothing is transmitted anywhere.

## Testing

- [x] Existing tests pass (`pytest` — 479 passed, 2 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually (below)

New `tests/test_failure_log.py` (41 tests, comfy-cli mocked — nothing needs a real binary): disabled-by-default writes nothing and creates no directory (the *default* path is pointed into `tmp_path` so "nothing was created" is actually observable); the switch's four value cases; the three per-OS default paths; one record per kind (`error_envelope` / `no_json` / `timeout` / `binary_missing` / `schema_mismatch`) with its fields asserted; `<empty>` markers and `...`-marked tail truncation; the streaming flag; failure-only (success and a pre-flight raise both write nothing); redaction (userinfo masked, query stripped, in both `args` and `message`); best-effort (an unopenable log leaves the `ComfyCliError` byte-identical, code included); real rotation (`.1` appears past an overridden `maxBytes`) plus a handler-config smoke assert; env-var-as-path.

A new autouse fixture in `tests/conftest.py` pins the log OFF for the whole suite and closes any handler a test opened. Without it, a developer with `COMFY_LOCAL_MCP_DEBUG_LOG` exported would have the suite writing real records into their app-support directory *and* would see the disabled-by-default tests fail for an environmental reason. Verified: `COMFY_LOCAL_MCP_DEBUG_LOG=1 pytest -q` is green and creates nothing under `~/Library/Application Support/comfy-local-mcp`.

**Manual, against a real subprocess** (a stub `comfy` on `PATH`, not a mock) — a missing-binary failure and an error-envelope failure with a credential-bearing URL argument:

```console
$ COMFY_LOCAL_MCP_DEBUG_LOG=/tmp/f.jsonl  # ... comfy model download --url https://user:tok@cdn.example/m.safetensors?token=SECRET
{"ts": "…", "kind": "error_envelope", "args": ["model", "download", "--url", "https://***@cdn.example/m.safetensors"],
 "exit_code": 1, "error_code": "download_failed",
 "message": "comfy model download --url https://***@cdn.example/m.safetensors failed [download_failed]: could not fetch",
 "stdout_tail": "{\"schema\":\"envelope/1\", …}", "stderr_tail": "<empty>", "streaming": false}
$ grep -c 'SECRET\|tok@' /tmp/f.jsonl
0
```

## Additional Notes

**Judgment calls, all flagged rather than silent:**

1. **`message` is scrubbed too, not just `args`.** Writing the tests surfaced a real leak the plan didn't anticipate: `_unwrap_envelope` builds its message as `comfy <args> failed …`, i.e. it echoes the **raw** argv, so scrubbing the `args` list alone left the `?token=…` credential intact in the very next JSON key. Added `_scrub_message`, which applies the same URL scrub to URL-shaped substrings (surrounding prose is preserved byte-for-byte). This does not change the message raised to the client — that behavior is untouched here — but this log *persists* it to a file a tester is invited to share, so the masking has to reach it.
2. **One `_FAILURE_LOG_PATH` global instead of the plan's `_FAILURE_LOG_ENABLED` + path pair.** `None` means disabled. Two globals could disagree (enabled-with-no-path would be a live tripwire), and tests monkeypatching one and forgetting the other is the classic way that bites.
3. **A lock around the lazy handler setup.** Tool calls reach `_run_comfy` from several worker pools, so two threads can fail simultaneously and race on first-write setup. `logging` makes *emitting* thread-safe but not this check-then-swap: an interleaving of two remove-all/add passes can leave the logger holding **both** handlers, duplicating every subsequent line for the process's life. Guarded with a double-checked `threading.Lock` — only the once-per-path setup takes it — and there's a 4-thread regression test asserting 4 lines and exactly 1 handler.
4. **The TCC-denial sub-branch of the no-envelope path is logged as `no_json`.** A macOS Full-Disk-Access denial is the *reason* comfy-cli emitted no envelope, not a different kind of failure, and it's a real failure worth a record. Unlike the raised message (which deliberately substitutes curated guidance for the raw stream), the record keeps `stdout` too — a trail is read after the fact, when curated guidance is no longer enough.
5. **Small refactor in `_run_comfy_streaming`'s timeout path:** it kept only a 500-char `_tail` of the drained stderr. Now the drained text is kept and `_tail` is applied where the message is built, so the log can record its own (much longer) slice instead of being silently capped to the message's bound. The raised message is byte-identical.
6. **Not hooked:** `_check_comfy_version`'s "upgrade comfy-cli" raise. It's a comfy-cli failure, but it isn't one of the plan's four hook points and none of the five `kind` values fit it. Easy follow-up if wanted — say the word and I'll add a `version_too_old` kind.
7. **AGENTS.md unchanged** — it has no section this touches (it already permits local file writes; no guardrail change needed), per the plan.
8. **The retry path writes one line per attempt.** `run_workflow`'s bounded credential retry calls through `_unwrap_envelope` per attempt, so a retried failure records 2–3 lines. That's correct — each attempt genuinely failed — but worth knowing before you read a log.

**Interaction with #76 (open, `matt/be-4580-redact-stream-tails`).** No dependency and no stacking: this branches off `main`. The two compose for free — #76 moves credential redaction into `_tail`, and since every tail here goes through `_stream_tail` → `_tail`, the recorded `stdout_tail` / `stderr_tail` become masked automatically once #76 lands. Both touch `_tail`/`_stream_tail`'s docstrings and append tests, so expect a small textual merge, not a semantic one.

**Negative-claim falsification (regression case: the "SVG/3D aren't supported — STOP" dead-end):** the trigger does not fire. This diff adds no `not supported` / `unavailable` / `STOP` string, no throw/deny dead-end path, and flips no test to assert a dead-end. Its user-facing outcome is purely additive — an opt-in diagnostic file — and it denies no capability, so there is nothing to attempt-and-falsify. Every raise it touches is one that already existed on `main`; the raised messages are unchanged apart from the strictly-more-informative streaming timeout tail noted above.
