### PR TITLE
fix: reject NaN and clamp oversized timeouts in run_workflow and wait_for_job

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -238,8 +238,10 @@ ENVELOPE_SCHEMA_MAJOR = 1
 # then rejects an older CLI (see ``_check_comfy_cli_version``).
 MIN_COMFY_CLI_VERSION = os.environ.get("COMFY_CLI_MIN_VERSION") or None
 
-# Hard ceiling for a single bounded watch so `float('inf')` / an absurd value
-# can't hold a `comfy jobs watch` child open effectively forever (1 hour).
+# Hard ceiling for a single bounded wait on an already-submitted job — the
+# streaming `watch_job` and the polling `wait_for_job` share it — so
+# `float('inf')` / an absurd value can't hold a `comfy jobs watch` child open,
+# or keep re-spawning `comfy jobs status`, effectively forever (1 hour).
 _MAX_WATCH_TIMEOUT = 3600.0
 
 
@@ -2310,7 +2312,9 @@ async def run_workflow(
     of an opaque client-side deadline. Keep it under your client's tool timeout;
     for generations that may exceed it, submit with ``wait=False`` and poll
     ``wait_for_job`` / ``watch_job`` (the server INSTRUCTIONS teach this flow)
-    rather than raising this bound.
+    rather than raising this bound. On the waiting path it is clamped to a sane
+    maximum, and a non-positive / NaN value is rejected outright; ``wait=False``
+    ignores it entirely (that submit runs on its own fixed budget).
 
     Partner-API nodes (Seedream/Veo/Kling/Gemini/…) need a Comfy credential in
     the server's environment (``COMFY_API_KEY`` in the client registration). A
@@ -2318,6 +2322,14 @@ async def run_workflow(
     the surfaced error carries comfy-cli's hint (including the working
     ``comfy auth set comfy-cloud-api-key`` fallback).
     """
+    if wait:
+        # Harden the caller's bound BEFORE it reaches `_run_comfy_streaming`
+        # (and from there `asyncio.wait_for`): `inf` would wait on the child
+        # forever and NaN is undefined timer behavior — see `_bounded_timeout`.
+        # Only on this path: `wait=False` runs on a fixed 60s budget and never
+        # reads this parameter, so validating it there would newly reject a
+        # submit that works fine today.
+        timeout_seconds = _bounded_timeout(timeout_seconds, _MAX_RUN_WORKFLOW_TIMEOUT)
 
     async def _attempt() -> Any:
         if not wait:
@@ -2356,6 +2368,13 @@ async def run_workflow(
                     ) from exc
                 raise
             await asyncio.sleep(backoff)
+
+
+# Hard ceiling for one waited `run_workflow`, so a `float('inf')` / absurd value
+# can't hold the `comfy run --wait` child open effectively forever. Matches the
+# other per-tool ceilings (partner_generate, run_template, watch_job) at an
+# hour; the docstring already steers genuinely long runs to `wait=False`.
+_MAX_RUN_WORKFLOW_TIMEOUT = 3600.0
 
 
 # The gallery template `generate_image` runs: ComfyUI's own default graph — the
@@ -3572,8 +3591,16 @@ def wait_for_job(prompt_id: str, timeout_seconds: float = 25.0) -> Any:
     or ``{"timed_out": True, "status": <last payload>}`` on expiry. The wait is
     bounded by design — chain several short ``wait_for_job`` calls (checking
     ``job_status`` in between) rather than issuing one long block. Use after
-    ``run_workflow(wait=False)``.
+    ``run_workflow(wait=False)``. ``timeout_seconds`` is clamped to a sane
+    maximum (the same ceiling as ``watch_job``, this tool's streaming
+    counterpart), and a non-positive / NaN value is rejected outright.
     """
+    # "Bounded by design" only holds if the bound itself is bounded. Left raw,
+    # `inf` keeps `remaining` positive forever and NaN makes every comparison
+    # False (so `remaining <= 0` never fires and `min(2.0, nan)` yields 2.0) —
+    # either way the poll loop re-spawns `comfy jobs status` until the client
+    # gives up. See `_bounded_timeout`.
+    timeout_seconds = _bounded_timeout(timeout_seconds, _MAX_WATCH_TIMEOUT)
     deadline = time.monotonic() + timeout_seconds
     poll_interval = 2.0
     last: Any = None

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -3408,6 +3408,10 @@ def job_status(prompt_id: str) -> Any:
     Wraps ``comfy jobs status <prompt_id>``. Returns the job status and, when
     finished, its output references. Poll this after ``run_workflow(wait=False)``.
     """
+    if prompt_id.startswith("-"):
+        # comfy-cli parses a leading-dash positional as an option/flag; reject
+        # it rather than let `jobs status` misread the id (argument injection).
+        raise ComfyCliError(f"invalid prompt_id: {prompt_id!r} (leading '-')")
     return _run_comfy("jobs", "status", prompt_id, timeout=60.0)
 
 
@@ -3595,6 +3599,10 @@ def wait_for_job(prompt_id: str, timeout_seconds: float = 25.0) -> Any:
     maximum (the same ceiling as ``watch_job``, this tool's streaming
     counterpart), and a non-positive / NaN value is rejected outright.
     """
+    if prompt_id.startswith("-"):
+        # comfy-cli parses a leading-dash positional as an option/flag; reject
+        # it rather than let `jobs status` misread the id (argument injection).
+        raise ComfyCliError(f"invalid prompt_id: {prompt_id!r} (leading '-')")
     # "Bounded by design" only holds if the bound itself is bounded. Left raw,
     # `inf` keeps `remaining` positive forever and NaN makes every comparison
     # False (so `remaining <= 0` never fires and `min(2.0, nan)` yields 2.0) —
@@ -3659,6 +3667,10 @@ def cancel_job(prompt_id: str) -> Any:
     submitted via ``run_workflow(wait=False)`` before it finishes; cancelling an
     unknown or already-finished ``prompt_id`` surfaces comfy-cli's error envelope.
     """
+    if prompt_id.startswith("-"):
+        # comfy-cli parses a leading-dash positional as an option/flag; reject
+        # it rather than let `jobs cancel` misread the id (argument injection).
+        raise ComfyCliError(f"invalid prompt_id: {prompt_id!r} (leading '-')")
     return _run_comfy("jobs", "cancel", prompt_id, timeout=60.0)
 
 
@@ -3829,6 +3841,11 @@ def fetch_outputs(
     (``_INLINE_IMAGE_MAX_COUNT`` files / ``_INLINE_IMAGE_MAX_BYTES`` aggregate) so
     a large batch can't blow up the reply — the on-disk copies are never capped.
     """
+    if prompt_id.startswith("-"):
+        # comfy-cli parses a leading-dash positional as an option/flag; reject it
+        # rather than let `download` misread the id (argument injection) — here it
+        # would sit directly alongside this command's own `-o` / `--url-only`.
+        raise ComfyCliError(f"invalid prompt_id: {prompt_id!r} (leading '-')")
     args = ["download", prompt_id, "-o", out_dir]
     if url_only:
         args.append("--url-only")

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -3632,8 +3632,11 @@ def wait_for_job(prompt_id: str, timeout_seconds: float = 25.0) -> Any:
     poll_interval = 2.0
     last: Any = None
     while True:
+        # `last is not None` keeps the one-poll minimum: a bound small enough to
+        # expire before the first poll (`timeout_seconds=1e-9`) must still report
+        # a real status rather than the degenerate `{"status": None}`.
         remaining = deadline - time.monotonic()
-        if remaining <= 0:
+        if remaining <= 0 and last is not None:
             return {"timed_out": True, "status": last}
         # Cap each poll's own subprocess budget to what is left of the caller's
         # bound. With a fixed 60s per poll the overall wait was only bounded

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -244,6 +244,20 @@ MIN_COMFY_CLI_VERSION = os.environ.get("COMFY_CLI_MIN_VERSION") or None
 # or keep re-spawning `comfy jobs status`, effectively forever (1 hour).
 _MAX_WATCH_TIMEOUT = 3600.0
 
+# Hard ceiling for one waited `run_workflow`, so a `float('inf')` / absurd value
+# can't hold the `comfy run --wait` child open effectively forever. Matches the
+# other per-tool ceilings (partner_generate, run_template, watch_job) at an
+# hour; the docstring already steers genuinely long runs to `wait=False`.
+_MAX_RUN_WORKFLOW_TIMEOUT = 3600.0
+
+# Per-poll subprocess budget for `wait_for_job`'s `comfy jobs status` calls, and
+# the smallest slice worth spawning one for. `wait_for_job` caps each poll to
+# whatever is left of the caller's own bound, so a wedged status call can't hold
+# a one-second wait open for the full budget; the floor keeps a sliver of
+# remaining time from spawning a poll that is guaranteed to hit its own deadline.
+_JOB_STATUS_POLL_TIMEOUT = 60.0
+_MIN_JOB_STATUS_POLL_TIMEOUT = 1.0
+
 
 def _bounded_timeout(timeout_seconds: float, ceiling: float) -> float:
     """Bound a caller-supplied timeout to ``(0, ceiling]``, rejecting NaN.
@@ -287,6 +301,25 @@ def _reject_nul(label: str, value: str) -> str:
             "cannot contain one."
         )
     return value
+
+
+def _guard_prompt_id(prompt_id: str) -> str:
+    """Reject a ``prompt_id`` comfy-cli would mis-read or ``subprocess`` can't carry.
+
+    Shared by the six tools that take one, so the family stays uniform. Every
+    ``jobs`` verb (and ``download``) takes the id as a bare positional — argv is
+    a list and there is no shell, so the real hazard is not injection but
+    *parsing*: a leading dash reaches comfy-cli as an option rather than an id,
+    most sharply in ``fetch_outputs`` where it sits beside that command's own
+    ``-o`` / ``--url-only``. An embedded NUL is a legal JSON (and so MCP) string
+    but makes ``subprocess.run`` raise a bare ``ValueError``, which would surface
+    as an internal error instead of the :class:`ComfyCliError` every other bad
+    input produces. An empty id can only ever be a caller mistake, and is
+    refused like every other positional this module guards.
+    """
+    if not prompt_id or prompt_id.startswith("-"):
+        raise ComfyCliError(f"invalid prompt_id: {prompt_id!r} (empty or leading '-')")
+    return _reject_nul("prompt_id", prompt_id)
 
 
 # Once the terminal envelope is read the authoritative result is in hand, but
@@ -2370,13 +2403,6 @@ async def run_workflow(
             await asyncio.sleep(backoff)
 
 
-# Hard ceiling for one waited `run_workflow`, so a `float('inf')` / absurd value
-# can't hold the `comfy run --wait` child open effectively forever. Matches the
-# other per-tool ceilings (partner_generate, run_template, watch_job) at an
-# hour; the docstring already steers genuinely long runs to `wait=False`.
-_MAX_RUN_WORKFLOW_TIMEOUT = 3600.0
-
-
 # The gallery template `generate_image` runs: ComfyUI's own default graph — the
 # basic SD1.5 text-to-image workflow whose CheckpointLoaderSimple default is
 # `v1-5-pruned-emaonly-fp16.safetensors`. Free (core nodes only, no partner-API
@@ -3408,10 +3434,7 @@ def job_status(prompt_id: str) -> Any:
     Wraps ``comfy jobs status <prompt_id>``. Returns the job status and, when
     finished, its output references. Poll this after ``run_workflow(wait=False)``.
     """
-    if prompt_id.startswith("-"):
-        # comfy-cli parses a leading-dash positional as an option/flag; reject
-        # it rather than let `jobs status` misread the id (argument injection).
-        raise ComfyCliError(f"invalid prompt_id: {prompt_id!r} (leading '-')")
+    prompt_id = _guard_prompt_id(prompt_id)
     return _run_comfy("jobs", "status", prompt_id, timeout=60.0)
 
 
@@ -3499,10 +3522,7 @@ def get_execution_error(prompt_id: str) -> Any:
     ``{"prompt_id", "status", "error": None}`` rather than raising, so it is safe
     to call speculatively.
     """
-    if prompt_id.startswith("-"):
-        # comfy-cli parses a leading-dash positional as an option/flag; reject
-        # it rather than let `jobs status` misread the id (argument injection).
-        raise ComfyCliError(f"invalid prompt_id: {prompt_id!r} (leading '-')")
+    prompt_id = _guard_prompt_id(prompt_id)
 
     status = _run_comfy("jobs", "status", prompt_id, timeout=60.0)
 
@@ -3597,12 +3617,11 @@ def wait_for_job(prompt_id: str, timeout_seconds: float = 25.0) -> Any:
     ``job_status`` in between) rather than issuing one long block. Use after
     ``run_workflow(wait=False)``. ``timeout_seconds`` is clamped to a sane
     maximum (the same ceiling as ``watch_job``, this tool's streaming
-    counterpart), and a non-positive / NaN value is rejected outright.
+    counterpart), and a non-positive / NaN value is rejected outright; each
+    individual poll is capped to the time left on that bound, so the call
+    returns at roughly the deadline even if a status poll wedges.
     """
-    if prompt_id.startswith("-"):
-        # comfy-cli parses a leading-dash positional as an option/flag; reject
-        # it rather than let `jobs status` misread the id (argument injection).
-        raise ComfyCliError(f"invalid prompt_id: {prompt_id!r} (leading '-')")
+    prompt_id = _guard_prompt_id(prompt_id)
     # "Bounded by design" only holds if the bound itself is bounded. Left raw,
     # `inf` keeps `remaining` positive forever and NaN makes every comparison
     # False (so `remaining <= 0` never fires and `min(2.0, nan)` yields 2.0) —
@@ -3613,7 +3632,24 @@ def wait_for_job(prompt_id: str, timeout_seconds: float = 25.0) -> Any:
     poll_interval = 2.0
     last: Any = None
     while True:
-        last = _run_comfy("jobs", "status", prompt_id, timeout=60.0)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return {"timed_out": True, "status": last}
+        # Cap each poll's own subprocess budget to what is left of the caller's
+        # bound. With a fixed 60s per poll the overall wait was only bounded
+        # between polls, so a wedged `comfy jobs status` could hold a
+        # `timeout_seconds=1` call open for a full minute. The floor keeps a
+        # sliver of remaining time from spawning a poll that is guaranteed to
+        # hit its own deadline (and raise) instead of returning `timed_out`; it
+        # overshoots the caller's bound by at most that floor, never by 60s.
+        last = _run_comfy(
+            "jobs",
+            "status",
+            prompt_id,
+            timeout=min(
+                _JOB_STATUS_POLL_TIMEOUT, max(remaining, _MIN_JOB_STATUS_POLL_TIMEOUT)
+            ),
+        )
         if _is_terminal(last):
             return last
         remaining = deadline - time.monotonic()
@@ -3644,10 +3680,7 @@ async def watch_job(
     except ``status`` here carries a live progress snapshot
     (``{progress, total, nodes_done}``) rather than a raw ``jobs status`` dict.
     """
-    if prompt_id.startswith("-"):
-        # comfy-cli parses a leading-dash positional as an option/flag; reject
-        # it rather than let `jobs watch` misread the id (argument injection).
-        raise ComfyCliError(f"invalid prompt_id: {prompt_id!r} (leading '-')")
+    prompt_id = _guard_prompt_id(prompt_id)
     timeout_seconds = _bounded_timeout(timeout_seconds, _MAX_WATCH_TIMEOUT)
     return await _run_comfy_streaming(
         "jobs",
@@ -3667,10 +3700,7 @@ def cancel_job(prompt_id: str) -> Any:
     submitted via ``run_workflow(wait=False)`` before it finishes; cancelling an
     unknown or already-finished ``prompt_id`` surfaces comfy-cli's error envelope.
     """
-    if prompt_id.startswith("-"):
-        # comfy-cli parses a leading-dash positional as an option/flag; reject
-        # it rather than let `jobs cancel` misread the id (argument injection).
-        raise ComfyCliError(f"invalid prompt_id: {prompt_id!r} (leading '-')")
+    prompt_id = _guard_prompt_id(prompt_id)
     return _run_comfy("jobs", "cancel", prompt_id, timeout=60.0)
 
 
@@ -3841,11 +3871,7 @@ def fetch_outputs(
     (``_INLINE_IMAGE_MAX_COUNT`` files / ``_INLINE_IMAGE_MAX_BYTES`` aggregate) so
     a large batch can't blow up the reply — the on-disk copies are never capped.
     """
-    if prompt_id.startswith("-"):
-        # comfy-cli parses a leading-dash positional as an option/flag; reject it
-        # rather than let `download` misread the id (argument injection) — here it
-        # would sit directly alongside this command's own `-o` / `--url-only`.
-        raise ComfyCliError(f"invalid prompt_id: {prompt_id!r} (leading '-')")
+    prompt_id = _guard_prompt_id(prompt_id)
     args = ["download", prompt_id, "-o", out_dir]
     if url_only:
         args.append("--url-only")

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -303,6 +303,15 @@ def _reject_nul(label: str, value: str) -> str:
     return value
 
 
+# Generous ceiling on a `prompt_id`'s length. Real ids are the server's UUIDs
+# (36 chars), and comfy-cli's own sanity check for one is `^[A-Za-z0-9_-]{1,128}$`
+# — so this deliberately sits at twice the engine's ceiling and can only refuse
+# input the engine would refuse anyway. What it buys: an oversized string reaches
+# argv, where the OS (not comfy-cli) rejects the exec with an `OSError` no caller
+# converts to a :class:`ComfyCliError`, and gets echoed back whole in the error.
+_MAX_PROMPT_ID_LEN = 256
+
+
 def _guard_prompt_id(prompt_id: str) -> str:
     """Reject a ``prompt_id`` comfy-cli would mis-read or ``subprocess`` can't carry.
 
@@ -315,10 +324,20 @@ def _guard_prompt_id(prompt_id: str) -> str:
     but makes ``subprocess.run`` raise a bare ``ValueError``, which would surface
     as an internal error instead of the :class:`ComfyCliError` every other bad
     input produces. An empty id can only ever be a caller mistake, and is
-    refused like every other positional this module guards.
+    refused like every other positional this module guards. A wildly oversized
+    id is the same story as the NUL: it fails in the exec, as an ``OSError``
+    nobody converts, rather than as a clean error — see
+    :data:`_MAX_PROMPT_ID_LEN`.
     """
     if not prompt_id or prompt_id.startswith("-"):
         raise ComfyCliError(f"invalid prompt_id: {prompt_id!r} (empty or leading '-')")
+    if len(prompt_id) > _MAX_PROMPT_ID_LEN:
+        # Report the length, not the value: echoing a megabyte-long "id" back is
+        # the same denial-of-legibility the cap exists to prevent.
+        raise ComfyCliError(
+            f"invalid prompt_id: {len(prompt_id)} characters exceeds the "
+            f"{_MAX_PROMPT_ID_LEN}-character maximum."
+        )
     return _reject_nul("prompt_id", prompt_id)
 
 
@@ -631,6 +650,13 @@ class ComfyCliError(RuntimeError):
     accept, which the message text alone cannot tell you. It stays ``None`` for
     the failures raised without ever reading a child's status (missing binary,
     timeout).
+
+    ``timed_out`` marks the one failure that is not comfy-cli misbehaving but us
+    running out of patience: the child was killed at the ``timeout=`` we handed
+    :func:`subprocess.run`. A caller that *chose* that budget can then tell its
+    own deadline firing from a genuine comfy-cli error without matching on the
+    message — :func:`wait_for_job`, which caps each poll to the time left on the
+    caller's bound, is exactly that caller.
     """
 
     def __init__(
@@ -639,11 +665,13 @@ class ComfyCliError(RuntimeError):
         code: str | None = None,
         no_envelope: bool = False,
         returncode: int | None = None,
+        timed_out: bool = False,
     ) -> None:
         super().__init__(*args)
         self.code = code
         self.no_envelope = no_envelope
         self.returncode = returncode
+        self.timed_out = timed_out
 
 
 def _comfy_bin_candidates() -> list[str]:
@@ -1010,7 +1038,7 @@ def _run_comfy_raw(
             stdout=exc.stdout,
             stderr=exc.stderr,
         )
-        raise ComfyCliError(message) from exc
+        raise ComfyCliError(message, timed_out=True) from exc
 
     return (
         _last_json_object(proc.stdout),
@@ -3619,7 +3647,12 @@ def wait_for_job(prompt_id: str, timeout_seconds: float = 25.0) -> Any:
     maximum (the same ceiling as ``watch_job``, this tool's streaming
     counterpart), and a non-positive / NaN value is rejected outright; each
     individual poll is capped to the time left on that bound, so the call
-    returns at roughly the deadline even if a status poll wedges.
+    returns at roughly the deadline even if a status poll wedges — a poll killed
+    at that cap yields the ``timed_out`` payload rather than an error. "Roughly"
+    covers two bounded overshoots: a poll is never given less than
+    ``_MIN_JOB_STATUS_POLL_TIMEOUT``, and the FIRST comfy-cli call in a process
+    also pays the one-time ``comfy --version`` compatibility probe (bounded
+    separately, memoized after) before this tool's own budget starts to apply.
     """
     prompt_id = _guard_prompt_id(prompt_id)
     # "Bounded by design" only holds if the bound itself is bounded. Left raw,
@@ -3645,14 +3678,32 @@ def wait_for_job(prompt_id: str, timeout_seconds: float = 25.0) -> Any:
         # sliver of remaining time from spawning a poll that is guaranteed to
         # hit its own deadline (and raise) instead of returning `timed_out`; it
         # overshoots the caller's bound by at most that floor, never by 60s.
-        last = _run_comfy(
-            "jobs",
-            "status",
-            prompt_id,
-            timeout=min(
-                _JOB_STATUS_POLL_TIMEOUT, max(remaining, _MIN_JOB_STATUS_POLL_TIMEOUT)
-            ),
-        )
+        try:
+            last = _run_comfy(
+                "jobs",
+                "status",
+                prompt_id,
+                timeout=min(
+                    _JOB_STATUS_POLL_TIMEOUT,
+                    max(remaining, _MIN_JOB_STATUS_POLL_TIMEOUT),
+                ),
+            )
+        except ComfyCliError as exc:
+            # Capping the poll to the time left means its deadline now doubles as
+            # the CALLER's: a slow-but-healthy `comfy jobs status` (cold start
+            # plus imports) near the bound is killed where the old fixed 60s
+            # budget would have let it finish. That is this call expiring, not
+            # comfy-cli failing, so honor the documented envelope — and keep the
+            # last real status instead of discarding it with the exception.
+            # Two timeouts still raise, because neither is the caller's bound
+            # expiring: one with time left on that bound (the poll burned the
+            # full `_JOB_STATUS_POLL_TIMEOUT` — comfy-cli is genuinely wedged,
+            # which raised before this cap existed too), and one with no status
+            # yet read, where `{"status": None}` would bury a real failure under
+            # a contentless envelope.
+            if not exc.timed_out or last is None or deadline - time.monotonic() > 0:
+                raise
+            return {"timed_out": True, "status": last}
         if _is_terminal(last):
             return last
         remaining = deadline - time.monotonic()
@@ -3875,6 +3926,13 @@ def fetch_outputs(
     a large batch can't blow up the reply — the on-disk copies are never capped.
     """
     prompt_id = _guard_prompt_id(prompt_id)
+    # `out_dir` is the sibling client-supplied positional and rides the same argv
+    # as the id, so it needs the same NUL refusal: `_run_comfy_raw` only converts
+    # `TimeoutExpired`, leaving `subprocess.run`'s bare "embedded null byte"
+    # ValueError to escape as an internal error. A leading dash is NOT rejected
+    # here — `-o` takes a value, so comfy-cli reads even a dash-led one as this
+    # option's argument, and a relative path is legitimate input.
+    out_dir = _reject_nul("out_dir", out_dir)
     args = ["download", prompt_id, "-o", out_dir]
     if url_only:
         args.append("--url-only")

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -358,10 +358,12 @@ def test_cancel_job_unknown_id_raises_error_envelope(patched_run):
 
 
 # `_run_comfy` builds argv with no `--` separator, so a leading-dash positional
-# reaches comfy-cli as an option rather than a job id. `watch_job` and
-# `get_execution_error` already refuse one (covered separately); these are the
-# remaining prompt_id-taking tools, checked together so the family stays uniform
-# — `fetch_outputs` most of all, since there the id sits beside a real `-o`.
+# reaches comfy-cli as an option rather than a job id — `fetch_outputs` most
+# sharply, since there the id sits beside a real `-o`. An embedded NUL is a legal
+# JSON (so MCP) string that `subprocess.run` refuses with a bare ValueError, and
+# an empty id can only be a caller mistake. `_guard_prompt_id` rejects all three
+# for every tool that takes one; the synchronous ones are checked here as a
+# family (`watch_job` and `get_execution_error` are covered separately).
 @pytest.mark.parametrize(
     ("tool", "extra_args"),
     [
@@ -372,19 +374,17 @@ def test_cancel_job_unknown_id_raises_error_envelope(patched_run):
     ],
     ids=lambda v: v if isinstance(v, str) else "",
 )
-@pytest.mark.parametrize("option_like", ["--help", "-o"])
-def test_job_tools_reject_an_option_like_prompt_id(
-    monkeypatch, tool, extra_args, option_like
-):
-    """A leading-dash prompt_id is refused before comfy-cli is ever spawned."""
+@pytest.mark.parametrize("bad_id", ["--help", "-o", "", "p\x001"])
+def test_job_tools_reject_an_unusable_prompt_id(monkeypatch, tool, extra_args, bad_id):
+    """A dash-led / empty / NUL-bearing prompt_id is refused before any spawn."""
 
     def fake_run(*args, **kwargs):
-        raise AssertionError(f"{tool} spawned comfy-cli with {option_like!r}")
+        raise AssertionError(f"{tool} spawned comfy-cli with {bad_id!r}")
 
     monkeypatch.setattr(server, "_run_comfy", fake_run)
 
-    with pytest.raises(server.ComfyCliError, match="invalid prompt_id"):
-        getattr(server, tool)(option_like, *extra_args)
+    with pytest.raises(server.ComfyCliError, match="prompt_id"):
+        getattr(server, tool)(bad_id, *extra_args)
 
 
 def test_get_queue_maps_command_and_returns_data(patched_run):
@@ -746,10 +746,11 @@ def test_wait_for_job_clamps_an_oversized_timeout(monkeypatch, oversized):
     monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: {"status": "running"})
     monkeypatch.setattr(server.time, "sleep", lambda _s: None)
 
-    # A clock that jumps just past the ceiling on its second read: clamped, the
-    # deadline has passed and the tool returns; unclamped, it would poll on and
-    # exhaust the iterator (failing loudly instead of hanging the suite).
-    reads = iter([0.0, server._MAX_WATCH_TIMEOUT + 1.0])
+    # A clock that jumps just past the ceiling once the first poll is done:
+    # clamped, the deadline has passed and the tool returns; unclamped, it would
+    # sleep and poll on, exhausting the iterator (failing loudly rather than
+    # hanging the suite). Reads are (deadline, pre-poll, post-poll).
+    reads = iter([0.0, 1.0, server._MAX_WATCH_TIMEOUT + 1.0])
 
     def fake_monotonic():
         try:
@@ -788,6 +789,52 @@ def test_wait_for_job_rejects_a_non_positive_or_nan_timeout(monkeypatch, bad):
         server.wait_for_job("pid", timeout_seconds=bad)
 
     assert polled is False
+
+
+def test_wait_for_job_caps_each_poll_to_the_remaining_bound(monkeypatch):
+    """A single poll never gets a longer subprocess budget than the wait itself.
+
+    Each `comfy jobs status` used a fixed 60s timeout, so a short wait was only
+    bounded *between* polls: one wedged status call could hold a
+    `timeout_seconds=1` wait open for a full minute.
+    """
+    seen: list[float] = []
+
+    def fake_run(*args, timeout=None, **kwargs):
+        seen.append(timeout)
+        return {"status": "running"}
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run)
+    monkeypatch.setattr(server.time, "sleep", lambda _s: None)
+
+    # A clock that advances 1s per read, so the 5s bound expires after two polls.
+    clock = {"t": 0.0}
+
+    def fake_monotonic():
+        now = clock["t"]
+        clock["t"] += 1.0
+        return now
+
+    monkeypatch.setattr(server.time, "monotonic", fake_monotonic)
+
+    result = server.wait_for_job("pid", timeout_seconds=5.0)
+
+    assert result == {"timed_out": True, "status": {"status": "running"}}
+    assert seen == [4.0, 2.0]  # each poll gets only what is left of the 5s bound
+
+
+def test_wait_for_job_gives_a_long_wait_the_full_poll_budget(monkeypatch):
+    """The per-poll cap only bites when it is *below* the normal poll budget."""
+    seen: list[float] = []
+
+    def fake_run(*args, timeout=None, **kwargs):
+        seen.append(timeout)
+        return {"status": "completed"}
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run)
+
+    assert server.wait_for_job("pid", timeout_seconds=600.0) == {"status": "completed"}
+    assert seen == [server._JOB_STATUS_POLL_TIMEOUT]
 
 
 def test_fetch_outputs_wraps_comfy_download(patched_run):
@@ -1698,10 +1745,11 @@ def test_watch_job_times_out_reports_progress_without_ctx(monkeypatch):
     assert procs[0].killed
 
 
-def test_watch_job_rejects_option_like_prompt_id():
-    """A leading-dash prompt_id is refused so comfy-cli can't parse it as a flag."""
-    with pytest.raises(server.ComfyCliError, match="invalid prompt_id"):
-        asyncio.run(server.watch_job("--help"))
+@pytest.mark.parametrize("bad_id", ["--help", "", "p\x001"])
+def test_watch_job_rejects_an_unusable_prompt_id(bad_id):
+    """watch_job shares the family guard: no dash-led, empty, or NUL-bearing id."""
+    with pytest.raises(server.ComfyCliError, match="prompt_id"):
+        asyncio.run(server.watch_job(bad_id))
 
 
 def test_watch_job_clamps_oversized_timeout(monkeypatch):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -791,6 +791,37 @@ def test_wait_for_job_rejects_a_non_positive_or_nan_timeout(monkeypatch, bad):
     assert polled is False
 
 
+def test_wait_for_job_always_polls_at_least_once(monkeypatch):
+    """A bound that expires before the first poll still reports a real status.
+
+    The per-poll cap re-checks the deadline at the top of the loop; that check
+    must not short-circuit the very first poll and return the degenerate
+    `{"timed_out": True, "status": None}` with nothing ever asked of comfy-cli.
+    """
+    calls = 0
+
+    def fake_run(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return {"status": "running"}
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run)
+
+    # A clock that is already past the deadline by the loop's first read: the
+    # bound is set at t=0 and every later read is t=1.
+    reads = iter([0.0])
+
+    def fake_monotonic():
+        return next(reads, 1.0)
+
+    monkeypatch.setattr(server.time, "monotonic", fake_monotonic)
+
+    result = server.wait_for_job("pid", timeout_seconds=1e-9)
+
+    assert calls == 1
+    assert result == {"timed_out": True, "status": {"status": "running"}}
+
+
 def test_wait_for_job_caps_each_poll_to_the_remaining_bound(monkeypatch):
     """A single poll never gets a longer subprocess budget than the wait itself.
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -705,6 +705,61 @@ def test_wait_for_job_times_out_cleanly(monkeypatch):
     assert result == {"timed_out": True, "status": {"status": "running"}}
 
 
+@pytest.mark.parametrize("oversized", [float("inf"), 86_400.0])
+def test_wait_for_job_clamps_an_oversized_timeout(monkeypatch, oversized):
+    """An oversized bound is clamped to the ceiling, so the poll loop terminates.
+
+    Left raw, `deadline = monotonic() + inf` keeps `remaining` positive forever
+    and the tool re-spawns `comfy jobs status` until the client gives up; a
+    day-long finite bound outlives any client's patience just as surely.
+    """
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: {"status": "running"})
+    monkeypatch.setattr(server.time, "sleep", lambda _s: None)
+
+    # A clock that jumps just past the ceiling on its second read: clamped, the
+    # deadline has passed and the tool returns; unclamped, it would poll on and
+    # exhaust the iterator (failing loudly instead of hanging the suite).
+    reads = iter([0.0, server._MAX_WATCH_TIMEOUT + 1.0])
+
+    def fake_monotonic():
+        try:
+            return next(reads)
+        except StopIteration:
+            pytest.fail("wait_for_job kept polling past the clamped ceiling")
+
+    monkeypatch.setattr(server.time, "monotonic", fake_monotonic)
+
+    result = server.wait_for_job("pid", timeout_seconds=oversized)
+
+    assert result == {"timed_out": True, "status": {"status": "running"}}
+
+
+@pytest.mark.parametrize("bad", [float("nan"), 0.0, -1.0])
+def test_wait_for_job_rejects_a_non_positive_or_nan_timeout(monkeypatch, bad):
+    """NaN/0/negative are refused before the first poll.
+
+    With NaN every comparison is False, so `remaining <= 0` never fires and
+    `min(2.0, nan)` returns 2.0 — the same forever-loop as `inf`.
+    """
+    polled = False
+
+    # Raise rather than return a status: with a NaN bound left unclamped this
+    # loop never exits (`remaining <= 0` is False and `sleep` is stubbed out),
+    # so a regression must fail the test rather than hang the suite.
+    def fake_run(*args, **kwargs):
+        nonlocal polled
+        polled = True
+        raise AssertionError("wait_for_job polled with an invalid timeout")
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run)
+    monkeypatch.setattr(server.time, "sleep", lambda _s: None)
+
+    with pytest.raises(server.ComfyCliError, match="timeout_seconds"):
+        server.wait_for_job("pid", timeout_seconds=bad)
+
+    assert polled is False
+
+
 def test_fetch_outputs_wraps_comfy_download(patched_run):
     """fetch_outputs is a thin `comfy download … --where local -o <dir>` passthrough."""
     calls = patched_run(
@@ -1676,6 +1731,68 @@ def test_run_workflow_wait_false_uses_plain_json_no_stream(monkeypatch):
 
     assert result == {"prompt_id": "p1"}
     assert seen["args"] == ("run", "--workflow", "wf.json")  # no --wait
+    assert seen["timeout"] == 60.0
+
+
+@pytest.mark.parametrize("oversized", [float("inf"), 86_400.0])
+def test_run_workflow_clamps_oversized_timeout(monkeypatch, oversized):
+    """timeout_seconds is clamped to the module ceiling, not passed through raw.
+
+    Raw, `inf` reaches `asyncio.wait_for` and the `comfy run --wait` child is
+    never given up on; a day-long finite bound is the same problem, slower.
+    """
+    seen: dict = {}
+
+    async def fake_stream(*args, ctx=None, timeout=None, **kwargs):
+        seen["timeout"] = timeout
+        return {"outputs": []}
+
+    monkeypatch.setattr(server, "_run_comfy_streaming", fake_stream)
+    asyncio.run(server.run_workflow("wf.json", wait=True, timeout_seconds=oversized))
+
+    assert seen["timeout"] == server._MAX_RUN_WORKFLOW_TIMEOUT
+
+
+@pytest.mark.parametrize("bad", [float("nan"), 0.0, -1.0])
+def test_run_workflow_rejects_a_non_positive_or_nan_timeout(monkeypatch, bad):
+    """NaN/0/negative are refused before the streaming child is spawned."""
+    started = False
+
+    async def fake_stream(*args, ctx=None, timeout=None, **kwargs):
+        nonlocal started
+        started = True
+        return {"outputs": []}
+
+    monkeypatch.setattr(server, "_run_comfy_streaming", fake_stream)
+
+    with pytest.raises(server.ComfyCliError, match="timeout_seconds"):
+        asyncio.run(server.run_workflow("wf.json", wait=True, timeout_seconds=bad))
+
+    assert started is False
+
+
+@pytest.mark.parametrize("ignored", [float("nan"), 0.0, float("inf")])
+def test_run_workflow_wait_false_still_submits_with_an_odd_timeout(
+    monkeypatch, ignored
+):
+    """`wait=False` never reads timeout_seconds, so the clamp must not reject it.
+
+    The submit runs on its own fixed 60s budget; hardening the waiting path must
+    not turn a working fire-and-return call into an error.
+    """
+    seen: dict = {}
+
+    def fake_run_comfy(*args, timeout=None):
+        seen["timeout"] = timeout
+        return {"prompt_id": "p1"}
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run_comfy)
+
+    result = asyncio.run(
+        server.run_workflow("wf.json", wait=False, timeout_seconds=ignored)
+    )
+
+    assert result == {"prompt_id": "p1"}
     assert seen["timeout"] == 60.0
 
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -868,6 +868,150 @@ def test_wait_for_job_gives_a_long_wait_the_full_poll_budget(monkeypatch):
     assert seen == [server._JOB_STATUS_POLL_TIMEOUT]
 
 
+def test_wait_for_job_reports_a_deadline_poll_timeout_as_timed_out(monkeypatch):
+    """A poll killed by the caller's own bound returns `timed_out`, not an error.
+
+    Capping each poll to the time left makes the poll's deadline double as the
+    caller's, so a slow-but-healthy `comfy jobs status` near the bound now raises
+    where the old fixed 60s budget let it finish. That is this call expiring, and
+    it must not discard the last real status behind a `ComfyCliError`.
+    """
+    statuses = iter([{"status": "running"}])
+
+    def fake_run(*args, **kwargs):
+        try:
+            return next(statuses)
+        except StopIteration:
+            raise server.ComfyCliError("comfy-cli timed out after 1.0s", timed_out=True)
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run)
+    monkeypatch.setattr(server.time, "sleep", lambda _s: None)
+
+    # 10s bound: the first poll succeeds, the second is granted the remainder and
+    # dies at it — by which time the clock is past the deadline.
+    reads = iter([0.0, 1.0, 2.0, 3.0, 11.0])
+    monkeypatch.setattr(server.time, "monotonic", lambda: next(reads))
+
+    result = server.wait_for_job("pid", timeout_seconds=10.0)
+
+    assert result == {"timed_out": True, "status": {"status": "running"}}
+
+
+def test_wait_for_job_reraises_a_wedged_poll_with_budget_left(monkeypatch):
+    """A poll that burns the FULL budget with time to spare is a real failure.
+
+    Only the caller's bound expiring earns the `timed_out` envelope. A poll that
+    exhausted `_JOB_STATUS_POLL_TIMEOUT` while the wait still has time left means
+    comfy-cli is wedged — which raised before the per-poll cap existed too.
+    """
+
+    def fake_run(*args, **kwargs):
+        raise server.ComfyCliError("comfy-cli timed out after 60.0s", timed_out=True)
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run)
+    monkeypatch.setattr(server.time, "sleep", lambda _s: None)
+
+    # A 600s bound with the clock barely moving: the deadline is nowhere near.
+    reads = iter([0.0, 1.0, 2.0])
+    monkeypatch.setattr(server.time, "monotonic", lambda: next(reads))
+
+    with pytest.raises(server.ComfyCliError, match="timed out"):
+        server.wait_for_job("pid", timeout_seconds=600.0)
+
+
+def test_wait_for_job_reraises_when_no_status_was_ever_read(monkeypatch):
+    """With no status in hand, the error beats a contentless `{"status": None}`.
+
+    `{"timed_out": True, "status": None}` would bury the real diagnosis (and the
+    budget that produced it) under an envelope the caller can do nothing with.
+    """
+
+    def fake_run(*args, **kwargs):
+        raise server.ComfyCliError("comfy-cli timed out after 1.0s", timed_out=True)
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run)
+    monkeypatch.setattr(server.time, "sleep", lambda _s: None)
+
+    reads = iter([0.0, 1.0, 2.0])
+    monkeypatch.setattr(server.time, "monotonic", lambda: next(reads))
+
+    with pytest.raises(server.ComfyCliError, match="timed out"):
+        server.wait_for_job("pid", timeout_seconds=1.0)
+
+
+def test_wait_for_job_reraises_a_non_timeout_poll_failure(monkeypatch):
+    """An ordinary comfy-cli error still propagates, deadline or not."""
+
+    def fake_run(*args, **kwargs):
+        raise server.ComfyCliError("job not found", code="not_found")
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run)
+    monkeypatch.setattr(server.time, "sleep", lambda _s: None)
+
+    reads = iter([0.0, 1.0, 99.0])
+    monkeypatch.setattr(server.time, "monotonic", lambda: next(reads))
+
+    with pytest.raises(server.ComfyCliError, match="job not found"):
+        server.wait_for_job("pid", timeout_seconds=1.0)
+
+
+def test_run_comfy_marks_a_subprocess_timeout(monkeypatch):
+    """The `timed_out` flag is set only where the child was killed at our budget.
+
+    `wait_for_job` branches on it to tell its own deadline from a comfy-cli
+    failure, so the flag has to come from the raise site rather than the message.
+    """
+
+    def fake_subprocess_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
+
+    monkeypatch.setattr(server.subprocess, "run", fake_subprocess_run)
+    monkeypatch.setattr(server, "_require_comfy_bin", lambda: None)
+    monkeypatch.setattr(server, "_check_comfy_version", lambda: None)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("jobs", "status", "pid", timeout=1.0)
+
+    assert excinfo.value.timed_out is True
+
+
+def test_prompt_id_guard_rejects_an_oversized_id(monkeypatch):
+    """An id far past any real one is refused before it can reach argv.
+
+    An oversized argv is rejected by the OS with an `OSError` no caller converts
+    (and echoed back whole in the error), rather than failing as a clean
+    `ComfyCliError` like every other bad input.
+    """
+    oversized = "p" * (server._MAX_PROMPT_ID_LEN + 1)
+
+    def fake_run(*args, **kwargs):
+        raise AssertionError("spawned comfy-cli with an oversized prompt_id")
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run)
+
+    with pytest.raises(server.ComfyCliError, match="exceeds"):
+        server.job_status(oversized)
+
+    # The cap is generous enough that a real (UUID-shaped) id is untouched.
+    assert server._guard_prompt_id("p" * server._MAX_PROMPT_ID_LEN)
+
+
+def test_fetch_outputs_rejects_a_nul_in_out_dir(monkeypatch):
+    """`out_dir` rides the same argv as the id and needs the same NUL refusal.
+
+    `_run_comfy_raw` converts only `TimeoutExpired`, so `subprocess.run`'s bare
+    "embedded null byte" ValueError would escape as an internal error.
+    """
+
+    def fake_run(*args, **kwargs):
+        raise AssertionError("spawned comfy-cli with a NUL-bearing out_dir")
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run)
+
+    with pytest.raises(server.ComfyCliError, match="out_dir"):
+        server.fetch_outputs("pid", "/tmp/o\x00ut")
+
+
 def test_fetch_outputs_wraps_comfy_download(patched_run):
     """fetch_outputs is a thin `comfy download … --where local -o <dir>` passthrough."""
     calls = patched_run(

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -357,6 +357,36 @@ def test_cancel_job_unknown_id_raises_error_envelope(patched_run):
         server.cancel_job("nope")
 
 
+# `_run_comfy` builds argv with no `--` separator, so a leading-dash positional
+# reaches comfy-cli as an option rather than a job id. `watch_job` and
+# `get_execution_error` already refuse one (covered separately); these are the
+# remaining prompt_id-taking tools, checked together so the family stays uniform
+# — `fetch_outputs` most of all, since there the id sits beside a real `-o`.
+@pytest.mark.parametrize(
+    ("tool", "extra_args"),
+    [
+        ("job_status", ()),
+        ("cancel_job", ()),
+        ("wait_for_job", ()),
+        ("fetch_outputs", ("/tmp/out",)),
+    ],
+    ids=lambda v: v if isinstance(v, str) else "",
+)
+@pytest.mark.parametrize("option_like", ["--help", "-o"])
+def test_job_tools_reject_an_option_like_prompt_id(
+    monkeypatch, tool, extra_args, option_like
+):
+    """A leading-dash prompt_id is refused before comfy-cli is ever spawned."""
+
+    def fake_run(*args, **kwargs):
+        raise AssertionError(f"{tool} spawned comfy-cli with {option_like!r}")
+
+    monkeypatch.setattr(server, "_run_comfy", fake_run)
+
+    with pytest.raises(server.ComfyCliError, match="invalid prompt_id"):
+        getattr(server, tool)(option_like, *extra_args)
+
+
 def test_get_queue_maps_command_and_returns_data(patched_run):
     """get_queue wraps `comfy jobs ls` and returns the merged job list."""
     jobs = {


### PR DESCRIPTION
## ELI-5

Two tools let you say how long to wait. If you said "wait forever" (`inf`) or handed them nonsense (`NaN`), they believed you: `run_workflow(wait=True)` would never give up on its comfy-cli child, and `wait_for_job` would re-poll `comfy jobs status` every two seconds until your client gave up — the tool call simply never returned. Four sibling tools already run their timeout through a helper that rejects nonsense and caps the wait at an hour. These two now do the same.

## Summary

`_bounded_timeout` (added for exactly this) rejects `NaN` / non-positive timeouts and clamps oversized ones to a ceiling. It was applied in `generate_image`, `partner_generate`, `run_template` and `watch_job`, but not in the other two tools that accept a caller timeout — `run_workflow` and `wait_for_job`.

## Changes

- `run_workflow`: on the `wait=True` path, `timeout_seconds` is clamped to a new `_MAX_RUN_WORKFLOW_TIMEOUT` (3600s) before it reaches `_run_comfy_streaming` → `asyncio.wait_for`. Raw, `inf` means the `comfy run --wait` child is never given up on and `NaN` is undefined timer behavior.
- `wait_for_job`: `timeout_seconds` is clamped to `_MAX_WATCH_TIMEOUT` (3600s, shared with `watch_job`, its streaming counterpart) before `deadline = monotonic() + timeout_seconds`. Raw, `inf` keeps `remaining` positive forever; `NaN` makes every comparison False, so `remaining <= 0` never fires and `min(2.0, nan)` returns `2.0` — the same infinite poll loop.
- Docstrings for both tools now state the clamp, and the `_MAX_WATCH_TIMEOUT` comment says it now covers both the streaming watch and the polling wait.
- Tests: per tool, `NaN` / `0` / negative raise `ComfyCliError` before any child is spawned, and `inf` / a day-long finite value are clamped to the ceiling. Plus a guard test that `wait=False` still submits normally with an odd `timeout_seconds` (see the judgment call below). All 10 new assertions were confirmed red against the pre-fix `server.py`.

## Motivation

The parameter is caller-supplied and JSON/pydantic accept `Infinity` and `NaN`, so both values are reachable from an MCP client. `wait_for_job`'s docstring promises a wait that is "bounded by design" — that only holds if the bound itself is bounded.

## Testing

- [x] Existing tests pass (`pytest` — 505 passed, 2 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually — unit-level only; the tests mock comfy-cli as the repo's convention requires.

Red/green proof: with the `server.py` change stashed, the 10 new clamp/reject assertions fail (fast, no hang) and the 3 `wait=False` guard assertions still pass; with it applied, all pass.

## Additional Notes

**Judgment call — `run_workflow` validates only on the `wait=True` path.** The obvious version of this change clamps unconditionally at the top of the function, matching the sibling tools. I didn't: `wait=False` never reads `timeout_seconds` (it submits on a fixed 60s budget), so validating there would newly reject `run_workflow(wait=False, timeout_seconds=0)` — a plausible "fire and forget, no timeout" call that works fine today. Hardening the hang shouldn't cost a working submit. There's a test pinning that behavior.

**One behavior change beyond NaN/inf, and where the capability went.** `_bounded_timeout` also rejects `0` and negatives, so `wait_for_job(prompt_id, timeout_seconds=0)` — which previously polled once and returned a `timed_out` envelope — is now an error. That is already the contract on the four tools that use the helper, and the "check a job once" capability is unchanged and directly available as `job_status(prompt_id)`, which is what that call was approximating. Similarly, waits longer than an hour are clamped rather than refused, and the documented pattern for a longer wait (chain several `wait_for_job` calls, or `watch_job`) still works. No capability is dead-ended by this diff.

**Naming.** `wait_for_job` reuses `_MAX_WATCH_TIMEOUT` (same wait-on-a-submitted-job family as `watch_job`, same envelope shape). `run_workflow` gets its own `_MAX_RUN_WORKFLOW_TIMEOUT` at the same 3600s value, following the repo's existing one-ceiling-per-tool pattern (`_MAX_GENERATE_TIMEOUT`, `_MAX_RUN_TEMPLATE_TIMEOUT`) rather than describing a foreground run as a "watch".

**Scope.** I checked all six tools that accept a `timeout_seconds`; the other four were already hardened, and there are no internal callers of these tools that could bypass the clamp. Tests went into `tests/test_wrapper.py`, where the existing `run_workflow` / `wait_for_job` / `watch_job` tests live.
