### PR TITLE
test: hoist the canned subprocess.run stub into a shared conftest fixture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,22 @@ the `comfy` binary. `_run_comfy` and the envelope parser are exercised directly
 (`test_discovery.py`, `test_templates.py`). When you add or change a tool, add or
 update its test in the same PR.
 
+**Mock comfy-cli through the shared fixtures in `tests/conftest.py`, never a
+hand-rolled stub.** They are the single place that mirrors how `server` spawns
+the CLI, so a change to the spawn signature is one edit rather than a sweep:
+
+- `envelope(ok=…, data=…, error=…)` — build an `envelope/1` body.
+- `patched_run(stdout=…, returncode=…, stderr=…, raises=…) -> calls` — the plain
+  `--json` path (`subprocess.run`); `calls` records `cmd`/`env`/`timeout`/
+  `encoding` per invocation for exact-argv assertions.
+- `patched_plain_run(returncode, stdout, stderr) -> calls` — same, for the verbs
+  that print human text and emit no envelope (`launch`/`stop`/`generate`).
+- `patched_stream(stdout_text) -> procs` — the `--json-stream` NDJSON path
+  (`subprocess.Popen`).
+
+A local stub is justified only where the call genuinely differs — the
+`comfy --version` probe (its own kwargs) and multi-call sequenced replies.
+
 ## Destined-public hygiene
 
 This repository is **private but destined to go public.** Treat everything you

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,15 @@ guard tests (`test_wrapper.py`) re-enable it explicitly and mock `--version`.
 ``partner_generate``'s spend-gate probe is a second such once-per-process
 shell-out and is neutralized the same way.
 
-This module also holds the shared test helpers for the streaming
-(``--json-stream``) tool paths. ``run_workflow``, ``watch_job`` and
-``generate_image`` all drive the same ``subprocess.Popen`` NDJSON streaming
-path, so their tests share the fakes and the ``patched_stream`` fixture defined
-here rather than each redefining them.
+This module also holds the shared test helpers for both comfy-cli spawn paths,
+so a change to how ``server`` shells out lands in ONE fake rather than in a
+copy per test file:
+
+* the plain ``--json`` path (``subprocess.run``) — ``envelope`` +
+  ``patched_run`` / ``patched_plain_run``;
+* the streaming ``--json-stream`` path (``subprocess.Popen``) —
+  ``patched_stream``. ``run_workflow``, ``watch_job`` and ``generate_image``
+  all drive the same NDJSON stream.
 """
 
 from __future__ import annotations
@@ -21,6 +25,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+import subprocess
 
 import pytest
 
@@ -110,6 +115,107 @@ def _clear_t2i_env(monkeypatch):
         "COMFY_T2I_CHECKPOINT_SLOT",
     ):
         monkeypatch.delenv(var, raising=False)
+
+
+_UNSET = object()
+
+
+def envelope(*, ok: bool = True, data=_UNSET, error=None) -> dict:
+    """Build a comfy-cli ``envelope/1`` result body.
+
+    Mirrors what the CLI emits on its ``--json`` path: an ``error`` object when
+    the call failed, a ``data`` payload otherwise. One builder here rather than
+    one re-derived per test file, so a schema bump has a single place to land.
+
+    ``data`` defaults to ``{}`` only when it is OMITTED — an explicit
+    ``data=None`` stays ``None``, which several tests rely on to exercise the
+    non-dict-payload branches.
+    """
+    body: dict = {"schema": "envelope/1", "type": "envelope", "ok": ok}
+    if error is not None:
+        body["error"] = error
+    else:
+        body["data"] = {} if data is _UNSET else data
+    return body
+
+
+def _canonical_run(calls: list[dict], *, stdout, returncode, stderr, raises):
+    """The one ``subprocess.run`` stand-in for the plain (non-streaming) path.
+
+    Its parameter list mirrors ``_run_comfy``'s exact ``subprocess.run`` kwargs
+    — which is precisely why it lives here: a kwarg added or renamed there (the
+    ``encoding=`` pin was the last one) is a one-line edit instead of a sweep
+    across every test file.
+
+    Each call is recorded as ``{"cmd", "env", "timeout", "encoding"}`` — a
+    superset of what any caller asserts on — BEFORE ``raises`` fires, so a test
+    for a spawn that blows up can still see the argv it blew up on.
+    """
+
+    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
+        calls.append({"cmd": cmd, "env": env, "timeout": timeout, "encoding": encoding})
+        if raises is not None:
+            raise raises
+        return subprocess.CompletedProcess(
+            cmd, returncode, stdout=stdout, stderr=stderr
+        )
+
+    return fake
+
+
+@pytest.fixture
+def patched_run(monkeypatch):
+    """Patch ``shutil.which`` + ``subprocess.run`` for the plain ``--json`` path.
+
+    Returns ``setup(stdout=…, returncode=…, stderr=…, raises=…) -> calls``:
+
+    * ``stdout`` — a dict (JSON-encoded for you, the common case: pass an
+      :func:`envelope`) or a raw string; defaults to an empty-``data`` success
+      envelope.
+    * ``raises`` — an exception instance the fake raises instead of returning,
+      for the spawn-failure paths (``TimeoutExpired`` and friends).
+
+    ``calls`` is the live list every invocation is recorded into, for the exact
+    argv assertions this suite is built on.
+    """
+
+    def setup(stdout=None, *, returncode: int = 0, stderr: str = "", raises=None):
+        if stdout is None:
+            stdout = envelope()
+        if isinstance(stdout, dict):
+            stdout = json.dumps(stdout)
+        calls: list[dict] = []
+        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+        monkeypatch.setattr(
+            server.subprocess,
+            "run",
+            _canonical_run(
+                calls,
+                stdout=stdout,
+                returncode=returncode,
+                stderr=stderr,
+                raises=raises,
+            ),
+        )
+        return calls
+
+    return setup
+
+
+@pytest.fixture
+def patched_plain_run(patched_run):
+    """``setup(returncode=…, stdout=…, stderr=…) -> calls`` for the NO-envelope path.
+
+    ``comfy launch`` / ``stop`` / ``generate`` print human text through their own
+    printer and never emit an ``envelope/1``, so their tests are about the exit
+    code and the streams. Same fake as :func:`patched_run`, with the returncode
+    first and an empty stdout default.
+    """
+
+    def setup(returncode: int = 0, stdout: str = "", stderr: str = "") -> list[dict]:
+        return patched_run(stdout, returncode=returncode, stderr=stderr)
+
+    return setup
 
 
 class _FakeProc:

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -67,17 +67,11 @@ def test_unwrap_rejects_incompatible_major_even_on_error_envelope():
         server._unwrap_envelope(envelope, ("env",), 0, "")
 
 
-def test_incompatible_envelope_propagates_through_run_comfy(monkeypatch):
+def test_incompatible_envelope_propagates_through_run_comfy(patched_run):
     """The assertion guards every tool: a bad-schema envelope raises via _run_comfy."""
-
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        import json
-
-        out = json.dumps({"schema": "envelope/99", "type": "envelope", "ok": True})
-        return subprocess.CompletedProcess(cmd, 0, stdout=out, stderr="")
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    # Deliberately NOT conftest's `envelope()` — the whole point is the major
+    # this server does not speak, which that builder cannot emit.
+    patched_run({"schema": "envelope/99", "type": "envelope", "ok": True})
 
     with pytest.raises(server.ComfyCliError, match="incompatible comfy-cli envelope"):
         server._run_comfy("env")
@@ -212,22 +206,11 @@ def test_check_warns_but_does_not_raise_when_floor_set_and_version_unknown(monke
 
 
 @pytest.fixture
-def patched_env(monkeypatch):
+def patched_env(monkeypatch, patched_run):
     """Patch comfy-cli so ``server_info`` sees a given ``comfy env`` envelope."""
 
-    def setup(envelope: dict, version: str | None = "1.12.0") -> list[dict]:
-        import json
-
-        calls: list[dict] = []
-
-        def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-            calls.append({"cmd": cmd})
-            return subprocess.CompletedProcess(
-                cmd, 0, stdout=json.dumps(envelope), stderr=""
-            )
-
-        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-        monkeypatch.setattr(server.subprocess, "run", fake)
+    def setup(payload: dict, version: str | None = "1.12.0") -> list[dict]:
+        calls = patched_run(payload)
         monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: version)
         return calls
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -7,38 +7,17 @@ contract) against a stubbed ``subprocess.run``, plus one error-envelope path
 
 from __future__ import annotations
 
-import json
-import subprocess
-
 import pytest
+from conftest import envelope
 
 from comfy_local_mcp import server
 
 
-def _stub_comfy(monkeypatch, envelope: dict):
-    """Stub shutil.which + subprocess.run; return the list that records each argv."""
-    calls: list[list[str]] = []
-
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        calls.append(cmd)
-        return subprocess.CompletedProcess(
-            cmd, 0, stdout=json.dumps(envelope), stderr=""
-        )
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
-    return calls
-
-
-def _ok(data):
-    return {"type": "envelope", "ok": True, "data": data}
-
-
-def test_search_nodes_argv(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok([{"name": "KSampler"}]))
+def test_search_nodes_argv(patched_run):
+    calls = patched_run(envelope(data=[{"name": "KSampler"}]))
     assert server.search_nodes("sampler") == [{"name": "KSampler"}]
     # global flags first, then the subcommand + query verbatim
-    assert calls[0] == [
+    assert calls[0]["cmd"] == [
         server.COMFY_BIN,
         "--json",
         "--where",
@@ -49,21 +28,21 @@ def test_search_nodes_argv(monkeypatch):
     ]
 
 
-def test_get_node_argv(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok({"name": "KSampler", "inputs": {}}))
+def test_get_node_argv(patched_run):
+    calls = patched_run(envelope(data={"name": "KSampler", "inputs": {}}))
     assert server.get_node("KSampler") == {"name": "KSampler", "inputs": {}}
-    assert calls[0][4:] == ["nodes", "show", "KSampler"]
+    assert calls[0]["cmd"][4:] == ["nodes", "show", "KSampler"]
 
 
-def test_list_nodes_no_filters_bare_ls(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok([{"name": "KSampler"}]))
+def test_list_nodes_no_filters_bare_ls(patched_run):
+    calls = patched_run(envelope(data=[{"name": "KSampler"}]))
     assert server.list_nodes() == [{"name": "KSampler"}]
     # no filters -> a bare `nodes ls`, no stray flags
-    assert calls[0][4:] == ["nodes", "ls"]
+    assert calls[0]["cmd"][4:] == ["nodes", "ls"]
 
 
-def test_list_nodes_all_filters_in_order(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok([]))
+def test_list_nodes_all_filters_in_order(patched_run):
+    calls = patched_run(envelope(data=[]))
     server.list_nodes(
         produces="IMAGE",
         accepts="MODEL",
@@ -71,7 +50,7 @@ def test_list_nodes_all_filters_in_order(monkeypatch):
         pack="was-suite",
         label="Load",
     )
-    assert calls[0][4:] == [
+    assert calls[0]["cmd"][4:] == [
         "nodes",
         "ls",
         "--produces",
@@ -87,11 +66,11 @@ def test_list_nodes_all_filters_in_order(monkeypatch):
     ]
 
 
-def test_list_nodes_omits_empty_filters(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok([]))
+def test_list_nodes_omits_empty_filters(patched_run):
+    calls = patched_run(envelope(data=[]))
     server.list_nodes(produces="IMAGE", category="sampling")
     # only the two non-empty filters are passed, in declared order
-    assert calls[0][4:] == [
+    assert calls[0]["cmd"][4:] == [
         "nodes",
         "ls",
         "--produces",
@@ -101,35 +80,35 @@ def test_list_nodes_omits_empty_filters(monkeypatch):
     ]
 
 
-def test_nodes_upstream_without_limit(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok([{"name": "CheckpointLoaderSimple"}]))
+def test_nodes_upstream_without_limit(patched_run):
+    calls = patched_run(envelope(data=[{"name": "CheckpointLoaderSimple"}]))
     assert server.nodes_upstream("KSampler") == [{"name": "CheckpointLoaderSimple"}]
-    assert calls[0][4:] == ["nodes", "upstream", "KSampler"]
+    assert calls[0]["cmd"][4:] == ["nodes", "upstream", "KSampler"]
 
 
-def test_nodes_upstream_with_limit(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok([]))
+def test_nodes_upstream_with_limit(patched_run):
+    calls = patched_run(envelope(data=[]))
     server.nodes_upstream("KSampler", limit=5)
-    assert calls[0][4:] == ["nodes", "upstream", "KSampler", "--limit", "5"]
+    assert calls[0]["cmd"][4:] == ["nodes", "upstream", "KSampler", "--limit", "5"]
 
 
-def test_nodes_downstream_without_limit(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok([{"name": "VAEDecode"}]))
+def test_nodes_downstream_without_limit(patched_run):
+    calls = patched_run(envelope(data=[{"name": "VAEDecode"}]))
     assert server.nodes_downstream("KSampler") == [{"name": "VAEDecode"}]
-    assert calls[0][4:] == ["nodes", "downstream", "KSampler"]
+    assert calls[0]["cmd"][4:] == ["nodes", "downstream", "KSampler"]
 
 
-def test_nodes_downstream_with_limit(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok([]))
+def test_nodes_downstream_with_limit(patched_run):
+    calls = patched_run(envelope(data=[]))
     server.nodes_downstream("KSampler", limit=3)
-    assert calls[0][4:] == ["nodes", "downstream", "KSampler", "--limit", "3"]
+    assert calls[0]["cmd"][4:] == ["nodes", "downstream", "KSampler", "--limit", "3"]
 
 
-def test_nodes_path_defaults(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok([]))
+def test_nodes_path_defaults(patched_run):
+    calls = patched_run(envelope(data=[]))
     server.nodes_path("MODEL", "IMAGE")
     # concrete int defaults are always passed, so the argv is deterministic
-    assert calls[0][4:] == [
+    assert calls[0]["cmd"][4:] == [
         "nodes",
         "path",
         "MODEL",
@@ -141,10 +120,10 @@ def test_nodes_path_defaults(monkeypatch):
     ]
 
 
-def test_nodes_path_overrides(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok([]))
+def test_nodes_path_overrides(patched_run):
+    calls = patched_run(envelope(data=[]))
     server.nodes_path("LATENT", "IMAGE", max_depth=3, max_paths=2)
-    assert calls[0][4:] == [
+    assert calls[0]["cmd"][4:] == [
         "nodes",
         "path",
         "LATENT",
@@ -156,56 +135,54 @@ def test_nodes_path_overrides(monkeypatch):
     ]
 
 
-def test_nodes_types_argv(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok(["MODEL", "IMAGE", "LATENT"]))
+def test_nodes_types_argv(patched_run):
+    calls = patched_run(envelope(data=["MODEL", "IMAGE", "LATENT"]))
     assert server.nodes_types() == ["MODEL", "IMAGE", "LATENT"]
-    assert calls[0][4:] == ["nodes", "types"]
+    assert calls[0]["cmd"][4:] == ["nodes", "types"]
 
 
-def test_nodes_categories_argv(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok({"loaders": {}}))
+def test_nodes_categories_argv(patched_run):
+    calls = patched_run(envelope(data={"loaders": {}}))
     assert server.nodes_categories() == {"loaders": {}}
-    assert calls[0][4:] == ["nodes", "categories"]
+    assert calls[0]["cmd"][4:] == ["nodes", "categories"]
 
 
-def test_search_models_query_uses_search(monkeypatch):
+def test_search_models_query_uses_search(patched_run):
     # BE-2952: comfy-cli 1.12's `models search` takes the query as `--text`,
     # not a positional — a positional exits 2 ("returned no JSON (exit 2)").
-    calls = _stub_comfy(monkeypatch, _ok(["sd_xl_base.safetensors"]))
+    calls = patched_run(envelope(data=["sd_xl_base.safetensors"]))
     assert server.search_models(query="xl") == ["sd_xl_base.safetensors"]
-    assert calls[0][4:] == ["models", "search", "--text", "xl"]
+    assert calls[0]["cmd"][4:] == ["models", "search", "--text", "xl"]
 
 
-def test_search_models_folder_uses_list_folder(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok(["model.ckpt"]))
+def test_search_models_folder_uses_list_folder(patched_run):
+    calls = patched_run(envelope(data=["model.ckpt"]))
     assert server.search_models(folder="checkpoints") == ["model.ckpt"]
-    assert calls[0][4:] == ["models", "list-folder", "checkpoints"]
+    assert calls[0]["cmd"][4:] == ["models", "list-folder", "checkpoints"]
 
 
-def test_search_models_empty_lists_folders(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok(["checkpoints", "loras"]))
+def test_search_models_empty_lists_folders(patched_run):
+    calls = patched_run(envelope(data=["checkpoints", "loras"]))
     assert server.search_models() == ["checkpoints", "loras"]
-    assert calls[0][4:] == ["models", "list-folders"]
+    assert calls[0]["cmd"][4:] == ["models", "list-folders"]
 
 
-def test_search_models_query_takes_precedence_over_folder(monkeypatch):
-    calls = _stub_comfy(monkeypatch, _ok([]))
+def test_search_models_query_takes_precedence_over_folder(patched_run):
+    calls = patched_run(envelope(data=[]))
     server.search_models(query="xl", folder="checkpoints")
-    assert calls[0][4:] == ["models", "search", "--text", "xl"]
+    assert calls[0]["cmd"][4:] == ["models", "search", "--text", "xl"]
 
 
-def test_discovery_surfaces_error_envelope(monkeypatch):
+def test_discovery_surfaces_error_envelope(patched_run):
     """A local server-not-running envelope must raise, not return silently."""
-    _stub_comfy(
-        monkeypatch,
-        {
-            "type": "envelope",
-            "ok": False,
-            "error": {
+    patched_run(
+        envelope(
+            ok=False,
+            error={
                 "code": "server_not_running",
                 "message": "local ComfyUI not running",
             },
-        },
+        )
     )
     with pytest.raises(server.ComfyCliError, match="server_not_running"):
         server.search_nodes("sampler")

--- a/tests/test_failure_log.py
+++ b/tests/test_failure_log.py
@@ -50,23 +50,16 @@ def log_path(monkeypatch, tmp_path):
 
 
 @pytest.fixture
-def fake_comfy(monkeypatch):
-    """Patch ``shutil.which`` + ``subprocess.run`` for one canned comfy-cli result.
+def fake_comfy(patched_run):
+    """``setup(stdout=…, stderr=…, returncode=…, raises=…)`` for one canned result.
 
-    ``setup(stdout=…, stderr=…, returncode=…, raises=…)`` — ``raises`` makes the
-    fake raise instead of returning (used for ``subprocess.TimeoutExpired``).
+    The shared ``patched_run`` (conftest) with this file's own default of an
+    EMPTY stdout — these tests are about what a *failing* call records, and "no
+    JSON at all" is one of the failures under test.
     """
 
     def setup(stdout="", stderr="", returncode=0, raises=None):
-        def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-            if raises is not None:
-                raise raises
-            return subprocess.CompletedProcess(
-                cmd, returncode, stdout=stdout, stderr=stderr
-            )
-
-        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-        monkeypatch.setattr(server.subprocess, "run", fake)
+        patched_run(stdout, stderr=stderr, returncode=returncode, raises=raises)
 
     return setup
 

--- a/tests/test_partner_generate.py
+++ b/tests/test_partner_generate.py
@@ -22,9 +22,9 @@ comfy-cli is mocked throughout: no real ComfyUI, and no real credit spend.
 from __future__ import annotations
 
 import asyncio
-import subprocess
 
 import pytest
+from conftest import envelope
 from mcp.server.elicitation import (
     AcceptedElicitation,
     CancelledElicitation,
@@ -75,36 +75,6 @@ class _FakeCtx:
         if self._action == "decline":
             return DeclinedElicitation()
         return CancelledElicitation()
-
-
-def _fake_run_plain(returncode: int, stdout: str = "", stderr: str = ""):
-    """``subprocess.run`` stand-in emitting HUMAN text (no envelope) + a returncode.
-
-    Mirrors the real ``comfy generate``, which prints its result through its own
-    printer and never emits a renderer envelope on the generate path.
-    """
-    calls: list[dict] = []
-
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        calls.append({"cmd": cmd, "env": env, "timeout": timeout})
-        return subprocess.CompletedProcess(
-            cmd, returncode, stdout=stdout, stderr=stderr
-        )
-
-    return fake, calls
-
-
-@pytest.fixture
-def patched_plain_run(monkeypatch):
-    """``setup(returncode, stdout, stderr) -> calls`` for the no-envelope path."""
-
-    def setup(returncode: int = 0, stdout: str = "", stderr: str = "") -> list[dict]:
-        fake, calls = _fake_run_plain(returncode, stdout, stderr)
-        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-        monkeypatch.setattr(server.subprocess, "run", fake)
-        return calls
-
-    return setup
 
 
 # --- passthrough argv -------------------------------------------------------
@@ -321,7 +291,9 @@ def test_partner_generate_surfaces_a_broken_elicitation_without_spending(
     assert calls == []
 
 
-def test_partner_generate_honors_the_engines_durable_always_proceed(monkeypatch):
+def test_partner_generate_honors_the_engines_durable_always_proceed(
+    monkeypatch, patched_plain_run
+):
     """`spend.auto_confirm` -> no prompt, and no `--yes`: the engine consents itself.
 
     The durable "always proceed" is the user's own choice, persisted in
@@ -330,20 +302,14 @@ def test_partner_generate_honors_the_engines_durable_always_proceed(monkeypatch)
     the wrapper re-asking a question the user already answered for good.
     """
     monkeypatch.setattr(server, "_engine_auto_confirms", lambda: True)
-    calls = []
-
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        calls.append(cmd)
-        return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_plain_run(0, stdout="done")
     ctx = _FakeCtx(action="decline")
 
     _generate("flux-pro", ctx=ctx)
 
     assert ctx.elicitations == []  # nothing left to ask
-    assert "--yes" not in calls[0]  # consent is the engine's, not ours to assert
+    # consent is the engine's, not ours to assert
+    assert "--yes" not in calls[0]["cmd"]
 
 
 # --- reading the engine's durable always-proceed ----------------------------
@@ -354,20 +320,14 @@ def test_partner_generate_honors_the_engines_durable_always_proceed(monkeypatch)
 _real_engine_auto_confirms = server._engine_auto_confirms
 
 
-def _patched_consent_show(monkeypatch, returncode: int, stdout: str) -> list[list[str]]:
+def _patched_consent_show(
+    patched_plain_run, returncode: int, stdout: str
+) -> list[dict]:
     """Stub `comfy generate consent show --json` with a canned exit + stdout."""
-    calls: list[list[str]] = []
-
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        calls.append(cmd)
-        return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr="")
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
-    return calls
+    return patched_plain_run(returncode, stdout=stdout)
 
 
-def test_engine_auto_confirms_reads_the_json_consent_payload(monkeypatch):
+def test_engine_auto_confirms_reads_the_json_consent_payload(patched_plain_run):
     """comfy-cli pretty-prints the setting, so it is read from the WHOLE stdout.
 
     `output.print_json` uses `indent=2`, so no single line parses — the
@@ -375,11 +335,13 @@ def test_engine_auto_confirms_reads_the_json_consent_payload(monkeypatch):
     who had turned it on.
     """
     calls = _patched_consent_show(
-        monkeypatch, 0, '{\n  "spend_auto_confirm": true,\n  "action": "show"\n}\n'
+        patched_plain_run,
+        0,
+        '{\n  "spend_auto_confirm": true,\n  "action": "show"\n}\n',
     )
 
     assert _real_engine_auto_confirms() is True
-    assert calls[0][4:] == ["generate", "consent", "show", "--json"]
+    assert calls[0]["cmd"][4:] == ["generate", "consent", "show", "--json"]
 
 
 @pytest.mark.parametrize(
@@ -394,14 +356,14 @@ def test_engine_auto_confirms_reads_the_json_consent_payload(monkeypatch):
     ],
 )
 def test_engine_auto_confirms_is_false_for_anything_unreadable(
-    monkeypatch, returncode, stdout
+    patched_plain_run, returncode, stdout
 ):
     """Only a real JSON `true` from a clean exit counts as pre-authorization.
 
     Every other answer falls through to ASKING the user — the failure direction
     that costs a prompt, not the one that costs money.
     """
-    _patched_consent_show(monkeypatch, returncode, stdout)
+    _patched_consent_show(patched_plain_run, returncode, stdout)
 
     assert _real_engine_auto_confirms() is False
 
@@ -439,7 +401,7 @@ def test_engine_auto_confirms_is_false_when_the_probe_blows_up(monkeypatch, exc)
     assert _real_engine_auto_confirms() is False
 
 
-def test_engine_auto_confirms_asks_comfy_cli_for_json_explicitly(monkeypatch):
+def test_engine_auto_confirms_asks_comfy_cli_for_json_explicitly(patched_plain_run):
     """The trailing `--json` is load-bearing and must not be "cleaned up" away.
 
     `comfy generate` takes `allow_extra_args`, so the tail after the target
@@ -448,18 +410,18 @@ def test_engine_auto_confirms_asks_comfy_cli_for_json_explicitly(monkeypatch):
     so dropping this flag would make the command print rich human text, fail the
     parse, and silently turn `comfy generate consent always` into a dead setting.
     """
-    calls = _patched_consent_show(monkeypatch, 0, '{"spend_auto_confirm": true}')
+    calls = _patched_consent_show(patched_plain_run, 0, '{"spend_auto_confirm": true}')
 
     assert _real_engine_auto_confirms() is True
     # The global flag precedes the subcommand; the subcommand's own flag trails it.
-    assert calls[0][:2] == [server.COMFY_BIN, "--json"]
-    assert calls[0][-1] == "--json"
+    assert calls[0]["cmd"][:2] == [server.COMFY_BIN, "--json"]
+    assert calls[0]["cmd"][-1] == "--json"
 
 
-def test_engine_auto_confirms_unwraps_a_future_envelope(monkeypatch):
+def test_engine_auto_confirms_unwraps_a_future_envelope(patched_plain_run):
     """If comfy-cli ever wraps this verb in an `envelope/1`, read `data`."""
     _patched_consent_show(
-        monkeypatch,
+        patched_plain_run,
         0,
         '{"schema": "envelope/1", "type": "envelope", "ok": true, '
         '"data": {"spend_auto_confirm": true}}',
@@ -651,7 +613,9 @@ def test_partner_generate_rejects_a_non_positive_or_nan_timeout(patched_plain_ru
 # --- the engine's spend gate must actually be installed ---------------------
 
 
-def test_partner_generate_refuses_when_comfy_cli_has_no_spend_gate(monkeypatch):
+def test_partner_generate_refuses_when_comfy_cli_has_no_spend_gate(
+    monkeypatch, patched_plain_run
+):
     """No `comfy generate consent` -> no interlock -> refuse BEFORE spending.
 
     The fail-closed guarantee is comfy-cli's, and it landed after the >= 1.12.0
@@ -660,37 +624,28 @@ def test_partner_generate_refuses_when_comfy_cli_has_no_spend_gate(monkeypatch):
     user with nothing to stop it.
     """
     monkeypatch.setattr(server, "_spend_gate_probed", False)
-    calls: list[list[str]] = []
-
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        calls.append(cmd)
-        # An older comfy-cli reads `consent` as a model name and exits non-zero.
-        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="no such model")
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    # An older comfy-cli reads `consent` as a model name and exits non-zero.
+    calls = patched_plain_run(1, stderr="no such model")
 
     with pytest.raises(server.ComfyCliError, match="no `comfy generate` spend gate"):
         _generate("flux-pro", params={"prompt": "a cat"})
 
     assert len(calls) == 1  # only the probe ran
-    assert calls[0][4:] == ["generate", "consent", "show"]  # never the generation
+    # never the generation
+    assert calls[0]["cmd"][4:] == ["generate", "consent", "show"]
     assert server._spend_gate_probed is False  # a failed probe is not latched
 
 
-def test_partner_generate_checks_the_gate_before_prompting_the_user(monkeypatch):
+def test_partner_generate_checks_the_gate_before_prompting_the_user(
+    monkeypatch, patched_plain_run
+):
     """The gate probe runs BEFORE the elicitation, not after.
 
     Prompting first would ask the user to authorize a spend this call was always
     going to refuse — a confirmation dialog whose only outcome is an error.
     """
     monkeypatch.setattr(server, "_spend_gate_probed", False)
-
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="no such model")
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    patched_plain_run(1, stderr="no such model")
     ctx = _FakeCtx(action="accept", approve=True)
 
     with pytest.raises(server.ComfyCliError, match="no `comfy generate` spend gate"):
@@ -845,22 +800,17 @@ def test_the_model_name_shown_in_the_prompt_is_length_capped(patched_plain_run):
     assert "SPENDS Comfy credits" in ctx.elicitations[0]
 
 
-def test_partner_generate_probes_the_spend_gate_once_then_generates(monkeypatch):
+def test_partner_generate_probes_the_spend_gate_once_then_generates(
+    monkeypatch, patched_plain_run
+):
     """A CLI that HAS the gate is probed once, then the generation goes through."""
     monkeypatch.setattr(server, "_spend_gate_probed", False)
-    calls: list[list[str]] = []
-
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        calls.append(cmd)
-        return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_plain_run(0, stdout="done")
 
     _generate("flux-pro", confirm_spend=True)
     _generate("flux-pro", confirm_spend=True)
 
-    assert [c[4:6] for c in calls] == [
+    assert [c["cmd"][4:6] for c in calls] == [
         ["generate", "consent"],  # probed once...
         ["generate", "flux-pro"],
         ["generate", "flux-pro"],  # ...not again on the second call
@@ -886,7 +836,7 @@ def test_partner_generate_synthesizes_success_without_an_envelope(patched_plain_
 
 
 def test_partner_generate_prefers_a_real_envelope_when_comfy_cli_emits_one(
-    monkeypatch,
+    patched_run,
 ):
     """If comfy-cli ever DOES emit an envelope for generate, its data wins.
 
@@ -894,37 +844,19 @@ def test_partner_generate_prefers_a_real_envelope_when_comfy_cli_emits_one(
     normally, so this tool needs no change when the CLI starts emitting one.
     """
 
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        return subprocess.CompletedProcess(
-            cmd,
-            0,
-            stdout='{"schema": "envelope/1", "type": "envelope", "ok": true, '
-            '"data": {"images": ["/tmp/out.png"]}}',
-            stderr="",
-        )
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    patched_run(envelope(data={"images": ["/tmp/out.png"]}))
 
     result = _generate("flux-pro", confirm_spend=True)
 
     assert result == {"images": ["/tmp/out.png"]}
 
 
-def test_partner_generate_error_envelope_raises_with_code(monkeypatch):
+def test_partner_generate_error_envelope_raises_with_code(patched_run):
     """A real error envelope still surfaces comfy-cli's structured code."""
-
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        return subprocess.CompletedProcess(
-            cmd,
-            1,
-            stdout='{"schema": "envelope/1", "type": "envelope", "ok": false, '
-            '"error": {"code": "unknown_model", "message": "no such model"}}',
-            stderr="",
-        )
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    patched_run(
+        envelope(ok=False, error={"code": "unknown_model", "message": "no such model"}),
+        returncode=1,
+    )
 
     with pytest.raises(server.ComfyCliError, match="unknown_model"):
         _generate("nope-not-a-model", confirm_spend=True)

--- a/tests/test_remote_host.py
+++ b/tests/test_remote_host.py
@@ -17,40 +17,11 @@ subcommand). These lock in:
 from __future__ import annotations
 
 import asyncio
-import json
-import subprocess
 
 import pytest
-from conftest import _OK_STREAM
+from conftest import _OK_STREAM, envelope
 
 from comfy_local_mcp import server
-
-
-def _fake_run(envelope: dict):
-    """A ``subprocess.run`` stand-in that captures calls and emits ``envelope``."""
-    calls: list[dict] = []
-
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        calls.append({"cmd": cmd, "env": env})
-        return subprocess.CompletedProcess(
-            cmd, 0, stdout=json.dumps(envelope), stderr=""
-        )
-
-    return fake, calls
-
-
-@pytest.fixture
-def patched_run(monkeypatch):
-    """Patch ``shutil.which`` + ``subprocess.run``; returns ``setup(envelope) -> calls``."""
-
-    def setup(envelope: dict) -> list[dict]:
-        fake, calls = _fake_run(envelope)
-        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-        monkeypatch.setattr(server.subprocess, "run", fake)
-        return calls
-
-    return setup
-
 
 # --- _comfy_target env parsing ---------------------------------------------
 
@@ -194,7 +165,7 @@ def test_local_only_verb_survives_malformed_config(patched_run, monkeypatch):
     monkeypatch.setenv(
         "COMFYUI_URL", "https://gpu.example"
     )  # scheme rejected by _comfy_target
-    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+    calls = patched_run(envelope())
 
     # `env` never touches the remote, so it must run despite the bad config.
     server._run_comfy("env")
@@ -209,7 +180,7 @@ def test_run_forwards_host_port_into_subcommand(patched_run, monkeypatch):
     """`comfy run` gets --host/--port appended AFTER the verb, not in the global prefix."""
     monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
     monkeypatch.setenv("COMFYUI_PORT", "9001")
-    calls = patched_run({"type": "envelope", "ok": True, "data": {"prompt_id": "p1"}})
+    calls = patched_run(envelope(data={"prompt_id": "p1"}))
 
     server._run_comfy("run", "--workflow", "wf.json")
 
@@ -229,7 +200,7 @@ def test_run_forwards_host_port_into_subcommand(patched_run, monkeypatch):
 def test_jobs_forwards_host_port_into_subcommand(patched_run, monkeypatch):
     """Every `comfy jobs` subcommand accepts --host/--port; they are forwarded."""
     monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
-    calls = patched_run({"type": "envelope", "ok": True, "data": {"status": "running"}})
+    calls = patched_run(envelope(data={"status": "running"}))
 
     server._run_comfy("jobs", "status", "abc")
 
@@ -247,7 +218,7 @@ def test_jobs_forwards_host_port_into_subcommand(patched_run, monkeypatch):
 def test_env_is_not_forwarded_host_port(patched_run, monkeypatch):
     """`comfy env` takes no --host/--port; forwarding would error 'No such option'."""
     monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
-    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+    calls = patched_run(envelope())
 
     server._run_comfy("env")
 
@@ -257,7 +228,7 @@ def test_env_is_not_forwarded_host_port(patched_run, monkeypatch):
 def test_download_and_upload_not_forwarded(patched_run, monkeypatch):
     """download / upload verbs don't accept --host/--port -> stay local-only."""
     monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
-    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+    calls = patched_run(envelope())
 
     server._run_comfy("download", "abc", "-o", "/tmp/out")
     server._run_comfy("upload", "a.png")
@@ -268,7 +239,7 @@ def test_download_and_upload_not_forwarded(patched_run, monkeypatch):
 
 def test_local_default_is_byte_identical(patched_run):
     """With nothing configured the argv is exactly today's — no --host appended."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+    calls = patched_run(envelope())
 
     server._run_comfy("run", "--workflow", "wf.json")
 
@@ -322,24 +293,15 @@ def test_watch_job_stream_forwards_host_port(patched_stream, monkeypatch):
 # --- server_info surfaces the configured target ----------------------------
 
 
-def _patch_env_for_server_info(monkeypatch):
+def _patch_env_for_server_info(monkeypatch, patched_run):
     """Stub `comfy env` + the version detection so `server_info()` runs offline."""
-    fake, _calls = _fake_run(
-        {
-            "schema": "envelope/1",
-            "type": "envelope",
-            "ok": True,
-            "data": {"running": False},
-        }
-    )
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    patched_run(envelope(data={"running": False}))
     monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", None)
     monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.12.0")
 
 
-def test_server_info_reports_remote_target(monkeypatch):
-    _patch_env_for_server_info(monkeypatch)
+def test_server_info_reports_remote_target(monkeypatch, patched_run):
+    _patch_env_for_server_info(monkeypatch, patched_run)
     monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
 
     result = server.server_info()
@@ -351,17 +313,17 @@ def test_server_info_reports_remote_target(monkeypatch):
     assert result["compatibility"]["envelope_schema"] == "envelope/1"
 
 
-def test_server_info_omits_target_when_local(monkeypatch):
-    _patch_env_for_server_info(monkeypatch)
+def test_server_info_omits_target_when_local(monkeypatch, patched_run):
+    _patch_env_for_server_info(monkeypatch, patched_run)
 
     result = server.server_info()
 
     assert "comfy_target" not in result  # no remote configured -> no block
 
 
-def test_server_info_reports_malformed_target_as_data(monkeypatch):
+def test_server_info_reports_malformed_target_as_data(monkeypatch, patched_run):
     """A malformed remote config surfaces as a diagnostic field, not a hard failure."""
-    _patch_env_for_server_info(monkeypatch)
+    _patch_env_for_server_info(monkeypatch, patched_run)
     monkeypatch.setenv("COMFYUI_URL", "https://gpu.example")
 
     result = server.server_info()

--- a/tests/test_run_template.py
+++ b/tests/test_run_template.py
@@ -23,10 +23,9 @@ comfy-cli is mocked throughout: no real ComfyUI, and no real credit spend.
 from __future__ import annotations
 
 import asyncio
-import json
-import subprocess
 
 import pytest
+from conftest import envelope
 from mcp.server.elicitation import (
     AcceptedElicitation,
     CancelledElicitation,
@@ -80,42 +79,10 @@ class _FakeCtx:
         return CancelledElicitation()
 
 
-def _envelope(*, ok: bool = True, data=None, error=None) -> str:
-    body: dict = {"schema": "envelope/1", "type": "envelope", "ok": ok}
-    if error is not None:
-        body["error"] = error
-    else:
-        body["data"] = data if data is not None else {}
-    return json.dumps(body)
-
-
-@pytest.fixture
-def patched_run(monkeypatch):
-    """``setup(stdout=..., returncode=...) -> calls`` mocking ``comfy`` via subprocess.
-
-    Defaults to a successful ``envelope/1`` so the happy path returns real data;
-    pass ``stdout`` to shape the envelope (e.g. an error) per test.
-    """
-
-    def setup(stdout: str | None = None, returncode: int = 0) -> list[dict]:
-        calls: list[dict] = []
-        payload = (
-            _envelope(data={"prompt_id": "p1", "outputs": ["/x.png"]})
-            if stdout is None
-            else stdout
-        )
-
-        def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-            calls.append({"cmd": cmd, "env": env, "timeout": timeout})
-            return subprocess.CompletedProcess(
-                cmd, returncode, stdout=payload, stderr=""
-            )
-
-        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-        monkeypatch.setattr(server.subprocess, "run", fake)
-        return calls
-
-    return setup
+# A realistic `comfy run-template` result, for the few tests that assert on what
+# comes BACK rather than on the argv that went out. The rest take conftest's
+# ``patched_run`` default (a success envelope with empty ``data``).
+_RUN_RESULT = {"prompt_id": "p1", "outputs": ["/x.png"]}
 
 
 # --- passthrough argv -------------------------------------------------------
@@ -123,14 +90,11 @@ def patched_run(monkeypatch):
 
 def test_run_template_argv_is_a_local_json_passthrough(patched_run):
     """`comfy --json --where local run-template <name> --param=k=v` (flags first)."""
-    calls = patched_run()
+    calls = patched_run(envelope(data=_RUN_RESULT))
 
     result = _run_template("image_flux2", params={"prompt": "a red fox"})
 
-    assert result == {
-        "prompt_id": "p1",
-        "outputs": ["/x.png"],
-    }  # envelope data unwrapped
+    assert result == _RUN_RESULT  # envelope data unwrapped
     cmd = calls[0]["cmd"]
     assert cmd[0] == server.COMFY_BIN
     assert cmd[1:4] == ["--json", "--where", "local"]  # global flags first
@@ -312,7 +276,9 @@ def test_run_template_falls_back_to_confirm_spend_when_client_cannot_elicit(
     assert "--allow-spend" in calls[0]["cmd"]
 
 
-def test_run_template_does_not_consult_the_generate_auto_confirm(monkeypatch):
+def test_run_template_does_not_consult_the_generate_auto_confirm(
+    monkeypatch, patched_run
+):
     """comfy-cli scopes `spend.auto_confirm` to `comfy generate`.
 
     `run-template` never reads it, so treating it as consent here would forward
@@ -327,14 +293,7 @@ def test_run_template_does_not_consult_the_generate_auto_confirm(monkeypatch):
     ctx = _FakeCtx()
 
     # A free run: no consent machinery should be reached at all.
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(
-        server.subprocess,
-        "run",
-        lambda *a, **k: subprocess.CompletedProcess(
-            [], 0, stdout=_envelope(data={"prompt_id": "p1"}), stderr=""
-        ),
-    )
+    patched_run(envelope(data=_RUN_RESULT))
 
     _run_template("image_flux2", confirm_spend=True, ctx=ctx)
 
@@ -344,7 +303,7 @@ def test_run_template_does_not_consult_the_generate_auto_confirm(monkeypatch):
 def test_run_template_spend_refusal_raises_with_code(patched_run):
     """The engine's fail-closed refusal (error envelope) raises — no false success."""
     patched_run(
-        stdout=_envelope(
+        envelope(
             ok=False,
             error={
                 "code": "spend_consent_required",
@@ -363,7 +322,7 @@ def test_run_template_spend_refusal_raises_with_code(patched_run):
 
 def test_run_template_wait_false_submits_async(patched_run):
     """`wait=False` appends `--async` and uses the short fire-and-return timeout."""
-    calls = patched_run(stdout=_envelope(data={"prompt_id": "p9"}))
+    calls = patched_run(envelope(data={"prompt_id": "p9"}))
 
     result = _run_template("image_flux2", params={"prompt": "x"}, wait=False)
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -16,26 +16,12 @@ comfy-cli's real ``templates ls`` payload:
 
 from __future__ import annotations
 
-import json
 import os
-import subprocess
 
 import pytest
+from conftest import envelope
 
 from comfy_local_mcp import server
-
-
-def _fake_run(envelope: dict):
-    """Return a subprocess.run stand-in that captures the call and emits an envelope."""
-    calls: list[dict] = []
-
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        calls.append({"cmd": cmd, "env": env})
-        return subprocess.CompletedProcess(
-            cmd, 0, stdout=json.dumps(envelope), stderr=""
-        )
-
-    return fake, calls
 
 
 # A representative slice of the real comfy-cli `templates ls` payload shape.
@@ -124,11 +110,9 @@ def _names(result) -> list[str]:
     return [r["name"] for r in _rows(result)]
 
 
-def test_search_templates_argv_and_empty_query_pages(monkeypatch):
+def test_search_templates_argv_and_empty_query_pages(patched_run):
     """Passthrough `comfy --json --where local templates ls`; empty query = first page + total."""
-    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": _payload()})
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run(envelope(data=_payload()))
 
     result = server.search_templates()
 
@@ -199,11 +183,9 @@ def test_search_templates_pagination(monkeypatch):
     assert server.search_templates(limit=2, offset=100)["rows"] == []  # past the end
 
 
-def test_search_templates_forwards_gallery_filters(monkeypatch):
+def test_search_templates_forwards_gallery_filters(patched_run):
     """tag/type/model/provider become the corresponding `templates ls` flags."""
-    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": _payload()})
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run(envelope(data=_payload()))
 
     server.search_templates(
         tag="API", type="image", model="Flux", provider="Black Forest Labs"
@@ -291,23 +273,17 @@ def test_search_templates_limit_capped(monkeypatch):
     assert result["shown"] == server._TEMPLATE_LIST_MAX_LIMIT  # page is capped
 
 
-def test_get_template_argv(monkeypatch):
+def test_get_template_argv(patched_run):
     """Passthrough: `comfy --json --where local templates show <name>`."""
-    fake, calls = _fake_run(
-        {"type": "envelope", "ok": True, "data": {"name": "flux_dev", "nodes": 12}}
-    )
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run(envelope(data={"name": "flux_dev", "nodes": 12}))
 
     assert server.get_template("flux_dev") == {"name": "flux_dev", "nodes": 12}
     assert calls[0]["cmd"][4:] == ["templates", "show", "flux_dev"]
 
 
-def test_fetch_template_argv_and_returns_abspath(monkeypatch, tmp_path):
+def test_fetch_template_argv_and_returns_abspath(patched_run, tmp_path):
     """Passthrough argv is `templates fetch <name> --out <path>`; returns the abs path."""
-    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": None})
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run(envelope(data=None))
 
     out = tmp_path / "flux.json"
     result = server.fetch_template("flux_dev", str(out))

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -13,31 +13,15 @@ they own on top of the passthrough:
 
 from __future__ import annotations
 
-import json
-import subprocess
+from conftest import envelope
 
 from comfy_local_mcp import server
 
 
-def _fake_run(envelope: dict):
-    """Return a subprocess.run stand-in that captures the call and emits an envelope."""
-    calls: list[dict] = []
-
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        calls.append({"cmd": cmd, "env": env})
-        return subprocess.CompletedProcess(
-            cmd, 0, stdout=json.dumps(envelope), stderr=""
-        )
-
-    return fake, calls
-
-
-def test_list_workflow_slots_argv(monkeypatch):
+def test_list_workflow_slots_argv(patched_run):
     """Passthrough: `comfy --json --where local workflow slots <path>`."""
     data = [{"addr": "6.text", "value": "a cat"}, {"addr": "3.seed", "value": 42}]
-    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": data})
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run(envelope(data=data))
 
     assert server.list_workflow_slots("/tmp/flux.json") == data
 
@@ -46,13 +30,9 @@ def test_list_workflow_slots_argv(monkeypatch):
     assert cmd[4:] == ["workflow", "slots", "/tmp/flux.json"]  # subcommand after
 
 
-def test_set_workflow_slot_argv_default_stdout(monkeypatch):
+def test_set_workflow_slot_argv_default_stdout(patched_run):
     """Default: positional ADDR=VALUE overrides + trailing --stdout (non-destructive)."""
-    fake, calls = _fake_run(
-        {"type": "envelope", "ok": True, "data": {"modified": True}}
-    )
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run(envelope(data={"modified": True}))
 
     result = server.set_workflow_slot(
         "/tmp/flux.json", ["6.text=a red bicycle", "3.seed=42"]
@@ -69,11 +49,9 @@ def test_set_workflow_slot_argv_default_stdout(monkeypatch):
     ]
 
 
-def test_set_workflow_slot_stdout_false_writes_in_place(monkeypatch):
+def test_set_workflow_slot_stdout_false_writes_in_place(patched_run):
     """stdout=False drops --stdout so comfy-cli writes the change back to the file."""
-    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": None})
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run(envelope(data=None))
 
     server.set_workflow_slot("/tmp/flux.json", ["3.seed=7"], stdout=False)
 
@@ -82,11 +60,9 @@ def test_set_workflow_slot_stdout_false_writes_in_place(monkeypatch):
     assert "--stdout" not in cmd
 
 
-def test_vary_workflow_argv_repeats_slot_flag(monkeypatch):
+def test_vary_workflow_argv_repeats_slot_flag(patched_run):
     """Each address becomes its own `--slot "ADDR=[...]"`; no --out-dir when unset."""
-    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": {"variants": 3}})
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run(envelope(data={"variants": 3}))
 
     result = server.vary_workflow(
         "/tmp/flux.json", ["3.seed=[1,2,3]", "6.text=[cat,dog,fish]"]
@@ -106,11 +82,9 @@ def test_vary_workflow_argv_repeats_slot_flag(monkeypatch):
     assert "--out-dir" not in cmd  # stdout NDJSON mode when out_dir is unset
 
 
-def test_vary_workflow_forwards_out_dir(monkeypatch, tmp_path):
+def test_vary_workflow_forwards_out_dir(patched_run, tmp_path):
     """out_dir appends `--out-dir <dir>` so variants are written to files."""
-    fake, calls = _fake_run({"type": "envelope", "ok": True, "data": None})
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", fake)
+    calls = patched_run(envelope(data=None))
 
     out = tmp_path / "variants"
     server.vary_workflow("/tmp/flux.json", ["3.seed=[1,2]"], out_dir=str(out))

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -22,49 +22,14 @@ import threading
 import time
 
 import pytest
-from conftest import _OK_STREAM, _FakeProc, _RecordingCtx
+from conftest import _OK_STREAM, _FakeProc, _RecordingCtx, envelope
 
 from comfy_local_mcp import server
 
 
-def _fake_run(envelope: dict):
-    """Return a ``subprocess.run`` stand-in that captures calls and emits ``envelope``.
-
-    Pure factory (no patching): returns ``(fake, calls)``. Tests either patch
-    ``fake`` in themselves or use the ``patched_run`` fixture, which wraps this.
-    """
-    calls: list[dict] = []
-
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        calls.append({"cmd": cmd, "env": env, "encoding": encoding})
-        return subprocess.CompletedProcess(
-            cmd, 0, stdout=json.dumps(envelope), stderr=""
-        )
-
-    return fake, calls
-
-
-@pytest.fixture
-def patched_run(monkeypatch):
-    """Patch away ``shutil.which`` + ``subprocess.run`` for ``_run_comfy``.
-
-    Returns a ``setup(envelope) -> calls`` helper: call it with the envelope
-    the fake comfy-cli should emit, and get back the list that captures each
-    invocation (``cmd`` + ``env``).
-    """
-
-    def setup(envelope: dict) -> list[dict]:
-        fake, calls = _fake_run(envelope)
-        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-        monkeypatch.setattr(server.subprocess, "run", fake)
-        return calls
-
-    return setup
-
-
 def test_global_flags_precede_subcommand(patched_run):
     """Regression: `comfy run … --json` errors; it must be `comfy --json … run`."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {"x": 1}})
+    calls = patched_run(envelope(data={"x": 1}))
 
     assert server._run_comfy("jobs", "status", "abc") == {"x": 1}
 
@@ -77,7 +42,7 @@ def test_global_flags_precede_subcommand(patched_run):
 
 def test_run_comfy_sets_no_watch_env(patched_run):
     """Agentic caller: comfy-cli's file watcher is suppressed via COMFY_NO_WATCH."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {"x": 1}})
+    calls = patched_run(envelope(data={"x": 1}))
 
     server._run_comfy("jobs", "status", "abc")
 
@@ -91,7 +56,7 @@ def test_run_comfy_forces_utf8_env(patched_run):
     printing the UTF-8 catalog and wedges, so discovery tools present as a 60s
     timeout. Forcing UTF-8 on the child prevents the crash (no-op on POSIX).
     """
-    calls = patched_run({"type": "envelope", "ok": True, "data": {"x": 1}})
+    calls = patched_run(envelope(data={"x": 1}))
 
     server._run_comfy("jobs", "status", "abc")
 
@@ -107,7 +72,7 @@ def test_run_comfy_pins_parent_decode_to_utf8(patched_run):
     output raises UnicodeDecodeError/mojibake before ``_unwrap_envelope`` — the
     same crash, just moved from the child's write to the parent's read.
     """
-    calls = patched_run({"type": "envelope", "ok": True, "data": {"x": 1}})
+    calls = patched_run(envelope(data={"x": 1}))
 
     server._run_comfy("jobs", "status", "abc")
 
@@ -118,7 +83,7 @@ def test_run_comfy_utf8_env_overrides_inherited(patched_run, monkeypatch):
     """The injected UTF-8 vars win over any conflicting value in the parent env."""
     monkeypatch.setenv("PYTHONUTF8", "0")
     monkeypatch.setenv("PYTHONIOENCODING", "cp1252")
-    calls = patched_run({"type": "envelope", "ok": True, "data": {"x": 1}})
+    calls = patched_run(envelope(data={"x": 1}))
 
     server._run_comfy("jobs", "status", "abc")
 
@@ -275,7 +240,7 @@ def test_get_logs_maps_command_and_returns_data(patched_run):
         "path": "/ws/user/comfyui_8188.log",
         "truncated": False,
     }
-    calls = patched_run({"type": "envelope", "ok": True, "data": payload})
+    calls = patched_run(envelope(data=payload))
 
     assert server.get_logs() == payload
 
@@ -286,7 +251,7 @@ def test_get_logs_maps_command_and_returns_data(patched_run):
 
 def test_get_logs_forwards_custom_tail(patched_run):
     """A custom tail is stringified and forwarded to `--tail`."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {"lines": []}})
+    calls = patched_run(envelope(data={"lines": []}))
 
     server.get_logs(tail=50)
 
@@ -296,7 +261,7 @@ def test_get_logs_forwards_custom_tail(patched_run):
 def test_get_logs_clamps_negative_and_huge_tail(patched_run):
     """A negative tail can't forward a malformed `--tail -N`, and an absurd tail
     is capped so comfy-cli isn't asked for an enormous slice."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {"lines": []}})
+    calls = patched_run(envelope(data={"lines": []}))
 
     server.get_logs(tail=-5)
     assert calls[-1]["cmd"][4:] == ["logs", "--tail", str(server._MIN_LOG_TAIL)]
@@ -337,7 +302,7 @@ def test_get_logs_other_error_still_raises(patched_run):
 
 def test_cancel_job_maps_command_and_returns_data(patched_run):
     """cancel_job wraps `comfy jobs cancel <id>` and returns the envelope data."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {"cancelled": "abc"}})
+    calls = patched_run(envelope(data={"cancelled": "abc"}))
 
     assert server.cancel_job("abc") == {"cancelled": "abc"}
     assert calls[0]["cmd"][4:] == ["jobs", "cancel", "abc"]  # mapped subcommand
@@ -365,7 +330,7 @@ def test_get_queue_maps_command_and_returns_data(patched_run):
             {"prompt_id": "b", "status": "completed"},
         ]
     }
-    calls = patched_run({"type": "envelope", "ok": True, "data": jobs})
+    calls = patched_run(envelope(data=jobs))
 
     assert server.get_queue() == jobs
     assert calls[0]["cmd"][4:] == ["jobs", "ls"]  # no positional args
@@ -479,7 +444,7 @@ def test_get_queue_passes_through_payload_without_jobs(patched_run):
 
 def test_upload_file_passes_paths_and_overwrite(patched_run):
     """upload_file forwards every path and appends --overwrite when asked."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {"uploaded": 2}})
+    calls = patched_run(envelope(data={"uploaded": 2}))
 
     assert server.upload_file(["a.png", "b.png"], overwrite=True) == {"uploaded": 2}
 
@@ -490,7 +455,7 @@ def test_upload_file_passes_paths_and_overwrite(patched_run):
 
 def test_upload_file_omits_overwrite_by_default(patched_run):
     """Without overwrite the flag must be absent, not passed as False."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {"uploaded": 1}})
+    calls = patched_run(envelope(data={"uploaded": 1}))
 
     server.upload_file(["only.png"])
 
@@ -516,7 +481,7 @@ def test_download_model_url_only(patched_run):
 
 def test_download_model_threads_relative_path(patched_run):
     """--relative-path is appended only when provided."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+    calls = patched_run(envelope(data={}))
 
     server.download_model("https://hf.co/l.safetensors", relative_path="models/loras")
 
@@ -532,7 +497,7 @@ def test_download_model_threads_relative_path(patched_run):
 
 def test_download_model_threads_filename(patched_run):
     """--filename is appended only when provided."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+    calls = patched_run(envelope(data={}))
 
     server.download_model("https://hf.co/c.safetensors", filename="renamed.safetensors")
 
@@ -548,7 +513,7 @@ def test_download_model_threads_filename(patched_run):
 
 def test_download_model_threads_all_optionals(patched_run):
     """Both optional args thread through together, in order, only when set."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+    calls = patched_run(envelope(data={}))
 
     server.download_model(
         "https://civitai.com/api/download/models/42",
@@ -570,7 +535,7 @@ def test_download_model_threads_all_optionals(patched_run):
 
 def test_download_model_omits_absent_optionals(patched_run):
     """Neither optional flag is emitted when the argument is left unset."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+    calls = patched_run(envelope(data={}))
 
     server.download_model("https://hf.co/x.safetensors")
 
@@ -624,7 +589,7 @@ def test_download_model_rejects_pathy_filename(bad_name):
 
 def test_download_model_omits_empty_string_optionals(patched_run):
     """Explicit empty-string optionals are treated as unset, not forwarded as ``""``."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+    calls = patched_run(envelope(data={}))
 
     server.download_model("https://hf.co/x.safetensors", relative_path="", filename="")
 
@@ -721,7 +686,7 @@ def test_fetch_outputs_wraps_comfy_download(patched_run):
 
 def test_fetch_outputs_url_only_appends_flag(patched_run):
     """url_only=True adds --url-only so comfy emits URLs without downloading bytes."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {"urls": []}})
+    calls = patched_run(envelope(data={"urls": []}))
 
     server.fetch_outputs("pid", "/tmp/out", url_only=True)
 
@@ -730,7 +695,7 @@ def test_fetch_outputs_url_only_appends_flag(patched_run):
 
 def test_fetch_outputs_omits_url_only_by_default(patched_run):
     """Without url_only the flag must be absent, not passed as False."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+    calls = patched_run(envelope(data={}))
 
     server.fetch_outputs("pid", "/tmp/out")
 
@@ -760,7 +725,7 @@ def test_auth_status_maps_command_and_passes_payload_through(patched_run, monkey
         "base_url": "https://api.comfy.example",
         "expired": False,
     }
-    calls = patched_run({"type": "envelope", "ok": True, "data": whoami})
+    calls = patched_run(envelope(data=whoami))
     # No registration env key set -> the added flag is False, everything else as-is.
     monkeypatch.delenv("COMFY_API_KEY", raising=False)
 
@@ -786,7 +751,7 @@ def test_auth_status_signed_out_payload_passes_through(patched_run, monkeypatch)
         "api_key_source": None,
         "base_url": "https://api.comfy.example",
     }
-    patched_run({"type": "envelope", "ok": True, "data": whoami})
+    patched_run(envelope(data=whoami))
     monkeypatch.delenv("COMFY_API_KEY", raising=False)
 
     result = server.auth_status()
@@ -820,7 +785,7 @@ def test_auth_status_reports_flag_even_for_non_dict_payload(patched_run, monkeyp
     """A non-dict whoami payload still carries registration_env_key_present."""
     # Defensive: whoami normally returns an object, but if it ever hands back a
     # non-dict (null / list), the flag must still be present per the docstring.
-    patched_run({"type": "envelope", "ok": True, "data": None})
+    patched_run(envelope(data=None))
     monkeypatch.setenv("COMFY_API_KEY", "sk-super-secret-value")
 
     result = server.auth_status()
@@ -842,7 +807,7 @@ def test_auth_status_never_returns_key_material(patched_run, monkeypatch):
         "session": {"api_key": "***REDACTED***", "token": "***REDACTED***"},
         "stale_base_url": False,
     }
-    patched_run({"type": "envelope", "ok": True, "data": whoami})
+    patched_run(envelope(data=whoami))
     monkeypatch.delenv("COMFY_API_KEY", raising=False)
 
     dumped = json.dumps(server.auth_status())
@@ -882,7 +847,7 @@ def test_server_instructions_cover_credential_steering():
 
 def test_launch_comfyui_passes_background_flag(patched_run):
     """launch_comfyui must run `comfy … launch --background` (detached start)."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {"pid": 42}})
+    calls = patched_run(envelope(data={"pid": 42}))
 
     assert server.launch_comfyui() == {"pid": 42}
 
@@ -893,7 +858,7 @@ def test_launch_comfyui_passes_background_flag(patched_run):
 
 def test_launch_comfyui_forwards_extra_args_after_separator(patched_run):
     """Extra args are forwarded to ComfyUI after a `--` separator."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+    calls = patched_run(envelope(data={}))
 
     server.launch_comfyui(["--port", "8189"])
 
@@ -920,36 +885,6 @@ def test_stop_comfyui_surfaces_no_recorded_server_error(patched_run):
 
 
 # --- lifecycle commands with no JSON envelope (BE-2953) --------------------
-
-
-def _fake_run_plain(returncode: int, stdout: str = "", stderr: str = ""):
-    """`subprocess.run` stand-in emitting HUMAN text (no envelope) + a returncode.
-
-    Mirrors ``launch``/``stop``: comfy-cli prints plain text and exits without
-    ever writing an ``envelope/1`` object.
-    """
-    calls: list[dict] = []
-
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        calls.append({"cmd": cmd, "env": env})
-        return subprocess.CompletedProcess(
-            cmd, returncode, stdout=stdout, stderr=stderr
-        )
-
-    return fake, calls
-
-
-@pytest.fixture
-def patched_plain_run(monkeypatch):
-    """`setup(returncode, stdout, stderr) -> calls` for the no-envelope path."""
-
-    def setup(returncode: int, stdout: str = "", stderr: str = "") -> list[dict]:
-        fake, calls = _fake_run_plain(returncode, stdout, stderr)
-        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-        monkeypatch.setattr(server.subprocess, "run", fake)
-        return calls
-
-    return setup
 
 
 def test_stop_comfyui_synthesizes_success_on_plain_exit(patched_plain_run):
@@ -1026,7 +961,7 @@ def test_non_plain_ok_rejects_stray_non_envelope_json(patched_plain_run):
 
 def test_plain_ok_still_honors_a_real_envelope(patched_run):
     """When comfy-cli DOES emit an envelope, plain_ok unwraps it normally."""
-    patched_run({"type": "envelope", "ok": True, "data": {"pid": 7}})
+    patched_run(envelope(data={"pid": 7}))
 
     assert server._run_comfy("launch", "--background", plain_ok=True) == {"pid": 7}
 
@@ -1384,7 +1319,7 @@ def test_download_model_fallback_omits_url_when_no_output(patched_plain_run):
 def test_discover_maps_command_and_returns_data(patched_run):
     """discover wraps `comfy discover` and returns the envelope data verbatim."""
     surface = {"commands": ["run", "env"], "error_codes": ["server_not_running"]}
-    calls = patched_run({"type": "envelope", "ok": True, "data": surface})
+    calls = patched_run(envelope(data=surface))
 
     assert server.discover() == surface
     cmd = calls[0]["cmd"]
@@ -1705,25 +1640,26 @@ def test_tail_bounds_and_decodes():
     )
 
 
-def _timeout_run(stderr, stdout):
-    """A `subprocess.run` stand-in that raises TimeoutExpired with given captures."""
+def _timeout(stderr, stdout):
+    """The ``TimeoutExpired`` a killed ``comfy discover`` child would raise.
 
-    def fake(cmd, capture_output, text, encoding, timeout, env, check):  # noqa: ARG001
-        raise subprocess.TimeoutExpired(cmd, timeout, output=stdout, stderr=stderr)
+    The captures are what ``subprocess.run(capture_output=True)`` attaches to the
+    exception before re-raising; the message the tests below read is built by
+    ``_run_comfy`` from its OWN cmd/timeout, so these two only have to be
+    plausible.
+    """
+    return subprocess.TimeoutExpired(
+        [server.COMFY_BIN, "discover"], 60.0, output=stdout, stderr=stderr
+    )
 
-    return fake
 
-
-def test_sync_timeout_surfaces_bytes_stderr(monkeypatch):
+def test_sync_timeout_surfaces_bytes_stderr(patched_run):
     """POSIX shape: TimeoutExpired carries bytes; the stderr traceback reaches the message."""
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(
-        server.subprocess,
-        "run",
-        _timeout_run(
+    patched_run(
+        raises=_timeout(
             stderr=b"Traceback (most recent call last):\nUnicodeEncodeError: 'charmap'",
             stdout=b"partial stdout",
-        ),
+        )
     )
     with pytest.raises(server.ComfyCliError) as exc:
         server._run_comfy("discover", timeout=60.0)
@@ -1733,14 +1669,9 @@ def test_sync_timeout_surfaces_bytes_stderr(monkeypatch):
     assert "partial stdout" in msg
 
 
-def test_sync_timeout_surfaces_str_stderr(monkeypatch):
+def test_sync_timeout_surfaces_str_stderr(patched_run):
     """Windows shape: run() re-communicates after the kill and returns str captures."""
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(
-        server.subprocess,
-        "run",
-        _timeout_run(stderr="boom on stderr", stdout="half a line"),
-    )
+    patched_run(raises=_timeout(stderr="boom on stderr", stdout="half a line"))
     with pytest.raises(server.ComfyCliError) as exc:
         server._run_comfy("discover", timeout=60.0)
     msg = str(exc.value)
@@ -1748,12 +1679,9 @@ def test_sync_timeout_surfaces_str_stderr(monkeypatch):
     assert "half a line" in msg
 
 
-def test_sync_timeout_with_no_captures_is_sane(monkeypatch):
+def test_sync_timeout_with_no_captures_is_sane(patched_run):
     """None captures (nothing written before the kill) must not crash and read sanely."""
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(
-        server.subprocess, "run", _timeout_run(stderr=None, stdout=None)
-    )
+    patched_run(raises=_timeout(stderr=None, stdout=None))
     with pytest.raises(server.ComfyCliError) as exc:
         server._run_comfy("discover", timeout=60.0)
     msg = str(exc.value)
@@ -1916,7 +1844,7 @@ def test_streaming_timeout_stderr_cancel_still_raises(monkeypatch):
 
 def test_restart_comfyui_runs_stop_then_launch(patched_run):
     """restart is a thin `comfy stop` then `comfy launch --background` composition."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {"pid": 7}})
+    calls = patched_run(envelope(data={"pid": 7}))
 
     # patched_run's fake emits the same envelope for every call, so launch's
     # data ({"pid": 7}) is what restart returns.
@@ -1929,7 +1857,7 @@ def test_restart_comfyui_runs_stop_then_launch(patched_run):
 
 def test_restart_comfyui_forwards_extra_args_to_launch(patched_run):
     """extra_args ride the launch step after the `--` separator, not the stop."""
-    calls = patched_run({"type": "envelope", "ok": True, "data": {}})
+    calls = patched_run(envelope(data={}))
 
     server.restart_comfyui(["--port", "8189"])
 
@@ -2010,7 +1938,7 @@ _FAKE_PNG = b"\x89PNG\r\n\x1a\nfake-pixels"
 def test_fetch_outputs_inline_images_returns_image_content(patched_run, tmp_path):
     """inline_images=True returns [metadata, Image...] for each downloaded image."""
     (tmp_path / "gen.png").write_bytes(_FAKE_PNG)
-    patched_run({"type": "envelope", "ok": True, "data": {"downloaded": ["gen.png"]}})
+    patched_run(envelope(data={"downloaded": ["gen.png"]}))
 
     result = server.fetch_outputs("pid", str(tmp_path), inline_images=True)
 
@@ -2090,7 +2018,7 @@ def test_fetch_outputs_inline_images_prefers_out_dir_over_cwd(
     (cwd / "gen.png").write_bytes(b"cwd-decoy-not-this-one")  # a CWD shadow
     monkeypatch.chdir(cwd)
 
-    patched_run({"type": "envelope", "ok": True, "data": {"downloaded": ["gen.png"]}})
+    patched_run(envelope(data={"downloaded": ["gen.png"]}))
 
     result = server.fetch_outputs("pid", str(out_dir), inline_images=True)
 
@@ -2127,7 +2055,7 @@ def test_fetch_outputs_inline_images_caps_count(patched_run, tmp_path):
     names = [f"g{i}.png" for i in range(server._INLINE_IMAGE_MAX_COUNT + 5)]
     for name in names:
         (tmp_path / name).write_bytes(_FAKE_PNG)
-    patched_run({"type": "envelope", "ok": True, "data": {"downloaded": names}})
+    patched_run(envelope(data={"downloaded": names}))
 
     result = server.fetch_outputs("pid", str(tmp_path), inline_images=True)
 
@@ -2190,7 +2118,7 @@ def test_fetch_outputs_inline_images_still_downloads(patched_run, tmp_path):
 def test_fetch_outputs_default_return_is_unchanged(patched_run, tmp_path):
     """Without inline_images the bare envelope data is returned (no list wrapping)."""
     (tmp_path / "gen.png").write_bytes(_FAKE_PNG)
-    patched_run({"type": "envelope", "ok": True, "data": {"downloaded": ["gen.png"]}})
+    patched_run(envelope(data={"downloaded": ["gen.png"]}))
 
     result = server.fetch_outputs("pid", str(tmp_path))
 
@@ -2807,7 +2735,7 @@ def test_get_logs_caps_oversized_line(patched_run):
         "path": "/ws/user/comfyui_8188.log",
         "truncated": False,
     }
-    patched_run({"type": "envelope", "ok": True, "data": payload})
+    patched_run(envelope(data=payload))
 
     result = server.get_logs()
     lines = result["lines"]


### PR DESCRIPTION
## ELI-5

Every test that pretends to be `comfy-cli` had its own hand-written copy of the same fake — 23 of them, spread over 9 files. Each copy had to spell out exactly how the server launches `comfy`, so changing one thing about that launch meant editing all 23. This PR writes the fake once, in `tests/conftest.py`, and points everybody at it. No product code changes; the tests still assert the same things.

## Summary

Hoists the canned `subprocess.run` stub for the plain `--json` spawn path into shared `tests/conftest.py` fixtures, modeled on the `patched_stream` fixture that already does this for the `--json-stream` path. Test-only — `src/` is untouched.

The duplicated stub was `def fake(cmd, capture_output, text, encoding, timeout, env, check): ... return subprocess.CompletedProcess(...)`, repeated 23 times across 9 files. Because each copy mirrors `_run_comfy`'s exact `subprocess.run` kwargs, any kwarg change there (the `encoding=` pin was the most recent) had to be applied to all of them. Envelope payloads were likewise re-derived per file (`_envelope` in `test_run_template.py`, `_ok` in `test_discovery.py`).

## Changes

- **`tests/conftest.py`** — three new shared helpers:
  - `envelope(ok=…, data=…, error=…)` builds an `envelope/1` body. `data` falls back to `{}` only when it is **omitted**; an explicit `data=None` stays `None`, because several tests use a null payload to exercise the non-dict branches.
  - `patched_run(stdout=…, returncode=…, stderr=…, raises=…) -> calls` is the single canonical fake. `stdout` takes a dict (JSON-encoded for you) or a raw string; `raises` covers the spawn-failure paths (`TimeoutExpired`); each invocation is recorded as `{cmd, env, timeout, encoding}` — a superset of what any caller asserts on — so exact-argv assertions keep working.
  - `patched_plain_run(returncode, stdout, stderr) -> calls` is the same fake for the verbs that print human text and emit no envelope (`launch` / `stop` / `generate`); it was itself duplicated verbatim in `test_wrapper.py` and `test_partner_generate.py`.
- **9 test files converted** — `test_wrapper`, `test_partner_generate`, `test_compat`, `test_run_template`, `test_remote_host`, `test_discovery`, `test_templates`, `test_failure_log`, `test_workflow`. All 20 stubs carrying the canonical signature now route through the fixture; single-line `{"type": "envelope", "ok": True, "data": X}` literals became `envelope(data=X)`.
- **`AGENTS.md`** — documents the fixtures in the Tests section so a new tool test starts from them rather than from copy 24.

**Bespoke stubs deliberately kept local** (3 remain, all genuinely different calls): the two `comfy --version` probes in `test_wrapper.py` / `test_compat.py` (different kwargs — `errors=`, no `env`/`encoding`), and `test_compat.py`'s `patched_env_then_outdated`, which queues one reply per call for `server_info`'s two-shell-out sequence.

## Motivation

One place to update when the spawn signature changes, instead of 23. Net −194 lines across the suite.

## Testing

- [x] Existing tests pass (`pytest`) — 492 passed, 2 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually — n/a, test-only refactor

## Additional Notes — judgment calls

- **`envelope()` emits `"schema": "envelope/1"`, which most of the replaced literals omitted.** That is what real comfy-cli emits, so the mocks got *more* faithful, not less. No coverage is lost: the "envelope with no `schema` is assumed compatible" case has its own direct `_unwrap_envelope` unit test in `test_compat.py`, which this PR does not touch.
- **`data=None` vs omitted `data` is a real distinction, and the first draft got it wrong.** Modeling `envelope()` on the old `_envelope` helper (`data if data is not None else {}`) silently turned a null whoami payload into `{}` and broke `test_auth_status_reports_flag_even_for_non_dict_payload`. Fixed with a sentinel default; the four call sites that want a null payload now pass `envelope(data=None)` explicitly.
- **`patched_run` records the call before `raises` fires**, unlike the two stubs it replaces (which raised without recording). Strictly more information; nothing asserts on the absence of a record.
- **`test_run_template.py`'s fixture had a non-empty default payload** (`{"prompt_id": "p1", ...}`) that only one test actually read. Rather than reproduce a per-file default in the shared fixture, that test now passes the payload explicitly (`_RUN_RESULT`) and the rest take conftest's empty-`data` success envelope.
- Multi-line envelope literals in `test_wrapper.py` were left as literals — converting them is churn that touches no spawn-signature surface.
- **Negative-claim check:** not applicable. The diff adds no capability denial, no throw/deny dead-end, and no test flipped to assert one — it is a test-only refactor that removes duplication and changes no product behavior.
