### PR TITLE
refactor: share one spawn site between the two comfy --version probes

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -693,6 +693,27 @@ def _parse_version(text: str) -> tuple[int, int, int] | None:
     return int(major), int(minor), int(patch)
 
 
+def _spawn_comfy_version() -> subprocess.CompletedProcess:
+    """Run ``comfy --version`` and return the completed process.
+
+    The single spawn site shared by the two ``--version`` probes —
+    :func:`_check_comfy_version` (the hard ``>= 1.12.0`` floor) and
+    :func:`_detect_comfy_cli_version` (the opt-in ``COMFY_CLI_MIN_VERSION``
+    report). It deliberately does NOT catch anything: the two callers have
+    different, load-bearing failure policies (fail-open with a latched timeout
+    and a macOS TCC translation vs. best-effort ``None``), so each keeps its own
+    ``try``/``except`` around this call. Only the invocation itself is shared.
+    """
+    return subprocess.run(
+        [COMFY_BIN, "--version"],
+        capture_output=True,
+        text=True,
+        errors="replace",  # never crash on undecodable `--version` bytes
+        timeout=30.0,
+        check=False,
+    )
+
+
 def _check_comfy_version() -> None:
     """Guard: refuse to run against a comfy-cli older than :data:`_MIN_COMFY_CLI`.
 
@@ -708,14 +729,7 @@ def _check_comfy_version() -> None:
     if _version_checked:
         return
     try:
-        proc = subprocess.run(
-            [COMFY_BIN, "--version"],
-            capture_output=True,
-            text=True,
-            errors="replace",  # never crash on undecodable `--version` bytes
-            timeout=30.0,
-            check=False,
-        )
+        proc = _spawn_comfy_version()
     except subprocess.TimeoutExpired:
         # A hung `--version` is latched so we don't re-block every later call on
         # the same 30s wait; fail OPEN for the rest of the process.
@@ -1909,15 +1923,12 @@ def _detect_comfy_cli_version() -> str | None:
     if shutil.which(COMFY_BIN) is None:
         return None
     try:
-        proc = subprocess.run(
-            [COMFY_BIN, "--version"],
-            capture_output=True,
-            text=True,
-            errors="replace",  # never crash on non-UTF-8 bytes; report None instead
-            timeout=30.0,
-            check=False,
-        )
+        proc = _spawn_comfy_version()
     except (subprocess.SubprocessError, OSError):
+        # Best-effort by design: this broad catch also swallows the
+        # TimeoutExpired / PermissionError cases that _check_comfy_version
+        # translates, because an undetermined version here is reported as
+        # "unknown" rather than raised. Do not narrow it to match that guard.
         return None
     # Only trust stdout on a clean exit: a non-zero exit or a stderr warning can
     # carry an unrelated dotted number (an embedded Python / ComfyUI core version)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -249,6 +249,57 @@ def test_version_guard_latches_on_timeout(monkeypatch):
     assert server._version_checked is True
 
 
+def test_spawn_comfy_version_keeps_the_bounded_decode_safe_invocation(monkeypatch):
+    """The one shared spawn site: right argv, bounded, and decode-safe."""
+    seen: dict[str, object] = {}
+
+    def fake(cmd, capture_output, text, errors, timeout, check):
+        seen.update(
+            cmd=cmd,
+            capture_output=capture_output,
+            text=text,
+            errors=errors,
+            timeout=timeout,
+            check=check,
+        )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(server.subprocess, "run", fake)
+    server._spawn_comfy_version()
+
+    assert seen == {
+        "cmd": [server.COMFY_BIN, "--version"],
+        "capture_output": True,
+        "text": True,
+        "errors": "replace",
+        "timeout": 30.0,
+        "check": False,
+    }
+
+
+def test_both_version_probes_go_through_the_shared_spawn(monkeypatch):
+    """The floor guard and the best-effort detector share ONE spawn site, so the
+    invocation can never drift between them (they keep their own policies)."""
+    monkeypatch.setattr(server, "_version_checked", False)
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    calls: list[str] = []
+
+    def fake_spawn():
+        calls.append("spawn")
+        return subprocess.CompletedProcess(
+            [server.COMFY_BIN, "--version"],
+            0,
+            stdout="comfy-cli, version 1.12.0\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(server, "_spawn_comfy_version", fake_spawn)
+
+    server._check_comfy_version()  # no raise: at the floor
+    assert server._detect_comfy_cli_version() == "1.12.0"
+    assert len(calls) == 2
+
+
 def test_parse_version_reads_two_and_three_part_and_none():
     assert server._parse_version("comfy-cli, version 1.12") == (1, 12, 0)
     assert server._parse_version("v2.0.5 extra") == (2, 0, 5)


### PR DESCRIPTION
## ELI-5

Two little helpers both ran the exact same `comfy --version` command, with the same 30-second time limit and the same "don't crash on weird bytes" setting, written out twice. If someone tweaked one copy, the other would quietly drift. This PR moves that one command into a single tiny function both helpers call. Nothing else changes: each helper still decides for itself what to do when the command fails, and those two decisions stay deliberately different.

## Summary

`_check_comfy_version` (the hard `>= 1.12.0` floor, memoized per process, TCC-aware) and `_detect_comfy_cli_version` (the best-effort probe feeding `server_info`'s `COMFY_CLI_MIN_VERSION` compatibility report) each carried a byte-identical `subprocess.run([COMFY_BIN, "--version"], capture_output=True, text=True, errors="replace", timeout=30.0, check=False)`. The invocation is now defined once in `_spawn_comfy_version()`; the two failure POLICIES are untouched and stay separate.

## Changes

- New `_spawn_comfy_version() -> subprocess.CompletedProcess` next to `_parse_version`: it holds only the `subprocess.run` call and deliberately catches nothing, so every exception propagates to the caller that has a policy for it.
- `_check_comfy_version` calls it and keeps its whole `except` ladder verbatim: the latched `TimeoutExpired` fail-open, the macOS TCC/`PermissionError` translation (which must precede the `OSError` handler), the unlatched transient-spawn fail-open, the TCC-in-stderr branch, and the non-memoized too-old raise.
- `_detect_comfy_cli_version` calls it and keeps its `shutil.which` precheck, its broad `except (SubprocessError, OSError)` → `None`, and its clean-exit/stdout-only gate. Added a comment recording that the broad catch swallowing `TimeoutExpired`/`PermissionError` is by design, not an oversight — so a future reader doesn't "fix" it into symmetry with the guard.
- Two regression tests in `tests/test_wrapper.py`: one pins the shared spawn's argv and kwargs (bounded timeout, `errors="replace"`, `check=False`), one asserts both probes actually route through the shared helper so the invocation cannot drift apart again.

## Motivation

One spawn site instead of two identical ones, and a guard against the drift the duplication invited. The two functions' names differ by one word while enforcing different floors with different fail-open policies, which is the second half of the hazard; their docstrings already disambiguate them and a rename would touch several test patch sites, so it was deliberately left out of scope (see Additional Notes).

## Testing

- [x] Existing tests pass (`pytest`) — 494 passed, 2 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually — not applicable: pure extraction with no behavior change, and the repo's tests mock comfy-cli by design. The existing suite already covers every branch that was preserved (`test_wrapper.py` version-guard tests for the floor path incl. the timeout latch and the transient-error non-latch; `test_permissions.py` for the TCC/PermissionError branches; `test_compat.py` for the detector's missing-binary, clean-parse, non-zero-exit, and spawn-error cases).

## Additional Notes

Judgment calls, all conservative:

- **No merge of the two functions or their policies.** Fail-open-with-a-hard-raise vs. warn-only-best-effort is documented and load-bearing; only the `subprocess.run` invocation is shared. This is the one thing that would have made the change risky, and it is explicitly not done.
- **No rename.** Disambiguating `_check_comfy_version` / `_detect_comfy_cli_version` by name would have to update every patch site (`tests/test_compat.py` and `tests/test_remote_host.py` both `monkeypatch.setattr(server, "_detect_comfy_cli_version", ...)`) in the same PR for no behavior gain; the docstrings already carry the distinction. Left for a follow-up if a reviewer wants it.
- **No memoization added to the detector.** `server_info` is infrequent and re-probing on retry is a feature (a user who upgrades comfy-cli mid-session sees the new version), so the deliberate asymmetry with the memoized guard stands.
- **Not a capability-denying change.** The diff adds no deny/dead-end path, no "not supported"/"unavailable" string, and no test asserting an absence — it is a pure extraction, so the falsification requirement for capability denials does not apply here.
- **Correction to the framing this came in with:** the premise that the timeout and `errors="replace"` existed in only one of the two copies is false — both copies carried both. The real value delivered is the single spawn site plus the drift-guard tests, not a latent-bug fix.
