### PR TITLE
refactor: extract shared _validate_param_key gate from the two param marshalers

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -2903,6 +2903,25 @@ async def _resolve_spend_consent(
     return confirm_spend
 
 
+def _validate_param_key(
+    key: str, *, empty_msg: str, invalid_msg: str, nul_label: str
+) -> None:
+    """Shared key-shape gate for the two argv param marshalers.
+
+    Order is load-bearing and identical in both callers: empty-or-leading-dash,
+    then ``=``-or-whitespace, then NUL. Each caller passes its own fully rendered
+    messages so its error text survives byte-for-byte, and keeps its own comment
+    for WHY the ``=``/whitespace check matters for its argv shape. If the two
+    gates ever need to diverge, split this back into the callers rather than
+    growing parameters here.
+    """
+    if not key or key.startswith("-"):
+        raise ComfyCliError(empty_msg)
+    if "=" in key or any(ch.isspace() for ch in key):
+        raise ComfyCliError(invalid_msg)
+    _reject_nul(nul_label, key)
+
+
 def _generate_param_args(params: dict[str, Any]) -> list[str]:
     """Marshal per-model ``params`` into ``comfy generate`` ``--name=value`` tokens.
 
@@ -2921,24 +2940,23 @@ def _generate_param_args(params: dict[str, Any]) -> list[str]:
     """
     argv: list[str] = []
     for name, value in params.items():
-        if not name or name.startswith("-"):
-            raise ComfyCliError(
+        # `=`/whitespace in a NAME is argv-integrity here: comfy-cli splits
+        # `--<body>` at the FIRST `=`, so a key carrying its own `=` would land
+        # as a run-level flag, smuggling past the meta-flag check below (which
+        # only ever sees the whole key).
+        _validate_param_key(
+            name,
+            empty_msg=(
                 f"invalid parameter name: {name!r} — expected a model parameter "
                 "name (e.g. 'prompt'), not an empty or option-like value."
-            )
-        # A name carrying its own `=` (or whitespace) is not a parameter name:
-        # comfy-cli splits `--<body>` at the FIRST `=`, so `{"output-prefix=/tmp/x":
-        # v}` renders `--output-prefix=/tmp/x=v` and lands as the run-level
-        # `output-prefix` flag — smuggling past the meta-flag check below, which
-        # only ever sees the whole key. Refuse the shape instead of trying to
-        # out-parse comfy-cli's splitter.
-        if "=" in name or any(ch.isspace() for ch in name):
-            raise ComfyCliError(
+            ),
+            invalid_msg=(
                 f"invalid parameter name: {name!r} — a parameter name cannot "
                 "contain '=' or whitespace. Pass the value as the dict value, "
                 "not inside the key."
-            )
-        _reject_nul(f"parameter name {name!r}", name)
+            ),
+            nul_label=f"parameter name {name!r}",
+        )
         # Compare hyphen-normalized so `api_key` / `emit_workflow` are caught
         # too; agents naturally spell CLI flags with underscores. Case is NOT
         # normalized: comfy-cli matches its run-level flags case-sensitively in
@@ -3222,26 +3240,24 @@ def _run_template_param_args(params: dict[str, Any]) -> list[str]:
     """
     argv: list[str] = []
     for key, value in params.items():
-        if not key or key.startswith("-"):
-            raise ComfyCliError(
+        # `=` is the load-bearing check here: comfy-cli splits the `--param`
+        # value on its FIRST `=` to separate slot key from value. Whitespace is
+        # refused for a weaker reason — KEY rides inside the single
+        # `--param=KEY=VALUE` token so it is never argv-ambiguous, but a clear
+        # error beats the engine's "matches no slot".
+        _validate_param_key(
+            key,
+            empty_msg=(
                 f"invalid param key: {key!r} — expected a slot address (e.g. "
                 "'6.text') or a slot name (e.g. 'prompt'), not an empty or "
                 "option-like value."
-            )
-        # `=` is the load-bearing one: comfy-cli splits the `--param` value on
-        # its FIRST `=` to separate slot key from value, so a key carrying its
-        # own `=` mis-splits. Refuse the shape rather than out-parse the
-        # splitter. Whitespace is refused for a weaker reason — KEY rides inside
-        # the single `--param=KEY=VALUE` token, so it is never argv-ambiguous,
-        # but comfy-cli `.strip()`s the key and slot names come from node input
-        # names (0 of the 574 gallery templates carry whitespace or a leading
-        # dash in one). A clear error here beats the engine's "matches no slot".
-        if "=" in key or any(ch.isspace() for ch in key):
-            raise ComfyCliError(
+            ),
+            invalid_msg=(
                 f"invalid param key: {key!r} — a slot key cannot contain '=' or "
                 "whitespace. Pass the value as the dict value, not in the key."
-            )
-        _reject_nul(f"param key {key!r}", key)
+            ),
+            nul_label=f"param key {key!r}",
+        )
         if value is None:
             continue
         # json.dumps escapes a NUL inside a string value (so it can't crash


### PR DESCRIPTION
## ELI-5

Two functions that turn a dict of parameters into command-line arguments were each doing the exact same three safety checks on the dict's keys, in the exact same order: reject an empty or `-`-leading key, reject a key containing `=` or whitespace, reject a key containing a NUL byte. This PR moves those three checks into one small helper both call. Nothing about what gets accepted or rejected changes, and every error message a user sees is byte-for-byte what it was before — each caller hands the helper its own fully written messages instead of letting the helper build them.

## Summary

Extracts the identical three-check key gate duplicated between `_generate_param_args` and `_run_template_param_args` into a shared `_validate_param_key` helper. Checks only — the messages stay at the call sites. This is injection-guard code feeding the spend-capable `comfy generate` / `comfy run-template` argv, so zero behavior change was the acceptance bar.

## Changes

- Adds `_validate_param_key(key, *, empty_msg, invalid_msg, nul_label)` immediately above `_generate_param_args`. It runs the three checks in the load-bearing order both callers already used: empty-or-leading-dash, then `=`-or-whitespace, then NUL via `_reject_nul`.
- Rewires `_generate_param_args` to call it, keeping a condensed comment for why `=`/whitespace matters for *its* argv shape (comfy-cli splits `--<body>` at the first `=`, so a key carrying its own `=` would land as a run-level flag and smuggle past the meta-flag check, which only ever sees the whole key).
- Rewires `_run_template_param_args` the same way, keeping its own condensed comment (`=` is the load-bearing check because comfy-cli splits the `--param` value on its first `=`; whitespace is refused for the weaker reason that a clear error beats the engine's "matches no slot").
- Each caller passes **fully rendered** messages rather than a single `hint` or message fragments. The two verbs' text differs in three independent places — the noun (`parameter name` vs `param key`), the expected-example clause, and `not inside the key` vs `not in the key` — so only caller-supplied strings preserve it byte-for-byte.
- The helper's docstring records that if the two gates ever need to diverge, the correct move is splitting it back into the callers, not growing parameters here.

Deliberately **not** shared, and untouched: the `_GENERATE_META_FLAGS` blocklist with its hyphen-normalization comment, the `None`-drop, the str/bool/JSON value rendering, `_reject_nul` on the rendered value, and `_run_template_param_args`'s `_reject_nul_deep` value check. The consent/spend path (`_resolve_spend_consent`, `_require_spend_gate`, elicitation) is not touched at all — per AGENTS.md the two verbs' consent contracts must not be generalized onto each other.

## Motivation

The same three checks, in the same order, existed in two places, so a future fix to the gate had to be made twice or silently drift on one verb. The per-verb *rationale comments* are genuinely different, though — they explain different argv shapes — which is why only the checks move and the comments and messages stay put.

## Testing

- [x] Existing tests pass (`pytest`) — 494 passed, 2 skipped, **zero test files changed**. Includes the six guards for this gate: `test_partner_generate_rejects_option_like_param_name`, `test_partner_generate_rejects_param_names_that_smuggle_a_value` (the `output-prefix=/tmp/x` smuggle), `test_partner_generate_rejects_embedded_nul`, `test_run_template_rejects_option_like_param_key`, `test_run_template_rejects_param_keys_with_equals_or_whitespace`, `test_run_template_rejects_embedded_nul`. `tests/test_generate.py` is green too, since `generate_image` also calls `_run_template_param_args`.
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] **Differential test against `main`, since "no behavior change" is the acceptance bar and the existing tests only cover six of the branches.** I loaded `main`'s `server.py` and this branch's side by side in one interpreter and compared both marshalers' full outcome — exception type *and* complete message string — across 11 key shapes (empty, `-x`, `a=b`, `a b`, tab, NUL, non-breaking space, vertical tab, `--`, newline, `output-prefix=/tmp/x`) plus 6 happy-path param dicts (each value kind, the `None`-drop, the three meta-flag keys, empty dict). All 34 comparisons identical. The harness was throwaway and lives in `/tmp`, not the repo — the diff is confined to `src/comfy_local_mcp/server.py`.

## Additional Notes

Judgment calls and self-review findings, none of which I think block review:

- **Docstring backtick style.** The ticket's helper snippet wrote `` `=` `` with single backticks; I used RST double-backticks (``` ``=`` ```) to match every other docstring in this file. The mandate was byte-identical *error messages*, which is satisfied exactly; this is a docstring-only consistency choice. Say the word and I'll revert it to the literal snippet.
- **The messages are now built eagerly.** Because they are call arguments, all three f-strings are formatted for every key, including valid ones — previously they were only built on the raise path. This is a small per-call formatting cost with no behavior change (`repr()` of a `str` key cannot raise, and these keys arrive as JSON object keys, so they are always `str`). It is negligible next to the subprocess spawn each marshaler's argv feeds, but it is a real, if tiny, cost of the fully-rendered-messages requirement.
- **Net line count goes up (~+16).** Sharing three `if`s while keeping four messages and two rationale comments at the call sites costs more lines than it saves. The win is single-sourcing the *checks and their order*, not brevity.
- **No missed call site.** The only remaining `not X or X.startswith("-")` occurrences in the file are single-value guards for different arguments (`template`, `model`, `prompt_id`, `url`, `filename`) — none is the three-check key gate, and they are explicitly out of scope. All three marshaler call sites (`comfy generate` argv, `comfy run-template` argv, and `generate_image`) are covered by the green suites above.
- **Negative-claim falsification (per the review checklist): trigger does not fire.** This diff denies no capability — it adds no "not supported"/"unavailable"/"STOP" string, adds no new throw/deny dead-end, removes nothing, and flips no test to assert a dead-end. It relocates two existing `raise`s verbatim, and the differential test above is the positive evidence that the accept/reject boundary is unchanged in both directions.
