### PR TITLE
fix(list_nodes): guard filter values against option-like and NUL input

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -3988,10 +3988,17 @@ def list_nodes(
     - ``produces`` → ``--produces <TYPE>``: nodes whose outputs include ``<TYPE>``
       (e.g. ``IMAGE``, ``MODEL``).
     - ``accepts`` → ``--accepts <TYPE>``: nodes with an input of ``<TYPE>``.
-    - ``category`` → ``--category <path>``: nodes under a menu category
-      (e.g. ``loaders``).
-    - ``pack`` → ``--pack <name>``: nodes from a given custom-node pack.
-    - ``label`` → ``--label <text>``: nodes matching a display-label substring.
+    - ``category`` → ``--category <glob>``: glob match on the category path, so
+      ``loaders`` matches only that exact category while ``loaders*`` /
+      ``sampling/*`` match a subtree (``%`` also works as the wildcard).
+    - ``pack`` → ``--pack <name>``: nodes from a custom-node pack, matched on the
+      pack's whole name, case-insensitively (e.g. ``core``,
+      ``comfyui-impact-pack``).
+    - ``label`` → ``--label <Label>``: nodes carrying one of comfy-cli's curated
+      *behavioral* labels — ``WritesToDisk``, ``NetworkAccess``,
+      ``ReadsArbitraryFile``, … — matched exactly, and only on the nodes
+      comfy-cli annotates (a purely local custom node carries none). This is not
+      a display-name search; use ``search_nodes`` for that.
 
     Reads the user's live install, so results include installed custom nodes —
     the broad "what nodes can do X?" companion to ``search_nodes``' name search.

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -4005,6 +4005,14 @@ def list_nodes(
         ("--label", label),
     ):
         if value:
+            # Same guarded loop as `search_templates`' filters, for the same two
+            # reasons: a dash-leading filter is input hygiene (Click reads an
+            # option's value verbatim, so this is a caller mistake worth naming
+            # rather than an injection vector — see `_reject_option_like`), and a
+            # NUL would otherwise escape as `subprocess`' bare ValueError instead
+            # of a `ComfyCliError`.
+            _reject_option_like(f"{flag} value", value)
+            _reject_nul(f"{flag} value", value)
             args += [flag, value]
     return _run_comfy(*args, timeout=60.0)
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -80,6 +80,52 @@ def test_list_nodes_omits_empty_filters(patched_run):
     ]
 
 
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"produces": "--help"},
+        {"accepts": "-x"},
+        {"category": "--pack"},
+        {"pack": "-p"},
+        {"label": "--label"},
+    ],
+    ids=lambda kw: next(iter(kw)),
+)
+def test_list_nodes_rejects_leading_dash_filter_values(patched_run, kwargs):
+    """A filter value starting with '-' is rejected before it reaches comfy-cli argv."""
+    calls = patched_run(envelope(data=[]))
+    with pytest.raises(server.ComfyCliError, match="leading '-'"):
+        server.list_nodes(**kwargs)
+    # refused before the spawn, not after
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"produces": "a\0"},
+        {"accepts": "a\0"},
+        {"category": "a\0"},
+        {"pack": "a\0"},
+        {"label": "a\0"},
+    ],
+    ids=lambda kw: next(iter(kw)),
+)
+def test_list_nodes_rejects_embedded_nul_filter_values(patched_run, kwargs):
+    """A NUL surfaces as ComfyCliError, not subprocess's bare ValueError."""
+    calls = patched_run(envelope(data=[]))
+    with pytest.raises(server.ComfyCliError, match="embedded NUL"):
+        server.list_nodes(**kwargs)
+    assert calls == []
+
+
+def test_list_nodes_still_passes_a_normal_filter_value(patched_run):
+    """The guards are value-shape only — an ordinary filter still reaches argv."""
+    calls = patched_run(envelope(data=[]))
+    server.list_nodes(produces="IMAGE")
+    assert calls[0]["cmd"][4:] == ["nodes", "ls", "--produces", "IMAGE"]
+
+
 def test_nodes_upstream_without_limit(patched_run):
     calls = patched_run(envelope(data=[{"name": "CheckpointLoaderSimple"}]))
     assert server.nodes_upstream("KSampler") == [{"name": "CheckpointLoaderSimple"}]


### PR DESCRIPTION
## ELI-5

`list_nodes` lets you narrow the node list with filters like `--produces IMAGE`. It was the last filter loop in the file that passed whatever you typed straight through to comfy-cli, including things that start with a `-` or contain a NUL byte. Now it checks the value first and gives you a clear error, exactly like the template search already does.

## Summary

Pure drift repair on the argument-guard family. Two of the three sites the task named were already fixed on `main`; this PR closes the one that was still open.

**Done here — `list_nodes` filter values.** The loop that builds `--produces` / `--accepts` / `--category` / `--pack` / `--label` used a bare `if value: args += [flag, value]`. It now mirrors `search_templates`' guarded loop: inside the same `if value:` branch it calls `_reject_option_like(f"{flag} value", value)` and `_reject_nul(f"{flag} value", value)` before appending. The `if value:` emptiness skip is deliberately unchanged — empty means "filter not set" here, unlike the raising positional sites.

**Already on `main`, not re-done — the `prompt_id` trio.** `job_status`, `wait_for_job`, and `cancel_job` are already guarded, via the shared `_guard_prompt_id` helper (`server.py:274`) rather than a bare `_reject_option_like` call: `job_status` at `server.py:3141`, `wait_for_job` once at function entry at `server.py:3333` (not inside the poll loop), `cancel_job` at `server.py:3433`. That helper is a superset of what was asked — it rejects leading-dash, empty, NUL-bearing, and oversized ids, and its message (`invalid prompt_id: '--help' (empty or leading '-')`) still matches the `leading '-'` shape. The matching rejection tests also already exist, as a parametrized family test over `job_status` / `cancel_job` / `wait_for_job` / `fetch_outputs` × `["--help", "-o", "", "p\x001"]` (`tests/test_wrapper.py:383`). Adding anything there would have been a duplicate, so nothing was touched.

## Changes

- `src/comfy_local_mcp/server.py` — guard the five `list_nodes` filter values inside the existing `if value:` branch.
- `tests/test_discovery.py` — rejection tests per filter for a leading dash and for an embedded NUL (each asserting nothing was spawned), plus a pass-through test that a normal `produces="IMAGE"` still emits `["nodes", "ls", "--produces", "IMAGE"]`.
- `src/comfy_local_mcp/server.py` (docstring, `bcb40ee`) — correct `list_nodes`' description of `category`, `pack`, and `label`. Added during review resolution; see the falsification note below for how it surfaced. No behavior change.

## Motivation

`list_nodes` was the only remaining `flag`/`value` loop in the module without value guards; `search_templates` has had them since the filter-guard pass. This converts a confusing usage error into the repo's named `ComfyCliError`.

## Testing

- [x] Existing tests pass (`pytest` — 575 passed, 2 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually — no local ComfyUI / `comfy` binary on this machine; the suite mocks comfy-cli as the repo intends.

## Additional Notes

**Judgment call 1 — `_reject_nul` as well as `_reject_option_like`.** The task named only `_reject_option_like`, but the twin loop in `search_templates` (`server.py:3868-3869`) runs both, and a NUL in a filter value would otherwise escape as `subprocess`' bare `ValueError` instead of a `ComfyCliError` — the same defect class the rest of this family fixes. Mirroring the twin exactly seemed more right than mirroring half of it. Easy to drop the `_reject_nul` line and its five tests if you disagree.

**Judgment call 2 — the inline comment does not copy the twin's wording.** `search_templates`' comment calls this "argument injection". For an option *value* that is not accurate, and `_reject_option_like`'s own docstring says so explicitly ("An option VALUE (`--flag VALUE`) is NOT [an injection vector]... that is input hygiene rather than injection defense"). I verified it: Click 8.4.2 parses `--label -foo` as `label='-foo'`, verbatim, no error. So the new comment states the hygiene rationale and points at the helper rather than repeating a claim the helper refutes.

**Negative-claim falsification.** This diff adds a deny path, so per the review discipline: the capability it removes is "filter the node list by a value that begins with `-`". I went looking for a legitimate one and there isn't any — checked against comfy-cli's `nodes ls` implementation and its bundled catalog, plus ComfyUI's node definitions:

- **`--label` cannot carry a dash-leading value by construction.** comfy-cli matches it exactly against a node's curated *behavioral* labels (`if label and label not in m.labels`, `comfy_cli/command/nodes.py`), sourced from `comfy_cli/cql/data/supported_nodes.yaml`. That vocabulary is closed — today ten values: `CreatesLargeOutputs`, `DisabledOnCloud`, `DuplicateOfCoreNode`, `HasCustomEndpoints`, `NetworkAccess`, `PathParsing`, `ReadsArbitraryFile`, `RequiresExternalAPI`, `Stateful`, `WritesToDisk`. None dash-leading, and a node's *display* label never reaches this flag at all.
- **`--pack`** is a whole-name case-insensitive match against the same file's pack list: 87 packs, none dash-leading.
- **`--produces` / `--accepts`** are uppercased datatypes and **`--category`** is an `fnmatch` glob on the category path. Enumerating ComfyUI's node definitions: 0 dash-leading return types, 0 dash-leading categories, 0 dash-leading display names.

So the denial refuses only caller mistakes, and every legitimate query still has a path: `search_nodes(query)` for name search, an unfiltered `list_nodes()` filtered client-side, or the correct filter value. The parse behavior itself is separately confirmed — Click 8.4.2 reads `--label -foo` as `label='-foo'`, verbatim — so this is hygiene, not injection defense, exactly as `_reject_option_like`'s docstring frames it. I still could not run `comfy nodes ls` end-to-end (no `comfy` binary or live ComfyUI on this machine); the evidence above is read off comfy-cli's source and its shipped data files rather than a live catalog.

That check also turned up a real docs bug, now fixed in `bcb40ee`: this tool's docstring described `label` as "a display-label substring" and `category` as "nodes under a menu category (e.g. `loaders`)". Both misdescribe the engine — `label` is the exact behavioral-label match above, and `loaders` as a glob matches only that exact category, never `loaders/audio`. An agent following the old wording would get zero rows with no explanation.

**Unmet criterion.** None outstanding — but note that the `prompt_id` half of the task is reported as already-satisfied rather than implemented, per the file references above. If the intent was specifically to replace `_guard_prompt_id` with bare `_reject_option_like` calls at those three sites, that would be a *narrowing* of the current guards and I did not do it.

