### PR TITLE
fix: guard the remaining unguarded template/node/workflow arguments

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -259,6 +259,20 @@ def _reject_option_like(label: str, value: str, expected: str = "") -> str:
     ``--help`` text that then fails envelope parsing. Read those as
     belt-and-braces, not as evidence that option values are unsafe — the
     distinction above still decides which guards are *mandatory*.
+
+    Two deliberate over-rejections, so neither reads as an oversight:
+
+    - **A lone ``-``.** Click treats it as a positional, not an option, so it is
+      not an injection vector. It is refused anyway because it is not a valid
+      value at any call site — not a path, template name, node class, connection
+      type, or slot address — and "wrote a file named ``-``" is precisely the
+      caller mistake the hygiene guards exist to name.
+    - **A dash-leading slot ADDR** (``vary_workflow``'s ``slots``). An ``ADDR``
+      begins with the node id, which comfy-cli surfaces non-negative via
+      ``list_workflow_slots``, so no reachable address starts with ``-``. It also
+      costs no capability: ``set_workflow_slot``'s overrides and both param
+      marshalers (:func:`_validate_param_key`) already refuse one, so every other
+      way to name a slot in this module rejects it too.
     """
     if value.startswith("-"):
         hint = f" — expected {expected}" if expected else ""

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -247,14 +247,18 @@ def _reject_option_like(label: str, value: str, expected: str = "") -> str:
       Click takes the token after a value-taking option verbatim — even one that is
       itself a valid option name (``--out-dir --slot`` parses as
       ``out_dir="--slot"``, not as a missing value). So ``vary_workflow``'s
-      ``slots`` / ``out_dir`` need no guard to be injection-safe.
+      ``slots`` / ``out_dir`` are already injection-safe before any guard runs.
 
-    Where a call site guards an option value anyway (``search_templates``'s
-    filters, ``download_model``'s ``relative_path`` / ``filename``), that is input
-    hygiene rather than injection defense: a dash-leading provider filter or output
-    filename is a caller mistake, and a named error beats comfy-cli matching zero
-    rows or writing a file named ``-x``. Read those as belt-and-braces, not as
-    evidence that option values are unsafe.
+    Option values ARE guarded anyway, uniformly across the module
+    (``search_templates``'s filters, ``download_model``'s ``relative_path`` /
+    ``filename``, ``fetch_template``'s ``out_path``, ``vary_workflow``'s ``slots``
+    / ``out_dir``, ``run_workflow`` / ``validate_workflow``'s ``workflow_path``).
+    That is input hygiene rather than injection defense: a dash-leading provider
+    filter or output filename is a caller mistake, and a named error beats
+    comfy-cli matching zero rows, writing a file named ``-x``, or printing
+    ``--help`` text that then fails envelope parsing. Read those as
+    belt-and-braces, not as evidence that option values are unsafe — the
+    distinction above still decides which guards are *mandatory*.
     """
     if value.startswith("-"):
         hint = f" — expected {expected}" if expected else ""
@@ -2014,6 +2018,20 @@ async def run_workflow(
     the surfaced error carries comfy-cli's hint (including the working
     ``comfy auth set comfy-cloud-api-key`` fallback).
     """
+    # Guarded HERE rather than inside `_attempt` so it covers BOTH the
+    # `wait=False` submit and the streaming path, and so a bad path fails once
+    # up front instead of being re-raised through the credential retry loop.
+    # `workflow_path` rides behind `--workflow` as an option value (Click takes
+    # that verbatim), so this is input hygiene, not injection defense — see
+    # `_reject_option_like`.
+    _reject_option_like(
+        "workflow_path",
+        workflow_path,
+        expected=(
+            "a path to a workflow JSON file (prefix a dash-leading name with './')"
+        ),
+    )
+    _reject_nul("workflow_path", workflow_path)
     if wait:
         # Harden the caller's bound BEFORE it reaches `_run_comfy_streaming`
         # (and from there `asyncio.wait_for`): `inf` would wait on the child
@@ -3923,6 +3941,10 @@ def get_template(name: str) -> Any:
     fetching it, then ``fetch_template(name, out_path)`` writes the runnable JSON
     for ``run_workflow``.
     """
+    # Bare positional: a leading-dash name is read by comfy-cli as an option
+    # rather than the template to show (argument injection).
+    _reject_option_like("name", name, expected="a template name (e.g. 'image_flux2')")
+    _reject_nul("name", name)
     return _run_comfy("templates", "show", name, timeout=60.0)
 
 
@@ -3942,6 +3964,19 @@ def fetch_template(name: str, out_path: str) -> str:
 
     so an agent reaches a working generation without hand-authoring workflow JSON.
     """
+    # `name` is a bare positional, so a leading-dash value is read as an option
+    # and every later token shifts up a slot. `out_path` rides behind `--out` as
+    # an option value, which Click takes verbatim — guarding it is input hygiene
+    # (a file literally named `-x` is a caller mistake worth naming), matching
+    # `download_model`'s `filename`. See `_reject_option_like` for the split.
+    _reject_option_like("name", name, expected="a template name (e.g. 'image_flux2')")
+    _reject_option_like(
+        "out_path",
+        out_path,
+        expected="a file path (prefix a dash-leading name with './')",
+    )
+    _reject_nul("name", name)
+    _reject_nul("out_path", out_path)
     _run_comfy("templates", "fetch", name, "--out", out_path, timeout=60.0)
     return os.path.abspath(out_path)
 
@@ -3956,6 +3991,12 @@ def search_nodes(query: str) -> Any:
     "KSampler", "load image") before authoring or repairing a workflow graph;
     pass the returned name to ``get_node`` for its full schema.
     """
+    # Bare positional: a leading-dash query is read as an option, not a search
+    # term (argument injection).
+    _reject_option_like(
+        "query", query, expected="a search term (e.g. 'KSampler' or 'load image')"
+    )
+    _reject_nul("query", query)
     return _run_comfy("nodes", "search", query, timeout=60.0)
 
 
@@ -3969,6 +4010,10 @@ def get_node(name: str) -> Any:
     repair a workflow graph. Reflects the user's live install, so it resolves
     custom-node classes too (not just built-ins).
     """
+    # Bare positional: a leading-dash name is read as an option rather than the
+    # node class to show (argument injection).
+    _reject_option_like("name", name, expected="a node class name (e.g. 'KSampler')")
+    _reject_nul("name", name)
     return _run_comfy("nodes", "show", name, timeout=60.0)
 
 
@@ -4018,6 +4063,10 @@ def nodes_upstream(name: str, limit: int | None = None) -> Any:
     computed against the live local ``object_info`` (custom nodes included). Pass
     ``limit`` to cap the number of results; omit it for the full set.
     """
+    # Bare positional, and it sits beside this command's own `--limit`: a
+    # leading-dash name is read as an option (argument injection).
+    _reject_option_like("name", name, expected="a node class name (e.g. 'KSampler')")
+    _reject_nul("name", name)
     args = ["nodes", "upstream", name]
     if limit is not None:
         args += ["--limit", str(limit)]
@@ -4034,6 +4083,10 @@ def nodes_downstream(name: str, limit: int | None = None) -> Any:
     included). Pass ``limit`` to cap the number of results; omit it for the full
     set.
     """
+    # Bare positional, and it sits beside this command's own `--limit`: a
+    # leading-dash name is read as an option (argument injection).
+    _reject_option_like("name", name, expected="a node class name (e.g. 'KSampler')")
+    _reject_nul("name", name)
     args = ["nodes", "downstream", name]
     if limit is not None:
         args += ["--limit", str(limit)]
@@ -4052,6 +4105,18 @@ def nodes_path(
     local ``object_info`` graph. ``max_depth`` bounds the chain length and
     ``max_paths`` caps how many routes are returned.
     """
+    # Two bare positionals ahead of `--max-depth` / `--max-paths`: a leading-dash
+    # type is read as an option and shifts every later token up a slot, so the
+    # second type could land in the first's place (argument injection).
+    # `max_depth` / `max_paths` need no guard: they are typed ints (so they
+    # cannot carry an arbitrary caller string at all) and they ride behind
+    # `--max-depth` / `--max-paths` as option values, which Click takes
+    # verbatim — even the `"-1"` a negative bound would render as.
+    for label, value in (("from_type", from_type), ("to_type", to_type)):
+        _reject_option_like(
+            label, value, expected="a connection type (e.g. 'MODEL' or 'IMAGE')"
+        )
+        _reject_nul(label, value)
     return _run_comfy(
         "nodes",
         "path",
@@ -4254,6 +4319,19 @@ def validate_workflow(workflow_path: str) -> Any:
     Treat ``valid:true`` as necessary-not-sufficient and rely on
     ``run_workflow`` errors for final authority.
     """
+    # `workflow_path` rides behind `--workflow` as an option value, which Click
+    # takes verbatim, so this is input hygiene rather than injection defense —
+    # the same call the guarded `search_templates` filters and `download_model`'s
+    # `filename` make. A dash-leading path reaches comfy-cli as a usage error (or
+    # prints `--help`) that fails envelope parsing; a named error is better.
+    _reject_option_like(
+        "workflow_path",
+        workflow_path,
+        expected=(
+            "a path to a workflow JSON file (prefix a dash-leading name with './')"
+        ),
+    )
+    _reject_nul("workflow_path", workflow_path)
     return _run_comfy("validate", "--workflow", workflow_path, timeout=60.0)
 
 
@@ -4353,8 +4431,8 @@ def vary_workflow(
     # Bare positional, same as `set_workflow_slot` — a leading-dash path is read
     # as a flag rather than the path. `slots` and `out_dir` ride behind `--slot`
     # / `--out-dir` as option VALUES, which Click takes verbatim, so they are
-    # injection-safe unguarded; see `_reject_option_like` for why the two cases
-    # differ.
+    # already injection-safe; they are guarded below as input hygiene, matching
+    # `search_templates`' filters. See `_reject_option_like` for the two cases.
     _reject_option_like(
         "workflow_path",
         workflow_path,
@@ -4366,11 +4444,19 @@ def vary_workflow(
     _reject_nul("workflow_path", workflow_path)
     args = ["workflow", "vary", workflow_path]
     for slot in slots:
-        # NUL is refused even though the leading-dash guard is not needed here:
-        # the two checks answer different questions (see `_reject_option_like`).
+        _reject_option_like(
+            "slot",
+            slot,
+            expected="an 'ADDR=[v1,v2,...]' string (e.g. '3.seed=[1,2,3]')",
+        )
         _reject_nul("slot", slot)
         args += ["--slot", slot]
     if out_dir:
+        _reject_option_like(
+            "out_dir",
+            out_dir,
+            expected="a directory path (prefix a dash-leading name with './')",
+        )
         _reject_nul("out_dir", out_dir)
         args += ["--out-dir", out_dir]
     return _run_comfy(*args, timeout=120.0)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -186,3 +186,75 @@ def test_discovery_surfaces_error_envelope(patched_run):
     )
     with pytest.raises(server.ComfyCliError, match="server_not_running"):
         server.search_nodes("sampler")
+
+
+def test_node_tools_reject_option_like_positionals(monkeypatch):
+    """Every bare positional on the `nodes` verbs refuses a leading-dash value.
+
+    `search_nodes`/`get_node`/`nodes_upstream`/`nodes_downstream`/`nodes_path`
+    all splat their caller string in as a positional, so comfy-cli reads a
+    dash-leading value as an option — sharpest on `upstream`/`downstream`
+    (beside their own `--limit`) and on `path`, where consuming the first type
+    as a flag shifts the second into its slot.
+    """
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+
+    for call in (
+        lambda: server.search_nodes("--help"),
+        lambda: server.get_node("--help"),
+        lambda: server.nodes_upstream("--help"),
+        lambda: server.nodes_downstream("--help"),
+        lambda: server.nodes_path("--help", "IMAGE"),
+        lambda: server.nodes_path("MODEL", "--help"),
+    ):
+        with pytest.raises(server.ComfyCliError, match="leading '-'"):
+            call()
+
+
+def test_nodes_path_still_passes_negative_bounds_through(patched_run):
+    """The guard covers the two types only — the int bounds are untouched.
+
+    They ride behind `--max-depth`/`--max-paths` as option values (Click takes
+    those verbatim), so even a negative bound is comfy-cli's to reject, not the
+    wrapper's to refuse for looking dash-leading.
+    """
+    calls = patched_run(envelope(data=[]))
+    server.nodes_path("MODEL", "IMAGE", max_depth=-1, max_paths=-2)
+    assert calls[0]["cmd"][4:] == [
+        "nodes",
+        "path",
+        "MODEL",
+        "IMAGE",
+        "--max-depth",
+        "-1",
+        "--max-paths",
+        "-2",
+    ]
+
+
+def test_node_tools_reject_embedded_nul(monkeypatch):
+    """A NUL surfaces as ComfyCliError, not subprocess's bare ValueError.
+
+    Orthogonal to the leading-dash guard: `subprocess` cannot carry a NUL in
+    argv at all, so it is refused wherever the value rides.
+    """
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+
+    for call in (
+        lambda: server.search_nodes("samp\0ler"),
+        lambda: server.get_node("KSamp\0ler"),
+        lambda: server.nodes_upstream("KSamp\0ler"),
+        lambda: server.nodes_downstream("KSamp\0ler"),
+        lambda: server.nodes_path("MOD\0EL", "IMAGE"),
+        lambda: server.nodes_path("MODEL", "IMA\0GE"),
+    ):
+        with pytest.raises(server.ComfyCliError, match="embedded NUL"):
+            call()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -312,3 +312,53 @@ def test_fetch_template_resolves_relative_path(monkeypatch):
     result = server.fetch_template("flux_dev", "flux.json")
     assert result == os.path.abspath("flux.json")
     assert os.path.isabs(result)
+
+
+def test_get_template_rejects_option_like_name(monkeypatch):
+    """A leading-dash name is refused before any child spawns.
+
+    ``name`` is a bare positional on ``templates show``, so comfy-cli reads a
+    dash-leading value as an option rather than the template to show.
+    """
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+
+    with pytest.raises(server.ComfyCliError, match="leading '-'"):
+        server.get_template("--help")
+
+
+def test_fetch_template_rejects_option_like_name_and_out_path(monkeypatch):
+    """Both the ``name`` positional and the ``--out`` value are guarded."""
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+
+    with pytest.raises(server.ComfyCliError, match="leading '-'"):
+        server.fetch_template("--help", "/tmp/flux.json")
+
+    # The escape hatch is named in the error, so a genuinely dash-leading
+    # filename stays reachable as `./-flux.json`.
+    with pytest.raises(server.ComfyCliError, match=r"leading '-'.*\./"):
+        server.fetch_template("flux_dev", "--help")
+
+
+def test_template_tools_reject_embedded_nul(monkeypatch):
+    """A NUL surfaces as ComfyCliError, not subprocess's bare ValueError."""
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+
+    for call in (
+        lambda: server.get_template("flux\0dev"),
+        lambda: server.fetch_template("flux\0dev", "/tmp/flux.json"),
+        lambda: server.fetch_template("flux_dev", "/tmp/f\0.json"),
+    ):
+        with pytest.raises(server.ComfyCliError, match="embedded NUL"):
+            call()

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -144,26 +144,28 @@ def test_workflow_tools_reject_embedded_nul(monkeypatch):
             call()
 
 
-def test_vary_workflow_option_values_are_not_guarded(patched_run):
-    """Option VALUES stay unguarded on purpose — only bare positionals are injectable.
+def test_vary_workflow_option_value_guards_read_the_first_char_only(patched_run):
+    """The `slots`/`out_dir` guards refuse a LEADING dash and nothing more.
 
-    comfy-cli is Click-backed and Click takes the token after a value-taking
-    option verbatim, so `--out-dir --slot` parses as `out_dir="--slot"` rather
-    than shifting anything. `slots`/`out_dir` therefore ride through untouched;
-    the guard above them is for `workflow_path`, which IS a bare positional.
+    Those two are option VALUES, which Click takes verbatim (`--out-dir --slot`
+    parses as `out_dir="--slot"`, not as a shift), so they were injection-safe
+    unguarded. They are guarded anyway as input hygiene — the same call
+    `search_templates` makes for its filters — which makes over-rejection the
+    real risk here rather than injection: a dash INSIDE a slot value, and a
+    relative path that merely contains one, must still ride through.
     """
     calls = patched_run(envelope(data={"variants": 2}))
 
-    server.vary_workflow("/tmp/flux.json", ["-3.seed=[1,2]"], out_dir="-out")
+    server.vary_workflow("/tmp/flux.json", ["6.text=[a -b,c]"], out_dir="./out-dir")
 
     assert calls[0]["cmd"][4:] == [
         "workflow",
         "vary",
         "/tmp/flux.json",
         "--slot",
-        "-3.seed=[1,2]",
+        "6.text=[a -b,c]",
         "--out-dir",
-        "-out",
+        "./out-dir",
     ]
 
 
@@ -221,3 +223,30 @@ def test_vary_workflow_forwards_out_dir(patched_run, tmp_path):
         "--out-dir",
         str(out),
     ]
+
+
+def test_vary_workflow_rejects_option_like_slot_and_out_dir(monkeypatch):
+    """`--slot` values and `--out-dir` are guarded as input hygiene.
+
+    Click takes an option's value verbatim, so neither is an injection vector
+    (unlike the sibling `workflow_path` positional, covered above). They are
+    still refused so a dash-leading slot expression or output directory fails
+    with a named error instead of a comfy-cli usage error or `--help` text that
+    then fails envelope parsing — the same call `search_templates` makes for its
+    filters.
+    """
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+
+    with pytest.raises(server.ComfyCliError, match="leading '-'"):
+        server.vary_workflow("/tmp/flux.json", ["--help"])
+
+    # The guard scans every slot, not just the first.
+    with pytest.raises(server.ComfyCliError, match="leading '-'"):
+        server.vary_workflow("/tmp/flux.json", ["3.seed=[1,2]", "--help"])
+
+    with pytest.raises(server.ComfyCliError, match=r"leading '-'.*\./"):
+        server.vary_workflow("/tmp/flux.json", ["3.seed=[1,2]"], out_dir="--help")

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -3238,3 +3238,60 @@ def test_get_logs_caps_oversized_line(patched_run):
     # TOTAL length (content + marker) never exceeds the hard cap.
     assert len(lines[1]) <= server._MAX_LOG_LINE_CHARS
     assert lines[1].endswith(server._TRACEBACK_TRUNCATION_MARKER)
+
+
+def test_validate_workflow_rejects_option_like_path(monkeypatch):
+    """A leading-dash `--workflow` value is refused before any child spawns."""
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+
+    with pytest.raises(server.ComfyCliError, match=r"leading '-'.*\./"):
+        server.validate_workflow("--help")
+
+
+@pytest.mark.parametrize("wait", [True, False])
+def test_run_workflow_rejects_option_like_path_on_both_paths(monkeypatch, wait):
+    """The guard sits at function entry, so it covers submit AND streaming.
+
+    `wait=False` goes through `_run_comfy` and `wait=True` through
+    `_run_comfy_streaming`; guarding once up front covers both, and fails before
+    the credential retry loop can re-raise it.
+    """
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+    monkeypatch.setattr(server, "_run_comfy_streaming", boom)
+
+    with pytest.raises(server.ComfyCliError, match=r"leading '-'.*\./"):
+        asyncio.run(server.run_workflow("--help", wait=wait))
+
+
+def test_validate_workflow_argv_unchanged_by_the_guard(patched_run):
+    """Happy-path argv is untouched: `validate --workflow <path>`."""
+    calls = patched_run(envelope(data={"valid": True}))
+
+    server.validate_workflow("./-wf.json")
+
+    assert calls[0]["cmd"][4:] == ["validate", "--workflow", "./-wf.json"]
+
+
+def test_run_and_validate_workflow_reject_embedded_nul(monkeypatch):
+    """A NUL surfaces as ComfyCliError, not subprocess's bare ValueError."""
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+    monkeypatch.setattr(server, "_run_comfy_streaming", boom)
+
+    with pytest.raises(server.ComfyCliError, match="embedded NUL"):
+        server.validate_workflow("/tmp/w\0f.json")
+
+    for wait in (True, False):
+        with pytest.raises(server.ComfyCliError, match="embedded NUL"):
+            asyncio.run(server.run_workflow("/tmp/w\0f.json", wait=wait))


### PR DESCRIPTION
## ELI-5

Some tools passed whatever text you gave them straight to the `comfy` command. If that text started with a dash, `comfy` read it as a *setting* instead of as your text — so `get_node("--help")` printed a help page instead of looking up a node, and the wrapper then choked trying to parse that help page as data. This PR checks those arguments up front and returns a clear error naming what was expected, instead of a confusing one from deep inside comfy-cli.

## Summary

Guards the eleven caller-supplied strings that still reached comfy-cli's argv unguarded across the template, node, workflow, and run/validate tools, using the shared `_reject_option_like` helper #83 introduced. Extends that PR's policy to the call sites it did not reach.

## Changes

**Bare positionals** — the real argument-injection vector (a dash-leading token is read as an option, shifting every later positional up a slot):

- `get_template` — `name`
- `fetch_template` — `name`
- `search_nodes` — `query`
- `get_node` — `name`
- `nodes_upstream` / `nodes_downstream` — `name`
- `nodes_path` — `from_type` and `to_type`

**Option values** (`--flag VALUE`) — not an injection vector, guarded as input hygiene:

- `fetch_template` — `out_path` (`--out`)
- `validate_workflow` — `workflow_path` (`--workflow`)
- `run_workflow` — `workflow_path` (`--workflow`)
- `vary_workflow` — each `--slot` value and `out_dir` (`--out-dir`)

`nodes_path`'s `max_depth` / `max_paths` are deliberately left alone: they are typed ints (so they cannot carry an arbitrary caller string) riding behind their own flags as option values, so even a negative bound's `"-1"` is taken verbatim by Click. A new test asserts that still forwards unchanged.

`list_workflow_slots`' `workflow_path` and `vary_workflow`'s `workflow_path` were already guarded on `main` by #83, so they needed no change here.

`run_workflow` is guarded **once at function entry** rather than at its two call sites, so it covers both the `wait=False` submit and the streaming path, and fails before the credential retry loop can re-raise it. A parametrized test proves both paths.

Each newly guarded site also gets the matching `_reject_nul`. That is a small, deliberate extension past the literal ask, and it is the repo's own precedent rather than my taste: the round-2 review of #83 caught exactly this omission as a defect (`upload_file`/`list_workflow_slots`/`set_workflow_slot`/`vary_workflow` gained a leading-dash guard but no NUL guard, so a NUL escaped as a bare `ValueError` instead of the `ComfyCliError` every other bad input produces). Shipping eleven new guard sites while repeating that miss would have invited the same finding.

## Motivation

Verified against comfy-cli rather than argued. Both shapes, run live:

```
$ comfy --json --where local templates show -foo
Error: No such option: -f

$ comfy --json --where local templates show --help
 Usage: comfy templates show [OPTIONS] NAME        # usage TEXT, no envelope at all

$ comfy --json --where local validate --workflow --help
{"ok": false, ..., "error": {"code": "workflow_not_found",
 "message": "Workflow file not found: --help", ...}}
```

The positional case is genuine argument injection. The option-value case confirms `_reject_option_like`'s documented split exactly — Click takes the token after a value-taking option verbatim, so it is *not* injectable — but the current failure is still an opaque usage error or unparseable `--help` output rather than a named one. That is the same call `search_templates`' filters and `download_model`'s `filename` already make.

## Judgment call — this revisits one decision from #83

Flagging this explicitly rather than burying it. #83 concluded that `vary_workflow`'s `slots` / `out_dir` "need no guard" and locked that in with `test_vary_workflow_option_values_are_not_guarded`.

The empirical finding behind that conclusion is **unchanged and reaffirmed here** — those values are injection-safe, and the docstring still says so. What changed is the consistency argument: the *same* PR kept the `search_templates` / `download_model` option-value guards as legitimate input hygiene, which left the module inconsistent about which option values get one — and that inconsistency is what a reviewer flagged in #83's first round in the first place. This applies the hygiene rule uniformly instead.

That test is therefore replaced, not deleted: `test_vary_workflow_option_value_guards_read_the_first_char_only` now locks the property that actually matters under the new rule — the guard reads the first character only, so a dash *inside* a slot value (`6.text=[a -b,c]`) and a relative path that merely contains one (`./out-dir`) both still ride through. Over-rejection, not injection, is the live risk on those two.

If reviewers prefer #83's line, dropping the `slots` / `out_dir` guards is a two-hunk revert that leaves the rest of the PR intact.

## Testing

- [x] Existing tests pass (`pytest`) — 576 passed, 2 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — see the live comfy-cli transcripts under Motivation

One rejection test per newly guarded tool, in the file mapped to that tool group (`test_templates.py`, `test_discovery.py`, `test_workflow.py`, `test_wrapper.py`), each asserting `ComfyCliError` with "leading '-'" and monkeypatching `_run_comfy` to `AssertionError` so a guard that fails open is caught rather than silently spawning a child. NUL companions alongside. The pre-existing happy-path argv assertions in each file are untouched and still pass, which is what proves the guards changed no argv.

## Additional Notes

**Negative-claim falsification.** The diff adds deny paths, so per the review checklist I went and looked rather than trusting my own premise.

- **Template names:** enumerated all 578 live via the product's own discovery tool (`comfy templates ls`); **zero** start with `-`. So no reachable template becomes unreachable.
- **Positional arguments generally:** the transcripts above show comfy-cli *already* refuses a dash-leading positional (`No such option: -f`). The guard denies no capability that worked before — it converts an opaque failure into a named one.
- **Option values:** `validate --workflow --help` already returns `workflow_not_found`. Same conclusion.
- **Path-shaped arguments** keep an escape hatch, named in the error text itself: a file or directory genuinely starting with a dash is still reachable as `./-name`. Covered by the existing `test_workflow_path_guard_allows_dot_slash_dash_name`.
- **Not falsified:** node class names and connection types could not be enumerated live — no ComfyUI was running on `:8188` in this environment (`cql_no_graph: cannot reach http://127.0.0.1:8188/object_info`). The positional-shape evidence above covers them (comfy-cli would refuse a dash-leading class name regardless of what this wrapper does), but I did not confirm the live catalog contains no dash-leading class name. Calling that out rather than implying I checked.

**Scope.** Nothing outside the guards changed; no argv, no behavior on valid input. The one docstring edit is to `_reject_option_like`, whose text explicitly named `vary_workflow`'s `slots` / `out_dir` as unguarded and would otherwise have shipped stale.
