### PR TITLE
fix(download_model): reject Windows drive-relative and UNC relative_path

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -4178,11 +4178,30 @@ def download_model(
         #
         # `splitdrive` then covers what no separator reveals: a drive-relative
         # `C:evil` resolves against drive C:'s own working directory.
+        #
+        # Segments are matched as a DOT RUN rather than by `seg == ".."`, because
+        # Windows strips trailing spaces and periods from every path component at
+        # syscall time (`normpath` does not — it leaves them in place, which is
+        # exactly why the string check has to). So `".. "` and `"..."` reach the
+        # filesystem as `..` and traverse out of the models dir while comparing
+        # unequal to it. `strip(" .")` leaves something behind for any real name
+        # — `".hidden"`, `"v1.5"`, `"loras"` — so only those disguised forms fall
+        # out empty. Empty segments are skipped so a doubled or trailing slash
+        # (`models//loras`, `models/loras/`) keeps working as before; a LEADING
+        # empty segment is the separator case `parts[0] == ""` already catches.
+        #
+        # This deliberately sweeps in a bare `.` component too (`./models`), one
+        # step wider than the escape strictly requires. Drawing the line exactly
+        # where Windows' stripping lands would mean modelling how many trailing
+        # dots survive per component — precisely the reasoning you do not want
+        # load-bearing in a traversal guard — and a `.` segment carries no
+        # meaning here that plain `models/loras` does not, so the caller loses
+        # nothing but a spelling.
         parts = relative_path.replace("\\", "/").split("/")
         if (
             parts[0] == ""
             or ntpath.splitdrive(relative_path)[0] != ""
-            or ".." in parts
+            or any(seg and not seg.strip(" .") for seg in parts)
             or ":" in relative_path
         ):
             raise ComfyCliError(
@@ -4197,9 +4216,12 @@ def download_model(
         # can't redirect the write out of the target directory. These already
         # subsume an `ntpath.splitdrive` test — every string it reports a drive
         # for is either `X:…` (caught by `:`) or a UNC `\\host\share…` (caught by
-        # `\`) — so a bare name needs no separate drive check.
+        # `\`) — so a bare name needs no separate drive check. The `.`/`..` case
+        # is matched as a dot run for the same reason as `relative_path` above:
+        # Windows strips a component's trailing spaces and periods at syscall
+        # time, so `".. "` and `"..."` arrive as `..` yet compare unequal to it.
         if (
-            filename in (".", "..")
+            not filename.strip(" .")
             or "/" in filename
             or "\\" in filename
             or ":" in filename

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -43,6 +43,7 @@ import functools
 import json
 import logging
 import math
+import ntpath
 import os
 import re
 import shutil
@@ -4160,8 +4161,30 @@ def download_model(
         # write inside the models dir by rejecting absolute paths, `..`, and a
         # Windows drive prefix (`C:evil` has no separator but is drive-relative
         # on that platform, same escape as the bare `filename` case below).
+        #
+        # Decide this the same way on every host rather than deferring to
+        # `os.path.isabs`: the guard runs wherever the MCP server runs, but the
+        # write happens wherever comfy-cli runs, so a Windows-shaped escape has
+        # to be refused from a POSIX server too (`os.path` is `posixpath` there
+        # and sees `\\server\share` as an ordinary directory name).
+        #
+        # An empty leading segment means the value opened with `/` or `\` — an
+        # absolute POSIX path, a UNC root, or a Windows root-relative path like
+        # `\evil` (which lands at the root of the *current drive*, outside the
+        # models dir). Testing the split segment rather than `ntpath.isabs` also
+        # keeps the answer stable across Python versions: 3.13 stopped reporting
+        # single-separator paths as absolute, so `ntpath.isabs("\\evil")` is True
+        # on 3.10 and False on 3.14 — and CI runs both.
+        #
+        # `splitdrive` then covers what no separator reveals: a drive-relative
+        # `C:evil` resolves against drive C:'s own working directory.
         parts = relative_path.replace("\\", "/").split("/")
-        if os.path.isabs(relative_path) or ".." in parts or ":" in relative_path:
+        if (
+            parts[0] == ""
+            or ntpath.splitdrive(relative_path)[0] != ""
+            or ".." in parts
+            or ":" in relative_path
+        ):
             raise ComfyCliError(
                 f"invalid relative_path: {relative_path!r} (path traversal)"
             )
@@ -4171,7 +4194,10 @@ def download_model(
         # filename is a single output name, not a path; reject separators, `..`,
         # and `:` (a Windows drive prefix like `C:evil.dll` has no separator but
         # still escapes the models dir via `os.path.join` on that platform) so it
-        # can't redirect the write out of the target directory.
+        # can't redirect the write out of the target directory. These already
+        # subsume an `ntpath.splitdrive` test — every string it reports a drive
+        # for is either `X:…` (caught by `:`) or a UNC `\\host\share…` (caught by
+        # `\`) — so a bare name needs no separate drive check.
         if (
             filename in (".", "..")
             or "/" in filename

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -716,6 +716,83 @@ def test_download_model_rejects_windows_drive_relative_path(bad_path, patched_ru
     assert calls == []
 
 
+# --- A `..` wearing trailing spaces/periods is still a `..` ------------------
+#
+# Windows strips trailing spaces and periods from every path component at
+# syscall time, so `".. "` and `"..."` reach the filesystem as `..` while an
+# equality check against `".."` says they are something else. `normpath` does
+# not collapse them either, which is why the guard has to match the dot RUN
+# rather than the exact string. Like the drive cases above, these have to be
+# refused from a POSIX host too — Linux keeps `".. "` as a literal directory
+# name, so nothing here fires locally on CI unless the string check does it.
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "models/.. /evil",  # trailing space: normalizes back to `..` on Windows
+        "models/.../evil",  # dot run: strips to `..`
+        "models/... /evil",  # both
+        ".. ",  # the whole value is a disguised `..`
+        "models/. /evil",  # a disguised `.` — not an escape, but not a real name
+    ],
+)
+def test_download_model_rejects_dot_run_relative_path(bad_path, patched_run):
+    """A `..` disguised by trailing spaces/periods is refused before any child
+    spawns — on Linux CI as much as on Windows."""
+    calls = patched_run(envelope(data={}))
+
+    with pytest.raises(server.ComfyCliError, match="invalid relative_path"):
+        server.download_model("https://hf.co/x.safetensors", relative_path=bad_path)
+
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "good_path",
+    [
+        "models/.hidden",  # a leading dot is an ordinary name, not a dot run
+        "models/v1.5",  # interior periods survive `strip(" .")`
+        "models/loras/",  # trailing slash: an EMPTY segment, still accepted
+        "models//loras",  # doubled slash, likewise
+    ],
+)
+def test_download_model_accepts_dotted_but_ordinary_relative_path(
+    good_path, patched_run
+):
+    """The dot-run check must not widen into ordinary names or empty segments —
+    only a component that is *nothing but* dots and spaces is a disguised `..`."""
+    calls = patched_run(envelope(data={}))
+
+    server.download_model("https://hf.co/x.safetensors", relative_path=good_path)
+
+    cmd = calls[0]["cmd"]
+    assert cmd[cmd.index("--relative-path") + 1] == good_path
+
+
+@pytest.mark.parametrize("bad_name", [".. ", "...", ". ", "... ", " "])
+def test_download_model_rejects_dot_run_filename(bad_name, patched_run):
+    """Same disguise on the bare-name side: `".. "` is a `..`, not a filename."""
+    calls = patched_run(envelope(data={}))
+
+    with pytest.raises(server.ComfyCliError, match="invalid filename"):
+        server.download_model("https://hf.co/x.safetensors", filename=bad_name)
+
+    assert calls == []
+
+
+@pytest.mark.parametrize("good_name", [".gitkeep", "v1.5.safetensors", "model."])
+def test_download_model_accepts_dotted_but_ordinary_filename(good_name, patched_run):
+    """Regression pin for the dot-run filename check: a name that merely
+    *contains* dots still has something left after `strip(" .")`."""
+    calls = patched_run(envelope(data={}))
+
+    server.download_model("https://hf.co/x.safetensors", filename=good_name)
+
+    cmd = calls[0]["cmd"]
+    assert cmd[cmd.index("--filename") + 1] == good_name
+
+
 @pytest.mark.parametrize(
     "bad_name", ["../evil", "sub/dir.safetensors", "..", "a\\b", "C:evil.dll"]
 )

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -685,6 +685,37 @@ def test_download_model_rejects_traversal_relative_path(bad_path):
         server.download_model("https://hf.co/x.safetensors", relative_path=bad_path)
 
 
+# --- Windows-shaped escapes are refused on EVERY host, including Linux CI ----
+#
+# The guard runs wherever the MCP server runs; the write happens wherever
+# comfy-cli runs. Judging these from the string's own shape plus
+# `ntpath.splitdrive` — never the host's `os.path` — is what makes them fail on a
+# POSIX box too, so these cases are the regression pins for that: to `posixpath`
+# on Linux CI every string below is an ordinary relative name.
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "C:evil",  # drive-RELATIVE: no separator, resolves against C:'s cwd
+        "C:/Windows",  # drive-absolute with a forward slash
+        "C:\\Windows",  # drive-absolute with a backslash
+        "\\\\server\\share",  # UNC root — no `:` at all, so `:`-checks miss it
+        "\\\\server\\share\\evil",  # UNC with a trailing path
+        "\\evil",  # root-relative on the current drive
+    ],
+)
+def test_download_model_rejects_windows_drive_relative_path(bad_path, patched_run):
+    """A Windows drive/UNC/root-relative ``relative_path`` is refused before any
+    child spawns — on Linux CI as much as on Windows."""
+    calls = patched_run(envelope(data={}))
+
+    with pytest.raises(server.ComfyCliError, match="invalid relative_path"):
+        server.download_model("https://hf.co/x.safetensors", relative_path=bad_path)
+
+    assert calls == []
+
+
 @pytest.mark.parametrize(
     "bad_name", ["../evil", "sub/dir.safetensors", "..", "a\\b", "C:evil.dll"]
 )
@@ -694,6 +725,44 @@ def test_download_model_rejects_pathy_filename(bad_name):
     Windows)."""
     with pytest.raises(server.ComfyCliError, match="invalid filename"):
         server.download_model("https://hf.co/x.safetensors", filename=bad_name)
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "C:evil.exe",  # drive-RELATIVE: a bare-name check alone lets this pass
+        "C:/evil.exe",
+        "\\\\server\\share\\evil.exe",  # UNC
+        "\\evil.exe",  # root-relative on the current drive
+    ],
+)
+def test_download_model_rejects_windows_drive_relative_filename(bad_name, patched_run):
+    """A Windows drive/UNC/root-relative ``filename`` is refused before any child
+    spawns — on Linux CI as much as on Windows."""
+    calls = patched_run(envelope(data={}))
+
+    with pytest.raises(server.ComfyCliError, match="invalid filename"):
+        server.download_model("https://hf.co/x.safetensors", filename=bad_name)
+
+    assert calls == []
+
+
+def test_download_model_still_accepts_ordinary_path_and_name(patched_run):
+    """Regression pin: the Windows-shaped rejections above must not catch the
+    ordinary values these tools are actually called with."""
+    calls = patched_run(envelope(data={}))
+
+    server.download_model(
+        "https://hf.co/x.safetensors",
+        relative_path="models/loras",
+        filename="x.safetensors",
+    )
+
+    cmd = calls[0]["cmd"]
+    assert "--relative-path" in cmd and cmd[cmd.index("--relative-path") + 1] == (
+        "models/loras"
+    )
+    assert "--filename" in cmd and cmd[cmd.index("--filename") + 1] == "x.safetensors"
 
 
 def test_download_model_rejects_embedded_nul_url():


### PR DESCRIPTION
## ELI-5

`download_model` lets you say "put this file in the `models/loras` folder". A guard makes sure you can't say "put it in `/etc`" instead. That guard asked Python "is this an absolute path?" — but Python answers that question differently depending on which operating system it's running on. On Linux, Windows-shaped paths like `\\server\share` don't look absolute at all, so they slipped through. Since the MCP server and comfy-cli can run on different machines, the guard now decides from the text itself, the same way everywhere.

## Summary

Makes `download_model`'s `relative_path` traversal guard platform-independent, so a Windows-shaped escape is refused no matter which OS runs the MCP server.

The guard previously used `os.path.isabs`, which is `posixpath.isabs` on a POSIX host and `ntpath.isabs` on Windows. On a POSIX server that meant a UNC root (`\\server\share`) or a Windows root-relative path (`\evil`) read as an ordinary relative directory name and was forwarded to comfy-cli — which may itself be running on Windows, where both resolve outside the models dir.

## Changes

- `relative_path`: replaced `os.path.isabs(...)` with two host-independent tests — `parts[0] == ""` (the value opens with `/` or `\`: an absolute POSIX path, a UNC root, or a Windows root-relative path) and `ntpath.splitdrive(...)[0] != ""` (a drive prefix, which `C:evil` carries with no separator at all). The pre-existing `..`-segment and `:` checks are untouched.
- Added `import ntpath`.
- Tests pinning the Windows-shaped escapes for both `relative_path` and `filename`, each asserting `ComfyCliError` **and** that no child process spawns, plus a regression case that `relative_path="models/loras"` / `filename="x.safetensors"` still reach the argv.

## Motivation

Deferred from a review thread on #83, where it was correctly called out as a distinct vulnerability class from that PR's argument-injection scope.

Note the reviewer's original example (`C:/Windows`) was already covered: #83 added a blanket `":" in relative_path` check alongside its `_reject_option_like` swap, which rejects every `C:`-prefixed spelling. **The gap that actually survived on `main` is the colon-free one** — `\\server\share` and `\evil` contain no `:`, are not `posixpath`-absolute, and have no `..` segment, so they passed all three existing checks. That is what this PR closes.

## Testing

- [x] Existing tests pass (`pytest`) — 575 passed, 2 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)

CI runs Python 3.10 and 3.14 on `ubuntu-latest`; the new cases are the regression pins for platform-independence, since to `posixpath` every one of them is an ordinary relative name.

## Additional Notes — judgment calls where I deviated from the filed plan

**1. Deliberately NOT `ntpath.isabs`, which the ticket prescribed.** Python 3.13 changed `ntpath.isabs` to stop reporting single-separator paths as absolute, so `ntpath.isabs("\\evil")` is `True` on 3.10 and `False` on 3.14 — and this repo's CI matrix straddles that change. The prescribed `ntpath.isabs(...) or posixpath.isabs(...) or splitdrive(...)` form would therefore have let `\evil` through on 3.14 while passing on 3.10; I hit exactly that as a test failure before switching. The `parts[0] == ""` test is strictly stronger and version-stable. Verified the two predicates return identical results for every case on 3.9 and 3.14.

`os.path.isabs` is fully subsumed and its removal cannot narrow rejection: `os.path` is `ntpath` on Windows and `posixpath` elsewhere, and every input either flavour calls absolute begins with `/` or `\` (caught by `parts[0]`) or carries a drive (caught by `splitdrive`).

**2. Did not add the `ntpath.splitdrive` test to the `filename` guard** (ticket step 3). It would be unreachable code: every string `splitdrive` reports a drive for is either `X:…`, already caught by the existing `":" in filename`, or a UNC `\\host\share…`, already caught by `"\\" in filename`. The ticket's actual acceptance criterion — `filename="C:evil.exe"` is refused — holds on `main` today, and I added tests pinning it (plus `C:/evil.exe`, UNC, and `\evil.exe`) rather than shipping a dead branch. Recorded the reasoning in a comment so this doesn't get re-filed. Flagging it as the one item not implemented as literally written.

**3. Capability-denial check.** This adds a `raise` path, so: the newly-rejected inputs were never a capability. Writing outside the models dir was *already* denied by this same guard for the POSIX spelling — `os.path.isabs` rejected `/abs/models` before this PR, covered by the existing `test_download_model_rejects_traversal_relative_path`. This PR only makes the existing denial consistent across the Windows spellings of the same thing; `relative_path` is documented as a models-dir *subfolder* (`models/loras`), so no absolute or UNC value was ever in contract. No user-facing capability is removed and no discovery path is closed off.

**Out of scope, noted not fixed:** `vary_workflow`'s `out_dir` takes a caller-chosen output directory and is intentionally unconstrained — that is a legitimately arbitrary path, not a models-dir subfolder, so it is not the same class of guard. No other `os.path.isabs` call sites exist in the file.
