### PR TITLE
fix: guard the five remaining unguarded argv sites against option-like and NUL input

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -3923,6 +3923,13 @@ def get_template(name: str) -> Any:
     fetching it, then ``fetch_template(name, out_path)`` writes the runnable JSON
     for ``run_workflow``.
     """
+    # `name` rides as a bare positional, so a leading dash reaches comfy-cli as
+    # an option rather than the template — the same guard `run_template` already
+    # applies to the same value.
+    _reject_option_like(
+        "template name", name, expected="a template name (e.g. 'flux_dev')"
+    )
+    _reject_nul("template name", name)
     return _run_comfy("templates", "show", name, timeout=60.0)
 
 
@@ -3942,6 +3949,16 @@ def fetch_template(name: str, out_path: str) -> str:
 
     so an agent reaches a working generation without hand-authoring workflow JSON.
     """
+    # `name` is a bare positional (mandatory guard); `out_path` rides as the
+    # `--out` value, where the leading-dash check is input hygiene rather than
+    # injection defense — a file named `-x` is a caller mistake, not a flag.
+    # See `_reject_option_like` for why the two cases differ.
+    _reject_option_like(
+        "template name", name, expected="a template name (e.g. 'flux_dev')"
+    )
+    _reject_nul("template name", name)
+    _reject_option_like("out_path", out_path)
+    _reject_nul("out_path", out_path)
     _run_comfy("templates", "fetch", name, "--out", out_path, timeout=60.0)
     return os.path.abspath(out_path)
 
@@ -3956,6 +3973,10 @@ def search_nodes(query: str) -> Any:
     "KSampler", "load image") before authoring or repairing a workflow graph;
     pass the returned name to ``get_node`` for its full schema.
     """
+    # `query` rides as a bare positional: a leading dash is read by comfy-cli as
+    # an option, not the search term.
+    _reject_option_like("query", query)
+    _reject_nul("query", query)
     return _run_comfy("nodes", "search", query, timeout=60.0)
 
 
@@ -3969,6 +3990,10 @@ def get_node(name: str) -> Any:
     repair a workflow graph. Reflects the user's live install, so it resolves
     custom-node classes too (not just built-ins).
     """
+    # `name` rides as a bare positional: a leading dash is read by comfy-cli as
+    # an option, not the class name.
+    _reject_option_like("node name", name, expected="a node class (e.g. 'KSampler')")
+    _reject_nul("node name", name)
     return _run_comfy("nodes", "show", name, timeout=60.0)
 
 
@@ -4107,9 +4132,22 @@ def search_models(query: str = "", folder: str = "") -> Any:
     download metadata). Agents should set expectations accordingly: it answers
     "which model files does this install have?", not "tell me about this model".
     """
+    # Both guards sit INSIDE their branch so an empty value keeps meaning "mode
+    # not selected" (the precedence above) rather than becoming an error.
     if query:
+        # `--text` value: the leading-dash check is input hygiene (Click reads
+        # the token after a value-taking option verbatim), the NUL check is not
+        # optional — see `_reject_option_like` / `_reject_nul`.
+        _reject_option_like("query", query)
+        _reject_nul("query", query)
         return _run_comfy("models", "search", "--text", query, timeout=60.0)
     if folder:
+        # `folder` rides as a bare positional, so its leading-dash guard is the
+        # mandatory kind.
+        _reject_option_like(
+            "folder", folder, expected="a model folder (e.g. 'checkpoints')"
+        )
+        _reject_nul("folder", folder)
         return _run_comfy("models", "list-folder", folder, timeout=60.0)
     return _run_comfy("models", "list-folders", timeout=60.0)
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -250,11 +250,20 @@ def _reject_option_like(label: str, value: str, expected: str = "") -> str:
       ``slots`` / ``out_dir`` need no guard to be injection-safe.
 
     Where a call site guards an option value anyway (``search_templates``'s
-    filters, ``download_model``'s ``relative_path`` / ``filename``), that is input
-    hygiene rather than injection defense: a dash-leading provider filter or output
-    filename is a caller mistake, and a named error beats comfy-cli matching zero
-    rows or writing a file named ``-x``. Read those as belt-and-braces, not as
-    evidence that option values are unsafe.
+    filters, ``download_model``'s ``relative_path`` / ``filename``,
+    ``fetch_template``'s ``out_path``), that is input hygiene rather than injection
+    defense: a dash-leading provider filter or output filename is a caller mistake,
+    and a named error beats comfy-cli matching zero rows or writing a file named
+    ``-x``. Read those as belt-and-braces, not as evidence that option values are
+    unsafe.
+
+    That hygiene guard is a judgement per call site, not a default — apply it only
+    where a leading dash cannot be real DATA for that value. It does **not** fit a
+    free-form search term: ``search_models``'s ``--text`` matches model filenames,
+    where ``-fp16`` / ``-fp8`` / ``-turbo`` are ordinary substrings, so guarding it
+    would refuse a working search that has no other spelling. The hygiene sites
+    above all leave an escape hatch (``./-x`` names the same file as ``-x``); a
+    search term does not.
     """
     if value.startswith("-"):
         hint = f" — expected {expected}" if expected else ""
@@ -3951,7 +3960,8 @@ def fetch_template(name: str, out_path: str) -> str:
     """
     # `name` is a bare positional (mandatory guard); `out_path` rides as the
     # `--out` value, where the leading-dash check is input hygiene rather than
-    # injection defense — a file named `-x` is a caller mistake, not a flag.
+    # injection defense — a file named `-x` is a caller mistake, not a flag, and
+    # a caller who really wants one can spell it `./-x` (same file, no guard).
     # See `_reject_option_like` for why the two cases differ.
     _reject_option_like(
         "template name", name, expected="a template name (e.g. 'flux_dev')"
@@ -4132,13 +4142,21 @@ def search_models(query: str = "", folder: str = "") -> Any:
     download metadata). Agents should set expectations accordingly: it answers
     "which model files does this install have?", not "tell me about this model".
     """
-    # Both guards sit INSIDE their branch so an empty value keeps meaning "mode
+    # The guards sit INSIDE their branch so an empty value keeps meaning "mode
     # not selected" (the precedence above) rather than becoming an error.
     if query:
-        # `--text` value: the leading-dash check is input hygiene (Click reads
-        # the token after a value-taking option verbatim), the NUL check is not
-        # optional — see `_reject_option_like` / `_reject_nul`.
-        _reject_option_like("query", query)
+        # NUL only — deliberately NO `_reject_option_like` here, unlike the other
+        # option values this module guards for hygiene. `--text` is a free-form
+        # substring match over model FILENAMES, and a leading dash is legitimate
+        # data in that position: the `-fp16` / `-fp8` / `-turbo` suffixes are
+        # ordinary in model filenames, so `query="-fp16"` is a real search that
+        # matches real rows. Click takes the token after a value-taking option
+        # verbatim, so comfy-cli accepts it and there is no other way to spell
+        # that substring — guarding it would refuse a working search rather than
+        # catch a mistake. Contrast the hygiene sites (`search_templates`'s
+        # enumerated filters, `download_model`'s output names, `fetch_template`'s
+        # `--out`), where a dash-leading value really is a caller slip and an
+        # escape hatch exists. See `_reject_option_like`.
         _reject_nul("query", query)
         return _run_comfy("models", "search", "--text", query, timeout=60.0)
     if folder:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -28,10 +28,45 @@ def test_search_nodes_argv(patched_run):
     ]
 
 
+@pytest.mark.parametrize("query", ["--help", "-x"])
+def test_search_nodes_rejects_leading_dash_query(patched_run, query):
+    """The query is a bare positional — a leading dash would reach comfy-cli as a flag."""
+    calls = patched_run(envelope(data=[]))
+    with pytest.raises(server.ComfyCliError, match="leading '-'"):
+        server.search_nodes(query)
+    # refused before the spawn, not after
+    assert calls == []
+
+
+def test_search_nodes_rejects_embedded_nul_query(patched_run):
+    """A NUL surfaces as ComfyCliError, not subprocess's bare ValueError."""
+    calls = patched_run(envelope(data=[]))
+    with pytest.raises(server.ComfyCliError, match="embedded NUL"):
+        server.search_nodes("samp\0ler")
+    assert calls == []
+
+
 def test_get_node_argv(patched_run):
     calls = patched_run(envelope(data={"name": "KSampler", "inputs": {}}))
     assert server.get_node("KSampler") == {"name": "KSampler", "inputs": {}}
     assert calls[0]["cmd"][4:] == ["nodes", "show", "KSampler"]
+
+
+@pytest.mark.parametrize("name", ["--help", "-x"])
+def test_get_node_rejects_leading_dash_name(patched_run, name):
+    """The class name is a bare positional — a leading dash is read as an option."""
+    calls = patched_run(envelope(data={}))
+    with pytest.raises(server.ComfyCliError, match="leading '-'"):
+        server.get_node(name)
+    assert calls == []
+
+
+def test_get_node_rejects_embedded_nul_name(patched_run):
+    """A NUL surfaces as ComfyCliError, not subprocess's bare ValueError."""
+    calls = patched_run(envelope(data={}))
+    with pytest.raises(server.ComfyCliError, match="embedded NUL"):
+        server.get_node("KSam\0pler")
+    assert calls == []
 
 
 def test_list_nodes_no_filters_bare_ls(patched_run):
@@ -171,6 +206,43 @@ def test_search_models_query_takes_precedence_over_folder(patched_run):
     calls = patched_run(envelope(data=[]))
     server.search_models(query="xl", folder="checkpoints")
     assert calls[0]["cmd"][4:] == ["models", "search", "--text", "xl"]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"query": "--help"}, {"query": "-x"}, {"folder": "--pack"}, {"folder": "-c"}],
+    ids=lambda kw: f"{next(iter(kw))}-{next(iter(kw.values()))}",
+)
+def test_search_models_rejects_leading_dash(patched_run, kwargs):
+    """`folder` is a bare positional; the `--text` value is guarded for hygiene."""
+    calls = patched_run(envelope(data=[]))
+    with pytest.raises(server.ComfyCliError, match="leading '-'"):
+        server.search_models(**kwargs)
+    # refused before the spawn, not after
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"query": "x\0l"}, {"folder": "check\0points"}],
+    ids=lambda kw: next(iter(kw)),
+)
+def test_search_models_rejects_embedded_nul(patched_run, kwargs):
+    """A NUL surfaces as ComfyCliError, not subprocess's bare ValueError."""
+    calls = patched_run(envelope(data=[]))
+    with pytest.raises(server.ComfyCliError, match="embedded NUL"):
+        server.search_models(**kwargs)
+    assert calls == []
+
+
+def test_search_models_empty_values_still_select_the_mode(patched_run):
+    """Empty stays the 'mode not selected' signal — the guards must not reject it."""
+    calls = patched_run(envelope(data=["checkpoints"]))
+    # empty query falls through to the folder mode, empty folder to list-folders
+    server.search_models(query="", folder="checkpoints")
+    server.search_models(query="", folder="")
+    assert calls[0]["cmd"][4:] == ["models", "list-folder", "checkpoints"]
+    assert calls[1]["cmd"][4:] == ["models", "list-folders"]
 
 
 def test_discovery_surfaces_error_envelope(patched_run):

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -208,18 +208,28 @@ def test_search_models_query_takes_precedence_over_folder(patched_run):
     assert calls[0]["cmd"][4:] == ["models", "search", "--text", "xl"]
 
 
-@pytest.mark.parametrize(
-    "kwargs",
-    [{"query": "--help"}, {"query": "-x"}, {"folder": "--pack"}, {"folder": "-c"}],
-    ids=lambda kw: f"{next(iter(kw))}-{next(iter(kw.values()))}",
-)
-def test_search_models_rejects_leading_dash(patched_run, kwargs):
-    """`folder` is a bare positional; the `--text` value is guarded for hygiene."""
+@pytest.mark.parametrize("folder", ["--pack", "-c"])
+def test_search_models_rejects_leading_dash_folder(patched_run, folder):
+    """`folder` is a bare positional — comfy-cli reads a leading dash as an option."""
     calls = patched_run(envelope(data=[]))
     with pytest.raises(server.ComfyCliError, match="leading '-'"):
-        server.search_models(**kwargs)
+        server.search_models(folder=folder)
     # refused before the spawn, not after
     assert calls == []
+
+
+@pytest.mark.parametrize("query", ["-fp16", "-fp8-e4m3fn", "--help"])
+def test_search_models_allows_leading_dash_query(patched_run, query):
+    """`--text` is free-form filename matching: a leading dash is data, not a flag.
+
+    Click takes the token after a value-taking option verbatim, so comfy-cli
+    receives these as the search term — and `-fp16` / `-fp8` are ordinary model
+    filename substrings with no other spelling. Guarding here would refuse a
+    working search. Contrast `folder` above, which really is a positional.
+    """
+    calls = patched_run(envelope(data=[]))
+    server.search_models(query=query)
+    assert calls[0]["cmd"][4:] == ["models", "search", "--text", query]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -294,6 +294,24 @@ def test_get_template_argv(patched_run):
     assert calls[0]["cmd"][4:] == ["templates", "show", "flux_dev"]
 
 
+@pytest.mark.parametrize("name", ["--help", "-x"])
+def test_get_template_rejects_leading_dash_name(patched_run, name):
+    """The name is a bare positional — a leading dash reaches comfy-cli as an option."""
+    calls = patched_run(envelope(data={}))
+    with pytest.raises(server.ComfyCliError, match="leading '-'"):
+        server.get_template(name)
+    # refused before the spawn, not after
+    assert calls == []
+
+
+def test_get_template_rejects_embedded_nul_name(patched_run):
+    """A NUL surfaces as ComfyCliError, not subprocess's bare ValueError."""
+    calls = patched_run(envelope(data={}))
+    with pytest.raises(server.ComfyCliError, match="embedded NUL"):
+        server.get_template("flux\0dev")
+    assert calls == []
+
+
 def test_fetch_template_argv_and_returns_abspath(patched_run, tmp_path):
     """Passthrough argv is `templates fetch <name> --out <path>`; returns the abs path."""
     calls = patched_run(envelope(data=None))
@@ -312,3 +330,30 @@ def test_fetch_template_resolves_relative_path(monkeypatch):
     result = server.fetch_template("flux_dev", "flux.json")
     assert result == os.path.abspath("flux.json")
     assert os.path.isabs(result)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [("--help", "/tmp/out.json"), ("-x", "/tmp/out.json"), ("flux_dev", "--out")],
+    ids=["name-long", "name-short", "out_path"],
+)
+def test_fetch_template_rejects_leading_dash(patched_run, args):
+    """`name` is a bare positional; the `--out` value is guarded for hygiene too."""
+    calls = patched_run(envelope(data=None))
+    with pytest.raises(server.ComfyCliError, match="leading '-'"):
+        server.fetch_template(*args)
+    # refused before the spawn — and before any file is written
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "args",
+    [("flux\0dev", "/tmp/out.json"), ("flux_dev", "/tmp/o\0ut.json")],
+    ids=["name", "out_path"],
+)
+def test_fetch_template_rejects_embedded_nul(patched_run, args):
+    """A NUL surfaces as ComfyCliError, not subprocess's bare ValueError."""
+    calls = patched_run(envelope(data=None))
+    with pytest.raises(server.ComfyCliError, match="embedded NUL"):
+        server.fetch_template(*args)
+    assert calls == []


### PR DESCRIPTION
## ELI-5

When this server calls `comfy`, it hands over the arguments as a plain list with no `--` marker to say "everything after this is data, not a flag". So if you ask for a template literally named `--help`, `comfy` sees a flag and prints its help text instead of doing what you asked. And if a value contains a NUL byte, Python's `subprocess` throws a raw `ValueError` that nothing here catches, so you get an "internal error" instead of this server's normal, readable error. Five caller-supplied values still had no check for either of those. This PR adds the checks, so those inputs now come back as a clear `ComfyCliError` instead of a confusing help dump or a crash.

## Summary

Adds the module's existing `_reject_option_like` / `_reject_nul` guards to the five remaining unguarded caller-supplied argv values in `server.py`. No behavior changes for any valid input — the diff is +155 lines, 0 deletions.

The module already disagreed with itself on one of these values: `run_template` refuses a dash-leading template name via `_run_template_argv`, while `get_template` / `fetch_template` passed the same name straight through.

## Changes

| Site | argv | Class |
|---|---|---|
| `get_template(name)` | `templates show <name>` | bare positional |
| `fetch_template(name, out_path)` | `templates fetch <name> --out <out_path>` | positional + option value |
| `search_nodes(query)` | `nodes search <query>` | bare positional |
| `get_node(name)` | `nodes show <name>` | bare positional |
| `search_models(folder)` | `models list-folder <folder>` | bare positional |
| `search_models(query)` | `models search --text <query>` | option value |

- Labels match the sibling call sites (`"template name"`, as `_run_template_argv` already uses).
- Emptiness is deliberately **not** guarded on `search_models` — empty is that tool's documented "mode not selected" signal (see its precedence order), so both guards sit *inside* their own branch rather than at the top of the function. A test pins that behavior.
- Rejection tests added in the file that already exercises each tool (`tests/test_templates.py`, `tests/test_discovery.py`), asserting `ComfyCliError` matching `leading '-'` / `embedded NUL` **and** that nothing was spawned (`calls == []`). The pre-existing pass-through argv test for each of the five tools still passes unchanged, which is what proves the guards are value-shape-only.

## Motivation

Both failure modes are live today, not latent:

1. **Leading dash.** `_run_comfy` builds argv with no `--` separator, so a dash-leading value reaches comfy-cli as an option rather than data. `_reject_option_like`'s own docstring calls guarding a bare positional **mandatory** — a leading-dash entry IS read as a flag and every later positional shifts up a slot.
2. **Embedded NUL.** `subprocess.run` raises a bare `ValueError: embedded null byte`, and `_run_comfy_raw` catches only `subprocess.TimeoutExpired`, so it escapes as an internal error instead of the `ComfyCliError` `_reject_nul`'s docstring states this module always produces for bad input.

## Judgment call: `_reject_option_like` on the two option values

Click takes the token after a value-taking option verbatim, so `--out <value>` and `--text <value>` are **not** injection vectors — `_reject_nul` is the required guard there, and the leading-dash check is input hygiene. I applied it anyway, for uniformity with the option values `search_templates` (`--tag`/`--type`/`--model`/`--provider`) and `download_model` (`--relative-path`/`--filename`) already guard the same way. Reviewers who prefer the narrower reading can drop two lines; nothing else depends on them.

## Testing

- [x] Existing tests pass (`pytest` — 585 passed, 2 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually against real comfy-cli — see the falsification section below

## Falsification of the capability denial

This diff adds deny paths, so I went and empirically checked, against a real `comfy` binary, whether the refused inputs actually work today rather than assuming they don't.

**The four bare positionals: the capability does not exist.** Run exactly as `_run_comfy` composes argv (no `--` separator), a dash-leading value is consumed as an option — each prints comfy-cli's help text and emits **no envelope** at all:

```
comfy --json --where local nodes search --help          -> prints `nodes search` help, no envelope
comfy --json --where local templates show --help        -> prints `templates show` help, no envelope
comfy --json --where local nodes show --help            -> prints `nodes show` help, no envelope
comfy --json --where local models list-folder --help    -> prints `models list-folder` help, no envelope
```

So these guards refuse nothing that works; they convert a confusing usage failure into a named error.

**The `--out` option value: the capability DOES exist, and there is a working redirect.** `templates fetch image_flux2 --out -x` succeeds today and writes a real 57,237-byte file literally named `-x`. Guarding it therefore does remove something that works — but not a capability, only one spelling of it. Both redirects were verified to produce the identical file and to pass the new guard:

```
comfy ... templates fetch image_flux2 --out ./-x        -> ok, writes ./-x       (57237 bytes)
comfy ... templates fetch image_flux2 --out /abs/dir/-x -> ok, writes /abs/dir/-x (57237 bytes)
```

So a caller who genuinely wants a dash-leading output filename passes `./-x` or an absolute path. That is called out in the code comment and above.

**The `--text` option value.** A live check needs a running ComfyUI (`models search` hits `object_info`), so this one is reasoned rather than executed: `--text` is a substring match, so the redirect for a query like `-xl` is `xl`, which returns a strict superset. This is the same class of value as `search_templates`' `--model` / `--provider` substring filters, which are already guarded on `main`.

## Additional Notes — the ticket's "five remaining" premise is incomplete

The scoping brief for this change asserted these were the *last* unguarded caller-supplied argv values. While verifying that, I enumerated every `_run_comfy` call site and found more. **I deliberately did not widen this PR** — it is a targeted guard PR and should match its title — but they should not be lost:

- **Bare positionals, same failure class as the four fixed here, same `nodes` tool group:** `nodes_upstream(name)`, `nodes_downstream(name)`, `nodes_path(from_type, to_type)`. These are the highest-value follow-up; the fix is mechanically identical to this PR.
- **Option values (NUL-only concern):** `run_workflow(workflow_path)` and `validate_workflow(workflow_path)` both ride as `--workflow <path>` with no `_reject_nul`.
- **Deliberately unguarded:** `launch_comfyui(extra_args)` forwards after a real `--` separator, so the leading-dash case is intentional there — but a NUL in `extra_args` would still surface as the bare `ValueError`. That one needs a design call, not a copy of this pattern.

`list_nodes`' filter loop is not in this list because it is already handled by the open PR #85; this branch does not touch it, so the two do not conflict.
