### PR TITLE
fix(restart_comfyui): recognize comfy-cli's plain "nothing to stop" message

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -705,14 +705,55 @@ def _check_comfy_version() -> None:
 # stop failure ``restart_comfyui`` treats as benign (see its docstring).
 _NO_RECORDED_SERVER_CODE = "no_recorded_server"
 
+# The SAME condition as comfy-cli actually prints it in the common case: `comfy
+# stop` with no recorded background server prints "No ComfyUI is running in the
+# background." and exits 1 WITHOUT an envelope (comfy-cli 1.12.0 `cmdline.stop`),
+# so there is no structured ``code`` for the check above to see and the literal
+# marker string never appears in the message either. That gap is what stopped
+# ``restart_comfyui`` from recycling a server it did not background-launch — a
+# foreground ``comfy launch``, the desktop app, a manual ``python main.py``, or
+# nothing running at all — even though its docstring has always promised to
+# swallow "nothing to stop".
+#
+# Matched with a case-insensitive REGEX on the stable part of the phrase rather
+# than by equality against the exact sentence: this is comfy-cli's human output,
+# free to drift in capitalization, punctuation, or an inserted word ("No ComfyUI
+# *server* is running in the background"), and pinning the exact bytes is what
+# made the original check brittle in the first place. It is deliberately still
+# narrow — it requires BOTH halves, a negated ComfyUI subject AND "running in the
+# background", inside a single sentence (``[^.\n]*?`` cannot cross a period or a
+# newline) — so it identifies "nothing was recorded to stop" and nothing else. A
+# permission error, a process that could not be killed, or any other comfy-cli
+# malfunction still re-raises: none of them claim no ComfyUI is running.
+_NO_RECORDED_SERVER_TEXT_RE = re.compile(
+    r"\bno\s+comfyui\b[^.\n]*?\brunning\s+in\s+the\s+background\b",
+    re.IGNORECASE,
+)
+
 
 def _is_no_recorded_server(exc: ComfyCliError) -> bool:
     """True when ``exc`` is comfy-cli's benign 'nothing recorded to stop' error.
 
     Prefers the structured ``code`` and falls back to the message so it also
-    recognizes the error when only the human-readable string carries the marker.
+    recognizes the error when only the human-readable string carries it — either
+    as the literal marker code, or as comfy-cli's own printed phrasing on the
+    bare non-zero exit that emits no envelope (see
+    :data:`_NO_RECORDED_SERVER_TEXT_RE`).
+
+    The text fallback is deliberately NOT gated on ``exc.no_envelope``, and it
+    searches the whole rendered message rather than a single stream: the phrase
+    itself is the signal, and which reporting path comfy-cli happens to use for
+    it is exactly the detail that should not matter here. It genuinely varies —
+    comfy-cli prints this one through Rich, i.e. on STDOUT, while the wrapper's
+    no-envelope message renders stdout and stderr side by side.
     """
-    return exc.code == _NO_RECORDED_SERVER_CODE or _NO_RECORDED_SERVER_CODE in str(exc)
+    if exc.code == _NO_RECORDED_SERVER_CODE:
+        return True
+    message = str(exc)
+    return (
+        _NO_RECORDED_SERVER_CODE in message
+        or _NO_RECORDED_SERVER_TEXT_RE.search(message) is not None
+    )
 
 
 def _strip_brackets(host: str) -> str:
@@ -3720,6 +3761,32 @@ def stop_comfyui() -> Any:
     return _run_comfy("stop", timeout=60.0, plain_ok=True)
 
 
+# A launch that lost the port race. Matched loosely (the substring, not a fixed
+# sentence) because comfy-cli and ComfyUI phrase it differently — "The 8188 port
+# is already in use." from comfy-cli's own preflight, "Address already in use"
+# from the socket bind underneath. Over-matching is cheap here and cannot mask a
+# failure: this only decides whether ``restart_comfyui`` APPENDS an explanation
+# to an error it is re-raising either way.
+_PORT_IN_USE_TEXT_RE = re.compile(r"\balready\s+in\s+use\b", re.IGNORECASE)
+
+# Appended when a restart's stop found nothing recorded AND the relaunch then
+# lost the port: together those two facts identify a server that is running but
+# was not started by comfy-cli, which the bare "port already in use" text does
+# not explain on its own. comfy-cli will not kill a process it did not start
+# (``stop_comfyui``'s ownership semantics), so the way out is the user's own
+# shell or a different port — this server exposes no stop-by-port/pid tool.
+_UNTRACKED_SERVER_GUIDANCE = (
+    "Something is already serving this port, but comfy-cli has no record of "
+    "launching it — so there was nothing for the restart to stop, and the fresh "
+    "launch then hit the occupied port. That server was almost certainly started "
+    "outside comfy-cli (a foreground `comfy launch`, the ComfyUI desktop app, or "
+    "`python main.py`), and comfy-cli only ever stops a server it started itself. "
+    "Either stop it the way you started it and retry, or bring one up alongside it "
+    'on a free port: restart_comfyui(extra_args=["--port", "8189"]). '
+    "`server_info` shows what is answering right now."
+)
+
+
 @mcp.tool()
 def restart_comfyui(extra_args: list[str] | None = None) -> Any:
     """Restart the LOCAL ComfyUI server: stop the running one, then launch a fresh one.
@@ -3733,17 +3800,40 @@ def restart_comfyui(extra_args: list[str] | None = None) -> Any:
 
     The stop step is best-effort ONLY for the benign "nothing to stop" case: if
     comfy-cli has no recorded server (e.g. nothing is running, or ComfyUI was
-    started outside comfy-cli) it returns the ``no_recorded_server`` code, which
-    is swallowed so the restart still brings the server up. Any OTHER stop
-    failure (a process that couldn't be killed, a permission error, a comfy-cli
-    malfunction) is re-raised rather than silently masked behind the launch.
+    started outside comfy-cli) it reports that — as the ``no_recorded_server``
+    code, or as a bare non-zero exit printing "No ComfyUI is running in the
+    background" — and either form is swallowed so the restart still brings the
+    server up. Any OTHER stop failure (a process that couldn't be killed, a
+    permission error, a comfy-cli malfunction) is re-raised rather than silently
+    masked behind the launch.
+
+    When that benign stop is followed by a launch that loses the port, the port
+    error is re-raised with an explanation of the combined situation: a server is
+    running that comfy-cli did not start and therefore cannot stop.
     """
+    nothing_to_stop = False
     try:
         stop_comfyui()
     except ComfyCliError as exc:
         if not _is_no_recorded_server(exc):
             raise
-    return launch_comfyui(extra_args)
+        nothing_to_stop = True
+    try:
+        return launch_comfyui(extra_args)
+    except ComfyCliError as exc:
+        # Only when BOTH halves happened — nothing recorded to stop, then the
+        # port was taken anyway. A port clash after a stop that genuinely killed
+        # comfy-cli's own server is a different problem (a lingering process, a
+        # second ComfyUI), so it keeps its original message untouched.
+        if not nothing_to_stop or not _PORT_IN_USE_TEXT_RE.search(str(exc)):
+            raise
+        raise ComfyCliError(
+            f"{exc}\n\n{_UNTRACKED_SERVER_GUIDANCE}",
+            code=exc.code,
+            no_envelope=exc.no_envelope,
+            returncode=exc.returncode,
+            timed_out=exc.timed_out,
+        ) from exc
 
 
 # comfy-cli's `logs` reports this error code when no persisted log file exists

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -721,12 +721,33 @@ _NO_RECORDED_SERVER_CODE = "no_recorded_server"
 # *server* is running in the background"), and pinning the exact bytes is what
 # made the original check brittle in the first place. It is deliberately still
 # narrow — it requires BOTH halves, a negated ComfyUI subject AND "running in the
-# background", inside a single sentence (``[^.\n]*?`` cannot cross a period or a
-# newline) — so it identifies "nothing was recorded to stop" and nothing else. A
-# permission error, a process that could not be killed, or any other comfy-cli
-# malfunction still re-raises: none of them claim no ComfyUI is running.
+# background", within one short clause — so it identifies "nothing was recorded to
+# stop" and nothing else. A permission error, a process that could not be killed,
+# or any other comfy-cli malfunction still re-raises: none of them claim no
+# ComfyUI is running.
+#
+# Two details keep "one short clause" honest, because the string it runs against
+# is the wrapper's ``stderr: … | stdout: …`` rendering of BOTH streams, not one
+# tidy sentence:
+#
+#   * The subject must OPEN a message, a line, or a field — start-of-string, a
+#     newline, the ``:`` / ``|`` the wrapper delimits streams with, or the
+#     ``...`` ``textutil._stream_tail`` prefixes a clipped capture with (a
+#     truncation marker is where a field begins, not prose). comfy-cli prints
+#     this sentence on its own; a hint buried mid-sentence in some other failure
+#     ("…, and ensure no ComfyUI is running in the background") is advice, not a
+#     report that nothing was recorded, and must not be swallowed.
+#   * The gap between the halves stops at any clause break — ``. , ; :`` — or at
+#     the ``|`` stream delimiter, and spans at most 40 characters. That is what
+#     stops the two halves being stitched together out of DIFFERENT streams or
+#     different clauses ("No ComfyUI process could be stopped; it is still
+#     running in the background" is a failed stop, the exact opposite case).
+#     Newlines are deliberately still allowed inside the gap: comfy-cli renders
+#     through Rich, which may soft-wrap the sentence, and a wrap is not a clause
+#     break.
 _NO_RECORDED_SERVER_TEXT_RE = re.compile(
-    r"\bno\s+comfyui\b[^.\n]*?\brunning\s+in\s+the\s+background\b",
+    r"(?:\A|[\n|:]|\.\.\.)\s*no\s+comfyui\b"
+    r"[^.,;:|]{0,40}?\brunning\s+in\s+the\s+background\b",
     re.IGNORECASE,
 )
 
@@ -740,20 +761,34 @@ def _is_no_recorded_server(exc: ComfyCliError) -> bool:
     bare non-zero exit that emits no envelope (see
     :data:`_NO_RECORDED_SERVER_TEXT_RE`).
 
-    The text fallback is deliberately NOT gated on ``exc.no_envelope``, and it
-    searches the whole rendered message rather than a single stream: the phrase
+    The text fallback searches the whole rendered message rather than a single
+    stream, and is deliberately NOT gated on ``exc.no_envelope``: the phrase
     itself is the signal, and which reporting path comfy-cli happens to use for
     it is exactly the detail that should not matter here. It genuinely varies —
     comfy-cli prints this one through Rich, i.e. on STDOUT, while the wrapper's
-    no-envelope message renders stdout and stderr side by side.
+    no-envelope message renders stdout and stderr side by side, and an envelope
+    that carries the sentence but omits ``error.code`` is the same benign case.
+
+    It IS gated on the two signals that outrank the prose, because reading text
+    over them would let a real failure be swallowed:
+
+    * ``exc.code`` set to something else. comfy-cli told us structurally what
+      went wrong; a stray sentence in the message does not overrule it (the
+      ``code == _NO_RECORDED_SERVER_CODE`` branch above already took the benign
+      case).
+    * ``exc.timed_out``. We killed the stop at our own deadline, so whatever it
+      printed before dying says nothing about whether a server is recorded — and
+      a stop that never finished is precisely the case ``restart_comfyui`` must
+      not relaunch over.
     """
     if exc.code == _NO_RECORDED_SERVER_CODE:
         return True
     message = str(exc)
-    return (
-        _NO_RECORDED_SERVER_CODE in message
-        or _NO_RECORDED_SERVER_TEXT_RE.search(message) is not None
-    )
+    if _NO_RECORDED_SERVER_CODE in message:
+        return True
+    if exc.code is not None or exc.timed_out:
+        return False
+    return _NO_RECORDED_SERVER_TEXT_RE.search(message) is not None
 
 
 def _strip_brackets(host: str) -> str:
@@ -3761,30 +3796,78 @@ def stop_comfyui() -> Any:
     return _run_comfy("stop", timeout=60.0, plain_ok=True)
 
 
-# A launch that lost the port race. Matched loosely (the substring, not a fixed
-# sentence) because comfy-cli and ComfyUI phrase it differently — "The 8188 port
-# is already in use." from comfy-cli's own preflight, "Address already in use"
-# from the socket bind underneath. Over-matching is cheap here and cannot mask a
-# failure: this only decides whether ``restart_comfyui`` APPENDS an explanation
-# to an error it is re-raising either way.
-_PORT_IN_USE_TEXT_RE = re.compile(r"\balready\s+in\s+use\b", re.IGNORECASE)
-
-# Appended when a restart's stop found nothing recorded AND the relaunch then
-# lost the port: together those two facts identify a server that is running but
-# was not started by comfy-cli, which the bare "port already in use" text does
-# not explain on its own. comfy-cli will not kill a process it did not start
-# (``stop_comfyui``'s ownership semantics), so the way out is the user's own
-# shell or a different port — this server exposes no stop-by-port/pid tool.
-_UNTRACKED_SERVER_GUIDANCE = (
-    "Something is already serving this port, but comfy-cli has no record of "
-    "launching it — so there was nothing for the restart to stop, and the fresh "
-    "launch then hit the occupied port. That server was almost certainly started "
-    "outside comfy-cli (a foreground `comfy launch`, the ComfyUI desktop app, or "
-    "`python main.py`), and comfy-cli only ever stops a server it started itself. "
-    "Either stop it the way you started it and retry, or bring one up alongside it "
-    'on a free port: restart_comfyui(extra_args=["--port", "8189"]). '
-    "`server_info` shows what is answering right now."
+# A launch that lost the port race. Matched on the phrasing rather than a fixed
+# sentence because comfy-cli and ComfyUI word it differently — "The 8188 port is
+# already in use." from comfy-cli's own preflight, "[Errno 48] Address already in
+# use" from the socket bind underneath — but it still requires the *subject* to
+# be a port or an address. A bare "already in use" also describes a locked model
+# file or a busy GPU, and the guidance below would then assert something false
+# ("Something is already serving this port") about a launch failure that has
+# nothing to do with the port. Failing to match only costs the explanation: the
+# original error is re-raised verbatim either way.
+_PORT_IN_USE_TEXT_RE = re.compile(
+    r"\b(?:port|address)\b[^.\n]{0,60}?\balready\s+in\s+use\b",
+    re.IGNORECASE,
 )
+
+# The alternate port the guidance below offers, and the fallback for the one case
+# where it would be useless advice: the caller already asked for it and that is
+# the launch that just lost the race.
+_ALT_PORT_SUGGESTION = 8189
+_ALT_PORT_FALLBACK = 8190
+
+
+def _requested_port(extra_args: list[str] | None) -> int | None:
+    """The ``--port`` the caller asked ``launch``/``restart`` to forward, if any.
+
+    Best-effort and read-only — it exists so the guidance below does not suggest
+    the very port that just failed. comfy-cli's own parser owns the real
+    interpretation of ``extra_args``; anything unparseable here simply yields
+    ``None`` and the default suggestion, never an error on top of an error.
+    """
+    if not extra_args:
+        return None
+    port: int | None = None
+    for index, arg in enumerate(extra_args):
+        if not isinstance(arg, str):
+            continue
+        if arg == "--port" and index + 1 < len(extra_args):
+            raw = extra_args[index + 1]
+        elif arg.startswith("--port="):
+            raw = arg[len("--port=") :]
+        else:
+            continue
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if 1 <= value <= 65535:
+            port = value  # last --port wins, as an argument parser would read it
+    return port
+
+
+def _untracked_server_guidance(extra_args: list[str] | None = None) -> str:
+    """Explain a port clash that followed a stop with nothing recorded to stop.
+
+    Together those two facts identify a server that is running but was not
+    started by comfy-cli, which the bare "port already in use" text does not
+    explain on its own. comfy-cli will not kill a process it did not start
+    (``stop_comfyui``'s ownership semantics), so the way out is the user's own
+    shell or a different port — this server exposes no stop-by-port/pid tool.
+    """
+    suggested = _ALT_PORT_SUGGESTION
+    if _requested_port(extra_args) == suggested:
+        suggested = _ALT_PORT_FALLBACK
+    return (
+        "Something is already serving this port, but comfy-cli has no record of "
+        "launching it — so there was nothing for the restart to stop, and the fresh "
+        "launch then hit the occupied port. That server was almost certainly started "
+        "outside comfy-cli (a foreground `comfy launch`, the ComfyUI desktop app, or "
+        "`python main.py`), and comfy-cli only ever stops a server it started itself. "
+        "Either stop it the way you started it and retry, or bring one up alongside it "
+        f'on some free port, e.g. restart_comfyui(extra_args=["--port", "{suggested}"]). '
+        "`server_info` shows what is answering right now."
+    )
 
 
 @mcp.tool()
@@ -3828,7 +3911,7 @@ def restart_comfyui(extra_args: list[str] | None = None) -> Any:
         if not nothing_to_stop or not _PORT_IN_USE_TEXT_RE.search(str(exc)):
             raise
         raise ComfyCliError(
-            f"{exc}\n\n{_UNTRACKED_SERVER_GUIDANCE}",
+            f"{exc}\n\n{_untracked_server_guidance(extra_args)}",
             code=exc.code,
             no_envelope=exc.no_envelope,
             returncode=exc.returncode,

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -705,6 +705,14 @@ def _check_comfy_version() -> None:
 # stop failure ``restart_comfyui`` treats as benign (see its docstring).
 _NO_RECORDED_SERVER_CODE = "no_recorded_server"
 
+# The same marker as it appears rendered INSIDE a message (e.g. "comfy stop
+# failed [no_recorded_server]: none"), for the failures that carry it as text
+# without a structured ``code``. Word-bounded rather than a bare substring test
+# so a longer, unrelated code that merely starts with it — ``no_recorded_server_pid``
+# — is not read as this one. (``_`` is a word character, so ``\b`` does not fire
+# between "server" and "_pid".)
+_NO_RECORDED_SERVER_CODE_RE = re.compile(rf"\b{re.escape(_NO_RECORDED_SERVER_CODE)}\b")
+
 # The SAME condition as comfy-cli actually prints it in the common case: `comfy
 # stop` with no recorded background server prints "No ComfyUI is running in the
 # background." and exits 1 WITHOUT an envelope (comfy-cli 1.12.0 `cmdline.stop`),
@@ -737,17 +745,25 @@ _NO_RECORDED_SERVER_CODE = "no_recorded_server"
 #     this sentence on its own; a hint buried mid-sentence in some other failure
 #     ("…, and ensure no ComfyUI is running in the background") is advice, not a
 #     report that nothing was recorded, and must not be swallowed.
-#   * The gap between the halves stops at any clause break — ``. , ; :`` — or at
-#     the ``|`` stream delimiter, and spans at most 40 characters. That is what
-#     stops the two halves being stitched together out of DIFFERENT streams or
-#     different clauses ("No ComfyUI process could be stopped; it is still
-#     running in the background" is a failed stop, the exact opposite case).
-#     Newlines are deliberately still allowed inside the gap: comfy-cli renders
-#     through Rich, which may soft-wrap the sentence, and a wrap is not a clause
-#     break.
+#   * The two halves must be joined by the GRAMMAR of the sentence, not merely
+#     sit near each other: at most two inserted words and an optional copula
+#     ("No ComfyUI *server is* running…", "No ComfyUI running…"). Because that
+#     gap is built from ``\s`` and ``\w`` only, it cannot cross ANY punctuation —
+#     so the halves can never be stitched out of two different streams
+#     (``… | stdout: …``), two different clauses ("No ComfyUI process could be
+#     stopped; it is still running in the background"), or across a conjunction
+#     or dash ("No ComfyUI process was stopped and remains running in the
+#     background"). Every one of those reports a stop that FAILED — the exact
+#     opposite case — and none of them survives this shape.
+#
+#     A character-class gap was tried first and is what this replaces: excluding
+#     punctuation one mark at a time is whack-a-mole, whereas admitting only
+#     word characters is closed by construction. Newlines still pass (``\s``
+#     covers them), so a Rich soft-wrap inside the sentence still matches — a
+#     wrap is not a clause break.
 _NO_RECORDED_SERVER_TEXT_RE = re.compile(
     r"(?:\A|[\n|:]|\.\.\.)\s*no\s+comfyui\b"
-    r"[^.,;:|]{0,40}?\brunning\s+in\s+the\s+background\b",
+    r"(?:\s+\w+){0,2}(?:\s+(?:is|was))?\s+running\s+in\s+the\s+background\b",
     re.IGNORECASE,
 )
 
@@ -769,26 +785,31 @@ def _is_no_recorded_server(exc: ComfyCliError) -> bool:
     no-envelope message renders stdout and stderr side by side, and an envelope
     that carries the sentence but omits ``error.code`` is the same benign case.
 
-    It IS gated on the two signals that outrank the prose, because reading text
-    over them would let a real failure be swallowed:
+    BOTH text reads — the marker and the phrase — are gated on the two signals
+    that outrank anything in the message, because reading text over them would
+    let a real failure be swallowed:
 
     * ``exc.code`` set to something else. comfy-cli told us structurally what
-      went wrong; a stray sentence in the message does not overrule it (the
+      went wrong; text in the message does not overrule it (the
       ``code == _NO_RECORDED_SERVER_CODE`` branch above already took the benign
       case).
     * ``exc.timed_out``. We killed the stop at our own deadline, so whatever it
       printed before dying says nothing about whether a server is recorded — and
       a stop that never finished is precisely the case ``restart_comfyui`` must
       not relaunch over.
+
+    The gate therefore sits ABOVE both reads rather than between them: a
+    timed-out stop whose output happens to quote the marker is still a timeout.
     """
     if exc.code == _NO_RECORDED_SERVER_CODE:
         return True
-    message = str(exc)
-    if _NO_RECORDED_SERVER_CODE in message:
-        return True
     if exc.code is not None or exc.timed_out:
         return False
-    return _NO_RECORDED_SERVER_TEXT_RE.search(message) is not None
+    message = str(exc)
+    return (
+        _NO_RECORDED_SERVER_CODE_RE.search(message) is not None
+        or _NO_RECORDED_SERVER_TEXT_RE.search(message) is not None
+    )
 
 
 def _strip_brackets(host: str) -> str:
@@ -3805,8 +3826,15 @@ def stop_comfyui() -> Any:
 # ("Something is already serving this port") about a launch failure that has
 # nothing to do with the port. Failing to match only costs the explanation: the
 # original error is re-raised verbatim either way.
+#
+# The subject and the complaint must be joined grammatically, by the same
+# word-characters-only gap :data:`_NO_RECORDED_SERVER_TEXT_RE` uses and for the
+# same reason: it cannot cross punctuation, so a `port` mentioned in one rendered
+# stream (or in a `--port` echoed back from the command) can never be stitched to
+# an `already in use` belonging to some other failure in another — `stderr: ...
+# --port 8188 ... | stdout: CUDA device 0 is already in use` no longer matches.
 _PORT_IN_USE_TEXT_RE = re.compile(
-    r"\b(?:port|address)\b[^.\n]{0,60}?\balready\s+in\s+use\b",
+    r"\b(?:port|address)\b(?:\s+\w+){0,3}\s+already\s+in\s+use\b",
     re.IGNORECASE,
 )
 
@@ -3837,13 +3865,48 @@ def _requested_port(extra_args: list[str] | None) -> int | None:
             raw = arg[len("--port=") :]
         else:
             continue
+        # The LAST --port is the one an argument parser would act on, so it
+        # supersedes an earlier one whether or not it parses: a trailing
+        # `--port bad` means we do not know the requested port, not that the
+        # previous value is still in effect.
         try:
             value = int(raw)
         except (TypeError, ValueError):
+            port = None
             continue
-        if 1 <= value <= 65535:
-            port = value  # last --port wins, as an argument parser would read it
+        port = value if 1 <= value <= 65535 else None
     return port
+
+
+# Past this many characters the rendered relaunch stops being copy-pasteable
+# guidance and starts being noise inside an error message, so a long
+# ``extra_args`` falls back to the bare ``--port`` form.
+_MAX_SUGGESTED_ARGS_LEN = 120
+
+
+def _suggested_relaunch_args(extra_args: list[str] | None, port: int) -> list[str]:
+    """``extra_args`` with any ``--port`` replaced by ``port``.
+
+    Keeping the caller's OTHER flags matters because the guidance is meant to be
+    pasted: a user who failed with ``["--cpu", "--port", "8188"]`` and copies a
+    suggestion that dropped ``--cpu`` relaunches with different behavior than
+    they asked for.
+    """
+    kept: list[str] = []
+    skip_next = False
+    for arg in extra_args or []:
+        if skip_next:
+            skip_next = False
+            continue
+        if not isinstance(arg, str):
+            continue
+        if arg == "--port":
+            skip_next = True  # drop its value too
+            continue
+        if arg.startswith("--port="):
+            continue
+        kept.append(arg)
+    return [*kept, "--port", str(port)]
 
 
 def _untracked_server_guidance(extra_args: list[str] | None = None) -> str:
@@ -3858,6 +3921,9 @@ def _untracked_server_guidance(extra_args: list[str] | None = None) -> str:
     suggested = _ALT_PORT_SUGGESTION
     if _requested_port(extra_args) == suggested:
         suggested = _ALT_PORT_FALLBACK
+    rendered = json.dumps(_suggested_relaunch_args(extra_args, suggested))
+    if len(rendered) > _MAX_SUGGESTED_ARGS_LEN:
+        rendered = json.dumps(["--port", str(suggested)])
     return (
         "Something is already serving this port, but comfy-cli has no record of "
         "launching it — so there was nothing for the restart to stop, and the fresh "
@@ -3865,7 +3931,7 @@ def _untracked_server_guidance(extra_args: list[str] | None = None) -> str:
         "outside comfy-cli (a foreground `comfy launch`, the ComfyUI desktop app, or "
         "`python main.py`), and comfy-cli only ever stops a server it started itself. "
         "Either stop it the way you started it and retry, or bring one up alongside it "
-        f'on some free port, e.g. restart_comfyui(extra_args=["--port", "{suggested}"]). '
+        f"on some free port, e.g. restart_comfyui(extra_args={rendered}). "
         "`server_info` shows what is answering right now."
     )
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -2645,6 +2645,14 @@ def test_is_no_recorded_server_matches_wording_drift(message):
         # that nothing was recorded: it does not open a message, line, or field.
         "comfy stop failed: cannot kill pid 7 (operation not permitted); "
         "check permissions and ensure no ComfyUI is running in the background",
+        # Opposite-meaning reports joined WITHOUT punctuation — a conjunction or
+        # a dash. The halves must be joined by the sentence's grammar, not just
+        # sit near each other.
+        "No ComfyUI process was stopped and remains running in the background",
+        "No ComfyUI process could be stopped — it is still running in the background",
+        "No ComfyUI was stopped so something else is running in the background",
+        # A longer, unrelated structured code that merely starts with the marker.
+        "comfy stop failed [no_recorded_server_pid]: none",
     ],
 )
 def test_is_no_recorded_server_rejects_other_failures(message):
@@ -2669,6 +2677,29 @@ def test_is_no_recorded_server_rejects_a_stop_we_timed_out():
         timed_out=True,
     )
 
+    assert not server._is_no_recorded_server(exc)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        # The gate has to sit above BOTH text reads, not between them: a message
+        # quoting the literal marker must not slip past a timeout or a different
+        # structured code.
+        server.ComfyCliError(
+            "comfy stop timed out after 60s. stdout: comfy stop failed "
+            "[no_recorded_server]: none",
+            timed_out=True,
+        ),
+        server.ComfyCliError(
+            "comfy stop failed [permission_denied]: cannot kill pid 7 "
+            "(previous run reported no_recorded_server)",
+            code="permission_denied",
+        ),
+    ],
+)
+def test_is_no_recorded_server_gate_outranks_the_literal_marker_too(exc):
+    """A quoted marker does not make a timeout or a coded failure benign."""
     assert not server._is_no_recorded_server(exc)
 
 
@@ -2806,6 +2837,12 @@ def test_port_in_use_matches_the_real_phrasings(message):
         "Cannot load model: the file is already in use by another process",
         "CUDA device 0 is already in use",
         "The output directory is already in use",
+        # A `--port` echoed back from the command in one stream must not be
+        # stitched to an unrelated "already in use" in the other.
+        "comfy-cli returned no JSON (exit 1). stderr: launch --background -- "
+        "--port 8188 | stdout: CUDA device 0 is already in use",
+        "comfy-cli returned no JSON (exit 1). stderr: could not bind port | "
+        "stdout: the model file is already in use",
     ],
 )
 def test_port_in_use_ignores_non_port_conflicts(message):
@@ -2849,11 +2886,48 @@ def test_restart_comfyui_leaves_a_non_port_resource_clash_alone(monkeypatch):
         (["--port", "0"], None),  # out of range
         (["--port", "70000"], None),
         (["--portable"], None),  # a different flag that merely shares the prefix
+        # A trailing unparseable --port supersedes an earlier good one: it means
+        # we do not know the requested port, not that 8189 still stands.
+        (["--port", "8189", "--port", "bad"], None),
+        (["--port", "8189", "--port", "99999"], None),
     ],
 )
 def test_requested_port_reads_the_forwarded_port(extra_args, expected):
     """Best-effort read of the caller's `--port`; anything odd yields None."""
     assert server._requested_port(extra_args) == expected
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected"),
+    [
+        (None, ["--port", "8189"]),
+        ([], ["--port", "8189"]),
+        (["--cpu"], ["--cpu", "--port", "8189"]),  # other flags survive
+        (["--cpu", "--port", "8188"], ["--cpu", "--port", "8189"]),
+        (["--port=8188", "--lowvram"], ["--lowvram", "--port", "8189"]),
+        (["--port"], ["--port", "8189"]),  # dangling flag dropped, not doubled
+    ],
+)
+def test_suggested_relaunch_args_swaps_the_port_and_keeps_the_rest(
+    extra_args, expected
+):
+    """The pasteable suggestion must not silently drop the caller's own flags."""
+    assert server._suggested_relaunch_args(extra_args, 8189) == expected
+
+
+def test_untracked_server_guidance_keeps_the_callers_other_flags():
+    """A user pasting the suggestion should not lose `--cpu` along the way."""
+    guidance = server._untracked_server_guidance(["--cpu", "--port", "8188"])
+
+    assert 'extra_args=["--cpu", "--port", "8189"]' in guidance
+
+
+def test_untracked_server_guidance_falls_back_when_the_args_are_long():
+    """Past the cap the suggestion degrades to the bare port rather than noise."""
+    guidance = server._untracked_server_guidance(["--some-very-long-flag"] * 12)
+
+    assert 'extra_args=["--port", "8189"]' in guidance
+    assert "--some-very-long-flag" not in guidance
 
 
 def test_untracked_server_guidance_avoids_suggesting_the_port_that_just_failed():

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -2602,6 +2602,13 @@ def test_stop_comfyui_plain_no_comfyui_running_carries_no_structured_code(
         "no comfyui is running in the background",  # casing drift
         "No ComfyUI server is running in the background.",  # inserted word
         "No ComfyUI running in the background",  # dropped copula
+        # Rich soft-wrapping the sentence at a narrow width: a line break inside
+        # the phrase is a wrap, not a clause break.
+        "No ComfyUI is running in the\nbackground.",
+        # A clipped capture: `textutil._stream_tail` prefixes `...`, which can
+        # land directly against the sentence. That marker opens a field.
+        "comfy-cli returned no JSON (exit 1). stderr: <empty> | stdout: ...No "
+        "ComfyUI is running in the background.",
         "comfy stop failed [no_recorded_server]: none",  # the pre-existing marker
     ],
 )
@@ -2624,11 +2631,76 @@ def test_is_no_recorded_server_matches_wording_drift(message):
         "call last): RuntimeError | stdout: <empty>",
         # Two unrelated sentences: the match must not span the sentence break.
         "No ComfyUI workspace is configured. Something is running in the background.",
+        # A failed stop whose clauses are separated by a semicolon, not a period:
+        # this one says the server IS still running, the opposite of benign.
+        "No ComfyUI process could be stopped; it is still running in the background.",
+        # The two halves living in DIFFERENT streams of the wrapper's rendering —
+        # the match must not stitch across the ` | ` delimiter.
+        "comfy-cli returned no JSON (exit 1). stderr: No ComfyUI workspace "
+        "configured | stdout: a server is running in the background",
+        # ...nor across a field label on its own line.
+        "comfy stop failed\nstderr: No ComfyUI workspace configured\n"
+        "stdout: a server is running in the background",
+        # The phrase as ADVICE inside another failure's hint, not as a report
+        # that nothing was recorded: it does not open a message, line, or field.
+        "comfy stop failed: cannot kill pid 7 (operation not permitted); "
+        "check permissions and ensure no ComfyUI is running in the background",
     ],
 )
 def test_is_no_recorded_server_rejects_other_failures(message):
     """Every OTHER stop failure stays outside the benign net."""
     assert not server._is_no_recorded_server(server.ComfyCliError(message))
+
+
+def test_is_no_recorded_server_lets_a_structured_code_outrank_the_text():
+    """comfy-cli said structurally what broke; stray prose does not overrule it."""
+    exc = server.ComfyCliError(
+        "No ComfyUI is running in the background.", code="permission_denied"
+    )
+
+    assert not server._is_no_recorded_server(exc)
+
+
+def test_is_no_recorded_server_rejects_a_stop_we_timed_out():
+    """A stop killed at OUR deadline never finished, so it reported nothing."""
+    exc = server.ComfyCliError(
+        "comfy stop timed out after 60s. stdout: No ComfyUI is running in the "
+        "background.",
+        timed_out=True,
+    )
+
+    assert not server._is_no_recorded_server(exc)
+
+
+def test_is_no_recorded_server_accepts_an_envelope_without_a_code():
+    """An envelope carrying the sentence but no `error.code` is the same case."""
+    exc = server.ComfyCliError(
+        "comfy stop failed: No ComfyUI is running in the background."
+    )
+
+    assert exc.no_envelope is False  # not gated on provenance, only on code
+    assert server._is_no_recorded_server(exc)
+
+
+def test_restart_comfyui_reraises_a_timed_out_stop_that_printed_the_phrase(monkeypatch):
+    """The gate is load-bearing: a timed-out stop must not be relaunched over."""
+
+    def fake_stop():
+        raise server.ComfyCliError(
+            "comfy stop timed out after 60s. stdout: No ComfyUI is running in "
+            "the background.",
+            timed_out=True,
+        )
+
+    launched: list = []
+    monkeypatch.setattr(server, "stop_comfyui", fake_stop)
+    monkeypatch.setattr(
+        server, "launch_comfyui", lambda extra_args=None: launched.append(extra_args)
+    )
+
+    with pytest.raises(server.ComfyCliError, match="timed out"):
+        server.restart_comfyui()
+    assert launched == []
 
 
 def test_restart_comfyui_reraises_unrelated_plain_stop_failure(
@@ -2709,6 +2781,111 @@ def test_restart_comfyui_leaves_non_port_launch_failure_alone(monkeypatch):
         server.restart_comfyui()
 
     assert str(excinfo.value) == "ComfyUI exited during startup: missing torch"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "The 8188 port is already in use.",  # comfy-cli's own preflight
+        "OSError: [Errno 48] Address already in use",  # the socket bind under it
+        "error while attempting to bind on address ('0.0.0.0', 8188): "
+        "address already in use",
+        "Port 8188 is already in use",
+    ],
+)
+def test_port_in_use_matches_the_real_phrasings(message):
+    """Both layers word the port clash differently; both must be recognized."""
+    assert server._PORT_IN_USE_TEXT_RE.search(message)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        # "already in use" with a subject that is NOT a port: appending the port
+        # guidance here would assert something plainly false about the failure.
+        "Cannot load model: the file is already in use by another process",
+        "CUDA device 0 is already in use",
+        "The output directory is already in use",
+    ],
+)
+def test_port_in_use_ignores_non_port_conflicts(message):
+    """A busy file or GPU is not a port clash, so it gets no port guidance."""
+    assert not server._PORT_IN_USE_TEXT_RE.search(message)
+
+
+def test_restart_comfyui_leaves_a_non_port_resource_clash_alone(monkeypatch):
+    """End to end: a busy model file after nothing-to-stop keeps its own message."""
+    monkeypatch.setattr(
+        server,
+        "stop_comfyui",
+        lambda: (_ for _ in ()).throw(
+            server.ComfyCliError("No ComfyUI is running in the background.")
+        ),
+    )
+
+    def fake_launch(extra_args=None):  # noqa: ARG001
+        raise server.ComfyCliError("Cannot load model: the file is already in use")
+
+    monkeypatch.setattr(server, "launch_comfyui", fake_launch)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.restart_comfyui()
+
+    assert str(excinfo.value) == "Cannot load model: the file is already in use"
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected"),
+    [
+        (None, None),
+        ([], None),
+        (["--cpu"], None),
+        (["--port", "8189"], 8189),
+        (["--port=8189"], 8189),
+        (["--cpu", "--port", "8300", "--lowvram"], 8300),
+        (["--port", "8189", "--port", "8300"], 8300),  # last one wins
+        (["--port"], None),  # dangling flag, no value
+        (["--port", "not-a-number"], None),
+        (["--port", "0"], None),  # out of range
+        (["--port", "70000"], None),
+        (["--portable"], None),  # a different flag that merely shares the prefix
+    ],
+)
+def test_requested_port_reads_the_forwarded_port(extra_args, expected):
+    """Best-effort read of the caller's `--port`; anything odd yields None."""
+    assert server._requested_port(extra_args) == expected
+
+
+def test_untracked_server_guidance_avoids_suggesting_the_port_that_just_failed():
+    """Suggesting the exact launch that just lost the race is useless advice."""
+    default = server._untracked_server_guidance(["--cpu"])
+    assert f'"--port", "{server._ALT_PORT_SUGGESTION}"' in default
+
+    collided = server._untracked_server_guidance(
+        ["--port", str(server._ALT_PORT_SUGGESTION)]
+    )
+    assert f'"--port", "{server._ALT_PORT_SUGGESTION}"' not in collided
+    assert f'"--port", "{server._ALT_PORT_FALLBACK}"' in collided
+
+
+def test_restart_comfyui_port_guidance_reflects_the_requested_port(monkeypatch):
+    """The suggestion the caller actually sees is derived from their own args."""
+
+    def fake_stop():
+        raise server.ComfyCliError("No ComfyUI is running in the background.")
+
+    def fake_launch(extra_args=None):  # noqa: ARG001
+        raise server.ComfyCliError("The 8189 port is already in use.")
+
+    monkeypatch.setattr(server, "stop_comfyui", fake_stop)
+    monkeypatch.setattr(server, "launch_comfyui", fake_launch)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.restart_comfyui(["--port", str(server._ALT_PORT_SUGGESTION)])
+
+    message = str(excinfo.value)
+    assert "The 8189 port is already in use." in message  # original kept verbatim
+    assert f'"--port", "{server._ALT_PORT_FALLBACK}"' in message
 
 
 def test_error_envelope_populates_structured_code(patched_run):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -2542,6 +2542,175 @@ def test_restart_comfyui_reraises_genuine_stop_failure(monkeypatch):
     assert launched == []  # genuine failure is not masked by a relaunch
 
 
+@pytest.mark.parametrize("stream", ["stdout", "stderr"])
+def test_restart_comfyui_tolerates_plain_no_comfyui_running_text(
+    patched_plain_run, monkeypatch, stream
+):
+    """The REAL shape of "nothing to stop": non-zero exit, no envelope, human text.
+
+    comfy-cli (1.12.0 `cmdline.stop`) does not emit a `no_recorded_server`
+    envelope when it has no background server recorded — it prints "No ComfyUI is
+    running in the background." and exits 1, which carries neither a structured
+    code nor the literal marker string. That is the common real-world case (a
+    foreground `comfy launch`, the desktop app, `python main.py`, or nothing
+    running), and it used to abort the restart before it ever reached the launch
+    step.
+
+    Parametrized over the stream because comfy-cli prints this one through Rich
+    (stdout) while the QA report captured it on stderr — the match must not care
+    which, so neither does this test.
+    """
+    calls = patched_plain_run(1, **{stream: "No ComfyUI is running in the background."})
+    launched: list = []
+
+    def fake_launch(extra_args=None):
+        launched.append(extra_args)
+        return {"pid": 3}
+
+    monkeypatch.setattr(server, "launch_comfyui", fake_launch)
+
+    assert server.restart_comfyui(["--cpu"]) == {"pid": 3}
+
+    assert calls[0]["cmd"][4:] == ["stop"]  # the stop really was attempted
+    assert launched == [["--cpu"]]  # and the relaunch still happened
+
+
+def test_stop_comfyui_plain_no_comfyui_running_carries_no_structured_code(
+    patched_plain_run,
+):
+    """Pin the gap this fix closes: that failure has no code and no envelope."""
+    patched_plain_run(1, stdout="No ComfyUI is running in the background.")
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.stop_comfyui()
+
+    assert excinfo.value.code is None  # nothing structured to branch on
+    assert excinfo.value.no_envelope is True
+    assert server._NO_RECORDED_SERVER_CODE not in str(excinfo.value)
+    assert server._is_no_recorded_server(excinfo.value)  # matched on the text
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        # comfy-cli 1.12.0, as the wrapper renders it — on either stream.
+        "comfy-cli returned no JSON (exit 1). stderr: <empty> | stdout: No "
+        "ComfyUI is running in the background.",
+        "comfy-cli returned no JSON (exit 1). stderr: No ComfyUI is running in "
+        "the background. | stdout: <empty>",
+        "No ComfyUI is running in the background.",
+        "no comfyui is running in the background",  # casing drift
+        "No ComfyUI server is running in the background.",  # inserted word
+        "No ComfyUI running in the background",  # dropped copula
+        "comfy stop failed [no_recorded_server]: none",  # the pre-existing marker
+    ],
+)
+def test_is_no_recorded_server_matches_wording_drift(message):
+    """The benign case is matched on the stable phrase, not one exact sentence."""
+    assert server._is_no_recorded_server(server.ComfyCliError(message))
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "comfy stop failed [permission_denied]: cannot kill pid 7",
+        # comfy-cli's OTHER stop message, verbatim: it DID have a server
+        # recorded and could not kill it. Nothing benign about that one.
+        "comfy-cli returned no JSON (exit 1). stderr: <empty> | stdout: Failed "
+        "to stop ComfyUI in the background.",
+        "comfy-cli returned no JSON (exit 1). stderr: Failed to stop ComfyUI "
+        "running in the background: operation not permitted | stdout: <empty>",
+        "comfy-cli returned no JSON (exit 2). stderr: Traceback (most recent "
+        "call last): RuntimeError | stdout: <empty>",
+        # Two unrelated sentences: the match must not span the sentence break.
+        "No ComfyUI workspace is configured. Something is running in the background.",
+    ],
+)
+def test_is_no_recorded_server_rejects_other_failures(message):
+    """Every OTHER stop failure stays outside the benign net."""
+    assert not server._is_no_recorded_server(server.ComfyCliError(message))
+
+
+def test_restart_comfyui_reraises_unrelated_plain_stop_failure(
+    patched_plain_run, monkeypatch
+):
+    """A plain non-zero stop whose text ISN'T the benign phrase still aborts."""
+    patched_plain_run(1, stderr="Failed to kill pid 7: operation not permitted")
+    launched: list = []
+    monkeypatch.setattr(
+        server, "launch_comfyui", lambda extra_args=None: launched.append(extra_args)
+    )
+
+    with pytest.raises(server.ComfyCliError, match="operation not permitted"):
+        server.restart_comfyui()
+    assert launched == []
+
+
+def test_restart_comfyui_explains_port_clash_after_nothing_to_stop(monkeypatch):
+    """Nothing to stop + port taken = a running server comfy-cli never launched."""
+
+    def fake_stop():
+        raise server.ComfyCliError("No ComfyUI is running in the background.")
+
+    def fake_launch(extra_args=None):  # noqa: ARG001
+        raise server.ComfyCliError(
+            "comfy-cli returned no JSON (exit 1). stderr: The 8188 port is "
+            "already in use. | stdout: <empty>",
+            no_envelope=True,
+            returncode=1,
+        )
+
+    monkeypatch.setattr(server, "stop_comfyui", fake_stop)
+    monkeypatch.setattr(server, "launch_comfyui", fake_launch)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.restart_comfyui()
+
+    message = str(excinfo.value)
+    assert "The 8188 port is already in use." in message  # original kept verbatim
+    assert "comfy-cli has no record of launching it" in message
+    assert "restart_comfyui" in message  # the different-port way out
+    # Provenance of the underlying failure survives the re-wrap.
+    assert excinfo.value.no_envelope is True
+    assert excinfo.value.returncode == 1
+
+
+def test_restart_comfyui_leaves_port_clash_alone_after_a_real_stop(monkeypatch):
+    """A port clash after a stop that DID kill comfy-cli's server is a different bug."""
+    monkeypatch.setattr(server, "stop_comfyui", lambda: {"ok": True})
+
+    def fake_launch(extra_args=None):  # noqa: ARG001
+        raise server.ComfyCliError("The 8188 port is already in use.")
+
+    monkeypatch.setattr(server, "launch_comfyui", fake_launch)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.restart_comfyui()
+
+    assert str(excinfo.value) == "The 8188 port is already in use."
+
+
+def test_restart_comfyui_leaves_non_port_launch_failure_alone(monkeypatch):
+    """A launch failure that isn't a port clash keeps its own message."""
+    monkeypatch.setattr(
+        server,
+        "stop_comfyui",
+        lambda: (_ for _ in ()).throw(
+            server.ComfyCliError("No ComfyUI is running in the background.")
+        ),
+    )
+
+    def fake_launch(extra_args=None):  # noqa: ARG001
+        raise server.ComfyCliError("ComfyUI exited during startup: missing torch")
+
+    monkeypatch.setattr(server, "launch_comfyui", fake_launch)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.restart_comfyui()
+
+    assert str(excinfo.value) == "ComfyUI exited during startup: missing torch"
+
+
 def test_error_envelope_populates_structured_code(patched_run):
     """ComfyCliError from an error envelope carries the code as an attribute, not just text."""
     patched_run(


### PR DESCRIPTION
## ELI-5

`restart_comfyui` is "stop the server, then start a fresh one". The stop step is allowed to fail in exactly one harmless way: comfy-cli has nothing recorded to stop. We were looking for the wrong words. comfy-cli says `No ComfyUI is running in the background.` and exits 1; we were only checking for a machine-readable `no_recorded_server` code that it never sends in that case. So restart gave up before it ever got to the "start a fresh one" half — which is precisely the case people hit most: recycling a ComfyUI they started themselves, or restarting when nothing is running. Now we recognize what comfy-cli actually says, and restart proceeds.

## Summary

Fixes `restart_comfyui` being unable to recycle any ComfyUI server that comfy-cli did not background-launch itself (a foreground `comfy launch`, the desktop app, a manual `python main.py`) — or to start one when nothing is running at all.

## Changes

- `_is_no_recorded_server` now also matches comfy-cli's human "nothing recorded to stop" text, not just the structured `no_recorded_server` envelope code. Both existing conditions are unchanged; this is purely additive.
- The match is a case-insensitive regex on the stable part of the phrase — `\bno\s+comfyui\b[^.\n]*?\brunning\s+in\s+the\s+background\b` — not an exact-string compare, so upstream wording drift ("No ComfyUI **server** is running in the background", casing, punctuation) does not silently reopen the same gap. It searches the whole rendered error message rather than one stream, because comfy-cli prints this through Rich (stdout) while the QA report captured it on stderr.
- `restart_comfyui` now annotates one specific combined failure: a stop that found nothing recorded, followed by a launch that lost the port. Together those two facts mean "a server is running that comfy-cli did not start and therefore cannot stop", which the bare `The 8188 port is already in use.` text does not convey. The error still raises; only its message grows, and it points at the two paths that do work.
- Nine new tests in `tests/test_wrapper.py` using the shared `patched_plain_run` fixture, plus parametrized positive (drift) and negative (other failures) cases for the matcher.

## Motivation

From a QA report: with ComfyUI started outside comfy-cli's background tracking (so `config.background` is unset), `restart_comfyui()` returned `comfy-cli returned no JSON (exit 1). stderr: No ComfyUI is running in the background.` and never attempted a relaunch. `restart_comfyui`'s docstring has always promised to swallow the "nothing to stop" case — this makes the implementation match that published contract rather than adding new behavior.

Verified against comfy-cli's own source (`comfy_cli/cmdline.py`, `stop`): when `CONFIG_KEY_BACKGROUND` is absent or `ConfigManager().background` is falsy it prints `No ComfyUI is running in the background.` via `rprint` and raises `typer.Exit(code=1)` — no envelope, no error code. The separate kill-failed path prints `Failed to stop ComfyUI in the background.`; that one is covered by an explicit negative test so it can never be swallowed.

## Testing

- [x] Existing tests pass (`pytest`) — 642 passed, 2 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Red/green verified: the new tests were run against the pre-fix `main` with the fix reverted — 11 fail there, and the 10 that pass are precisely the negative cases (they must pass both before and after, since their job is to prove the benign net was not widened). All pass with the fix.

Not tested against a live comfy-cli: this environment has no `comfy` binary, so the "nothing to stop" message was confirmed by reading comfy-cli's source rather than by running it (see Motivation).

## Additional Notes

### Chesterton's fence

This broadens an existing check, so: `git log -L` on `_is_no_recorded_server` shows it was introduced whole in `fc9684c`, with the docstring "Prefers the structured `code` and falls back to the message so it also recognizes the error when only the human-readable string carries the marker." The human-readable fallback was always the intent — it just assumed the literal code string would appear in that text, which it does not. This change corrects the fallback's premise; it does not add a new one.

### Capability-denial falsification

The new guidance text tells the user comfy-cli will not stop a server it did not start, so I checked whether any path actually can, rather than asserting it:

- This server's full tool surface (every `@mcp.tool()` in `server.py`) has no stop-by-pid or stop-by-port tool; `stop_comfyui` is the only stop, and it wraps `comfy stop`.
- comfy-cli's own top-level command list (`cmdline.py`) has exactly one stop/kill command, `stop`, with no arguments and no `--force`; it kills only `ConfigManager().background`'s recorded pid.

So the limitation is real. The message is therefore written as a redirect, not a dead-end: it names two paths that do work — stop the server the way you started it, or `restart_comfyui(extra_args=["--port", "8189"])` to come up alongside it on a free port — and points at `server_info` to see what is currently answering. Forcibly killing an untracked server by pid/port is explicitly out of scope (it is a policy change with its own safety implications).

### Judgment calls

- **Text match not gated on `no_envelope`.** I considered restricting the text fallback to `exc.no_envelope is True`, since that is the exact shape observed. I chose not to: the phrase itself is the signal, and gating on *how* comfy-cli reported it is the same class of brittleness that caused this bug. The regex is narrow enough to carry the discrimination alone.
- **Port-in-use guidance is slightly more than a pure bug fix.** The acceptance criteria asked me to "consider" it; I implemented it. It adds error-message text (and two docstring sentences describing it), which is user-visible in the sense that agents read tool docstrings. It changes no control flow — the port error raises either way — and it is gated on both halves of the situation, so a port clash after a stop that genuinely killed comfy-cli's own server keeps its original message untouched.
- **`_PORT_IN_USE_TEXT_RE` is loose on purpose** (`already in use`, case-insensitive) because comfy-cli and the socket bind under it phrase this differently. A false positive there can only append an unhelpful paragraph to an error that was already failing; it cannot swallow anything.

### Known limit

comfy-cli renders this message through Rich, which wraps at the console width (80 columns when not a TTY). The current sentence is 39 characters so it never wraps, but a future longer phrasing that Rich hard-wrapped mid-sentence would not match, since the regex deliberately refuses to cross a newline. That fails in the safe direction — re-raise, i.e. today's behavior — rather than by over-matching.
