### PR TITLE
fix(vary_workflow): pre-check the JSON-array slot contract and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ the originals stay in the ComfyUI workspace.
 | `validate_workflow(workflow_path)` | `comfy validate --workflow <path>` | Pre-flight a workflow against the live `object_info` before a slow run; surfaces the structured error code on failure. |
 | `list_workflow_slots(workflow_path)` | `comfy workflow slots <path>` | List the agent-tweakable slots (addresses + current values) a frontend-format workflow exposes. |
 | `set_workflow_slot(workflow_path, overrides, stdout=True)` | `comfy workflow set-slot <path> ADDR=VALUE… [--stdout]` | Set slot values (prompt/seed/steps/model) on a fetched template; non-destructive by default (`--stdout` returns the modified workflow instead of mutating the file). |
-| `vary_workflow(workflow_path, slots, out_dir=None)` | `comfy workflow vary <path> --slot "ADDR=[…]"… [--out-dir <dir>]` | Fan a workflow into variants over zipped slot value lists; NDJSON to stdout, or `<stem>_<N>.json` files when `out_dir` is set. |
+| `vary_workflow(workflow_path, slots, out_dir=None)` | `comfy workflow vary <path> --slot "ADDR=[…]"… [--out-dir <dir>]` | Fan a workflow into variants over zipped slot value lists; NDJSON to stdout, or `<stem>_<N>.json` files when `out_dir` is set. Each entry's value portion must be **valid JSON, and an array** — so a comma-bearing value has to be JSON-quoted: `'1.prompt=["a lighthouse at dawn, oil painting", "a cabin at dusk"]'`, not `1.prompt=[a lighthouse at dawn, oil painting]`. |
 
 ### Discovery and templates
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -4532,19 +4532,24 @@ _SLOT_QUOTED_EXAMPLE = '6.text=["a lighthouse at dawn, oil painting", "a cabin"]
 
 
 def _clip_for_error(text: str) -> str:
-    """Bound a caller-supplied fragment echoed back in an error message.
+    """Render a caller-supplied fragment for an error message, bounded.
 
     A slot's value list is caller-sized — a sweep over long prompts is KBs of
     text — and the whole point of naming the offending entry is lost if the
-    message it rides in is unreadable. Same per-field cap the envelope errors use:
-    ``_MAX_ERROR_FIELD_CHARS`` bounds the caller-supplied CONTENT, exactly as the
-    bare ``[:_MAX_ERROR_FIELD_CHARS]`` slices in :func:`_render_error_details` do.
-    The one-character ellipsis rides on top as a truncation marker — it is ours,
-    not the caller's, so it is not counted against their budget.
+    message it rides in is unreadable. Same per-field cap the envelope errors use.
+
+    This quotes the fragment itself rather than leaving that to an ``!r`` at the
+    call site, because the cap has to apply to what is actually RENDERED. ``repr``
+    expands a control or non-printable character into a 4-to-10-character escape
+    (``\\x00``, ``\\uXXXX``, ``\\U000XXXXX``), so clipping the raw text first and
+    quoting after would let 500 such characters land as ~2000+ in the message —
+    the bound would read as if it held while the field blew past it. Clipping the
+    rendered form is what :func:`_render_error_details` does too.
     """
-    if len(text) <= _MAX_ERROR_FIELD_CHARS:
-        return text
-    return text[:_MAX_ERROR_FIELD_CHARS] + "…"
+    rendered = repr(text)
+    if len(rendered) <= _MAX_ERROR_FIELD_CHARS:
+        return rendered
+    return rendered[:_MAX_ERROR_FIELD_CHARS] + "…"
 
 
 def _reject_non_json_array_slot(index: int, slot: str) -> None:
@@ -4569,9 +4574,12 @@ def _reject_non_json_array_slot(index: int, slot: str) -> None:
 
     This mirrors comfy-cli's own parse exactly — ``json.loads`` on the value
     portion, accept only a ``list`` — so it can only refuse input comfy-cli would
-    also refuse. The one place the mirror cannot hold is stack depth, which is a
-    property of the process doing the parsing rather than of the input; that case
-    is handed to the engine untouched rather than guessed at.
+    also refuse — with one deliberate exception. A failure that is a property of
+    the PARSING PROCESS rather than of the input (recursion depth, an interpreter
+    limit like ``sys.get_int_max_str_digits``) says nothing about how comfy-cli's
+    own fresh subprocess will fare, so those are handed to the engine untouched
+    rather than guessed at. Only a genuine syntax error — a
+    :class:`json.JSONDecodeError` — is refused here.
     """
     preview = _clip_for_error(slot)
     fix = (
@@ -4581,7 +4589,7 @@ def _reject_non_json_array_slot(index: int, slot: str) -> None:
     )
     if "=" not in slot:
         raise ComfyCliError(
-            f"invalid slots[{index}] {preview!r}: expected an 'ADDR=[v1,v2,...]' "
+            f"invalid slots[{index}] {preview}: expected an 'ADDR=[v1,v2,...]' "
             f"string whose value is a JSON array — {fix}"
         )
     addr, _, raw = slot.partition("=")
@@ -4591,23 +4599,26 @@ def _reject_non_json_array_slot(index: int, slot: str) -> None:
     addr = _clip_for_error(addr.strip())
     try:
         value = json.loads(raw)
-    except RecursionError:
-        # Nesting deep enough to exhaust THIS process's stack says nothing about
-        # comfy-cli's: it parses in a fresh subprocess that is not already
-        # carrying the MCP handler -> tool -> loop frames underneath, so a value
-        # that blows the limit here can still parse there. Refusing it would
-        # break the invariant this whole pre-check rests on — that it can only
-        # refuse what comfy-cli would also refuse — so defer to the engine and
-        # let its own parse be the verdict.
-        return
-    except ValueError:
+    except json.JSONDecodeError:
         raise ComfyCliError(
-            f"invalid slots[{index}] for address {addr!r}: value must be a JSON "
-            f"array, but {_clip_for_error(raw)!r} is not valid JSON — {fix}"
+            f"invalid slots[{index}] for address {addr}: value must be a JSON "
+            f"array, but {_clip_for_error(raw)} is not valid JSON — {fix}"
         ) from None
+    except (ValueError, RecursionError):
+        # NOT a syntax error — the input is well-formed JSON that THIS
+        # interpreter declined to build: nesting deeper than the stack left us
+        # (`RecursionError`), or an integer literal over
+        # `sys.get_int_max_str_digits` (a plain `ValueError`, not a
+        # `JSONDecodeError`, since 3.11). Both are limits of the process doing
+        # the parsing, and this one parses several frames down from the MCP
+        # handler with whatever limits this interpreter was started with, while
+        # comfy-cli parses in a fresh subprocess of its own. Refusing here would
+        # reject values the engine accepts and break the invariant above, so
+        # abstain and let the engine's parse be the verdict.
+        return
     if not isinstance(value, list):
         raise ComfyCliError(
-            f"invalid slots[{index}] for address {addr!r}: value must be a JSON "
+            f"invalid slots[{index}] for address {addr}: value must be a JSON "
             f"array, got {type(value).__name__} — wrap a single value in a "
             f"one-element array ('3.seed=[42]'), and {fix}"
         )

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -4536,7 +4536,11 @@ def _clip_for_error(text: str) -> str:
 
     A slot's value list is caller-sized — a sweep over long prompts is KBs of
     text — and the whole point of naming the offending entry is lost if the
-    message it rides in is unreadable. Same per-field cap the envelope errors use.
+    message it rides in is unreadable. Same per-field cap the envelope errors use:
+    ``_MAX_ERROR_FIELD_CHARS`` bounds the caller-supplied CONTENT, exactly as the
+    bare ``[:_MAX_ERROR_FIELD_CHARS]`` slices in :func:`_render_error_details` do.
+    The one-character ellipsis rides on top as a truncation marker — it is ours,
+    not the caller's, so it is not counted against their budget.
     """
     if len(text) <= _MAX_ERROR_FIELD_CHARS:
         return text
@@ -4565,7 +4569,9 @@ def _reject_non_json_array_slot(index: int, slot: str) -> None:
 
     This mirrors comfy-cli's own parse exactly — ``json.loads`` on the value
     portion, accept only a ``list`` — so it can only refuse input comfy-cli would
-    also refuse.
+    also refuse. The one place the mirror cannot hold is stack depth, which is a
+    property of the process doing the parsing rather than of the input; that case
+    is handed to the engine untouched rather than guessed at.
     """
     preview = _clip_for_error(slot)
     fix = (
@@ -4579,14 +4585,22 @@ def _reject_non_json_array_slot(index: int, slot: str) -> None:
             f"string whose value is a JSON array — {fix}"
         )
     addr, _, raw = slot.partition("=")
-    addr = addr.strip()
+    # Clipped like every other caller-supplied fragment here: the address is the
+    # portion BEFORE the first `=` and is just as caller-sized as the value, so
+    # echoing it raw would hand back a multi-KB message and defeat the bound.
+    addr = _clip_for_error(addr.strip())
     try:
         value = json.loads(raw)
-    except (ValueError, RecursionError):
-        # `_parse_value` catches only `ValueError` (`JSONDecodeError` is one), so
-        # the nesting depth that makes `json.loads` blow the stack escapes it and
-        # crashes comfy-cli mid-command. Refusing it here is a strict improvement
-        # over that, and still refuses nothing the engine would have accepted.
+    except RecursionError:
+        # Nesting deep enough to exhaust THIS process's stack says nothing about
+        # comfy-cli's: it parses in a fresh subprocess that is not already
+        # carrying the MCP handler -> tool -> loop frames underneath, so a value
+        # that blows the limit here can still parse there. Refusing it would
+        # break the invariant this whole pre-check rests on — that it can only
+        # refuse what comfy-cli would also refuse — so defer to the engine and
+        # let its own parse be the verdict.
+        return
+    except ValueError:
         raise ComfyCliError(
             f"invalid slots[{index}] for address {addr!r}: value must be a JSON "
             f"array, but {_clip_for_error(raw)!r} is not valid JSON — {fix}"

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -4554,11 +4554,15 @@ def _clip_for_error(text: str) -> str:
     rendered form is what :func:`_render_error_details` does too.
 
     The source text is sliced BEFORE ``repr`` so an MB-sized value never
-    materializes an expanded copy just to have it thrown away: the first
-    ``_MAX_ERROR_FIELD_CHARS`` characters of ``repr(text)`` can only depend on
-    the first ``_MAX_ERROR_FIELD_CHARS`` characters of ``text``, since every
-    source character contributes at least one character to the repr. The
-    ellipsis is counted inside the cap, so the returned field never exceeds it.
+    materializes an expanded copy just to have it thrown away. That is safe for
+    the characters shown: every source character contributes at least one
+    character to the repr, so the escaping of the retained prefix cannot depend
+    on anything past the cap. The one thing it does change is ``repr``'s choice
+    of surrounding quote — it switches to double quotes for a string containing
+    an apostrophe and no double quote, and that decision is now made over the
+    slice, so an apostrophe past the cap flips it. Cosmetic, in a preview that
+    is already truncated. The ellipsis is counted inside the cap, so the
+    returned field never exceeds it.
     """
     rendered = repr(text[:_MAX_ERROR_FIELD_CHARS])
     if len(rendered) <= _MAX_ERROR_FIELD_CHARS:

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -4530,6 +4530,13 @@ def set_workflow_slot(
 _SLOT_VALUE_EXAMPLE = "3.seed=[1,2,3]"
 _SLOT_QUOTED_EXAMPLE = '6.text=["a lighthouse at dawn, oil painting", "a cabin"]'
 
+# Past this, a slot value cannot reach comfy-cli at all: Linux caps a SINGLE
+# argv entry at `MAX_ARG_STRLEN` (32 pages = 128 KiB) regardless of the roomier
+# total `ARG_MAX`, so the spawn fails before comfy-cli parses anything. That
+# makes this a bound the pre-check can honor without inventing a policy — it is
+# the engine's own reachability limit, not a taste call about sweep size.
+_MAX_PRECHECKED_SLOT_CHARS = 128 * 1024
+
 
 def _clip_for_error(text: str) -> str:
     """Render a caller-supplied fragment for an error message, bounded.
@@ -4545,11 +4552,18 @@ def _clip_for_error(text: str) -> str:
     quoting after would let 500 such characters land as ~2000+ in the message —
     the bound would read as if it held while the field blew past it. Clipping the
     rendered form is what :func:`_render_error_details` does too.
+
+    The source text is sliced BEFORE ``repr`` so an MB-sized value never
+    materializes an expanded copy just to have it thrown away: the first
+    ``_MAX_ERROR_FIELD_CHARS`` characters of ``repr(text)`` can only depend on
+    the first ``_MAX_ERROR_FIELD_CHARS`` characters of ``text``, since every
+    source character contributes at least one character to the repr. The
+    ellipsis is counted inside the cap, so the returned field never exceeds it.
     """
-    rendered = repr(text)
+    rendered = repr(text[:_MAX_ERROR_FIELD_CHARS])
     if len(rendered) <= _MAX_ERROR_FIELD_CHARS:
         return rendered
-    return rendered[:_MAX_ERROR_FIELD_CHARS] + "…"
+    return rendered[: _MAX_ERROR_FIELD_CHARS - 1] + "…"
 
 
 def _reject_non_json_array_slot(index: int, slot: str) -> None:
@@ -4580,8 +4594,12 @@ def _reject_non_json_array_slot(index: int, slot: str) -> None:
     own fresh subprocess will fare, so those are handed to the engine untouched
     rather than guessed at. Only a genuine syntax error — a
     :class:`json.JSONDecodeError` — is refused here.
+
+    A value too long to survive ``execve`` abstains the same way: see
+    :data:`_MAX_PRECHECKED_SLOT_CHARS`. That keeps the parse — the one piece of
+    real work this thin wrapper does in-process rather than in the disposable
+    subprocess — bounded by what the engine could actually have received.
     """
-    preview = _clip_for_error(slot)
     fix = (
         f"quote each value as JSON — e.g. '{_SLOT_VALUE_EXAMPLE}', or "
         f"'{_SLOT_QUOTED_EXAMPLE}' when a value contains a comma or spaces "
@@ -4589,10 +4607,21 @@ def _reject_non_json_array_slot(index: int, slot: str) -> None:
     )
     if "=" not in slot:
         raise ComfyCliError(
-            f"invalid slots[{index}] {preview}: expected an 'ADDR=[v1,v2,...]' "
-            f"string whose value is a JSON array — {fix}"
+            f"invalid slots[{index}] {_clip_for_error(slot)}: expected an "
+            f"'ADDR=[v1,v2,...]' string whose value is a JSON array — {fix}"
         )
     addr, _, raw = slot.partition("=")
+    if len(raw) > _MAX_PRECHECKED_SLOT_CHARS:
+        # Too long to survive `execve` (see `_MAX_PRECHECKED_SLOT_CHARS`), so
+        # there is no verdict worth computing: the spawn fails before comfy-cli
+        # reads it either way. Parsing it anyway would do real work in the
+        # long-lived parent for a value that cannot land — allocating an object
+        # graph several times its size, and on an interpreter without
+        # `sys.get_int_max_str_digits` converting a multi-million-digit literal
+        # in quadratic time. Abstaining costs nothing: this is the same
+        # engine-decides path the other unparseable cases take, so it cannot
+        # over-reject.
+        return
     # Clipped like every other caller-supplied fragment here: the address is the
     # portion BEFORE the first `=` and is just as caller-sized as the value, so
     # echoing it raw would hand back a multi-KB message and defeat the bound.

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -4530,12 +4530,14 @@ def set_workflow_slot(
 _SLOT_VALUE_EXAMPLE = "3.seed=[1,2,3]"
 _SLOT_QUOTED_EXAMPLE = '6.text=["a lighthouse at dawn, oil painting", "a cabin"]'
 
-# Past this, a slot value cannot reach comfy-cli at all: Linux caps a SINGLE
-# argv entry at `MAX_ARG_STRLEN` (32 pages = 128 KiB) regardless of the roomier
-# total `ARG_MAX`, so the spawn fails before comfy-cli parses anything. That
-# makes this a bound the pre-check can honor without inventing a policy — it is
-# the engine's own reachability limit, not a taste call about sweep size.
-_MAX_PRECHECKED_SLOT_CHARS = 128 * 1024
+# Past this, a slot cannot reach comfy-cli at all: Linux caps a SINGLE argv
+# entry at `MAX_ARG_STRLEN` (32 pages = 128 KiB) regardless of the roomier total
+# `ARG_MAX`, so the spawn fails before comfy-cli parses anything. That makes this
+# a bound the pre-check can honor without inventing a policy — it is the engine's
+# own reachability limit, not a taste call about sweep size. The kernel counts
+# BYTES, so this must be measured after encoding: a value of multibyte
+# characters is several times its character count on the wire.
+_MAX_PRECHECKED_SLOT_BYTES = 128 * 1024
 
 
 def _clip_for_error(text: str) -> str:
@@ -4600,7 +4602,7 @@ def _reject_non_json_array_slot(index: int, slot: str) -> None:
     :class:`json.JSONDecodeError` — is refused here.
 
     A value too long to survive ``execve`` abstains the same way: see
-    :data:`_MAX_PRECHECKED_SLOT_CHARS`. That keeps the parse — the one piece of
+    :data:`_MAX_PRECHECKED_SLOT_BYTES`. That keeps the parse — the one piece of
     real work this thin wrapper does in-process rather than in the disposable
     subprocess — bounded by what the engine could actually have received.
     """
@@ -4614,9 +4616,11 @@ def _reject_non_json_array_slot(index: int, slot: str) -> None:
             f"invalid slots[{index}] {_clip_for_error(slot)}: expected an "
             f"'ADDR=[v1,v2,...]' string whose value is a JSON array — {fix}"
         )
-    addr, _, raw = slot.partition("=")
-    if len(raw) > _MAX_PRECHECKED_SLOT_CHARS:
-        # Too long to survive `execve` (see `_MAX_PRECHECKED_SLOT_CHARS`), so
+    # Measured over the whole entry, encoded: `slot` IS the argv string, and the
+    # kernel's limit is in bytes. `surrogatepass` because a lone surrogate can
+    # arrive over the wire and this guard must not be the thing that raises.
+    if len(slot.encode("utf-8", "surrogatepass")) > _MAX_PRECHECKED_SLOT_BYTES:
+        # Too long to survive `execve` (see `_MAX_PRECHECKED_SLOT_BYTES`), so
         # there is no verdict worth computing: the spawn fails before comfy-cli
         # reads it either way. Parsing it anyway would do real work in the
         # long-lived parent for a value that cannot land — allocating an object
@@ -4626,6 +4630,7 @@ def _reject_non_json_array_slot(index: int, slot: str) -> None:
         # engine-decides path the other unparseable cases take, so it cannot
         # over-reject.
         return
+    addr, _, raw = slot.partition("=")
     # Clipped like every other caller-supplied fragment here: the address is the
     # portion BEFORE the first `=` and is just as caller-sized as the value, so
     # echoing it raw would hand back a multi-KB message and defeat the bound.

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -4523,6 +4523,82 @@ def set_workflow_slot(
     return _run_comfy(*args, timeout=60.0)
 
 
+# A slot entry's value portion is fed to `json.loads` by comfy-cli, so the two
+# examples that make the contract concrete: the mechanical shape, and the one
+# that trips callers up — a string value containing a comma, which is ONLY a
+# single value when it is JSON-quoted.
+_SLOT_VALUE_EXAMPLE = "3.seed=[1,2,3]"
+_SLOT_QUOTED_EXAMPLE = '6.text=["a lighthouse at dawn, oil painting", "a cabin"]'
+
+
+def _clip_for_error(text: str) -> str:
+    """Bound a caller-supplied fragment echoed back in an error message.
+
+    A slot's value list is caller-sized — a sweep over long prompts is KBs of
+    text — and the whole point of naming the offending entry is lost if the
+    message it rides in is unreadable. Same per-field cap the envelope errors use.
+    """
+    if len(text) <= _MAX_ERROR_FIELD_CHARS:
+        return text
+    return text[:_MAX_ERROR_FIELD_CHARS] + "…"
+
+
+def _reject_non_json_array_slot(index: int, slot: str) -> None:
+    """Reject a ``vary_workflow`` slot whose value is not a JSON array.
+
+    comfy-cli splits each ``--slot`` entry on its first ``=`` and runs the value
+    portion through :func:`json.loads`, *falling back to the literal string* when
+    that fails — then rejects anything that did not parse to a list. So the
+    natural first attempt at a text sweep,
+    ``6.text=[a lighthouse at dawn, oil painting]``, is not a two-element list at
+    all: it is invalid JSON, comes back as one bare string, and dies as
+    ``value must be a JSON array (got str)`` with nothing pointing at the missing
+    quotes.
+
+    Checking here rather than passing the failure through buys two things. The
+    message can name WHICH entry was malformed and show the quoted form that
+    fixes it (comfy-cli sees only the value it already failed to parse), and the
+    check lands before the subprocess: ``comfy workflow vary`` loads the file and
+    fetches ``object_info`` from the live ComfyUI *before* it parses ``--slot``,
+    so with the server down a malformed slot surfaces as a connection failure
+    that hides the real mistake entirely.
+
+    This mirrors comfy-cli's own parse exactly — ``json.loads`` on the value
+    portion, accept only a ``list`` — so it can only refuse input comfy-cli would
+    also refuse.
+    """
+    preview = _clip_for_error(slot)
+    fix = (
+        f"quote each value as JSON — e.g. '{_SLOT_VALUE_EXAMPLE}', or "
+        f"'{_SLOT_QUOTED_EXAMPLE}' when a value contains a comma or spaces "
+        "(an unquoted comma splits the value, and unquoted text is not JSON)"
+    )
+    if "=" not in slot:
+        raise ComfyCliError(
+            f"invalid slots[{index}] {preview!r}: expected an 'ADDR=[v1,v2,...]' "
+            f"string whose value is a JSON array — {fix}"
+        )
+    addr, _, raw = slot.partition("=")
+    addr = addr.strip()
+    try:
+        value = json.loads(raw)
+    except (ValueError, RecursionError):
+        # `_parse_value` catches only `ValueError` (`JSONDecodeError` is one), so
+        # the nesting depth that makes `json.loads` blow the stack escapes it and
+        # crashes comfy-cli mid-command. Refusing it here is a strict improvement
+        # over that, and still refuses nothing the engine would have accepted.
+        raise ComfyCliError(
+            f"invalid slots[{index}] for address {addr!r}: value must be a JSON "
+            f"array, but {_clip_for_error(raw)!r} is not valid JSON — {fix}"
+        ) from None
+    if not isinstance(value, list):
+        raise ComfyCliError(
+            f"invalid slots[{index}] for address {addr!r}: value must be a JSON "
+            f"array, got {type(value).__name__} — wrap a single value in a "
+            f"one-element array ('3.seed=[42]'), and {fix}"
+        )
+
+
 @mcp.tool()
 def vary_workflow(
     workflow_path: str, slots: list[str], out_dir: str | None = None
@@ -4532,9 +4608,26 @@ def vary_workflow(
     Wraps ``comfy workflow vary <path> --slot "ADDR=[v1,v2,...]" [--slot ...]``.
     ``slots`` is a list of ``"ADDR=[v1,v2,...]"`` strings, one per address (the
     ``ADDR``s come from ``list_workflow_slots``); comfy-cli ZIPS the value lists,
-    so every list MUST be the same length — e.g. ``["3.seed=[1,2,3]",
-    "6.text=[cat,dog,fish]"]`` yields three variants pairing seed 1/cat, 2/dog,
-    3/fish.
+    so every list MUST be the same length — e.g. ``['3.seed=[1,2,3]',
+    '6.text=["a cat", "a dog", "a fish"]']`` yields three variants pairing seed
+    1/cat, 2/dog, 3/fish.
+
+    **Each entry's value portion (everything after the first ``=``) must be
+    valid JSON, and must parse to a JSON ARRAY.** That is the whole gotcha, and
+    it bites hardest on prompts: a value containing a comma or spaces has to be
+    JSON-quoted, or it is not a list at all. Concretely::
+
+        # WRONG — not valid JSON; comfy-cli reads it as one bare string and
+        # fails with `value must be a JSON array (got str)`
+        ["1.prompt=[a lighthouse at dawn, oil painting, a cabin at dusk]"]
+
+        # RIGHT — each value is a JSON string, so the commas INSIDE a value
+        # stay part of that value
+        ['1.prompt=["a lighthouse at dawn, oil painting", "a cabin at dusk"]']
+
+    Numbers and booleans need no quoting (``"3.seed=[1,2,3]"``), and a single
+    value still needs its array (``"3.seed=[42]"``, not ``"3.seed=42"``). This
+    tool pre-checks each entry and names the offending one before shelling out.
 
     With ``out_dir`` unset (default) comfy-cli emits the variants as NDJSON to
     stdout; set ``out_dir`` to instead write ``<stem>_<N>.json`` files there (and
@@ -4556,13 +4649,16 @@ def vary_workflow(
     )
     _reject_nul("workflow_path", workflow_path)
     args = ["workflow", "vary", workflow_path]
-    for slot in slots:
+    for index, slot in enumerate(slots):
         _reject_option_like(
             "slot",
             slot,
             expected="an 'ADDR=[v1,v2,...]' string (e.g. '3.seed=[1,2,3]')",
         )
         _reject_nul("slot", slot)
+        # After the argv guards, not before: a dash-leading or NUL-bearing entry
+        # is an argv problem first, and its named error is the more useful one.
+        _reject_non_json_array_slot(index, slot)
         args += ["--slot", slot]
     if out_dir:
         _reject_option_like(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,6 +203,23 @@ def patched_run(monkeypatch):
 
 
 @pytest.fixture
+def no_spawn(monkeypatch):
+    """Assert no comfy-cli child is spawned — an input guard must refuse first.
+
+    The counterpart to :func:`patched_run` for the guard tests: they are not
+    about what the CLI returns but about never reaching it, and the point of a
+    pre-flight check is lost if the argv still goes out. Failing inside the fake
+    puts the assertion at the moment of the spawn, so a guard that stops
+    refusing surfaces as a spawn, not as a vague missing error.
+    """
+
+    def boom(*args, **kwargs):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+
+
+@pytest.fixture
 def patched_plain_run(patched_run):
     """``setup(returncode=…, stdout=…, stderr=…) -> calls`` for the NO-envelope path.
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -66,18 +66,12 @@ def test_set_workflow_slot_stdout_false_writes_in_place(patched_run):
     assert "--stdout" not in cmd
 
 
-def test_set_workflow_slot_rejects_option_like_override(monkeypatch):
+def test_set_workflow_slot_rejects_option_like_override(no_spawn):
     """A leading-dash override is refused before any child spawns.
 
     Splatted in as a positional it would BE the flag — `"--stdout"` would flip
     the in-place-write behavior the ``stdout`` argument owns.
     """
-
-    def boom(*a, **k):
-        raise AssertionError("no comfy-cli child may be spawned")
-
-    monkeypatch.setattr(server, "_run_comfy", boom)
-
     with pytest.raises(server.ComfyCliError, match="leading '-'"):
         server.set_workflow_slot("/tmp/flux.json", ["--stdout"])
 
@@ -85,7 +79,7 @@ def test_set_workflow_slot_rejects_option_like_override(monkeypatch):
         server.set_workflow_slot("/tmp/flux.json", ["6.text=x", "--stdout"])
 
 
-def test_workflow_path_positional_rejects_option_like(monkeypatch):
+def test_workflow_path_positional_rejects_option_like(no_spawn):
     """The sibling `workflow_path` positional is guarded too, not just the overrides.
 
     All three tools splat the path in bare, so a leading-dash path is read as a
@@ -93,12 +87,6 @@ def test_workflow_path_positional_rejects_option_like(monkeypatch):
     which is the very injection the override guard exists to stop. The error
     names the escape hatch — a genuinely dash-leading filename works as `./-x`.
     """
-
-    def boom(*a, **k):
-        raise AssertionError("no comfy-cli child may be spawned")
-
-    monkeypatch.setattr(server, "_run_comfy", boom)
-
     with pytest.raises(server.ComfyCliError, match=r"leading '-'.*\./"):
         server.set_workflow_slot("--stdout", ["6.text=x"])
 
@@ -124,19 +112,13 @@ def test_workflow_path_guard_allows_dot_slash_dash_name(patched_run):
     ]
 
 
-def test_workflow_tools_reject_embedded_nul(monkeypatch):
+def test_workflow_tools_reject_embedded_nul(no_spawn):
     """A NUL anywhere surfaces as ComfyCliError, not subprocess's bare ValueError.
 
     Orthogonal to the leading-dash guard: `subprocess` cannot carry a NUL in
     argv at all, so it is refused on option values (`--slot`, `--out-dir`) too,
     not just on the bare positionals.
     """
-
-    def boom(*a, **k):
-        raise AssertionError("no comfy-cli child may be spawned")
-
-    monkeypatch.setattr(server, "_run_comfy", boom)
-
     for call in (
         lambda: server.list_workflow_slots("/tmp/f\0.json"),
         lambda: server.set_workflow_slot("/tmp/f\0.json", ["6.text=x"]),
@@ -232,7 +214,7 @@ def test_vary_workflow_forwards_out_dir(patched_run, tmp_path):
     ]
 
 
-def test_vary_workflow_rejects_option_like_slot_and_out_dir(monkeypatch):
+def test_vary_workflow_rejects_option_like_slot_and_out_dir(no_spawn):
     """`--slot` values and `--out-dir` are guarded as input hygiene.
 
     Click takes an option's value verbatim, so neither is an injection vector
@@ -242,12 +224,6 @@ def test_vary_workflow_rejects_option_like_slot_and_out_dir(monkeypatch):
     then fails envelope parsing — the same call `search_templates` makes for its
     filters.
     """
-
-    def boom(*a, **k):
-        raise AssertionError("no comfy-cli child may be spawned")
-
-    monkeypatch.setattr(server, "_run_comfy", boom)
-
     with pytest.raises(server.ComfyCliError, match="leading '-'"):
         server.vary_workflow("/tmp/flux.json", ["--help"])
 
@@ -285,7 +261,7 @@ def test_vary_workflow_accepts_json_quoted_comma_bearing_prompt(patched_run):
     ]
 
 
-def test_vary_workflow_rejects_unquoted_comma_bearing_slot_value(monkeypatch):
+def test_vary_workflow_rejects_unquoted_comma_bearing_slot_value(no_spawn):
     """The failing form from the field, named before any child spawns.
 
     `[a lighthouse at dawn, oil painting]` is not valid JSON, so comfy-cli reads
@@ -294,12 +270,6 @@ def test_vary_workflow_rejects_unquoted_comma_bearing_slot_value(monkeypatch):
     with ComfyUI down the real mistake never surfaces at all. The pre-flight
     names WHICH entry is wrong and shows the quoted form that fixes it.
     """
-
-    def boom(*a, **k):
-        raise AssertionError("no comfy-cli child may be spawned")
-
-    monkeypatch.setattr(server, "_run_comfy", boom)
-
     with pytest.raises(server.ComfyCliError) as excinfo:
         server.vary_workflow(
             "/tmp/flux.json",
@@ -314,18 +284,12 @@ def test_vary_workflow_rejects_unquoted_comma_bearing_slot_value(monkeypatch):
     assert '"a lighthouse at dawn, oil painting"' in message  # ...and the fix
 
 
-def test_vary_workflow_rejects_non_array_json_slot_value(monkeypatch):
+def test_vary_workflow_rejects_non_array_json_slot_value(no_spawn):
     """Valid JSON that isn't an array is refused too, with the type named.
 
     comfy-cli parses `3.seed=42` fine — as an int — then rejects it, because
     `vary` zips LISTS. The one-element-array fix is spelled out.
     """
-
-    def boom(*a, **k):
-        raise AssertionError("no comfy-cli child may be spawned")
-
-    monkeypatch.setattr(server, "_run_comfy", boom)
-
     with pytest.raises(server.ComfyCliError, match=r"slots\[0\].*must be a JSON array"):
         server.vary_workflow("/tmp/flux.json", ["3.seed=42"])
 
@@ -336,31 +300,19 @@ def test_vary_workflow_rejects_non_array_json_slot_value(monkeypatch):
         server.vary_workflow("/tmp/flux.json", ["3.seed=42"])
 
 
-def test_vary_workflow_rejects_slot_without_equals(monkeypatch):
+def test_vary_workflow_rejects_slot_without_equals(no_spawn):
     """An entry with no `=` can't be split into ADDR and value — say so here.
 
     comfy-cli's own message for this (`Expected ADDR=VALUE`) never mentions the
     JSON-array half of the contract, so a caller who fixes only the `=` walks
     straight into the second error.
     """
-
-    def boom(*a, **k):
-        raise AssertionError("no comfy-cli child may be spawned")
-
-    monkeypatch.setattr(server, "_run_comfy", boom)
-
     with pytest.raises(server.ComfyCliError, match=r"slots\[0\].*ADDR=\[v1,v2"):
         server.vary_workflow("/tmp/flux.json", ["3.seed"])
 
 
-def test_vary_workflow_slot_error_is_bounded(monkeypatch):
+def test_vary_workflow_slot_error_is_bounded(no_spawn):
     """A huge malformed slot can't produce an unbounded error string."""
-
-    def boom(*a, **k):
-        raise AssertionError("no comfy-cli child may be spawned")
-
-    monkeypatch.setattr(server, "_run_comfy", boom)
-
     with pytest.raises(server.ComfyCliError) as excinfo:
         server.vary_workflow("/tmp/flux.json", ["6.text=[" + "x" * 10_000 + "]"])
 
@@ -373,7 +325,7 @@ def test_vary_workflow_slot_error_is_bounded(monkeypatch):
     [("42", "got int"), ("[bad", "not valid JSON")],
     ids=["non-array", "invalid-json"],
 )
-def test_vary_workflow_slot_error_bounds_the_address_too(monkeypatch, value, marker):
+def test_vary_workflow_slot_error_bounds_the_address_too(no_spawn, value, marker):
     """The ADDRESS half is caller-sized as well, and is clipped like the value.
 
     Everything before the first `=` is whatever the caller sent — nothing
@@ -381,12 +333,6 @@ def test_vary_workflow_slot_error_bounds_the_address_too(monkeypatch, value, mar
     other side and, with the opt-in failure log on, write a multi-KB line per
     attempt. Both error branches interpolate the address, so both are checked.
     """
-
-    def boom(*a, **k):
-        raise AssertionError("no comfy-cli child may be spawned")
-
-    monkeypatch.setattr(server, "_run_comfy", boom)
-
     address = "A" * 10_000
     with pytest.raises(server.ComfyCliError) as excinfo:
         server.vary_workflow("/tmp/flux.json", [f"{address}={value}"])
@@ -458,8 +404,16 @@ def test_vary_workflow_survives_a_real_recursion_error(patched_run):
     Skipped rather than silently vacuous if the interpreter happens to swallow
     the depth: the threshold moved between 3.10 and 3.14 and may move again.
     """
-    depth = 200_000
+    # The whole entry must stay UNDER the spawn-size gate, or the guard abstains
+    # there and never reaches `json.loads` — the assertions below would still
+    # pass while proving nothing about recursion. Derived from the gate and
+    # asserted, so it cannot drift back over if either number changes.
+    prefix = "6.text="
+    depth = (server._MAX_PRECHECKED_SLOT_BYTES - len(prefix)) // 2
     nested = "[" * depth + "]" * depth
+    slot = prefix + nested
+    assert len(slot.encode("utf-8")) <= server._MAX_PRECHECKED_SLOT_BYTES
+
     try:
         json.loads(nested)
     except RecursionError:
@@ -469,7 +423,7 @@ def test_vary_workflow_survives_a_real_recursion_error(patched_run):
 
     calls = patched_run(envelope(data={"count": 1}))
 
-    server.vary_workflow("/tmp/flux.json", [f"6.text={nested}"])
+    server.vary_workflow("/tmp/flux.json", [slot])
     server.vary_workflow("/tmp/flux.json", ["3.seed=[1,2]"])
 
     assert len(calls) == 2
@@ -495,7 +449,7 @@ def test_vary_workflow_defers_oversized_int_literal_to_the_engine(patched_run):
     assert calls[0]["cmd"][4:] == ["workflow", "vary", "/tmp/flux.json", "--slot", slot]
 
 
-def test_vary_workflow_slot_error_bound_survives_repr_escaping(monkeypatch):
+def test_vary_workflow_slot_error_bound_survives_repr_escaping(no_spawn):
     """The cap has to hold on the RENDERED field, not the pre-quoted content.
 
     `repr` turns one control character into a 4-character escape, so clipping
@@ -503,12 +457,6 @@ def test_vary_workflow_slot_error_bound_survives_repr_escaping(monkeypatch):
     the message — a bound that reads as if it holds while the field blows past
     it. The other bounded tests use printable characters and would not catch it.
     """
-
-    def boom(*a, **k):
-        raise AssertionError("no comfy-cli child may be spawned")
-
-    monkeypatch.setattr(server, "_run_comfy", boom)
-
     # NUL is rejected earlier by `_reject_nul`; \x01 is not, and reprs as `\x01`.
     with pytest.raises(server.ComfyCliError) as excinfo:
         server.vary_workflow("/tmp/flux.json", ["6.text=[" + "\x01" * 10_000 + "]"])
@@ -576,26 +524,48 @@ def test_vary_workflow_defers_unspawnably_long_slot_to_the_engine(patched_run):
     """
     calls = patched_run(envelope(data={"count": 1}))
 
-    oversized = "[" + "9" * (server._MAX_PRECHECKED_SLOT_CHARS + 1) + "]"
+    # Deliberately a value the contract check would REFUSE (a JSON string, not
+    # an array): forwarding it is only possible if the gate abstained before the
+    # parse. A well-formed array here would ride through either way and prove
+    # nothing about which branch ran.
+    oversized = '"' + "9" * (server._MAX_PRECHECKED_SLOT_BYTES + 1) + '"'
     slot = f"3.seed={oversized}"
     server.vary_workflow("/tmp/flux.json", [slot])
 
     assert calls[0]["cmd"][4:] == ["workflow", "vary", "/tmp/flux.json", "--slot", slot]
 
 
-def test_vary_workflow_still_checks_a_slot_just_under_the_spawn_limit(monkeypatch):
+def test_vary_workflow_size_gate_counts_bytes_not_characters(patched_run):
+    """`MAX_ARG_STRLEN` is a BYTE cap, so the gate has to encode before measuring.
+
+    A value of astral characters is four bytes each: well under the limit by
+    `len()` and well over it once `execve` sees it. Counting characters would
+    let exactly the largest values — the ones the gate exists for — slip through
+    and be parsed in the parent anyway.
+    """
+    calls = patched_run(envelope(data={"count": 1}))
+
+    # A quarter of the byte budget in characters, four bytes each => over it.
+    # A JSON string rather than an array, so reaching the parse would REFUSE it
+    # and forwarding proves the gate measured bytes and abstained.
+    chars = (server._MAX_PRECHECKED_SLOT_BYTES // 4) + 100
+    value = '"' + "\U0001f600" * chars + '"'
+    slot = f"6.text={value}"
+    assert len(slot) < server._MAX_PRECHECKED_SLOT_BYTES  # under, counted wrong
+    assert len(slot.encode("utf-8")) > server._MAX_PRECHECKED_SLOT_BYTES  # over
+
+    server.vary_workflow("/tmp/flux.json", [slot])
+
+    assert calls[0]["cmd"][4:] == ["workflow", "vary", "/tmp/flux.json", "--slot", slot]
+
+
+def test_vary_workflow_still_checks_a_slot_just_under_the_spawn_limit(no_spawn):
     """The abstain threshold is a ceiling, not a hole — just under it still checks.
 
     Guards against the size gate silently swallowing the ordinary contract check
     for any value large enough to matter.
     """
-
-    def boom(*a, **k):
-        raise AssertionError("no comfy-cli child may be spawned")
-
-    monkeypatch.setattr(server, "_run_comfy", boom)
-
     # Well-formed JSON, not an array, at a length the gate still inspects.
-    value = '"' + "p" * (server._MAX_PRECHECKED_SLOT_CHARS - 100) + '"'
+    value = '"' + "p" * (server._MAX_PRECHECKED_SLOT_BYTES - 100) + '"'
     with pytest.raises(server.ComfyCliError, match="got str"):
         server.vary_workflow("/tmp/flux.json", [f"6.text={value}"])

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -364,3 +364,73 @@ def test_vary_workflow_slot_error_is_bounded(monkeypatch):
 
     assert "x" * 10_000 not in str(excinfo.value)
     assert len(str(excinfo.value)) < 2_000
+
+
+@pytest.mark.parametrize(
+    "value, marker",
+    [("42", "got int"), ("[bad", "not valid JSON")],
+    ids=["non-array", "invalid-json"],
+)
+def test_vary_workflow_slot_error_bounds_the_address_too(monkeypatch, value, marker):
+    """The ADDRESS half is caller-sized as well, and is clipped like the value.
+
+    Everything before the first `=` is whatever the caller sent — nothing
+    upstream caps it — so echoing it raw would blow the per-field bound from the
+    other side and, with the opt-in failure log on, write a multi-KB line per
+    attempt. Both error branches interpolate the address, so both are checked.
+    """
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+
+    address = "A" * 10_000
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.vary_workflow("/tmp/flux.json", [f"{address}={value}"])
+
+    message = str(excinfo.value)
+    assert marker in message  # still the branch we meant to exercise
+    assert address not in message
+    assert len(message) < 2_000
+
+
+def test_vary_workflow_defers_unparseably_nested_slot_to_the_engine(
+    patched_run, monkeypatch
+):
+    """Nesting too deep for THIS stack is not a verdict on comfy-cli's.
+
+    `json.loads` raises `RecursionError` once the nesting outruns the remaining
+    stack, and this pre-check runs several frames down (MCP handler -> tool ->
+    loop -> helper) from where comfy-cli parses — a fresh subprocess. So a depth
+    that fails here can still parse there, and refusing it would break the
+    invariant the pre-check rests on: it may only refuse what comfy-cli would
+    also refuse. Forward it and let the engine's own parse decide.
+
+    The error is injected rather than provoked with real nesting: the depth that
+    trips the C scanner moved between 3.10 and 3.14 (3.14 parses 20k-deep arrays
+    that 3.10 refuses), so a literal deep value would silently stop exercising
+    this branch on one of the two interpreters CI runs.
+    """
+    calls = patched_run(envelope(data={"count": 1}))
+
+    nested = "[" * 200 + "]" * 200
+    slot = f"6.text={nested}"
+    real_loads = server.json.loads
+
+    def loads(text, *args, **kwargs):
+        if text == nested:
+            raise RecursionError("maximum recursion depth exceeded")
+        return real_loads(text, *args, **kwargs)
+
+    monkeypatch.setattr(server.json, "loads", loads)
+
+    server.vary_workflow("/tmp/flux.json", [slot])
+
+    assert calls[0]["cmd"][4:] == [
+        "workflow",
+        "vary",
+        "/tmp/flux.json",
+        "--slot",
+        slot,  # untouched: the guard abstained, it did not rewrite or refuse
+    ]

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -9,6 +9,9 @@ they own on top of the passthrough:
    defaults to ``--stdout`` (non-destructive), togglable off.
 2. ``vary_workflow`` repeats ``--slot`` per address and forwards ``--out-dir``
    only when given.
+3. ``vary_workflow`` pre-checks each slot entry's value against the JSON-array
+   contract comfy-cli enforces, so an unquoted comma-bearing prompt is named
+   here instead of failing opaquely (or behind a server-connection error) later.
 """
 
 from __future__ import annotations
@@ -156,14 +159,16 @@ def test_vary_workflow_option_value_guards_read_the_first_char_only(patched_run)
     """
     calls = patched_run(envelope(data={"variants": 2}))
 
-    server.vary_workflow("/tmp/flux.json", ["6.text=[a -b,c]"], out_dir="./out-dir")
+    server.vary_workflow(
+        "/tmp/flux.json", ['6.text=["a -b", "c"]'], out_dir="./out-dir"
+    )
 
     assert calls[0]["cmd"][4:] == [
         "workflow",
         "vary",
         "/tmp/flux.json",
         "--slot",
-        "6.text=[a -b,c]",
+        '6.text=["a -b", "c"]',
         "--out-dir",
         "./out-dir",
     ]
@@ -190,7 +195,7 @@ def test_vary_workflow_argv_repeats_slot_flag(patched_run):
     calls = patched_run(envelope(data={"variants": 3}))
 
     result = server.vary_workflow(
-        "/tmp/flux.json", ["3.seed=[1,2,3]", "6.text=[cat,dog,fish]"]
+        "/tmp/flux.json", ["3.seed=[1,2,3]", '6.text=["cat","dog","fish"]']
     )
     assert result == {"variants": 3}
 
@@ -202,7 +207,7 @@ def test_vary_workflow_argv_repeats_slot_flag(patched_run):
         "--slot",
         "3.seed=[1,2,3]",
         "--slot",
-        "6.text=[cat,dog,fish]",
+        '6.text=["cat","dog","fish"]',
     ]
     assert "--out-dir" not in cmd  # stdout NDJSON mode when out_dir is unset
 
@@ -250,3 +255,112 @@ def test_vary_workflow_rejects_option_like_slot_and_out_dir(monkeypatch):
 
     with pytest.raises(server.ComfyCliError, match=r"leading '-'.*\./"):
         server.vary_workflow("/tmp/flux.json", ["3.seed=[1,2]"], out_dir="--help")
+
+
+def test_vary_workflow_accepts_json_quoted_comma_bearing_prompt(patched_run):
+    """The working form from the field: commas INSIDE a JSON-quoted prompt.
+
+    This is the case the contract exists for — a prompt naturally contains
+    commas, and only JSON quoting keeps them part of one value instead of
+    splitting it. Two prompts, one seed each, zipped into two variants.
+    """
+    calls = patched_run(envelope(data={"count": 2}))
+
+    slot = (
+        '1.prompt=["a lighthouse at dawn, oil painting", '
+        '"a lighthouse at noon, watercolor"]'
+    )
+    server.vary_workflow("/tmp/flux.json", [slot, "3.seed=[1,2]"])
+
+    assert calls[0]["cmd"][4:] == [
+        "workflow",
+        "vary",
+        "/tmp/flux.json",
+        "--slot",
+        slot,  # forwarded byte-for-byte; the guard parses, it never rewrites
+        "--slot",
+        "3.seed=[1,2]",
+    ]
+
+
+def test_vary_workflow_rejects_unquoted_comma_bearing_slot_value(monkeypatch):
+    """The failing form from the field, named before any child spawns.
+
+    `[a lighthouse at dawn, oil painting]` is not valid JSON, so comfy-cli reads
+    it as one bare string and dies with `value must be a JSON array (got str)`
+    — after it has already loaded the workflow and fetched `object_info`, so
+    with ComfyUI down the real mistake never surfaces at all. The pre-flight
+    names WHICH entry is wrong and shows the quoted form that fixes it.
+    """
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.vary_workflow(
+            "/tmp/flux.json",
+            ["3.seed=[1,2]", "1.prompt=[a lighthouse at dawn, oil painting]"],
+        )
+
+    message = str(excinfo.value)
+    assert "slots[1]" in message  # names the offending entry, not just "a value"
+    assert "1.prompt" in message  # ...and its address
+    assert "must be a JSON array" in message  # ...and the contract it broke
+    assert "not valid JSON" in message
+    assert '"a lighthouse at dawn, oil painting"' in message  # ...and the fix
+
+
+def test_vary_workflow_rejects_non_array_json_slot_value(monkeypatch):
+    """Valid JSON that isn't an array is refused too, with the type named.
+
+    comfy-cli parses `3.seed=42` fine — as an int — then rejects it, because
+    `vary` zips LISTS. The one-element-array fix is spelled out.
+    """
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+
+    with pytest.raises(server.ComfyCliError, match=r"slots\[0\].*must be a JSON array"):
+        server.vary_workflow("/tmp/flux.json", ["3.seed=42"])
+
+    with pytest.raises(server.ComfyCliError, match="got int"):
+        server.vary_workflow("/tmp/flux.json", ["3.seed=42"])
+
+    with pytest.raises(server.ComfyCliError, match=r"3\.seed=\[42\]"):
+        server.vary_workflow("/tmp/flux.json", ["3.seed=42"])
+
+
+def test_vary_workflow_rejects_slot_without_equals(monkeypatch):
+    """An entry with no `=` can't be split into ADDR and value — say so here.
+
+    comfy-cli's own message for this (`Expected ADDR=VALUE`) never mentions the
+    JSON-array half of the contract, so a caller who fixes only the `=` walks
+    straight into the second error.
+    """
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+
+    with pytest.raises(server.ComfyCliError, match=r"slots\[0\].*ADDR=\[v1,v2"):
+        server.vary_workflow("/tmp/flux.json", ["3.seed"])
+
+
+def test_vary_workflow_slot_error_is_bounded(monkeypatch):
+    """A huge malformed slot can't produce an unbounded error string."""
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.vary_workflow("/tmp/flux.json", ["6.text=[" + "x" * 10_000 + "]"])
+
+    assert "x" * 10_000 not in str(excinfo.value)
+    assert len(str(excinfo.value)) < 2_000

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -534,14 +534,35 @@ def test_clip_for_error_matches_an_unsliced_repr():
     """Slicing the source before `repr` must not change the rendered prefix.
 
     The pre-slice is an allocation guard, not a behavior change: every source
-    character contributes at least one character to the repr, so the first
-    `_MAX_ERROR_FIELD_CHARS` of `repr(text)` cannot depend on anything past the
-    first `_MAX_ERROR_FIELD_CHARS` of `text`.
+    character contributes at least one character to the repr, so the escaping of
+    the retained prefix cannot depend on anything past the cap.
+
+    Stated over quote-free input on purpose — the surrounding quote character is
+    the one part that CAN differ, which the next test pins down.
     """
     for text in ("\x01" * 10_000, "y" * 10_000, "a, b" * 5_000):
         clipped = server._clip_for_error(text)
         assert clipped.endswith("…")
         assert repr(text).startswith(clipped[:-1])
+
+
+def test_clip_for_error_quote_style_follows_the_slice():
+    """The one thing the pre-slice changes, pinned so it stays cosmetic.
+
+    `repr` switches to double quotes for a string containing an apostrophe and
+    no double quote. That decision is now made over the SLICED prefix, so an
+    apostrophe past the cap flips it relative to an unsliced `repr`. Harmless in
+    an already-truncated preview — but asserted rather than assumed, so it stays
+    a quoting difference and does not quietly become an escaping one.
+    """
+    cap = server._MAX_ERROR_FIELD_CHARS
+    text = "a" * (cap + 100) + "'"
+
+    clipped = server._clip_for_error(text)
+
+    assert len(clipped) <= cap
+    assert not repr(text).startswith(clipped[:-1])  # the quote char differs...
+    assert repr(text[:cap]).startswith(clipped[:-1])  # ...and nothing else does
 
 
 def test_vary_workflow_defers_unspawnably_long_slot_to_the_engine(patched_run):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -514,3 +514,67 @@ def test_vary_workflow_slot_error_bound_survives_repr_escaping(monkeypatch):
         server.vary_workflow("/tmp/flux.json", ["6.text=[" + "\x01" * 10_000 + "]"])
 
     assert len(str(excinfo.value)) < 2_000
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["\x01" * 10_000, "x" * 10_000, "\U0001f600" * 10_000],
+    ids=["control", "printable", "astral"],
+)
+def test_clip_for_error_never_exceeds_the_cap(text):
+    """The returned field is bounded whatever the escaping does to it.
+
+    Checked directly rather than through a message, because the cap is this
+    helper's whole contract and the call sites add their own fixed prose on top.
+    """
+    assert len(server._clip_for_error(text)) <= server._MAX_ERROR_FIELD_CHARS
+
+
+def test_clip_for_error_matches_an_unsliced_repr():
+    """Slicing the source before `repr` must not change the rendered prefix.
+
+    The pre-slice is an allocation guard, not a behavior change: every source
+    character contributes at least one character to the repr, so the first
+    `_MAX_ERROR_FIELD_CHARS` of `repr(text)` cannot depend on anything past the
+    first `_MAX_ERROR_FIELD_CHARS` of `text`.
+    """
+    for text in ("\x01" * 10_000, "y" * 10_000, "a, b" * 5_000):
+        clipped = server._clip_for_error(text)
+        assert clipped.endswith("…")
+        assert repr(text).startswith(clipped[:-1])
+
+
+def test_vary_workflow_defers_unspawnably_long_slot_to_the_engine(patched_run):
+    """A value past the single-argv limit is forwarded, not parsed and not refused.
+
+    Linux caps one argv entry at `MAX_ARG_STRLEN` (128 KiB), so a `--slot` value
+    beyond it can never reach comfy-cli — the spawn fails first. Parsing it here
+    would be real work in the long-lived parent for a value that cannot land, so
+    the guard abstains. Crucially it abstains rather than refuses: the pre-check
+    still never rejects anything the engine would have accepted.
+    """
+    calls = patched_run(envelope(data={"count": 1}))
+
+    oversized = "[" + "9" * (server._MAX_PRECHECKED_SLOT_CHARS + 1) + "]"
+    slot = f"3.seed={oversized}"
+    server.vary_workflow("/tmp/flux.json", [slot])
+
+    assert calls[0]["cmd"][4:] == ["workflow", "vary", "/tmp/flux.json", "--slot", slot]
+
+
+def test_vary_workflow_still_checks_a_slot_just_under_the_spawn_limit(monkeypatch):
+    """The abstain threshold is a ceiling, not a hole — just under it still checks.
+
+    Guards against the size gate silently swallowing the ordinary contract check
+    for any value large enough to matter.
+    """
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+
+    # Well-formed JSON, not an array, at a length the gate still inspects.
+    value = '"' + "p" * (server._MAX_PRECHECKED_SLOT_CHARS - 100) + '"'
+    with pytest.raises(server.ComfyCliError, match="got str"):
+        server.vary_workflow("/tmp/flux.json", [f"6.text={value}"])

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -16,6 +16,8 @@ they own on top of the passthrough:
 
 from __future__ import annotations
 
+import json
+
 import pytest
 from conftest import envelope
 
@@ -434,3 +436,81 @@ def test_vary_workflow_defers_unparseably_nested_slot_to_the_engine(
         "--slot",
         slot,  # untouched: the guard abstained, it did not rewrite or refuse
     ]
+
+    # No sticky state: the injected failure is scoped to `nested`, so a normal
+    # entry right behind it still goes through the guard and out to the engine.
+    server.vary_workflow("/tmp/flux.json", ["3.seed=[1,2]"])
+    assert calls[1]["cmd"][4:][-2:] == ["--slot", "3.seed=[1,2]"]
+
+
+def test_vary_workflow_survives_a_real_recursion_error(patched_run):
+    """A genuine stack exhaustion, not an injected one, leaves the server usable.
+
+    The companion test above injects `RecursionError` for deterministic branch
+    coverage, which by construction cannot say anything about the interpreter's
+    health afterwards. This one provokes the real thing: CPython's JSON C
+    scanner raises through `Py_EnterRecursiveCall`, which reserves stack
+    headroom rather than running the stack to the ground, so the frames unwind
+    cleanly and the next call parses normally. That matters here because this is
+    a long-lived single process — one hostile slot must not degrade every later
+    one.
+
+    Skipped rather than silently vacuous if the interpreter happens to swallow
+    the depth: the threshold moved between 3.10 and 3.14 and may move again.
+    """
+    depth = 200_000
+    nested = "[" * depth + "]" * depth
+    try:
+        json.loads(nested)
+    except RecursionError:
+        pass
+    else:  # pragma: no cover - depends on the interpreter's limit
+        pytest.skip(f"this interpreter parses {depth}-deep arrays without raising")
+
+    calls = patched_run(envelope(data={"count": 1}))
+
+    server.vary_workflow("/tmp/flux.json", [f"6.text={nested}"])
+    server.vary_workflow("/tmp/flux.json", ["3.seed=[1,2]"])
+
+    assert len(calls) == 2
+    assert calls[1]["cmd"][4:][-2:] == ["--slot", "3.seed=[1,2]"]
+
+
+def test_vary_workflow_defers_oversized_int_literal_to_the_engine(patched_run):
+    """An interpreter limit is not a syntax error, and must not be reported as one.
+
+    Since 3.11 `json.loads` refuses an integer literal longer than
+    `sys.get_int_max_str_digits()` (4300 by default) with a PLAIN `ValueError`,
+    not a `JSONDecodeError` — `[<5000 digits>]` is perfectly well-formed JSON
+    that this interpreter simply declines to build. comfy-cli parses in its own
+    subprocess, under its own interpreter and limit, so it may well accept it.
+    Refusing here would both mislabel it 'not valid JSON' and reject a value the
+    engine takes, so the guard abstains.
+    """
+    calls = patched_run(envelope(data={"count": 1}))
+
+    slot = "3.seed=[" + "9" * 5_000 + "]"
+    server.vary_workflow("/tmp/flux.json", [slot])
+
+    assert calls[0]["cmd"][4:] == ["workflow", "vary", "/tmp/flux.json", "--slot", slot]
+
+
+def test_vary_workflow_slot_error_bound_survives_repr_escaping(monkeypatch):
+    """The cap has to hold on the RENDERED field, not the pre-quoted content.
+
+    `repr` turns one control character into a 4-character escape, so clipping
+    the raw text to the cap and quoting afterwards would put ~4x the cap into
+    the message — a bound that reads as if it holds while the field blows past
+    it. The other bounded tests use printable characters and would not catch it.
+    """
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+
+    # NUL is rejected earlier by `_reject_nul`; \x01 is not, and reprs as `\x01`.
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.vary_workflow("/tmp/flux.json", ["6.text=[" + "\x01" * 10_000 + "]"])
+
+    assert len(str(excinfo.value)) < 2_000


### PR DESCRIPTION
## ELI-5

`vary_workflow` fans a workflow out into variants — "render this prompt at seeds 1, 2 and 3." Each entry you pass looks like `ADDR=[value, value, ...]`, and the part after the `=` has to be **real JSON**. Nobody said so. So the first thing anyone tries — a list of prompts, and prompts have commas in them — falls apart: `[a lighthouse at dawn, oil painting]` isn't valid JSON, so it arrives as one bare string and the tool dies with `value must be a JSON array (got str)`, which explains nothing. This PR says the rule out loud in the docstring (with the comma example that actually bites), and checks each entry up front so the error names *which* entry is wrong and shows the quoted form that works.

## Changes

- **Docstring**: states that each entry's value portion must be valid JSON *and* a JSON array, with a WRONG/RIGHT pair built around a comma-bearing prompt, plus the two adjacent rules (numbers need no quotes; a single value still needs its array).
- **Docstring bug fixed**: the previous example `"6.text=[cat,dog,fish]"` is not valid JSON and never worked — the tool's own documentation was demonstrating the failing form. Now `'6.text=["a cat", "a dog", "a fish"]'`.
- **Pre-flight check** (`_reject_non_json_array_slot`): mirrors comfy-cli's parse exactly — `json.loads` on the portion after the first `=`, accept only a `list` — and raises a `ComfyCliError` naming `slots[i]`, its address, what it got, and the quoted form that fixes it. Bounded by the module's existing `_MAX_ERROR_FIELD_CHARS`, so a KB-sized prompt list can't produce an unreadable error.
- **README** tool row carries the same contract.
- **Tests**: the working comma-bearing case from the field report, the failing unquoted one (asserting the new message names the entry, the address, the requirement, and the fix), valid-JSON-but-not-an-array, a missing `=`, and the error-size bound.

## Motivation

Field report: `vary_workflow(..., slots=["1.prompt=[a lighthouse at dawn, oil painting, ...]"])` → `value must be a JSON array (got str)`; it only works once JSON-quoted. Everything else about the tool behaved well — it writes `<stem>_<N>.json` per variant, zips the value lists, preserves non-varied widgets, and never touches the queue. The contract was the only rough edge, and it was undiscoverable from the tool's schema or docs.

## Judgment call: pre-validate, don't just document

The ticket asked this PR to decide and record whether to pre-validate or ship documentation alone. **Decided: pre-validate.** Three reasons:

1. **The error can only be good here.** comfy-cli sees a value it already failed to parse; it can't tell you which of your `slots` entries it came from. This layer has the list, so it can say `invalid slots[1] for address '1.prompt'` and show the corrected string.
2. **Ordering in comfy-cli makes the passthrough error actively misleading.** `comfy workflow vary` loads the workflow and fetches `object_info` from the **live ComfyUI** *before* it parses `--slot`. With ComfyUI not running, a malformed slot surfaces as a connection failure and the real mistake never appears at all. The pre-flight catches it with no server needed.
3. **It's the existing pattern, not new product behavior.** `vary_workflow` already pre-validates its inputs (`_reject_option_like`, `_reject_nul`) for exactly this reason — name the caller's mistake instead of letting it become an opaque downstream failure. The thin-wrapper rule stays intact: no logic is reimplemented, the check is a strict mirror of the engine's own parse, and every accepted input is still forwarded byte-for-byte.

The check runs *after* the argv guards, so a dash-leading or NUL-bearing entry keeps its own (more specific) error.

## Falsification — this diff adds a deny path, so I went and looked

The new check refuses input, and two existing test fixtures had to change (`6.text=[cat,dog,fish]` and `6.text=[a -b,c]` → JSON-quoted equivalents), which is exactly the shape of a change that could silently remove a working capability. So I ran comfy-cli's own `_parse_value` (`comfy_cli/command/workflow.py`) against every form:

```
'[a lighthouse at dawn, oil painting, a cabin at dusk]' -> str  | accepted by vary: False
'[cat,dog,fish]'                                        -> str  | accepted by vary: False
'[a -b,c]'                                              -> str  | accepted by vary: False
'["a lighthouse at dawn, oil painting", "a cabin at dusk"]' -> list | accepted by vary: True
'[1,2,3]'                                               -> list | accepted by vary: True
'42'                                                    -> int  | accepted by vary: False
```

Every form this PR now rejects is a form `vary_cmd` already rejected (`if not isinstance(value, list)`), so **no working input is denied** — the two changed fixtures were asserting argv passthrough of values the engine would have thrown out. Nothing that previously succeeded fails now; the only user-visible change is a better error, earlier.

## Testing

- [x] Existing tests pass (`pytest` — 628 passed, 2 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — exercised the new guard directly against the failing/working forms above and confirmed the rendered messages; falsified the deny path against comfy-cli's real parser (above)

## Additional Notes

- **Deliberately out of scope**: `set_workflow_slot`'s analogous `overrides` string contract (tracked separately), a structured `{address: [values]}` input form, and the two *other* things comfy-cli only reports after the `object_info` fetch — an empty `slots` list, and value lists of unequal length. Both of those already produce clear messages; only the JSON contract was opaque. Worth a follow-up if the late-failure ordering bites again.
- The pre-flight raises `ComfyCliError` with no `code`, following the convention documented on that class: a null `code` marks a failure this wrapper raised itself rather than one comfy-cli reported. A caller branching on `workflow_slot_invalid` for this case would no longer see it — that code is only consumed by `_t2i_slot_hint` on an unrelated tool path.
- The `json.loads` guard catches `RecursionError` alongside `ValueError`. comfy-cli's `_parse_value` catches only `ValueError`, so a deeply nested value (~100k levels, verified) escapes its fallback and crashes the command; refusing it here is strictly better and still refuses nothing the engine would have accepted.
