### PR TITLE
docs: warn that an oversized graph can OOM-kill the local ComfyUI

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -2042,6 +2042,24 @@ async def run_workflow(
     maximum, and a non-positive / NaN value is rejected outright; ``wait=False``
     ignores it entirely (that submit runs on its own fixed budget).
 
+    CAUTION — a workflow whose nodes request a huge TOTAL allocation (e.g. an
+    ``EmptyImage`` / ``EmptyLatentImage`` with a very large width x height x
+    ``batch_size``) can pass ALL validation — every input is within its declared
+    range, and no layer estimates memory — and then crash the whole local
+    ComfyUI process mid-run when the OS kills it on the allocation. When that
+    happens there is no node-level error to fetch: this tool surfaces a
+    connection-loss / timeout error, and subsequent ``job_status`` /
+    ``get_execution_error`` calls report ``server_not_running`` (both query the
+    live server, which is gone). The evidence is still on disk — ``get_logs``
+    reads comfy-cli's captured log file rather than the server, so it keeps
+    working across the crash whenever the server was started with
+    ``launch_comfyui``; call it to confirm the kill. If you get
+    ``server_not_running`` right after running a workflow with large
+    image/latent dimensions or batch sizes, assume that workflow killed the
+    server: reduce width/height/``batch_size``, and relaunch with
+    ``launch_comfyui`` (or ``restart_comfyui`` if a stale server record remains)
+    before retrying.
+
     Partner-API nodes (Seedream/Veo/Kling/Gemini/…) need a Comfy credential in
     the server's environment (``COMFY_API_KEY`` in the client registration). A
     transient credential failure is retried up to twice with a short backoff;
@@ -3185,6 +3203,13 @@ def job_status(prompt_id: str) -> Any:
 
     Wraps ``comfy jobs status <prompt_id>``. Returns the job status and, when
     finished, its output references. Poll this after ``run_workflow(wait=False)``.
+
+    A ``server_not_running`` error from this tool immediately after a
+    ``run_workflow`` most likely means that run crashed the server (commonly an
+    out-of-memory kill from an oversized allocation) — this tool queries the
+    live server, so it has no history left to read, but ``get_logs`` reads the
+    captured log file and still works across the crash; check it, then relaunch
+    the server and reduce the workflow's allocation sizes before retrying.
     """
     prompt_id = _guard_prompt_id(prompt_id)
     return _run_comfy("jobs", "status", prompt_id, timeout=60.0)
@@ -3273,6 +3298,13 @@ def get_execution_error(prompt_id: str) -> Any:
     On a healthy prompt (completed / queued / running — no ``error``) it returns
     ``{"prompt_id", "status", "error": None}`` rather than raising, so it is safe
     to call speculatively.
+
+    A ``server_not_running`` error from this tool immediately after a
+    ``run_workflow`` most likely means that run crashed the server (commonly an
+    out-of-memory kill from an oversized allocation) — this tool queries the
+    live server, so it has no history left to read, but ``get_logs`` reads the
+    captured log file and still works across the crash; check it, then relaunch
+    the server and reduce the workflow's allocation sizes before retrying.
     """
     prompt_id = _guard_prompt_id(prompt_id)
 
@@ -4428,6 +4460,11 @@ def validate_workflow(workflow_path: str) -> Any:
        and the result is vacuously valid. Ignore those ``non_node_key``
        warnings (do not "fix" the file); export API format (or rely on
        ``run_workflow``'s auto-conversion) if validation fidelity matters.
+    4. No memory/allocation estimate — a graph whose individual inputs are all
+       in-range can still request an impossible TOTAL allocation (e.g. 16384 x
+       16384 at ``batch_size`` 64, roughly 206 GB) and will validate clean here
+       AND on the server, then OOM-kill the ComfyUI process at execution time.
+       See ``run_workflow``'s CAUTION for how that failure reads.
 
     Treat ``valid:true`` as necessary-not-sufficient and rely on
     ``run_workflow`` errors for final authority.


### PR DESCRIPTION
## ELI-5

You can ask for a picture so enormous that the computer runs out of memory trying to make it — and nothing warns you first, because every single number you typed was individually allowed. ComfyUI then gets killed by the operating system, and the tools that would normally tell you what went wrong just say "the server isn't running," because it isn't — it died. This PR writes that down in the tool descriptions the agent reads, so it recognizes the symptom instead of being baffled by it, and points it at the one tool that still works afterwards.

## Summary

Documents the oversized-graph server-crash failure mode in the docstrings of the four tools an agent actually hits it through. Docstrings only — no logic, parameter, or validation changes.

A workflow whose declared inputs are each individually in-range can still request an absurd total allocation (an `EmptyImage`/`EmptyLatentImage` at very large width x height x `batch_size`) and get the whole local ComfyUI process OOM-killed mid-run. Nothing catches it beforehand: every input is within its declared min/max, so `validate_workflow`, ComfyUI's own `/prompt` validation, and comfy-cli's preflight all pass. It then surfaces as an unexplained connection-loss/timeout from `run_workflow`, followed by a bare `server_not_running` from `job_status` / `get_execution_error` — with nothing in any docstring saying the failure mode exists or how to read it.

## Changes

- `run_workflow` — a `CAUTION` paragraph after the timeout paragraph: what passes validation, that the OS kill takes the whole server down mid-run, how it reads (connection-loss/timeout here, then `server_not_running`), and the recovery (shrink width/height/`batch_size`, relaunch).
- `validate_workflow` — a fourth entry in the existing "Known blind spots" list: no memory/allocation estimate, so an impossible total allocation validates clean here *and* on the server, then OOM-kills at execution time.
- `job_status` and `get_execution_error` — one sentence each: a `server_not_running` right after a `run_workflow` most likely means that run crashed the server.

## Motivation

The MCP docstrings are the tool's agent-facing UI, so this is where the failure mode has to be described — an agent that hits it today has no way to distinguish "my workflow killed the server" from a random disconnect, and will typically retry the identical oversized workflow. Consistent with the thin-wrapper rule in `AGENTS.md`: documentation of existing behavior, no product logic added here.

## Testing

- [x] Existing tests pass (`pytest`) — 623 passed, 2 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually (see below)

Verified on Python 3.10 in a clean venv built from `pip install -e '.[dev]'`. No test asserts on these docstrings' text (grepped `tests/` for `__doc__` — no hits), so nothing needed updating alongside. No behavior change, so no new tests.

## Additional Notes

**Judgment call — I did not ship the dead-end the ticket described, because it turned out to be false.** The planned wording said that after this crash "there is no history left to read." Checking that claim before shipping it: `get_logs` wraps `comfy logs`, which reads comfy-cli's **captured log file** (`<workspace>/user/comfyui_<port>.log`) and never consults the live server — so it keeps working across the crash. Probed against comfy-cli 1.12.0 with no server running (the same state as after an OOM kill):

```
$ comfy --json --where local jobs status <id>
{... "ok": false, "error": {"code": "server_not_running", "message": "ComfyUI not running on 127.0.0.1:8188" ...}}

$ comfy --json --where local logs --tail 5
{... "ok": false, "error": {"code": "no_log_file", "message": "No captured ComfyUI log was found. Looked for: .../user/comfyui_8188.log" ...}}
```

`logs` fails with `no_log_file` (nothing was ever launched on this machine), **not** `server_not_running` — it looked on disk and never asked the server. So server liveness is not a precondition, and where the server *was* started with `launch_comfyui`, that file exists and holds the crash evidence. Telling an agent "there is no history left to read" would have steered it away from the one diagnostic that survives. All three spots now redirect to `get_logs` instead, conditioned on the background launch that produces the log.

**Other judgment calls:**

- The ticket's placeholder relaunch tool `launch_comfy` does not exist; the real tool is **`launch_comfyui`**. I also mention `restart_comfyui` as the alternative when a stale server record remains — after an OOM kill comfy-cli still holds the recorded pid of the dead process, and `restart_comfyui` swallows `no_recorded_server` for exactly that case. Phrased as a hedge, so it is correct whether or not a bare `launch_comfyui` would have complained.
- The `~206 GB` figure checks out arithmetically and is stated as "roughly": 16384 x 16384 x 64 x 3 channels x 4 bytes = 206,158,430,208 bytes.
- The `job_status` and `get_execution_error` sentences are deliberately near-identical rather than factored into a cross-reference — each docstring is surfaced to the agent independently, so each has to stand alone.

**Deliberately out of scope:** `wait_for_job` and `watch_job` poll the same job state and would also report `server_not_running` after this crash, but the ticket scoped the change to the four tools above and I kept the diff to that. Worth a follow-up if reviewers want the coverage — say so and I will extend it.
