### PR TITLE
fix(launch): guarantee COMFY_BIN's directory is on the child PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ Cloud MCP** — comfy-cli is the engine.
   clients launch the server with their own environment, which often does **not** include your
   shell's `PATH` — so if `comfy` lives in a virtualenv or a non-standard location, set
   `COMFY_BIN` to its absolute path (e.g. `/path/to/venv/bin/comfy`). Every client example below
-  shows where it goes.
+  shows where it goes. Setting it is sufficient on its own — you do **not** also have to put
+  that directory on the client's `PATH`. The server prepends the resolved binary's directory to
+  the `PATH` it hands comfy-cli, because some comfy-cli commands (notably the background
+  `launch`) re-invoke `comfy` by name and have to be able to find themselves.
 - **`COMFY_API_KEY` (optional — needed only for partner-API nodes).** Workflows that use
   partner-API nodes (Seedream / Seedance / Nano Banana / Gemini / Veo / Kling / …) need a Comfy
   credential, and — exactly like `COMFY_BIN` — an MCP client launches the server with its own

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -488,8 +488,24 @@ def _comfy_env() -> dict[str, str]:
       keychain credential helper does not use stdin, so it still works with
       stdin closed; overriding it would break private-remote updates that
       succeed today.
+
+    ``PATH`` is the one inherited variable this rewrites rather than injects
+    alongside: the directory of the RESOLVED ``COMFY_BIN`` is guaranteed to be
+    on the child's ``PATH``, first. This exists because ``comfy launch
+    --background`` re-invokes ``comfy`` by BARE NAME via ``PATH`` (comfy-cli
+    1.12's ``launch.py`` spawns ``Popen(["comfy", ...])`` for the detached
+    process). Without the prepend, an absolute ``COMFY_BIN`` pointing outside
+    the inherited ``PATH`` — the normal state for an MCP server launched by a
+    GUI client on macOS — crashes background launch with ``FileNotFoundError:
+    'comfy'`` before ComfyUI is ever spawned, surfacing here as the opaque
+    ``comfy-cli returned no JSON (exit 1)`` (BE-4735). Prepending rather than
+    appending is deliberate: it also stops a stale second comfy install earlier
+    on the user's ``PATH`` from shadowing the intended one inside the child
+    (BE-3780). The entry is absolutized because comfy-cli ``os.chdir``s to the
+    workspace in the child before that re-invocation resolves, so a relative
+    entry would point somewhere else by then.
     """
-    return {
+    env = {
         **os.environ,
         "COMFY_WHERE": "local",
         "COMFY_NO_WATCH": "1",
@@ -498,6 +514,20 @@ def _comfy_env() -> dict[str, str]:
         "GIT_TERMINAL_PROMPT": "0",
         "PIP_NO_INPUT": "1",
     }
+    # `shutil.which` handles both shapes of COMFY_BIN: a value carrying a
+    # directory separator is checked as that exact file, a bare name is resolved
+    # against PATH. None means we could not locate the binary at all — skip
+    # silently rather than guess, since `_require_comfy_bin` already raises the
+    # curated missing-binary error ahead of any spawn and this must not add a
+    # second failure mode.
+    resolved = shutil.which(COMFY_BIN)
+    if resolved:
+        bin_dir = os.path.dirname(os.path.abspath(resolved))
+        path = env.get("PATH", "")
+        entries = path.split(os.pathsep) if path else []
+        if not entries or entries[0] != bin_dir:
+            env["PATH"] = bin_dir + (os.pathsep + path if path else "")
+    return env
 
 
 class ComfyCliError(RuntimeError):
@@ -3727,6 +3757,23 @@ def launch_comfyui(extra_args: list[str] | None = None) -> Any:
     in review upstream). On affected comfy-cli versions the crash surfaces here
     as a clean :class:`ComfyCliError` from the error envelope. Remove this note
     once the upstream fix ships.
+
+    NOTE (second upstream caveat, handled): ``comfy launch --background``
+    re-invokes ``comfy`` by BARE NAME via ``PATH`` to spawn the detached
+    process, so it needs to find itself on the child's ``PATH`` no matter how
+    this server was told to call it. This server therefore guarantees the
+    resolved ``COMFY_BIN``'s directory is first on the child ``PATH`` — see
+    :func:`_comfy_env`. Before that guarantee, an absolute ``COMFY_BIN``
+    pointing outside the inherited ``PATH`` (an MCP server started by a GUI
+    client plus a venv-installed comfy-cli) failed HERE, and only here, as
+    ``comfy-cli returned no JSON (exit 1)`` with a traceback whose first visible
+    frame is ``comfy_cli/tracking.py:334``. That frame is a red herring — it is
+    the ``track_command`` passthrough wrapper, not telemetry (typer's pretty
+    exceptions hide the frames above it, and the crash reproduces with
+    ``DO_NOT_TRACK=1``); the real exception is ``FileNotFoundError: 'comfy'``
+    from the inner re-invocation. See BE-4735. The upstream fix — re-invoking
+    via ``sys.executable -m comfy_cli`` instead of a bare name — is still
+    desirable, but this server no longer depends on it.
     """
     args = ["launch", "--background"]
     if extra_args:

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -504,6 +504,19 @@ def _comfy_env() -> dict[str, str]:
     (BE-3780). The entry is absolutized because comfy-cli ``os.chdir``s to the
     workspace in the child before that re-invocation resolves, so a relative
     entry would point somewhere else by then.
+
+    The rewrite is strictly additive and never *shrinks* the child's search
+    path: it is skipped outright when the directory cannot be expressed as a
+    PATH entry (it contains ``os.pathsep``), and an absent inherited ``PATH``
+    falls back to ``os.defpath`` — CPython's own fallback — rather than
+    resolving to the binary's directory alone.
+
+    What it cannot fix: comfy-cli re-invokes the literal name ``comfy``, so a
+    ``COMFY_BIN`` pointing at a RENAMED binary (``comfy-1.12``) still leaves the
+    child's bare-name lookup to find some other ``comfy`` — or none. Hoisting
+    the directory is still correct there (a sibling ``comfy`` symlink, the
+    common venv shape, then wins), but the residual case belongs upstream: only
+    comfy-cli can stop re-invoking by bare name.
     """
     env = {
         **os.environ,
@@ -523,10 +536,27 @@ def _comfy_env() -> dict[str, str]:
     resolved = shutil.which(COMFY_BIN)
     if resolved:
         bin_dir = os.path.dirname(os.path.abspath(resolved))
-        path = env.get("PATH", "")
-        entries = path.split(os.pathsep) if path else []
-        if not entries or entries[0] != bin_dir:
-            env["PATH"] = bin_dir + (os.pathsep + path if path else "")
+        # A directory whose own name contains `os.pathsep` cannot be expressed as
+        # a PATH entry — the separator has no escape in either POSIX or Windows
+        # PATH syntax, so writing it would split into fragments: the intended
+        # directory is lost AND the tail becomes a RELATIVE entry, which the
+        # child resolves against the workspace comfy-cli chdir'd into. Skip, the
+        # same silent no-op as an unresolvable binary: leaving the inherited
+        # PATH intact is strictly better than corrupting it.
+        if os.pathsep not in bin_dir:
+            # `None` (no PATH inherited at all) is NOT the same as `""`. With no
+            # PATH in the environment, CPython resolves a child's bare-name exec
+            # against `os.defpath` (see `os.get_exec_path`), so writing `bin_dir`
+            # alone would REPLACE that implicit default and strip the child of
+            # the `git` / `python` / `uv` helpers comfy-cli shells out to.
+            # Substituting `os.defpath` keeps the prepend strictly additive there
+            # too. An empty STRING is a deliberate "search nothing" and is left
+            # to mean exactly that.
+            inherited = env.get("PATH")
+            path = os.defpath if inherited is None else inherited
+            entries = path.split(os.pathsep) if path else []
+            if not entries or entries[0] != bin_dir:
+                env["PATH"] = bin_dir + (os.pathsep + path if path else "")
     return env
 
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import os
+import shutil
 import subprocess
+import sys
 import threading
 import time
 
@@ -133,6 +136,200 @@ def test_run_comfy_leaves_askpass_alone(patched_run, monkeypatch):
     server._run_comfy("jobs", "status", "abc")
 
     assert calls[0]["env"]["GIT_ASKPASS"] == "/usr/local/bin/my-helper"
+
+
+# --- COMFY_BIN's directory is guaranteed first on the child PATH -------------
+#
+# `comfy launch --background` re-invokes `comfy` by BARE NAME via PATH to spawn
+# the detached process, so an absolute COMFY_BIN whose directory is not on the
+# inherited PATH (an MCP server started by a GUI client + a venv-installed
+# comfy-cli) crashed the child with FileNotFoundError before ComfyUI was ever
+# started. See `_comfy_env` (BE-4735 / BE-3780).
+
+_needs_posix_exec = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX exec bit; which() needs a PATHEXT suffix on Windows",
+)
+
+# The spawn-site fixtures stub `shutil.which` to a fixed "/fake/comfy" (they
+# patch the shared module attribute), which would mask the real resolution the
+# two end-to-end tests below are checking. Captured at import, before any test
+# has had a chance to patch it, so they can put the genuine one back.
+_real_which = shutil.which
+
+
+def _dummy_comfy(tmp_path, dirname="venv-bin", name="comfy"):
+    """A real, executable file on disk standing in for the comfy-cli binary.
+
+    `shutil.which` checks the exec bit, so a bare `tmp_path.touch()` would
+    resolve to None and quietly exercise the skip path instead of the prepend.
+    """
+    bin_dir = tmp_path / dirname
+    bin_dir.mkdir(exist_ok=True)
+    exe = bin_dir / name
+    exe.write_text("#!/bin/sh\nexit 0\n")
+    exe.chmod(0o755)
+    return exe
+
+
+@_needs_posix_exec
+def test_comfy_env_prepends_absolute_comfy_bin_dir(tmp_path, monkeypatch):
+    """The QA case: absolute COMFY_BIN in a venv, minimal PATH that excludes it."""
+    exe = _dummy_comfy(tmp_path)
+    bin_dir = str(exe.parent)
+    inherited = os.pathsep.join(["/usr/bin", "/bin"])
+    monkeypatch.setattr(server, "COMFY_BIN", str(exe))
+    monkeypatch.setenv("PATH", inherited)
+
+    path = server._comfy_env()["PATH"]
+
+    assert path.startswith(bin_dir + os.pathsep)
+    # The inherited PATH is preserved behind it, not replaced.
+    assert path == bin_dir + os.pathsep + inherited
+
+
+@_needs_posix_exec
+def test_comfy_env_absolutizes_a_relative_comfy_bin(tmp_path, monkeypatch):
+    """comfy-cli chdirs to the workspace before re-resolving, so a relative entry
+    would point somewhere else by then — the prepended entry must be absolute."""
+    exe = _dummy_comfy(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(server, "COMFY_BIN", os.path.join(".", "venv-bin", "comfy"))
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    first = server._comfy_env()["PATH"].split(os.pathsep)[0]
+
+    assert os.path.isabs(first)
+    assert os.path.realpath(first) == os.path.realpath(str(exe.parent))
+
+
+@_needs_posix_exec
+def test_comfy_env_does_not_duplicate_bin_dir_already_first(tmp_path, monkeypatch):
+    """Already first: PATH is left exactly as inherited — no repeated prepend."""
+    exe = _dummy_comfy(tmp_path)
+    bin_dir = str(exe.parent)
+    inherited = os.pathsep.join([bin_dir, "/usr/bin"])
+    monkeypatch.setattr(server, "COMFY_BIN", str(exe))
+    monkeypatch.setenv("PATH", inherited)
+
+    path = server._comfy_env()["PATH"]
+
+    assert path == inherited
+    assert path.split(os.pathsep).count(bin_dir) == 1
+
+
+@_needs_posix_exec
+def test_comfy_env_prepends_even_when_bin_dir_is_later_on_path(tmp_path, monkeypatch):
+    """Present but shadowed: prepend anyway so an earlier stale comfy can't win.
+
+    Prepending (rather than appending, or skipping on "already present") is the
+    deliberate half of this: inside the child, `comfy` must resolve to the SAME
+    install this server was pointed at, not to whichever one happens to be
+    earlier on the user's PATH.
+    """
+    exe = _dummy_comfy(tmp_path)
+    bin_dir = str(exe.parent)
+    stale = tmp_path / "stale-bin"
+    stale.mkdir()
+    monkeypatch.setattr(server, "COMFY_BIN", str(exe))
+    monkeypatch.setenv("PATH", os.pathsep.join([str(stale), bin_dir]))
+
+    path = server._comfy_env()["PATH"]
+
+    assert path.split(os.pathsep)[0] == bin_dir
+
+
+@_needs_posix_exec
+def test_comfy_env_prepends_dir_of_bare_name_resolved_on_path(tmp_path, monkeypatch):
+    """A bare COMFY_BIN is resolved through PATH, and ITS directory is hoisted."""
+    exe = _dummy_comfy(tmp_path)
+    bin_dir = str(exe.parent)
+    other = tmp_path / "other-bin"
+    other.mkdir()
+    monkeypatch.setattr(server, "COMFY_BIN", "comfy")
+    monkeypatch.setenv("PATH", os.pathsep.join([str(other), bin_dir]))
+
+    # Sanity: the bare name really does resolve into bin_dir under this PATH.
+    assert shutil.which("comfy") == str(exe)
+
+    assert server._comfy_env()["PATH"].split(os.pathsep)[0] == bin_dir
+
+
+def test_comfy_env_leaves_path_alone_when_comfy_bin_unresolvable(tmp_path, monkeypatch):
+    """Unresolvable COMFY_BIN: skip silently, never raise, never touch PATH.
+
+    `_require_comfy_bin` already raises the curated missing-binary error before
+    any spawn, so `_comfy_env` must not add a second failure mode here.
+    """
+    inherited = os.pathsep.join([str(tmp_path / "a"), str(tmp_path / "b")])
+    monkeypatch.setattr(server, "COMFY_BIN", str(tmp_path / "nope" / "comfy"))
+    monkeypatch.setenv("PATH", inherited)
+
+    assert server._comfy_env()["PATH"] == inherited
+
+
+def test_comfy_env_skips_a_non_executable_comfy_bin(tmp_path, monkeypatch):
+    """A file that exists but is not executable is not a resolution — skip it."""
+    exe = tmp_path / "not-exec" / "comfy"
+    exe.parent.mkdir()
+    exe.write_text("")
+    exe.chmod(0o644)
+    monkeypatch.setattr(server, "COMFY_BIN", str(exe))
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    assert server._comfy_env()["PATH"] == "/usr/bin"
+
+
+def test_comfy_env_unresolvable_with_no_inherited_path(tmp_path, monkeypatch):
+    """No PATH at all and nothing to resolve: PATH stays absent, no KeyError."""
+    monkeypatch.setattr(server, "COMFY_BIN", str(tmp_path / "nope" / "comfy"))
+    monkeypatch.delenv("PATH", raising=False)
+
+    assert "PATH" not in server._comfy_env()
+
+
+@_needs_posix_exec
+def test_comfy_env_sets_bare_path_when_none_inherited(tmp_path, monkeypatch):
+    """An empty/absent inherited PATH yields the bin dir alone — no stray separator."""
+    exe = _dummy_comfy(tmp_path)
+    monkeypatch.setattr(server, "COMFY_BIN", str(exe))
+    monkeypatch.setenv("PATH", "")
+
+    assert server._comfy_env()["PATH"] == str(exe.parent)
+
+
+@_needs_posix_exec
+def test_comfy_env_path_prepend_keeps_the_existing_pins(tmp_path, monkeypatch):
+    """The PATH rewrite is additive — every previously-injected pin still holds."""
+    exe = _dummy_comfy(tmp_path)
+    monkeypatch.setattr(server, "COMFY_BIN", str(exe))
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    env = server._comfy_env()
+
+    assert env["COMFY_WHERE"] == "local"
+    assert env["COMFY_NO_WATCH"] == "1"
+    assert env["PYTHONUTF8"] == "1"
+    assert env["PYTHONIOENCODING"] == "utf-8"
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    assert env["PIP_NO_INPUT"] == "1"
+    assert env["PATH"].split(os.pathsep)[0] == str(exe.parent)
+
+
+@_needs_posix_exec
+def test_run_comfy_child_env_carries_the_bin_dir_on_path(
+    tmp_path, monkeypatch, patched_run
+):
+    """The plain `--json` spawn site really hands the child the rewritten PATH."""
+    exe = _dummy_comfy(tmp_path)
+    monkeypatch.setattr(server, "COMFY_BIN", str(exe))
+    monkeypatch.setenv("PATH", "/usr/bin")
+    calls = patched_run(envelope(data={"x": 1}))
+    monkeypatch.setattr(server.shutil, "which", _real_which)
+
+    server._run_comfy("jobs", "status", "abc")
+
+    assert calls[0]["env"]["PATH"].split(os.pathsep)[0] == str(exe.parent)
 
 
 def test_error_envelope_raises_with_code(patched_run):
@@ -1997,6 +2194,22 @@ def test_run_workflow_stream_forces_utf8_env(patched_stream):
     # And the parent-side stream read is pinned to UTF-8 to match (readline()/
     # stderr.read() would otherwise decode with the cp1252 parent locale).
     assert procs[0].encoding == "utf-8"
+
+
+@_needs_posix_exec
+def test_run_workflow_stream_carries_the_bin_dir_on_path(
+    tmp_path, monkeypatch, patched_stream
+):
+    """The streaming (Popen) spawn site hands the child the rewritten PATH too."""
+    exe = _dummy_comfy(tmp_path)
+    monkeypatch.setattr(server, "COMFY_BIN", str(exe))
+    monkeypatch.setenv("PATH", "/usr/bin")
+    procs = patched_stream(_OK_STREAM)
+    monkeypatch.setattr(server.shutil, "which", _real_which)
+
+    asyncio.run(server.run_workflow("wf.json", wait=True))
+
+    assert procs[0].env["PATH"].split(os.pathsep)[0] == str(exe.parent)
 
 
 def test_run_workflow_stream_closes_child_stdin(patched_stream):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -299,6 +299,48 @@ def test_comfy_env_sets_bare_path_when_none_inherited(tmp_path, monkeypatch):
 
 
 @_needs_posix_exec
+def test_comfy_env_falls_back_to_defpath_when_no_path_inherited(tmp_path, monkeypatch):
+    """No PATH inherited: keep the platform default behind the bin dir.
+
+    With no PATH in the environment CPython resolves a child's bare-name exec
+    against `os.defpath` (`os.get_exec_path`). Writing the bin dir ALONE would
+    replace that implicit default, leaving the child unable to find the `git` /
+    `python` / `uv` helpers comfy-cli shells out to — a strict regression on the
+    pre-prepend behavior. The prepend has to stay additive here too.
+    """
+    exe = _dummy_comfy(tmp_path)
+    monkeypatch.setattr(server, "COMFY_BIN", str(exe))
+    monkeypatch.delenv("PATH", raising=False)
+
+    entries = server._comfy_env()["PATH"].split(os.pathsep)
+
+    assert entries[0] == str(exe.parent)
+    assert entries[1:] == os.defpath.split(os.pathsep)
+
+
+@_needs_posix_exec
+def test_comfy_env_skips_prepend_when_bin_dir_contains_pathsep(tmp_path, monkeypatch):
+    """A bin dir containing `os.pathsep` is unrepresentable — leave PATH alone.
+
+    There is no escape for the separator in PATH syntax, so writing such a
+    directory splits it into fragments: the intended entry is destroyed AND its
+    tail becomes a RELATIVE entry, which the child resolves against the
+    workspace comfy-cli chdir'd into. Skipping preserves the inherited PATH;
+    corrupting it would be strictly worse than not helping.
+    """
+    exe = _dummy_comfy(tmp_path, dirname="we" + os.pathsep + "ird")
+    inherited = os.pathsep.join(["/usr/bin", "/bin"])
+    monkeypatch.setattr(server, "COMFY_BIN", str(exe))
+    monkeypatch.setenv("PATH", inherited)
+
+    path = server._comfy_env()["PATH"]
+
+    assert path == inherited
+    # Nothing relative leaked in — that is the half with security weight.
+    assert all(os.path.isabs(entry) for entry in path.split(os.pathsep))
+
+
+@_needs_posix_exec
 def test_comfy_env_path_prepend_keeps_the_existing_pins(tmp_path, monkeypatch):
     """The PATH rewrite is additive — every previously-injected pin still holds."""
     exe = _dummy_comfy(tmp_path)


### PR DESCRIPTION
## ELI-5

`comfy launch --background` doesn't do the launching itself — it turns around and runs `comfy` *again* as a detached process, and it does that by typing the plain word `comfy` and letting the OS look it up on `PATH`. So if you told this server "call comfy-cli at `/some/venv/bin/comfy`" but that folder isn't on the `PATH` the server inherited, comfy-cli can't find *itself* the second time. It blows up with `FileNotFoundError: 'comfy'` before ComfyUI is ever started, and `launch_comfyui` reports the unhelpful `comfy-cli returned no JSON (exit 1)`. Fix: whatever binary we resolved `COMFY_BIN` to, we now put its folder first on the `PATH` we hand the child, so comfy-cli can always find itself.

## Summary

Fixes `launch_comfyui` failing outright whenever `COMFY_BIN` is an absolute path (e.g. a virtualenv install) and that directory is not on the `PATH` the MCP server inherited — which is the normal state for a server launched by a GUI client on macOS, and exactly the configuration the README tells people to use.

## Changes

- **`_comfy_env()`** — after building the merged child environment, resolve `COMFY_BIN` with `shutil.which` and prepend the resolved binary's directory to `PATH` unless it is already first. `_comfy_env` is the documented single source of truth for the child environment, so both spawn sites (`_run_comfy_raw` and `_run_comfy_streaming`) pick this up with no per-site change. Its docstring gains the rationale.
- **`launch_comfyui` docstring** — its "temporary upstream caveat" section documented only the Python 3.14 asyncio crash. It now also documents the bare-name re-invocation, the guarantee this server makes about it, and the fact that the traceback's first rendered frame (`comfy_cli/tracking.py`) is a red herring rather than a telemetry problem.
- **`README.md`** — one sentence on the `COMFY_BIN` bullet stating that setting it is sufficient on its own; you do not also have to put the directory on the client's `PATH`. That was the documented promise before this change, and it was not true for `launch_comfyui`.
- **13 new tests** in `tests/test_wrapper.py` covering the absolute-path prepend, absolutization of a relative `COMFY_BIN`, the no-duplicate case when the directory is already first, the deliberate prepend when it is present but *later*, the bare-name case, both no-op cases (unresolvable / non-executable), the empty and absent `PATH` edges, the previously-injected pins still holding, and both spawn sites actually handing the rewritten `PATH` to the child.

## Motivation

Confirmed by live repro against comfy-cli 1.12.0. `comfy_cli/command/launch.py` builds the detached command as a literal `["comfy", f"--workspace={...}", "launch"]` and hands it to `subprocess.Popen`. On POSIX, `Popen` resolves that bare name against the `PATH` in the environment it is given, so the outer process must be reachable by name from inside its own child environment. `launch.py` also `os.chdir`s to the workspace before that point, which is why the prepended entry is absolutized — a relative one would resolve against the wrong directory by the time it is used.

## Testing

- [x] Full suite passes (`pytest`) — 659 passed, 2 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] **Red/green verified at the unit level.** With the `server.py` change reverted, 8 of the 13 new tests fail; the 5 that pass are precisely the ones asserting `PATH` is left *untouched* (unresolvable `COMFY_BIN`, non-executable file, no inherited `PATH`, and the already-first no-op), which must hold both before and after. All 13 pass with the fix.
- [x] **Red/green verified end-to-end against a real comfy-cli 1.12.0 binary**, not just mocks. Driving `launch_comfyui()` under `env -i PATH=/usr/bin:/bin COMFY_BIN=<venv>/bin/comfy DO_NOT_TRACK=1`:
  - *Before:* child `PATH` = `/usr/bin:/bin` → `comfy-cli returned no JSON (exit 1)` … `FileNotFoundError: [Errno 2] No such file or directory: 'comfy'`.
  - *After:* child `PATH` = `<venv>/bin:/usr/bin:/bin` → the re-invocation resolves, comfy-cli proceeds to `Launching ComfyUI from: …` and then fails only because that scratch workspace holds no real ComfyUI install. The `FileNotFoundError` is gone; the failure has moved past the bug.

## Additional Notes

### Chesterton's fence

`PATH` is the only inherited variable this function now rewrites rather than injecting alongside, so the existing behavior deserves the check. `_comfy_env` has always forwarded `os.environ` wholesale on purpose (that passthrough is how `COMFY_LOCAL_URL` / `COMFY_API_KEY` reach comfy-cli), and nothing in its history treats the inherited `PATH` as load-bearing in a way this breaks: the change is strictly a prepend, so every entry that resolved in the child before still resolves, in the same relative order. Nothing is removed or reordered among the inherited entries.

### Known side effect, accepted deliberately

Prepending the binary's directory also hoists everything *else* in that directory. For the common case — a virtualenv `bin/` — that means the child's `python`, `pip`, etc. now resolve to the venv comfy-cli itself is installed in. That is the same resolution you would get from activating that venv before running `comfy` by hand, so it makes the child *more* consistent with the install it was pointed at, not less. Prepending rather than appending is also the point: it stops a stale second comfy install earlier on the user's `PATH` from shadowing the intended one inside the child, which is a separately-reported failure flavor. Appending would fix the missing-binary crash but leave that shadowing case broken.

For a bare-name `COMFY_BIN` (the default), the prepend cannot change which `comfy` is selected — `shutil.which` already returned the first match on `PATH` — so there it is purely defensive against comfy-cli reordering `PATH` internally.

### Out of scope

The cleaner fix belongs upstream in comfy-cli: `background_launch` should re-invoke via `sys.executable -m comfy_cli` rather than a bare `comfy`, which would remove the `PATH` dependency entirely. That remains desirable and is not attempted here — this repo is a thin wrapper and cannot change comfy-cli's re-invocation, and the guarantee added here is correct regardless of whether the upstream change lands.

### Judgment call

The originating ticket asked for its tracker IDs to be cross-referenced in this PR description. `AGENTS.md` ("Destined-public hygiene") forbids internal-tracker references in PR titles and bodies, and none of the repo's recent PRs carry them, so the two referenced reports are described by their content here instead. The IDs are retained in the source comments and docstrings, where the same `AGENTS.md` bullet does not apply and the existing convention already uses them, and the branch name carries the tracker autolink as usual.
