### PR TITLE
fix: reap the whole process group when a comfy-cli spawn times out

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -195,7 +195,7 @@ def _bounded_timeout(timeout_seconds: float, ceiling: float) -> float:
 
     ``min(max(t, 0.0), ceiling)`` looks like it does this and does not: every
     NaN comparison is False, so ``max(nan, 0.0)`` returns ``nan``, ``min`` keeps
-    it, and it reaches ``subprocess.run(timeout=nan)`` — where the selector
+    it, and it reaches ``Popen.communicate(timeout=nan)`` — where the selector
     raises a bare :class:`ValueError` that no caller catches (only
     ``TimeoutExpired`` is handled). The one value the ceiling exists to stop was
     the one that slipped through, and NaN is reachable because JSON and pydantic
@@ -221,7 +221,7 @@ def _reject_nul(label: str, value: str) -> str:
     """Reject an embedded NUL, which ``subprocess`` cannot carry in argv.
 
     A NUL is a valid character in a JSON (and so MCP) string, but
-    ``subprocess.run`` raises a bare ``ValueError: embedded null byte`` on one —
+    ``subprocess.Popen`` raises a bare ``ValueError: embedded null byte`` on one —
     uncaught here, so it would surface as an internal error rather than the
     :class:`ComfyCliError` every other bad input produces. Only NUL is refused:
     values are free-form model input (a prompt legitimately spans lines).
@@ -315,7 +315,7 @@ def _guard_prompt_id(prompt_id: str) -> str:
     *parsing*: a leading dash reaches comfy-cli as an option rather than an id,
     most sharply in ``fetch_outputs`` where it sits beside that command's own
     ``-o`` / ``--url-only``. An embedded NUL is a legal JSON (and so MCP) string
-    but makes ``subprocess.run`` raise a bare ``ValueError``, which would surface
+    but makes ``subprocess.Popen`` raise a bare ``ValueError``, which would surface
     as an internal error instead of the :class:`ComfyCliError` every other bad
     input produces. An empty id can only ever be a caller mistake, and is
     refused like every other positional this module guards. A wildly oversized
@@ -341,6 +341,12 @@ def _guard_prompt_id(prompt_id: str) -> str:
 # its own, then fall through to the `finally` that kills it — never block on a
 # lingering child once the answer is already parsed.
 _POST_ENVELOPE_REAP_GRACE = 5.0
+
+# Ceiling on the post-kill drain of a timed-out plain spawn (`_drain_timed_out`).
+# The group is already dead by then, so the pipes are at EOF and the read
+# returns immediately; the bound only exists so a child that survived SIGKILL
+# (uninterruptible sleep) cannot hold the tool call open past its deadline.
+_DRAIN_TIMEOUT = 5.0
 
 # Dedicated, bounded thread pool for the blocking pipe reads / process waits in
 # `_run_comfy_streaming` (`stdout.readline`, `stderr.read`, `proc.wait`).
@@ -376,7 +382,7 @@ def _in_pipe_pool(func, *args):
 # generate` run.
 #
 # That run is the longest blocking call in this server — up to
-# `_MAX_GENERATE_TIMEOUT` (an hour) parked in `subprocess.run`. Cancelling the
+# `_MAX_GENERATE_TIMEOUT` (an hour) parked in `_run_comfy_raw`. Cancelling the
 # awaiting coroutine (an MCP cancellation, a client disconnect) does NOT
 # interrupt the OS thread, so on asyncio's shared *default* executor a handful
 # of abandoned partner runs could occupy that pool for an hour and starve every
@@ -385,7 +391,7 @@ def _in_pipe_pool(func, *args):
 # streaming pipe reads.
 #
 # Shared with the `run_template` / `generate_image` submit paths, which are the
-# same class of call: a blocking `subprocess.run` on a tool that is async for its
+# same class of call: a blocking `_run_comfy_raw` on a tool that is async for its
 # own spend-consent round-trip. Their `wait=True` runs stream instead (see
 # `_run_comfy_streaming`), so what those two park here is the short
 # fire-and-return submit, not the hour-long wait.
@@ -527,11 +533,11 @@ class ComfyCliError(RuntimeError):
     timeout).
 
     ``timed_out`` marks the one failure that is not comfy-cli misbehaving but us
-    running out of patience: the child was killed at the ``timeout=`` we handed
-    :func:`subprocess.run`. A caller that *chose* that budget can then tell its
-    own deadline firing from a genuine comfy-cli error without matching on the
-    message — :func:`wait_for_job`, which caps each poll to the time left on the
-    caller's bound, is exactly that caller.
+    running out of patience: the child's whole process group was killed at the
+    ``timeout=`` we handed ``communicate``. A caller that *chose* that budget
+    can then tell its own deadline firing from a genuine comfy-cli error without
+    matching on the message — :func:`wait_for_job`, which caps each poll to the
+    time left on the caller's bound, is exactly that caller.
     """
 
     def __init__(
@@ -969,39 +975,53 @@ def _run_comfy_raw(
     # a trailing --json errors with "No such option". (Verified against comfy-cli.)
     cmd = [COMFY_BIN, "--json", "--where", "local", *args]
     env = _comfy_env()
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        # This process speaks JSON-RPC over stdio, so the parent's stdin IS
+        # the protocol channel. A child that inherits it (the subprocess
+        # default) can consume request bytes the client sent us — silently
+        # corrupting the session — or block on a prompt nobody can answer.
+        # No comfy-cli invocation here is interactive, so close it outright;
+        # `_comfy_env` also sets GIT_TERMINAL_PROMPT=0 / PIP_NO_INPUT=1 so a
+        # child that WOULD have prompted fails fast instead of hanging.
+        stdin=subprocess.DEVNULL,
+        text=True,
+        # Pin the parent-side decode to UTF-8 so it matches what the child
+        # is forced to emit (_comfy_env). Without this, text=True decodes
+        # the pipe with the system locale (cp1252 on a default Windows
+        # console) and the non-ASCII catalog output raises UnicodeDecodeError
+        # or yields mojibake before _unwrap_envelope — the exact crash this
+        # fix targets, just moved to the reader.
+        encoding="utf-8",
+        env=env,
+        # Own process group so a timeout can kill the whole TREE, exactly as the
+        # streaming path has since BE-3343. comfy-cli's long verbs fork real
+        # work — `update` runs `git pull` and then a multi-GB
+        # `pip install -r requirements.txt`, `model download` streams a large
+        # file — and `subprocess.run` (which this used to be) kills only the
+        # direct `comfy` child on a timeout, so those grandchildren kept
+        # mutating the ComfyUI workspace and Python environment long after the
+        # tool reported failure. `Popen` is what exposes the pid the group kill
+        # needs. See `_kill_proc_tree`.
+        start_new_session=True,
+    )
     try:
-        proc = subprocess.run(
-            cmd,
-            capture_output=True,
-            # This process speaks JSON-RPC over stdio, so the parent's stdin IS
-            # the protocol channel. A child that inherits it (the subprocess
-            # default) can consume request bytes the client sent us — silently
-            # corrupting the session — or block on a prompt nobody can answer.
-            # No comfy-cli invocation here is interactive, so close it outright;
-            # `_comfy_env` also sets GIT_TERMINAL_PROMPT=0 / PIP_NO_INPUT=1 so a
-            # child that WOULD have prompted fails fast instead of hanging.
-            stdin=subprocess.DEVNULL,
-            text=True,
-            # Pin the parent-side decode to UTF-8 so it matches what the child
-            # is forced to emit (_comfy_env). Without this, text=True decodes
-            # the pipe with the system locale (cp1252 on a default Windows
-            # console) and the non-ASCII catalog output raises UnicodeDecodeError
-            # or yields mojibake before _unwrap_envelope — the exact crash this
-            # fix targets, just moved to the reader.
-            encoding="utf-8",
-            timeout=timeout,
-            env=env,
-            check=False,
-        )
+        stdout, stderr = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired as exc:
-        # subprocess.run attaches whatever the child wrote before being killed
-        # (capture_output=True) to the exception — surface it so a crashed,
-        # wedged comfy-cli (e.g. a traceback on stderr) is not indistinguishable
-        # from a genuinely slow one. See BE-3343.
+        # Kill the GROUP, not just `comfy`, then reap on a bounded wait so a
+        # child stuck in D state cannot park this call forever.
+        _kill_proc_tree(proc)
+        _reap(proc)
+        # Whatever the child wrote before being killed — surface it so a
+        # crashed, wedged comfy-cli (e.g. a traceback on stderr) is not
+        # indistinguishable from a genuinely slow one. See BE-3343.
+        stdout, stderr = _drain_timed_out(proc, exc)
         message = (
             f"comfy-cli timed out after {timeout}s: {' '.join(cmd)}. "
-            f"stderr tail: {textutil._tail(exc.stderr) or '<empty>'}; "
-            f"stdout tail: {textutil._tail(exc.stdout) or '<empty>'}"
+            f"stderr tail: {textutil._tail(stderr) or '<empty>'}; "
+            f"stdout tail: {textutil._tail(stdout) or '<empty>'}"
         )
         # `exit_code=None`: the child was killed at the deadline, so it never
         # reported one. The log keeps a longer slice of both streams than the
@@ -1010,17 +1030,28 @@ def _run_comfy_raw(
             "timeout",
             args,
             message=message,
-            stdout=exc.stdout,
-            stderr=exc.stderr,
+            stdout=stdout,
+            stderr=stderr,
         )
         raise ComfyCliError(message, timed_out=True) from exc
+    except BaseException:
+        # Mirrors `subprocess.run`'s own bare `except` (it kills the child and
+        # lets `Popen.__exit__` clean up): anything else raised while draining
+        # the pipes — a strict-UTF-8 `UnicodeDecodeError` on the child's output,
+        # a `KeyboardInterrupt` — must not leave the child running either. This
+        # kills the whole group and bounds the wait, where `run` killed only the
+        # direct child and then waited on it without a deadline.
+        _kill_proc_tree(proc)
+        _reap(proc)
+        _close_pipes(proc)
+        raise
 
     return (
-        _last_json_object(proc.stdout),
-        proc.stdout,
+        _last_json_object(stdout),
+        stdout,
         args,
         proc.returncode,
-        proc.stderr,
+        stderr,
     )
 
 
@@ -1086,14 +1117,22 @@ def _envelope_major(envelope: dict) -> int | None:
 def _kill_proc_tree(proc: subprocess.Popen) -> None:
     """Kill the child *and* any grandchildren it spawned.
 
-    comfy-cli can fork a ComfyUI/helper grandchild that inherits the stderr
-    pipe's write-end; killing only the direct child leaves that fd open, so the
-    blocking ``proc.stderr.read()`` we run in a ``to_thread`` worker never sees
-    EOF and the thread leaks — repeated timeouts then exhaust the default
-    ``to_thread`` pool and wedge the server. Killing the whole process group
-    (the child is spawned with ``start_new_session=True``, so it leads its own
-    group) closes every copy of the pipe. Falls back to a plain ``kill`` on
-    Windows / test fakes, where ``killpg`` is unavailable. (BE-3343)
+    Shared by both spawn sites — :func:`_run_comfy_raw` and
+    :func:`_run_comfy_streaming` both pass ``start_new_session=True``, so the
+    child leads its own process group and one ``killpg`` reaps the whole tree.
+
+    On the streaming path that closes every copy of the stderr pipe: comfy-cli
+    can fork a ComfyUI/helper grandchild that inherits the pipe's write-end, and
+    killing only the direct child leaves that fd open, so the blocking
+    ``proc.stderr.read()`` we run in a ``to_thread`` worker never sees EOF and
+    the thread leaks — repeated timeouts then exhaust the default ``to_thread``
+    pool and wedge the server. On the plain path the stake is the work itself:
+    ``comfy update``'s ``git pull`` + ``pip install`` and ``comfy model
+    download``'s transfer keep mutating the workspace after the tool has already
+    reported a timeout, so they have to die with their parent.
+
+    Falls back to a plain ``kill`` on Windows / test fakes, where ``killpg`` is
+    unavailable. (BE-3343)
     """
     if proc.poll() is not None:
         return
@@ -1118,6 +1157,53 @@ def _reap(proc: subprocess.Popen, timeout: float = 5.0) -> None:
         proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         pass
+
+
+def _close_pipes(proc: subprocess.Popen) -> None:
+    """Close a spawn's stdout/stderr pipes, best-effort.
+
+    ``communicate()`` closes them itself on both of its normal exits, so this is
+    only for the path where it raised something other than a timeout: without it
+    the parent would leak two fds per failed spawn in a long-lived server.
+    ``subprocess.run`` got this from the ``with Popen(...)`` block it wrapped
+    every call in; :func:`_run_comfy_raw` manages the process by hand (that
+    block's ``__exit__`` waits on the child WITHOUT a deadline, which is the
+    wedge :func:`_reap` exists to bound), so it closes them here instead.
+    """
+    for pipe in (proc.stdout, proc.stderr):
+        if pipe is None:
+            continue
+        try:
+            pipe.close()
+        except OSError:
+            pass
+
+
+def _drain_timed_out(
+    proc: subprocess.Popen, exc: subprocess.TimeoutExpired
+) -> tuple[Any, Any]:
+    """Whatever a killed-at-the-deadline child wrote before it died.
+
+    ``subprocess.run`` handed this back attached to the ``TimeoutExpired`` it
+    re-raised; with ``Popen`` we drain it ourselves. A ``communicate()`` after a
+    timeout resumes the same accumulation buffers, so it returns the FULL
+    partial output rather than only what arrived after the deadline — and it is
+    bounded, because a child that survived ``SIGKILL`` (D state) could otherwise
+    hold the pipes open forever. The exception's own captures are the fallback
+    for exactly that case; either stream may be ``None`` (nothing written) or
+    ``bytes`` (POSIX attaches the undecoded partial read), both of which
+    ``textutil._tail`` and ``failure_log`` already handle.
+    """
+    try:
+        stdout, stderr = proc.communicate(timeout=_DRAIN_TIMEOUT)
+    except (OSError, ValueError, subprocess.SubprocessError):
+        # The drain itself gave up, so nothing else will close these.
+        _close_pipes(proc)
+        return exc.stdout, exc.stderr
+    return (
+        exc.stdout if stdout is None else stdout,
+        exc.stderr if stderr is None else stderr,
+    )
 
 
 def _unwrap_envelope(
@@ -3813,7 +3899,7 @@ def fetch_outputs(
     prompt_id = _guard_prompt_id(prompt_id)
     # `out_dir` is the sibling client-supplied positional and rides the same argv
     # as the id, so it needs the same NUL refusal: `_run_comfy_raw` only converts
-    # `TimeoutExpired`, leaving `subprocess.run`'s bare "embedded null byte"
+    # `TimeoutExpired`, leaving `subprocess.Popen`'s bare "embedded null byte"
     # ValueError to escape as an internal error. A leading dash is NOT rejected
     # here — `-o` takes a value, so comfy-cli reads even a dash-led one as this
     # option's argument, and a relative path is legitimate input.

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -1191,17 +1191,40 @@ def _kill_proc_tree(proc: subprocess.Popen) -> None:
     download``'s transfer keep mutating the workspace after the tool has already
     reported a timeout, so they have to die with their parent.
 
+    The group kill is UNCONDITIONAL — deliberately NOT gated on ``proc.poll()``.
+    A dead leader does not mean a dead tree: the case that matters most is
+    precisely the one where ``comfy`` itself has already exited but a forked
+    grandchild (``update``'s ``git pull`` / ``pip install``, a ``model
+    download``'s transfer) is still running and still holding the pipe open —
+    which is *why* ``communicate()`` blew its deadline. A ``poll()`` gate would
+    read that survivor's exited parent and skip the kill exactly when the
+    descendant most needs reaping, defeating the point of the group. The
+    zombie leader keeps the process group alive for its members, so the
+    ``killpg`` still lands.
+
+    Callers must therefore invoke this BEFORE anything reaps the child (a
+    ``wait``/``poll`` that returns a code). Once reaped, the pid is free for the
+    OS to reuse and ``killpg`` could signal an unrelated group; the streaming
+    path's two call sites gate on ``proc.poll() is None`` for that reason (they
+    can run after a completed ``proc.wait``), while :func:`_run_comfy_raw` calls
+    in straight off a ``communicate()`` that never reaped.
+
+    Signals ``proc.pid`` directly rather than ``os.getpgid(proc.pid)``: with
+    ``start_new_session=True`` the child IS its own group leader, so the two are
+    the same number, and ``getpgid`` on an already-reaped child raises — turning
+    the lookup itself into a way to skip the kill.
+
     Falls back to a plain ``kill`` on Windows / test fakes, where ``killpg`` is
-    unavailable. (BE-3343)
+    unavailable. That fallback reaches only the direct child; a Windows tree
+    kill needs ``taskkill /T`` or a Job Object and is tracked separately.
+    (BE-3343)
     """
-    if proc.poll() is not None:
-        return
     try:
-        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        os.killpg(proc.pid, signal.SIGKILL)
     except (OSError, AttributeError, ValueError):
         try:
             proc.kill()
-        except (OSError, AttributeError):
+        except (OSError, AttributeError, ValueError):
             pass
 
 
@@ -1239,6 +1262,20 @@ def _close_pipes(proc: subprocess.Popen) -> None:
             pass
 
 
+def _longer_capture(first: Any, second: Any) -> Any:
+    """Whichever of two partial captures of the SAME stream carries more.
+
+    Both come from consecutive ``TimeoutExpired``s on one pipe, so they are the
+    same type (``bytes`` on POSIX, which is what CPython attaches even in text
+    mode) or ``None`` for "nothing written" — never a mix worth guarding.
+    """
+    if first is None:
+        return second
+    if second is None:
+        return first
+    return second if len(second) > len(first) else first
+
+
 def _drain_timed_out(
     proc: subprocess.Popen, exc: subprocess.TimeoutExpired
 ) -> tuple[Any, Any]:
@@ -1256,8 +1293,22 @@ def _drain_timed_out(
     """
     try:
         stdout, stderr = proc.communicate(timeout=_DRAIN_TIMEOUT)
+    except subprocess.TimeoutExpired as second:
+        # The drain blew its own deadline — a descendant survived `SIGKILL` and
+        # is still holding the pipes. `communicate()` resumes the SAME
+        # accumulation buffers, so what it attaches to this second exception is
+        # a superset of the first's: keep the longer capture rather than
+        # discarding everything that arrived after the original deadline.
+        _close_pipes(proc)
+        return (
+            _longer_capture(exc.stdout, second.stdout),
+            _longer_capture(exc.stderr, second.stderr),
+        )
     except (OSError, ValueError, subprocess.SubprocessError):
-        # The drain itself gave up, so nothing else will close these.
+        # The drain itself gave up, so nothing else will close these. Unlike the
+        # second-timeout case above, these carry no partial capture of their own
+        # (a `UnicodeDecodeError` holds only the chunk it choked on), so the
+        # first exception's is genuinely the best available.
         _close_pipes(proc)
         return exc.stdout, exc.stderr
     return (

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -1252,13 +1252,19 @@ def _close_pipes(proc: subprocess.Popen) -> None:
     every call in; :func:`_run_comfy_raw` manages the process by hand (that
     block's ``__exit__`` waits on the child WITHOUT a deadline, which is the
     wedge :func:`_reap` exists to bound), so it closes them here instead.
+
+    Swallows ``ValueError`` alongside ``OSError``: closing a text wrapper whose
+    underlying buffer was already detached raises the former, and this runs from
+    the ``except BaseException`` cleanup whose whole job is that nothing escapes
+    it — matching the same tolerance in :func:`_kill_proc_tree` and
+    :func:`_drain_timed_out`.
     """
     for pipe in (proc.stdout, proc.stderr):
         if pipe is None:
             continue
         try:
             pipe.close()
-        except OSError:
+        except (OSError, ValueError):
             pass
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 The comfy-cli version guard (`server._check_comfy_version`) shells out to
 `comfy --version` once per process from inside `_run_comfy`. The unit tests stub
-`subprocess.run` to emit canned envelopes and assert the exact argv — a stray
+the comfy-cli spawn to emit canned envelopes and assert the exact argv — a stray
 `comfy --version` call would consume that stub and pollute those assertions. So
 by default we mark the guard "already checked" for every test; the dedicated
 guard tests (`test_wrapper.py`) re-enable it explicitly and mock `--version`.
@@ -13,11 +13,14 @@ This module also holds the shared test helpers for both comfy-cli spawn paths,
 so a change to how ``server`` shells out lands in ONE fake rather than in a
 copy per test file:
 
-* the plain ``--json`` path (``subprocess.run``) — ``envelope`` +
-  ``patched_run`` / ``patched_plain_run``;
-* the streaming ``--json-stream`` path (``subprocess.Popen``) —
-  ``patched_stream``. ``run_workflow``, ``watch_job`` and ``generate_image``
-  all drive the same NDJSON stream.
+* the plain ``--json`` path (``subprocess.Popen`` + a bounded
+  ``communicate``) — ``envelope`` + ``patched_run`` / ``patched_plain_run``;
+* the streaming ``--json-stream`` path (``subprocess.Popen`` + incremental
+  reads) — ``patched_stream``. ``run_workflow``, ``watch_job`` and
+  ``generate_image`` all drive the same NDJSON stream.
+
+Both paths spawn with ``start_new_session=True`` so a timeout can kill the whole
+process group; the fakes model that too (see ``_FakeRunProc``).
 """
 
 from __future__ import annotations
@@ -25,7 +28,6 @@ from __future__ import annotations
 import io
 import json
 import logging
-import subprocess
 
 import pytest
 
@@ -44,7 +46,7 @@ def _skip_spend_gate_probe(monkeypatch):
 
     Same reason as the version guard above: the probe shells out to
     ``comfy generate consent show`` before the first spending call, which would
-    consume the stubbed ``subprocess.run`` and shift every exact-argv assertion.
+    consume the stubbed spawn and shift every exact-argv assertion.
     The dedicated probe tests (`test_partner_generate.py`) re-enable it.
     """
     monkeypatch.setattr(server, "_spend_gate_probed", True)
@@ -55,7 +57,7 @@ def _skip_engine_auto_confirm_probe(monkeypatch):
     """Answer ``partner_generate``'s per-call ``spend.auto_confirm`` read as OFF.
 
     Third once-per-call shell-out on the spending path (``comfy generate consent
-    show --json``); it would consume the stubbed ``subprocess.run`` and shift the
+    show --json``); it would consume the stubbed spawn and shift the
     exact-argv assertions the same way the two guards above would. ``False`` is
     also the default posture under test — the engine has no durable
     always-proceed, so consent has to come from the call itself. The dedicated
@@ -139,33 +141,118 @@ def envelope(*, ok: bool = True, data=_UNSET, error=None) -> dict:
     return body
 
 
-def _canonical_run(calls: list[dict], *, stdout, returncode, stderr, raises):
-    """The one ``subprocess.run`` stand-in for the plain (non-streaming) path.
+def _raises_at_spawn(exc: BaseException) -> bool:
+    """Whether the real :class:`subprocess.Popen` would raise ``exc`` itself.
 
-    Its parameter list mirrors ``_run_comfy``'s exact ``subprocess.run`` kwargs
-    — which is precisely why it lives here: a kwarg added or renamed there (the
-    ``encoding=`` pin was the last one) is a one-line edit instead of a sweep
-    across every test file.
+    The constructor fails with an ``OSError`` (no such binary, EPERM, a
+    wrong-arch exec) or the bare ``ValueError`` an embedded NUL in argv
+    produces; a deadline (``TimeoutExpired``) and a strict-UTF-8
+    ``UnicodeDecodeError`` on the child's output both surface from the bounded
+    ``communicate`` instead. The fakes place an injected exception where the
+    real pair would, so it reaches the handler it would reach in production —
+    ``UnicodeDecodeError`` is explicitly excluded because it is a ``ValueError``
+    subclass and would otherwise be mistaken for the NUL case.
+    """
+    return isinstance(exc, (OSError, ValueError)) and not isinstance(
+        exc, UnicodeDecodeError
+    )
 
-    Each call is recorded as ``{"cmd", "env", "timeout", "encoding", "stdin"}`` —
-    a superset of what any caller asserts on — BEFORE ``raises`` fires, so a test
-    for a spawn that blows up can still see the argv it blew up on.
+
+class _FakeRunProc:
+    """A ``Popen`` stand-in for the plain path: one canned result, no real pipes.
+
+    ``_run_comfy_raw`` spawns with :class:`subprocess.Popen` and bounds the run
+    with ``communicate(timeout=…)``, so the fake models both halves — the spawn
+    (argv / env / stdin / encoding) and the wait (the timeout, the canned
+    output, and on the timeout path the kill → reap → drain sequence).
+
+    It deliberately carries NO ``pid``, exactly like :class:`_FakeProc`: that
+    sends ``server._kill_proc_tree`` down its ``AttributeError`` fallback to
+    ``proc.kill()`` instead of calling ``os.killpg`` on a made-up pid, which on
+    a real machine could signal an unrelated process group. The dedicated
+    group-kill test supplies its own fake with a pid and stubs ``os.killpg``.
     """
 
-    def fake(cmd, capture_output, stdin, text, encoding, timeout, env, check):  # noqa: ARG001
-        calls.append(
-            {
-                "cmd": cmd,
-                "env": env,
-                "timeout": timeout,
-                "encoding": encoding,
-                "stdin": stdin,
-            }
-        )
-        if raises is not None:
+    def __init__(self, cmd, record, *, stdout, stderr, returncode, raises):
+        self.args = cmd
+        self.record = record
+        # Back-reference so a test can assert on what the timeout/failure
+        # handler did to the process it spawned (``calls[0]["proc"].killed``).
+        record["proc"] = self
+        self.stdout = None  # `communicate` hands back the canned text directly
+        self.stderr = None
+        self.returncode = None
+        self.killed = False
+        self._stdout = stdout
+        self._stderr = stderr
+        self._exit_code = returncode
+        self._raises = raises
+        self._communicates = 0
+
+    def communicate(self, timeout=None):
+        self._communicates += 1
+        if self._communicates > 1:
+            # The post-kill drain. A real ``communicate()`` after a timeout
+            # resumes the buffers it was filling when the deadline fired, so it
+            # returns the partial output ``subprocess.run`` used to attach to
+            # the ``TimeoutExpired`` — replay the exception's captures.
+            return getattr(self._raises, "stdout", None), getattr(
+                self._raises, "stderr", None
+            )
+        self.record["timeout"] = timeout  # the bound only reaches us here
+        if self._raises is not None:
+            raise self._raises
+        self.returncode = self._exit_code
+        return self._stdout, self._stderr
+
+    def poll(self):
+        return self.returncode  # None until it exits or is killed
+
+    def wait(self, timeout=None):  # noqa: ARG002
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+
+def _canonical_run(calls: list[dict], *, stdout, returncode, stderr, raises):
+    """The one ``subprocess.Popen`` stand-in for the plain (non-streaming) path.
+
+    Its parameter list mirrors ``_run_comfy_raw``'s exact ``subprocess.Popen``
+    kwargs — which is precisely why it lives here: a kwarg added or renamed
+    there (``start_new_session=`` was the last one, when the timeout handler
+    started reaping the whole process group) is a one-line edit instead of a
+    sweep across every test file.
+
+    Each call is recorded as ``{"cmd", "env", "timeout", "encoding", "stdin",
+    "start_new_session", "proc"}`` — a superset of what any caller asserts on —
+    BEFORE ``raises`` fires, so a test for a spawn that blows up can still see
+    the argv it blew up on. ``timeout`` is filled in by ``communicate``, which
+    is where the bound now lands, and ``proc`` is the spawned
+    :class:`_FakeRunProc` (absent when the spawn itself raised).
+    """
+    canned_stdout, canned_stderr = stdout, stderr
+
+    def fake(cmd, stdout, stderr, stdin, text, encoding, env, start_new_session):  # noqa: ARG001
+        record = {
+            "cmd": cmd,
+            "env": env,
+            "timeout": None,
+            "encoding": encoding,
+            "stdin": stdin,
+            "start_new_session": start_new_session,
+        }
+        calls.append(record)
+        if raises is not None and _raises_at_spawn(raises):
             raise raises
-        return subprocess.CompletedProcess(
-            cmd, returncode, stdout=stdout, stderr=stderr
+        return _FakeRunProc(
+            cmd,
+            record,
+            stdout=canned_stdout,
+            stderr=canned_stderr,
+            returncode=returncode,
+            raises=raises,
         )
 
     return fake
@@ -173,7 +260,7 @@ def _canonical_run(calls: list[dict], *, stdout, returncode, stderr, raises):
 
 @pytest.fixture
 def patched_run(monkeypatch):
-    """Patch ``shutil.which`` + ``subprocess.run`` for the plain ``--json`` path.
+    """Patch ``shutil.which`` + ``subprocess.Popen`` for the plain ``--json`` path.
 
     Returns ``setup(stdout=…, returncode=…, stderr=…, raises=…) -> calls``:
 
@@ -181,7 +268,9 @@ def patched_run(monkeypatch):
       :func:`envelope`) or a raw string; defaults to an empty-``data`` success
       envelope.
     * ``raises`` — an exception instance the fake raises instead of returning,
-      for the spawn-failure paths (``TimeoutExpired`` and friends).
+      from the spawn or from the wait per :func:`_raises_at_spawn`. A
+      ``TimeoutExpired`` comes out of the wait, and the fake then plays out the
+      kill → reap → drain the handler runs against it.
 
     ``calls`` is the live list every invocation is recorded into, for the exact
     argv assertions this suite is built on.
@@ -196,7 +285,7 @@ def patched_run(monkeypatch):
         monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
         monkeypatch.setattr(
             server.subprocess,
-            "run",
+            "Popen",
             _canonical_run(
                 calls,
                 stdout=stdout,

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import subprocess
 
 import pytest
+from conftest import _FakeRunProc, _raises_at_spawn
 
 from comfy_local_mcp import server
 
@@ -329,25 +330,37 @@ def patched_env_then_outdated(monkeypatch):
 
     ``server_info`` shells out twice — ``comfy env`` then ``comfy outdated`` —
     so unlike ``patched_env`` (same envelope every call) this queues ONE reply
-    per call: each entry is a ``CompletedProcess``-shaping tuple
-    ``(returncode, stdout, stderr)`` or an exception instance to raise.
+    per call: each entry is a result-shaping tuple ``(returncode, stdout,
+    stderr)`` or an exception instance to raise.
+
+    Sequenced replies are the carve-out AGENTS.md allows for a local stub, but
+    it still mirrors the shared fake's spawn signature and reuses its
+    :class:`_FakeRunProc`, so a change to how ``server`` shells out breaks here
+    loudly rather than drifting.
     """
 
     def setup(replies: list) -> list[dict]:
         calls: list[dict] = []
 
-        def fake(cmd, capture_output, stdin, text, encoding, timeout, env, check):  # noqa: ARG001
-            calls.append({"cmd": cmd, "timeout": timeout})
+        def fake(cmd, stdout, stderr, stdin, text, encoding, env, start_new_session):  # noqa: ARG001
+            record = {"cmd": cmd, "timeout": None}
+            calls.append(record)
             reply = replies[len(calls) - 1]
-            if isinstance(reply, BaseException):
+            failed = isinstance(reply, BaseException)
+            if failed and _raises_at_spawn(reply):
                 raise reply
-            returncode, stdout, stderr = reply
-            return subprocess.CompletedProcess(
-                cmd, returncode, stdout=stdout, stderr=stderr
+            returncode, out, err = (None, None, None) if failed else reply
+            return _FakeRunProc(
+                cmd,
+                record,
+                stdout=out,
+                stderr=err,
+                returncode=returncode,
+                raises=reply if failed else None,
             )
 
         monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-        monkeypatch.setattr(server.subprocess, "run", fake)
+        monkeypatch.setattr(server.subprocess, "Popen", fake)
         monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.12.0")
         monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", None)
         return calls

--- a/tests/test_partner_generate.py
+++ b/tests/test_partner_generate.py
@@ -383,20 +383,20 @@ def test_engine_auto_confirms_is_false_when_the_probe_cannot_run(monkeypatch):
         UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"),
     ],
 )
-def test_engine_auto_confirms_is_false_when_the_probe_blows_up(monkeypatch, exc):
+def test_engine_auto_confirms_is_false_when_the_probe_blows_up(patched_run, exc):
     """The docstring promises EVERY failure answers False — including non-CLI ones.
 
     `_run_comfy_raw` converts a timeout and a missing binary into `ComfyCliError`,
     but a present-but-unusable one (`PermissionError`/`OSError`) and invalid-UTF-8
     child output (`UnicodeDecodeError`) escape it raw. Crashing `partner_generate`
     on those is strictly worse than falling back to asking the user.
+
+    The shared fake raises each of these from the place the real spawn would —
+    the two `OSError`s from `Popen`, the decode error from `communicate` — so
+    this also covers the handler that kills the process group on a non-timeout
+    failure.
     """
-
-    def boom(*args, **kwargs):  # noqa: ARG001
-        raise exc
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "run", boom)
+    patched_run(raises=exc)
 
     assert _real_engine_auto_confirms() is False
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -20,6 +20,7 @@ import os
 import subprocess
 
 import pytest
+from conftest import _FakeRunProc
 
 from comfy_local_mcp import server, tcc
 
@@ -336,12 +337,15 @@ def test_version_guard_ignores_a_healthy_comfy_cli(on_macos, monkeypatch):
 
 
 def _patch_failing_run(monkeypatch, stderr: str) -> None:
+    """A comfy-cli spawn that exits 1 with ``stderr`` and no envelope."""
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
 
-    def fake_run(cmd, **kwargs):  # noqa: ARG001
-        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr=stderr)
+    def fake_popen(cmd, **kwargs):  # noqa: ARG001
+        return _FakeRunProc(
+            cmd, {}, stdout="", stderr=stderr, returncode=1, raises=None
+        )
 
-    monkeypatch.setattr(server.subprocess, "run", fake_run)
+    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
 
 
 def test_tool_call_surfaces_the_fix_instead_of_returned_no_json(on_macos, monkeypatch):
@@ -379,9 +383,9 @@ def test_a_real_error_envelope_is_untouched(on_macos, monkeypatch):
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
     monkeypatch.setattr(
         server.subprocess,
-        "run",
-        lambda cmd, **kw: subprocess.CompletedProcess(  # noqa: ARG005
-            cmd, 1, stdout=envelope, stderr=_FATAL_STDERR
+        "Popen",
+        lambda cmd, **kw: _FakeRunProc(  # noqa: ARG005
+            cmd, {}, stdout=envelope, stderr=_FATAL_STDERR, returncode=1, raises=None
         ),
     )
 

--- a/tests/test_run_template.py
+++ b/tests/test_run_template.py
@@ -99,14 +99,15 @@ class _FakeCtx:
 def patched_streamed_run(patched_stream, monkeypatch):
     """``setup(stdout=...) -> calls`` — the same recorder over the STREAMING path.
 
-    ``wait=True`` spawns comfy-cli with ``subprocess.Popen`` and reads NDJSON, so
-    ``patched_run``'s ``subprocess.run`` stub never sees it. This wraps the shared
-    ``patched_stream`` fixture and spies on :func:`server._run_comfy_streaming`
-    (delegating to the real one, so the whole streaming path still runs) to record
-    the same ``{"cmd", "timeout"}`` shape the plain-path tests assert — ``cmd``
-    from the spawned fake process, ``timeout`` being the parent's backstop budget,
-    which the streaming path takes as an argument rather than handing to
-    ``subprocess.run``.
+    ``wait=True`` reads NDJSON incrementally off the ``Popen`` pipes rather than
+    draining them with one bounded ``communicate``, so ``patched_run``'s
+    canned-result stub cannot serve it. This wraps the shared ``patched_stream``
+    fixture and spies on :func:`server._run_comfy_streaming` (delegating to the
+    real one, so the whole streaming path still runs) to record the same
+    ``{"cmd", "timeout"}`` shape the plain-path tests assert — ``cmd`` from the
+    spawned fake process, ``timeout`` being the parent's backstop budget, which
+    the streaming path bounds the read loop with rather than handing to
+    ``communicate``.
 
     ``stdout`` mirrors ``patched_run``'s contract — a dict (an :func:`envelope`,
     NDJSON-encoded as the stream's final line for you) or a raw NDJSON string;

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -2654,16 +2654,20 @@ class _GroupKillProc:
 
     conftest's `_FakeRunProc` deliberately carries no `pid` so `_kill_proc_tree`
     takes its single-child fallback rather than calling `os.killpg` on a made-up
-    one. This fake has a pid, and the test stubs `os.getpgid`/`os.killpg`, so the
-    group path is the one under test.
+    one. This fake has a pid, and the test stubs `os.killpg`, so the group path
+    is the one under test.
+
+    `exited` models the case the group kill exists for: the direct `comfy` child
+    is already gone (a non-None `poll()`) while a forked grandchild is still
+    running and holding the pipes — which is why `communicate()` timed out.
     """
 
-    def __init__(self, cmd, exc):
+    def __init__(self, cmd, exc, *, exited=False):
         self.args = cmd
         self.pid = 424242
         self.stdout = None
         self.stderr = None
-        self.returncode = None
+        self.returncode = -1 if exited else None
         self.killed = False
         self._exc = exc
         self._communicates = 0
@@ -2702,7 +2706,6 @@ def test_sync_timeout_kills_the_whole_process_group(monkeypatch):
     signalled: list[tuple[int, int]] = []
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
     monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: proc)  # noqa: ARG005
-    monkeypatch.setattr(server.os, "getpgid", lambda pid: pid)  # it leads its group
     monkeypatch.setattr(
         server.os, "killpg", lambda pgid, sig: signalled.append((pgid, sig))
     )
@@ -2710,12 +2713,101 @@ def test_sync_timeout_kills_the_whole_process_group(monkeypatch):
     with pytest.raises(server.ComfyCliError) as exc:
         server._run_comfy("update", "all", timeout=1800.0)
 
+    # `start_new_session=True` makes the child its own group leader, so its pid
+    # IS the pgid — signalled directly, without an `os.getpgid` lookup that
+    # would raise (and so skip the kill) on an already-reaped leader.
     assert signalled == [(proc.pid, signal.SIGKILL)]  # the GROUP, not the child
     assert proc.killed is False  # so the single-child fallback never had to fire
     assert exc.value.timed_out is True
     # The drain after the kill is what recovers the partial output that
     # `subprocess.run` used to attach to the `TimeoutExpired` itself.
     assert "drained stderr" in str(exc.value)
+
+
+def test_group_kill_is_not_gated_on_the_leader_still_running(monkeypatch):
+    """A dead `comfy` does not mean a dead tree — kill the group regardless.
+
+    The case this whole change exists for is a `comfy update` whose `git pull` /
+    `pip install` (or a `model download`) outlives its parent: `comfy` itself has
+    exited, the grandchild is still running and still holding the pipe open —
+    which is exactly WHY `communicate()` blew its deadline. Gating the group kill
+    on `proc.poll() is None` would read the exited leader and skip the kill in
+    precisely that case, leaving the descendant to keep mutating the workspace.
+    """
+    proc = _GroupKillProc(
+        [server.COMFY_BIN, "update", "all"],
+        _timeout(stderr=None, stdout=None),
+        exited=True,  # the leader is already gone; its group is not
+    )
+    signalled: list[tuple[int, int]] = []
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: proc)  # noqa: ARG005
+    monkeypatch.setattr(
+        server.os, "killpg", lambda pgid, sig: signalled.append((pgid, sig))
+    )
+
+    with pytest.raises(server.ComfyCliError):
+        server._run_comfy("update", "all", timeout=1800.0)
+
+    assert signalled == [(proc.pid, signal.SIGKILL)]  # the survivors still die
+
+
+def test_drain_second_timeout_keeps_the_longer_capture(monkeypatch):
+    """A drain that times out too still reports what it managed to read.
+
+    `communicate()` resumes the same accumulation buffers, so the capture on the
+    drain's own `TimeoutExpired` is a superset of the first one's. Falling back
+    to the first would silently under-report the diagnostics in the timeout
+    message and the failure log.
+    """
+
+    class _DoubleTimeoutProc(_GroupKillProc):
+        def communicate(self, timeout=None):  # noqa: ARG002
+            self._communicates += 1
+            if self._communicates == 1:
+                raise self._exc
+            raise subprocess.TimeoutExpired(
+                self.args, 5.0, output=b"first chunk + more", stderr=b"traceback tail"
+            )
+
+    proc = _DoubleTimeoutProc(
+        [server.COMFY_BIN, "update", "all"],
+        _timeout(stderr=b"trace", stdout=b"first"),
+    )
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: proc)  # noqa: ARG005
+    monkeypatch.setattr(server.os, "killpg", lambda pgid, sig: None)  # noqa: ARG005
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        server._run_comfy("update", "all", timeout=1800.0)
+
+    msg = str(exc.value)
+    assert "first chunk + more" in msg  # the drain's longer read, not `first`
+    assert "traceback tail" in msg
+
+
+def test_drain_non_timeout_failure_falls_back_to_the_first_capture(monkeypatch):
+    """A drain that dies on a decode error has nothing better than the first read."""
+
+    class _DecodeFailProc(_GroupKillProc):
+        def communicate(self, timeout=None):  # noqa: ARG002
+            self._communicates += 1
+            if self._communicates == 1:
+                raise self._exc
+            raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+
+    proc = _DecodeFailProc(
+        [server.COMFY_BIN, "update", "all"],
+        _timeout(stderr="partial trace", stdout="partial out"),
+    )
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: proc)  # noqa: ARG005
+    monkeypatch.setattr(server.os, "killpg", lambda pgid, sig: None)  # noqa: ARG005
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        server._run_comfy("update", "all", timeout=1800.0)
+
+    assert "partial trace" in str(exc.value)
 
 
 def test_sync_non_timeout_failure_still_reaps_the_child(patched_run):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -2671,9 +2671,16 @@ class _GroupKillProc:
         self.killed = False
         self._exc = exc
         self._communicates = 0
+        # Every bound this fake was handed, in order: [0] is the caller's own
+        # timeout, [1] the post-kill drain's. Recorded so a test can pin that
+        # the drain stays BOUNDED — an unbounded second `communicate()` is the
+        # exact wedge `_DRAIN_TIMEOUT` exists to prevent, and a fake that merely
+        # ignores the argument would never notice it going missing.
+        self.timeouts: list = []
 
-    def communicate(self, timeout=None):  # noqa: ARG002
+    def communicate(self, timeout=None):
         self._communicates += 1
+        self.timeouts.append(timeout)
         if self._communicates == 1:
             raise self._exc
         return "drained stdout", "drained stderr"  # the post-kill drain
@@ -2762,8 +2769,9 @@ def test_drain_second_timeout_keeps_the_longer_capture(monkeypatch):
     """
 
     class _DoubleTimeoutProc(_GroupKillProc):
-        def communicate(self, timeout=None):  # noqa: ARG002
+        def communicate(self, timeout=None):
             self._communicates += 1
+            self.timeouts.append(timeout)
             if self._communicates == 1:
                 raise self._exc
             raise subprocess.TimeoutExpired(
@@ -2784,14 +2792,19 @@ def test_drain_second_timeout_keeps_the_longer_capture(monkeypatch):
     msg = str(exc.value)
     assert "first chunk + more" in msg  # the drain's longer read, not `first`
     assert "traceback tail" in msg
+    # And the drain that produced it stayed bounded: a post-kill `communicate()`
+    # with no deadline is what `_DRAIN_TIMEOUT` exists to stop, since a
+    # descendant that survived SIGKILL can hold the pipes open indefinitely.
+    assert proc.timeouts == [1800.0, server._DRAIN_TIMEOUT]
 
 
 def test_drain_non_timeout_failure_falls_back_to_the_first_capture(monkeypatch):
     """A drain that dies on a decode error has nothing better than the first read."""
 
     class _DecodeFailProc(_GroupKillProc):
-        def communicate(self, timeout=None):  # noqa: ARG002
+        def communicate(self, timeout=None):
             self._communicates += 1
+            self.timeouts.append(timeout)
             if self._communicates == 1:
                 raise self._exc
             raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
@@ -2808,6 +2821,7 @@ def test_drain_non_timeout_failure_falls_back_to_the_first_capture(monkeypatch):
         server._run_comfy("update", "all", timeout=1800.0)
 
     assert "partial trace" in str(exc.value)
+    assert proc.timeouts == [1800.0, server._DRAIN_TIMEOUT]  # still a bounded drain
 
 
 def test_sync_non_timeout_failure_still_reaps_the_child(patched_run):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import signal
 import subprocess
 import threading
 import time
@@ -1205,24 +1206,21 @@ def test_wait_for_job_reraises_a_non_timeout_poll_failure(monkeypatch):
         server.wait_for_job("pid", timeout_seconds=1.0)
 
 
-def test_run_comfy_marks_a_subprocess_timeout(monkeypatch):
+def test_run_comfy_marks_a_subprocess_timeout(patched_run):
     """The `timed_out` flag is set only where the child was killed at our budget.
 
     `wait_for_job` branches on it to tell its own deadline from a comfy-cli
     failure, so the flag has to come from the raise site rather than the message.
     """
-
-    def fake_subprocess_run(cmd, **kwargs):
-        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
-
-    monkeypatch.setattr(server.subprocess, "run", fake_subprocess_run)
-    monkeypatch.setattr(server, "_require_comfy_bin", lambda: None)
-    monkeypatch.setattr(server, "_check_comfy_version", lambda: None)
+    calls = patched_run(
+        raises=subprocess.TimeoutExpired([server.COMFY_BIN, "jobs"], 1.0)
+    )
 
     with pytest.raises(server.ComfyCliError) as excinfo:
         server._run_comfy("jobs", "status", "pid", timeout=1.0)
 
     assert excinfo.value.timed_out is True
+    assert calls[0]["timeout"] == 1.0  # the caller's budget bounded the wait
 
 
 def test_prompt_id_guard_rejects_an_oversized_id(monkeypatch):
@@ -2382,6 +2380,107 @@ def test_sync_timeout_with_no_captures_is_sane(patched_run):
     assert "stdout tail: <empty>" in msg
 
 
+def test_plain_spawn_leads_its_own_process_group(patched_run):
+    """The plain path spawns with `start_new_session=True`, like the streaming one.
+
+    Prerequisite for the group kill below: without it the child sits in the MCP
+    server's OWN process group, so `os.getpgid(child)` would resolve to the
+    server and the timeout handler would SIGKILL itself.
+    """
+    calls = patched_run()
+
+    server._run_comfy("env", timeout=5.0)
+
+    assert calls[0]["start_new_session"] is True
+
+
+class _GroupKillProc:
+    """A `Popen` fake with a pid, for the process-group assertions below.
+
+    conftest's `_FakeRunProc` deliberately carries no `pid` so `_kill_proc_tree`
+    takes its single-child fallback rather than calling `os.killpg` on a made-up
+    one. This fake has a pid, and the test stubs `os.getpgid`/`os.killpg`, so the
+    group path is the one under test.
+    """
+
+    def __init__(self, cmd, exc):
+        self.args = cmd
+        self.pid = 424242
+        self.stdout = None
+        self.stderr = None
+        self.returncode = None
+        self.killed = False
+        self._exc = exc
+        self._communicates = 0
+
+    def communicate(self, timeout=None):  # noqa: ARG002
+        self._communicates += 1
+        if self._communicates == 1:
+            raise self._exc
+        return "drained stdout", "drained stderr"  # the post-kill drain
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):  # noqa: ARG002
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+
+def test_sync_timeout_kills_the_whole_process_group(monkeypatch):
+    """A timed-out plain spawn reaps comfy-cli's DESCENDANTS, not just comfy-cli.
+
+    comfy-cli's long verbs fork real work — `comfy update` runs `git pull` and
+    then a multi-GB `pip install -r requirements.txt`, `comfy model download`
+    streams a large file — and both ride a 1800s ceiling. `subprocess.run` (what
+    this path used to be) kills only the direct child at the deadline, so those
+    grandchildren kept mutating the ComfyUI workspace and Python environment
+    long after the tool had reported failure, or died mid-write. Assert on the
+    signal that actually reaches the group.
+    """
+    proc = _GroupKillProc(
+        [server.COMFY_BIN, "update", "all"], _timeout(stderr=None, stdout=None)
+    )
+    signalled: list[tuple[int, int]] = []
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: proc)  # noqa: ARG005
+    monkeypatch.setattr(server.os, "getpgid", lambda pid: pid)  # it leads its group
+    monkeypatch.setattr(
+        server.os, "killpg", lambda pgid, sig: signalled.append((pgid, sig))
+    )
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        server._run_comfy("update", "all", timeout=1800.0)
+
+    assert signalled == [(proc.pid, signal.SIGKILL)]  # the GROUP, not the child
+    assert proc.killed is False  # so the single-child fallback never had to fire
+    assert exc.value.timed_out is True
+    # The drain after the kill is what recovers the partial output that
+    # `subprocess.run` used to attach to the `TimeoutExpired` itself.
+    assert "drained stderr" in str(exc.value)
+
+
+def test_sync_non_timeout_failure_still_reaps_the_child(patched_run):
+    """A decode error mid-drain must not leak the child either.
+
+    `subprocess.run` wrapped every call in `with Popen(...)` and had a bare
+    `except` that killed the process before re-raising; `_run_comfy_raw` owns
+    the process by hand now, so it has to do that itself — and it kills the
+    whole group rather than just the child.
+    """
+    calls = patched_run(
+        raises=UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+    )
+
+    with pytest.raises(UnicodeDecodeError):
+        server._run_comfy("env", timeout=5.0)
+
+    assert calls[0]["proc"].killed is True
+
+
 class _BlockingProcWithStderr:
     """A blocking Popen fake that also carries buffered stderr (a crashed child's traceback)."""
 
@@ -3172,14 +3271,14 @@ def test_update_comfyui_refuses_a_concurrent_update(monkeypatch, patched_plain_r
     calls = patched_plain_run(0, stderr="done")
     inside = threading.Event()
     release = threading.Event()
-    fixture_run = server.subprocess.run
+    fixture_popen = server.subprocess.Popen
 
-    def blocking_run(*args, **kwargs):
+    def blocking_popen(*args, **kwargs):
         inside.set()  # the first update now holds the lock...
         release.wait(5)  # ...and keeps holding it until this test lets go
-        return fixture_run(*args, **kwargs)
+        return fixture_popen(*args, **kwargs)
 
-    monkeypatch.setattr(server.subprocess, "run", blocking_run)
+    monkeypatch.setattr(server.subprocess, "Popen", blocking_popen)
     worker = threading.Thread(target=server.update_comfyui, args=("comfy",))
     worker.start()
     try:


### PR DESCRIPTION
## ELI-5

When a `comfy` command took too long, we hung up on it — but only on the thing we were talking to directly. Anything IT had started (a `git pull`, a multi-gigabyte `pip install`, a model download) kept right on running, still writing into the user's ComfyUI folder and Python environment, while the tool had already reported "timed out". Now the whole family goes down together.

## Summary

`_run_comfy_raw` is the one spawn behind every non-streaming tool. It used `subprocess.run`, and `subprocess.run` kills only the DIRECT child on `TimeoutExpired` — grandchildren survive. That matters because comfy-cli's long verbs fork real work: `comfy update` runs `git pull` and then `pip install -r requirements.txt`, and `comfy model download` streams a large file. Both ride a 1800s ceiling, so any update or download that exceeds 30 minutes (slow network, big requirements install) left an orphaned `git`/`pip` mutating the workspace — or dying mid-write — with nothing in the server aware of it.

This converts the spawn to `subprocess.Popen` + `communicate(timeout=…)` with `start_new_session=True`, which is exactly how `_run_comfy_streaming` has spawned since the same class of bug was fixed on the streaming path. `Popen` is what exposes the pid the group kill needs; `subprocess.run` never does.

## Changes

- `_run_comfy_raw`: `subprocess.run(...)` → `subprocess.Popen(...)` + `proc.communicate(timeout=timeout)`, with `start_new_session=True` so the child leads its own process group. Every other kwarg (`stdin=DEVNULL`, `text`, `encoding="utf-8"`, `env`) and its comment is carried over verbatim; `capture_output=True` becomes the equivalent `stdout=PIPE, stderr=PIPE`.
- On `TimeoutExpired`: `_kill_proc_tree(proc)` (killpg the group, with the existing `proc.kill()` fallback for Windows/test fakes) → `_reap(proc)` (bounded wait) → a second `communicate()` to drain the pipes. That drain is what recovers the partial output `subprocess.run` used to attach to the exception.
- New `_drain_timed_out` helper: the drain is itself bounded (`_DRAIN_TIMEOUT = 5.0`) so a child that survived `SIGKILL` in uninterruptible sleep can't hold the tool call open, and it falls back to the exception's own captures if the drain gives up. Either stream can be `None` or `bytes`, both of which `textutil._tail` and `failure_log` already handle.
- New `except BaseException` branch that also reaps, mirroring the bare `except` inside `subprocess.run` (which killed the child before re-raising, and let its `with Popen(...)` block clean up). Without it a `UnicodeDecodeError` on the child's output — a real path here, since the decode is strict UTF-8 — would leak the process. It kills the whole group and bounds the wait, where `run` killed only the direct child and then waited on it with no deadline; new `_close_pipes` covers the fd cleanup that block used to provide.
- `_kill_proc_tree`'s docstring now states both callers and both stakes (the leaked stderr-reader thread on the streaming path, the still-running `git`/`pip` on the plain one).
- Doc/comment references to `subprocess.run` that described THIS spawn are updated to name what actually raises now (`Popen` for the NUL `ValueError`, `communicate` for the NaN timeout). The `comfy --version` probe still uses `subprocess.run` and is untouched.

Tests:

- `tests/conftest.py`: the shared `_canonical_run` fake now patches `subprocess.Popen` and returns a `_FakeRunProc` that models the wait — it records `cmd`/`env`/`timeout`/`encoding`/`stdin` (plus `start_new_session` and a `proc` back-reference) exactly as before, so **no exact-argv assertion in the suite needed editing**. An injected exception is raised from the place the real pair would raise it (`_raises_at_spawn`: `OSError`/NUL-`ValueError` from the spawn, `TimeoutExpired`/`UnicodeDecodeError` from the wait), so each one reaches the handler it reaches in production. The fake deliberately carries no `pid`, so `_kill_proc_tree` takes its documented single-child fallback rather than calling `os.killpg` on a made-up pid.
- Three new tests: the plain spawn passes `start_new_session=True`; a timed-out spawn signals the process GROUP (`killpg(pgid, SIGKILL)`) and never falls back to the child-only kill; a non-timeout failure still reaps.
- Four other spawn stubs had to move to `Popen` as well (the ticket named only `test_compat`'s sequenced-reply fixture): `test_permissions`' two `_run_comfy` stubs, `test_partner_generate`'s probe-blows-up parametrization (now on the shared fixture), and `test_wrapper`'s timeout-flag and concurrent-update stubs. None of them is an argv assertion — they are all "how does the spawn fail/return" stubs.

## Motivation

Deferred from a review thread on #92 — the defect is a property of the shared spawn helper and predates that PR; every non-streaming tool has the same exposure, `download_model` most of all. It had to be done as one piece: adding `start_new_session=True` alone, without group reaping, would DETACH descendants from the server's process group so they'd survive even the parent MCP server dying — strictly worse than the bug.

## Testing

- [x] Existing tests pass (`pytest`) — 719 passed, 2 skipped, on Python 3.10 and 3.14
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — see below

**Real-process verification (not a mock).** Pointed `COMFY_BIN` at a shell script that forks a grandchild (`sleep 60`, recording its pid) and then blocks, and called `_run_comfy_raw(..., timeout=2.0)`:

| | error message | grandchild after the timeout |
|---|---|---|
| `origin/main` | `comfy-cli timed out after 2.0s: … stderr tail: partial stderr; stdout tail: partial stdout` | **still alive — orphaned** |
| this branch | *byte-for-byte the same string* | **gone — process group reaped** |

That is the acceptance criteria proven directly: descendants die, and the message is identical. Both runs returned at the 2.0s deadline, and `timed_out=True` on both.

**Mutation-checked the new tests** so they aren't decorative — each of these breaks exactly one test and nothing else: replacing `_kill_proc_tree(proc)` with `proc.kill()` fails the group-kill test; flipping `start_new_session` to `False` fails the session test; removing the `except BaseException` reap fails the non-timeout-reap test.

## Additional Notes

- **Judgment call — scope.** The diff is ~420 changed lines, over the small-PR preference, but a large share is carried-over comments and the fake's docstrings; the functional change is the ~40 lines of `_run_comfy_raw` plus the conftest fake. It is not splittable: the spawn conversion and the shared fake have to land together or the suite is red in between.
- **Judgment call — four extra test stubs.** The ticket predicted `conftest` + one `test_compat` stub. Four more stubs mock the plain-path spawn directly and had to move to `Popen` too; two of them I folded onto the shared `patched_run` fixture instead of rewriting the local stub, per AGENTS.md's "mock through the shared fixtures" rule.
- **Windows.** `start_new_session` is a documented POSIX-only knob that CPython's Windows `_execute_child` accepts and ignores (it is bound as `unused_start_new_session`), and `_kill_proc_tree` already falls back to `proc.kill()` where `os.killpg` is absent. The streaming path has passed the same flag unconditionally since it was written, so this adds no new Windows exposure.
- **Capability-denial check:** not applicable — this diff denies nothing. It adds no "not supported"/"unavailable"/deny path and flips no test to assert a dead-end; the user-visible outcome of a timeout is identical to before, only the cleanup is complete.
- The `comfy --version` probe (`_spawn_comfy_version`) still uses `subprocess.run`. It is a 30s bounded, non-forking call with no grandchildren to leak, so converting it would be churn.
