### PR TITLE
docs(server_info): document that workspace.manager_mode is not Manager presence

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -2067,6 +2067,17 @@ def server_info() -> Any:
     and, to see the dropped warning, run ``COMFY_LOCAL_URL=<value> comfy env``
     in a terminal.
 
+    ``workspace.manager_mode`` describes the cm-cli integration comfy-cli can
+    use, not whether ComfyUI-Manager exists: it reflects a per-user config
+    override first and otherwise whether the ``comfyui_manager`` pip package is
+    importable in the workspace venv. A Manager installed the legacy way —
+    cloned into ``custom_nodes/`` — is fully functional server-side yet still
+    reports ``"not-installed"`` here, and a stale config value can report a
+    mode for a Manager that was since removed. Treat ``"not-installed"`` as
+    "comfy-cli's Manager commands are unavailable", never as "Manager is
+    absent" — do not advise the user to install ComfyUI-Manager on the strength
+    of this field alone.
+
     Also the compatibility gate for the unpinned comfy-cli this server shells
     out to: it asserts comfy-cli's envelope schema major matches the
     ``envelope/N`` this wrapper parses, and — when a ``COMFY_CLI_MIN_VERSION``


### PR DESCRIPTION
## ELI-5

`server_info` reports a `workspace.manager_mode` field that comes straight from comfy-cli. Agents have been reading `"not-installed"` as "ComfyUI-Manager isn't here" and nagging users to install a Manager they already have. The field doesn't mean that — it means "comfy-cli's Manager commands aren't wired up." This PR says so in the tool's own description, so the agent reading it stops giving that bad advice. Docstring only; no code changes.

## Summary

Extends the `server_info` docstring — which is the MCP tool description agents actually see — with a paragraph explaining what `workspace.manager_mode` does and does not mean.

## Changes

- `src/comfy_local_mcp/server.py`: added an 11-line paragraph to the `server_info` docstring, placed after the existing `COMFY_LOCAL_URL` guidance and before the compatibility-gate paragraph, in the same voice as the rest of the docstring.

## Motivation

`workspace.manager_mode` is a pass-through from `comfy env`. Verified against comfy-cli `origin/main`, it is computed as: `ConfigManager.get(CONFIG_KEY_MANAGER_GUI_MODE)` if set, else the legacy `CONFIG_KEY_MANAGER_GUI_ENABLED` migrated to `disable`/`enable-gui`, else `find_cm_cli()` — an `import cm_cli` probe against the workspace venv Python (`comfy_cli/command/custom_nodes/cm_cli_util.py`). `comfy_cli/workspace_manager.py` `fill_data()` passes `not_installed_value="not-installed"`, and `comfy_cli/cmdline.py` nests that dict as `data["workspace"]`, so the field path in the docstring is exactly right. I confirmed the `cm_cli` top-level module ships in the `comfyui-manager` PyPI wheel (4.2.2), so "the `comfyui_manager` pip package is importable" is the accurate description of that probe.

The consequence: a ComfyUI-Manager installed the legacy way — git-cloned into `custom_nodes/` — is fully functional server-side but invisible to that probe, so it reports `"not-installed"`. The reverse is possible too: a stale config value reports a mode for a Manager that has since been removed.

Per the thin-wrapper rule in `AGENTS.md`, this repo must not add its own Manager detection — the detection fix belongs in comfy-cli and is tracked separately. This PR is deliberately docstring-only.

## Testing

- [x] Existing tests pass (`pytest`) — 749 passed, 2 skipped (e2e), **identical before and after the change** (ran the suite with the diff stashed to confirm a zero test-behavior delta)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — verified via `await mcp.list_tools()` that the caveat is present in the `server_info` **MCP tool description** (not just the source docstring); the description is 4380 chars and the paragraph renders in place.

## Additional Notes

**Judgment call — "a per-user config override" instead of naming the key.** The ticket plan's wording is used verbatim except that I did not name `manager_gui_mode`. comfy-cli honors *two* config keys here (the current `manager_gui_mode` and a legacy `manager_gui_enabled` that migrates to `disable`/`enable-gui`), so naming only one would be inaccurate and would drift as the migration path changes. The generic phrase covers both, and the actionable point for the agent is unchanged.

**Negative-claim falsification.** The diff adds the string "unavailable", so I checked whether it denies a capability. Its net user-facing effect is the opposite of a denial: it stops agents from falsely reporting Manager as absent, and explicitly points at the path that *does* work (the legacy `custom_nodes/` clone is functional server-side). The one narrow denial it does state — that when the field reads `"not-installed"`, comfy-cli's Manager commands are unavailable — I verified by reading comfy-cli rather than assuming: `execute_cm_cli` (`cm_cli_util.py`) and `validate_comfyui_manager` (`custom_nodes/command.py`) both hard-gate on the same `find_cm_cli()` that produces the `"not-installed"` value, so there is no comfy-cli Manager path that works while the field reads that. This server also exposes no Manager tool of its own, so no tool path is being closed off.

**No other call sites.** `manager_mode` appears nowhere else in this repo (no code, no README, no test), and no test snapshots tool descriptions — so there is no snapshot to update and nothing else to keep in sync.
