### PR TITLE
feat(workflow): accept structured {address, value} slot items in set_workflow_slot and vary_workflow

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -53,7 +53,7 @@ import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any
+from typing import Any, TypeVar
 from urllib.parse import urlparse
 
 from mcp import types
@@ -272,9 +272,10 @@ def _reject_option_like(label: str, value: str, expected: str = "") -> str:
     - **A dash-leading slot ADDR** (``vary_workflow``'s ``slots``). An ``ADDR``
       begins with the node id, which comfy-cli surfaces non-negative via
       ``list_workflow_slots``, so no reachable address starts with ``-``. It also
-      costs no capability: ``set_workflow_slot``'s overrides and both param
-      marshalers (:func:`_validate_param_key`) already refuse one, so every other
-      way to name a slot in this module rejects it too.
+      costs no capability: ``set_workflow_slot``'s overrides, the structured
+      forms' ``address`` (:func:`_slot_address_arg`), and both param marshalers
+      (:func:`_validate_param_key`) already refuse one, so every other way to
+      name a slot in this module rejects it too.
 
     And one deliberate NON-rejection, which is what "nearly" above is doing:
 
@@ -4963,25 +4964,192 @@ def list_workflow_slots(workflow_path: str) -> Any:
     return _run_comfy("workflow", "slots", workflow_path, timeout=60.0)
 
 
+class SlotOverride(BaseModel):
+    """One ``set_workflow_slot`` override, as structured data instead of a string.
+
+    The reason this form exists: comfy-cli splits an override on its first ``=``
+    and runs the value portion through ``json.loads``, falling back to the
+    literal string when that fails. So the ``"ADDR=VALUE"`` string form
+    COERCES — ``"6.text=true"`` sets the boolean ``true``, ``"6.text=123"`` sets
+    the integer ``123``, and there is no way to spell the literal strings
+    ``"true"`` / ``"123"`` through it. Sending the value as DATA is lossless in
+    both directions: this server JSON-encodes it, and comfy-cli's ``json.loads``
+    decodes exactly what was sent.
+    """
+
+    address: str = Field(
+        description=(
+            "The slot address to set, exactly as `list_workflow_slots` reports "
+            "it in a slot's `address` field (e.g. '6.text')."
+        )
+    )
+    value: Any = Field(
+        description=(
+            "The value to set, as JSON data. Its type is preserved exactly: a "
+            "string stays a string (even 'true' or '42'), a number stays a "
+            "number, a boolean stays a boolean."
+        )
+    )
+
+
+class SlotVariants(BaseModel):
+    """One ``vary_workflow`` slot — an address and the values to sweep over it.
+
+    The structured counterpart to the ``"ADDR=[v1,v2,...]"`` string form, and
+    the same lossless-vs-coercing trade-off as :class:`SlotOverride`: comfy-cli
+    requires the value portion to parse to a JSON array, so ``values`` is sent
+    as one and every element keeps its type. It also removes the quoting
+    footgun the string form carries — a comma inside a prompt no longer has to
+    be hand-quoted to stay part of its value.
+    """
+
+    address: str = Field(
+        description=(
+            "The slot address to vary, exactly as `list_workflow_slots` reports "
+            "it in a slot's `address` field (e.g. '3.seed')."
+        )
+    )
+    values: list[Any] = Field(
+        description=(
+            "The values to sweep over this address, as JSON data. comfy-cli "
+            "ZIPS the lists across slots, so every slot's list must be the same "
+            "length. Must be non-empty."
+        )
+    )
+
+
+def _slot_address_arg(label: str, address: str) -> str:
+    """Validate a structured slot item's ``address`` and return it normalized.
+
+    A structured item's address becomes the portion before the first ``=`` of an
+    argv entry, so it inherits every constraint the string form's entry already
+    carries — hence the same ``_reject_option_like`` / ``_reject_nul`` pair the
+    string path runs, applied to the address specifically so the error names the
+    field the caller actually sent.
+
+    Two checks are new here because only the structured form can express them.
+    An empty (or all-whitespace) address would produce a bare ``"=value"`` entry
+    that comfy-cli splits into an address of ``""``; and an address containing
+    ``=`` would silently re-split, so ``{"address": "6.text=x", "value": "y"}``
+    would reach the engine as address ``6.text`` with value ``x="y"`` rather
+    than failing. Both are caller mistakes worth naming rather than forwarding.
+
+    The dash-leading rejection is defense in depth: a node id is non-negative
+    where ``list_workflow_slots`` surfaces it, so no reachable address starts
+    with ``-`` (see :func:`_reject_option_like`'s note on slot ADDRs). It is
+    guarded anyway for parity with the string path.
+    """
+    _reject_nul(f"{label} address", address)
+    stripped = address.strip()
+    expected = (
+        "a '<node_id>.<input>' address as `list_workflow_slots` reports it "
+        "(e.g. '6.text')"
+    )
+    if not stripped:
+        raise ComfyCliError(f"invalid {label} address: empty — expected {expected}")
+    if "=" in stripped:
+        raise ComfyCliError(
+            f"invalid {label} address: {_clip_for_error(stripped)} contains "
+            f"'=' — the address is only the part BEFORE the first '=', and the "
+            f"value belongs in its own field; expected {expected}"
+        )
+    return _reject_option_like(f"{label} address", stripped, expected=expected)
+
+
+def _slot_value_json(label: str, value: Any) -> str:
+    """JSON-encode a structured slot value, naming a non-encodable one.
+
+    Everything arriving over MCP is JSON already, so this can only fire for a
+    direct in-process caller that passed a Python object with no JSON form (a
+    ``set``, a ``datetime``). Naming it beats letting ``TypeError`` escape a
+    tool that reports every other input mistake as :class:`ComfyCliError`.
+
+    Note what encoding does to the NUL guard, since the asymmetry is deliberate:
+    the string form refuses a NUL because a raw one cannot ride in argv at all,
+    while ``json.dumps`` escapes it to ``\\u0000`` — so a structured value may
+    carry one, and comfy-cli's ``json.loads`` decodes it back on the far side.
+    That is the encoding doing its job (argv stays clean), not a hole in the
+    guard: the reason to refuse it never applies to an encoded value.
+    """
+    try:
+        return json.dumps(value)
+    except (TypeError, ValueError) as exc:
+        raise ComfyCliError(
+            f"invalid {label}: a {type(value).__name__} is not JSON data — send "
+            "a string, number, boolean, null, array, or object."
+        ) from exc
+
+
+_SlotModel = TypeVar("_SlotModel", bound=BaseModel)
+
+
+def _as_slot_model(item: Any, model: type[_SlotModel]) -> _SlotModel:
+    """Coerce one structured slot item to its model.
+
+    Over MCP, FastMCP has already validated the item into ``model``. A plain
+    mapping only reaches here from an in-process caller (this module's own
+    tests, a script importing the tool), so it is validated through the same
+    model rather than read key-by-key — one definition of the shape, one set of
+    error messages.
+    """
+    return item if isinstance(item, model) else model.model_validate(item)
+
+
+def _slot_override_arg(item: str | SlotOverride) -> str:
+    """Render one ``set_workflow_slot`` override as the ``ADDR=VALUE`` argv entry.
+
+    A string passes through byte-for-byte — that is the pre-existing form and
+    its coercing-but-established behavior is unchanged. A structured item is
+    serialized with ``json.dumps``, which is exactly what makes it lossless:
+    comfy-cli's ``json.loads`` is the inverse, so ``"true"`` arrives as the
+    string ``"true"`` (encoded ``"true"`` with its quotes) and ``42`` as the
+    integer.
+    """
+    if isinstance(item, str):
+        return item
+    override = _as_slot_model(item, SlotOverride)
+    address = _slot_address_arg("override", override.address)
+    return f"{address}={_slot_value_json('override value', override.value)}"
+
+
 @mcp.tool()
 def set_workflow_slot(
-    workflow_path: str, overrides: list[str], stdout: bool = True
+    workflow_path: str,
+    overrides: list[str | SlotOverride],
+    stdout: bool = True,
 ) -> Any:
     """Set one or more slot values on a frontend-format workflow.
 
-    Wraps ``comfy workflow set-slot <path> ADDR=VALUE [ADDR=VALUE ...]``, where
-    ``overrides`` is a list of ``"ADDR=VALUE"`` strings (the ``ADDR``s come from
-    ``list_workflow_slots``). This is the parameterize step of the template
-    on-ramp — change the prompt / seed / steps / model of a fetched template
-    without hand-editing its JSON.
+    Wraps ``comfy workflow set-slot <path> ADDR=VALUE [ADDR=VALUE ...]``. This
+    is the parameterize step of the template on-ramp — change the prompt / seed
+    / steps / model of a fetched template without hand-editing its JSON.
+
+    Each entry of ``overrides`` may be EITHER form, and the two can be mixed in
+    one list:
+
+    - **Structured (preferred)** — ``{"address": "6.text", "value": "a cat"}``.
+      The value's type is PRESERVED EXACTLY, because this server JSON-encodes it
+      and comfy-cli decodes it with ``json.loads``. Feed ``list_workflow_slots``'
+      ``address`` straight in.
+    - **String** — ``"6.text=a cat"``, the original form. comfy-cli parses the
+      part after the first ``=`` as JSON and falls back to the literal string,
+      so this form COERCES: ``"6.text=true"`` sets the boolean ``true`` and
+      ``"6.text=123"`` sets the integer ``123``. Use the structured form when
+      you mean the literal strings ``"true"`` / ``"123"``.
 
     ``stdout`` defaults to ``True`` (``--stdout``), so the tool is
     NON-DESTRUCTIVE: comfy-cli returns the modified workflow instead of mutating
     ``workflow_path`` in place. Set ``stdout=False`` to write the change back to
-    the file. Canonical loop::
+    the file. Canonical loop, driven off the slot list::
 
         path = fetch_template("flux_dev", "/tmp/flux.json")
-        modified = set_workflow_slot(path, ["6.text=a red bicycle", "3.seed=42"])
+        wanted = {"6.text": "a red bicycle", "3.seed": 42}
+        overrides = [
+            {"address": slot["address"], "value": wanted[slot["address"]]}
+            for slot in list_workflow_slots(path)["slots"]
+            if slot["address"] in wanted
+        ]
+        modified = set_workflow_slot(path, overrides)
         # write `modified` to disk (or call with stdout=False), then run_workflow
     """
     # `workflow_path` and each override are splatted in as bare positionals, so
@@ -4999,14 +5167,21 @@ def set_workflow_slot(
         ),
     )
     _reject_nul("workflow_path", workflow_path)
-    for o in overrides:
+    rendered = []
+    for item in overrides:
+        # Rendered per item, then guarded, so the argv guards read what actually
+        # reaches argv — a structured item is held to the same bar as a string
+        # one rather than to a laxer one on the strength of having been typed —
+        # and the first bad entry is still the one reported.
+        o = _slot_override_arg(item)
         _reject_option_like(
             "override",
             o,
             expected="an 'ADDR=VALUE' string (e.g. '6.text=a red bicycle')",
         )
         _reject_nul("override", o)
-    args = ["workflow", "set-slot", workflow_path, *overrides]
+        rendered.append(o)
+    args = ["workflow", "set-slot", workflow_path, *rendered]
     if stdout:
         args.append("--stdout")
     return _run_comfy(*args, timeout=60.0)
@@ -5151,23 +5326,75 @@ def _reject_non_json_array_slot(index: int, slot: str) -> None:
         )
 
 
+def _slot_variants_arg(index: int, item: str | SlotVariants) -> str:
+    """Render one ``vary_workflow`` slot as the ``ADDR=[v1,v2,...]`` argv entry.
+
+    A string passes through byte-for-byte, into the existing
+    :func:`_reject_non_json_array_slot` pre-check. A structured item is
+    serialized with ``json.dumps(values)`` — which IS the wire form comfy-cli
+    wants, since it requires the value portion to parse to a JSON array — so the
+    quoting gotcha the string form carries cannot arise: a comma inside a prompt
+    stays inside its value with nothing for the caller to escape.
+
+    An empty ``values`` is refused here rather than forwarded. comfy-cli zips
+    the lists, so an empty one yields zero variants: the run "succeeds" having
+    done nothing, which reads as a broken sweep rather than as the input mistake
+    it is.
+    """
+    if isinstance(item, str):
+        return item
+    variants = _as_slot_model(item, SlotVariants)
+    address = _slot_address_arg("slot", variants.address)
+    if not variants.values:
+        raise ComfyCliError(
+            f"invalid slots[{index}] for address {_clip_for_error(address)}: "
+            "`values` is empty — comfy-cli zips the value lists, so an empty "
+            "one produces zero variants. Give at least one value (and the same "
+            "count as every other slot)."
+        )
+    return f"{address}={_slot_value_json(f'slots[{index}] values', variants.values)}"
+
+
 @mcp.tool()
 def vary_workflow(
-    workflow_path: str, slots: list[str], out_dir: str | None = None
+    workflow_path: str,
+    slots: list[str | SlotVariants],
+    out_dir: str | None = None,
 ) -> Any:
     """Fan a frontend-format workflow out into variants over slot value lists.
 
-    Wraps ``comfy workflow vary <path> --slot "ADDR=[v1,v2,...]" [--slot ...]``.
-    ``slots`` is a list of ``"ADDR=[v1,v2,...]"`` strings, one per address (the
-    ``ADDR``s come from ``list_workflow_slots``); comfy-cli ZIPS the value lists,
-    so every list MUST be the same length — e.g. ``['3.seed=[1,2,3]',
-    '6.text=["a cat", "a dog", "a fish"]']`` yields three variants pairing seed
+    Wraps ``comfy workflow vary <path> --slot "ADDR=[v1,v2,...]" [--slot ...]``,
+    one entry per address (the addresses come from ``list_workflow_slots``).
+    comfy-cli ZIPS the value lists, so every list MUST be the same length — a
+    seed list of 3 and a prompt list of 3 yield three variants pairing seed
     1/cat, 2/dog, 3/fish.
 
-    **Each entry's value portion (everything after the first ``=``) must be
-    valid JSON, and must parse to a JSON ARRAY.** That is the whole gotcha, and
-    it bites hardest on prompts: a value containing a comma or spaces has to be
-    JSON-quoted, or it is not a list at all. Concretely::
+    Each entry of ``slots`` may be EITHER form, and the two can be mixed in one
+    list:
+
+    - **Structured (preferred)** — ``{"address": "6.text", "values": ["a cat",
+      "a dog"]}``. Each value's type is PRESERVED EXACTLY (this server encodes
+      the list with ``json.dumps``, which is the wire form comfy-cli wants), and
+      the JSON-quoting gotcha below cannot arise at all: a comma or spaces
+      inside a prompt stay part of that value with nothing to escape. ``values``
+      must be non-empty. Feed ``list_workflow_slots``' ``address`` straight in::
+
+          slots = [
+              {"address": slot["address"], "values": ["a cat", "a dog"]}
+              for slot in list_workflow_slots(path)["slots"]
+              if slot["address"] == "6.text"
+          ]
+          vary_workflow(path, slots)
+
+    - **String** — ``'6.text=["a cat", "a dog"]'``, the original form. Its value
+      portion is parsed as JSON by comfy-cli, so it COERCES (``'6.text=[true]'``
+      is a boolean, not the string ``"true"``) and it has the quoting gotcha
+      spelled out next.
+
+    **In the STRING form, each entry's value portion (everything after the first
+    ``=``) must be valid JSON, and must parse to a JSON ARRAY.** That is the
+    whole gotcha, and it bites hardest on prompts: a value containing a comma or
+    spaces has to be JSON-quoted, or it is not a list at all. Concretely::
 
         # WRONG — not valid JSON; comfy-cli reads it as one bare string and
         # fails with `value must be a JSON array (got str)`
@@ -5201,7 +5428,10 @@ def vary_workflow(
     )
     _reject_nul("workflow_path", workflow_path)
     args = ["workflow", "vary", workflow_path]
-    for index, slot in enumerate(slots):
+    for index, item in enumerate(slots):
+        # Rendered first so every guard below reads what actually reaches argv,
+        # structured and string entries alike (same order as `set_workflow_slot`).
+        slot = _slot_variants_arg(index, item)
         _reject_option_like(
             "slot",
             slot,

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -16,10 +16,12 @@ they own on top of the passthrough:
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 import pytest
 from conftest import envelope
+from pydantic import ValidationError
 
 from comfy_local_mcp import server
 
@@ -569,3 +571,366 @@ def test_vary_workflow_still_checks_a_slot_just_under_the_spawn_limit(no_spawn):
     value = '"' + "p" * (server._MAX_PRECHECKED_SLOT_BYTES - 100) + '"'
     with pytest.raises(server.ComfyCliError, match="got str"):
         server.vary_workflow("/tmp/flux.json", [f"6.text={value}"])
+
+
+# --- structured {address, value} slot items -------------------------------
+#
+# The second accepted form for both tools' slot lists, added because the string
+# form's value portion is JSON-parsed by comfy-cli with a literal-string
+# fallback — so `"6.text=true"` sets a BOOLEAN and there is no way to spell the
+# literal string "true" through it. The structured form is lossless precisely
+# because `json.dumps` is the inverse of the `json.loads` comfy-cli runs, so
+# these tests assert on the exact argv the encode produces.
+
+
+def test_set_workflow_slot_structured_override_serializes_to_addr_json(patched_run):
+    """A structured override reaches argv as `ADDR=<json>`, positionally as before."""
+    calls = patched_run(envelope(data={"modified": True}))
+
+    result = server.set_workflow_slot(
+        "/tmp/flux.json", [{"address": "6.text", "value": "a cat"}]
+    )
+    assert result == {"modified": True}
+
+    assert calls[0]["cmd"][4:] == [
+        "workflow",
+        "set-slot",
+        "/tmp/flux.json",
+        '6.text="a cat"',  # JSON-encoded, so comfy-cli's json.loads returns a str
+        "--stdout",
+    ]
+
+
+@pytest.mark.parametrize(
+    "value, encoded",
+    [
+        ("true", '"true"'),  # the footgun: a string that LOOKS like a boolean
+        ("42", '"42"'),  # ...and one that looks like a number
+        (True, "true"),  # a real boolean still arrives as one
+        (42, "42"),
+        (1.5, "1.5"),
+        (None, "null"),
+        ("a lighthouse at dawn, oil painting", '"a lighthouse at dawn, oil painting"'),
+        ({"k": [1, 2]}, '{"k": [1, 2]}'),
+    ],
+    ids=["str-true", "str-42", "bool", "int", "float", "null", "comma-str", "object"],
+)
+def test_set_workflow_slot_structured_override_preserves_value_type(
+    patched_run, value, encoded
+):
+    """Round-trip fidelity: `json.dumps` here, `json.loads` in comfy-cli.
+
+    The string form cannot express the first two rows at all — `"6.text=true"`
+    parses to the boolean and `"6.text=42"` to the int — which is the whole
+    reason this form exists.
+    """
+    calls = patched_run(envelope(data={"modified": True}))
+
+    server.set_workflow_slot("/tmp/flux.json", [{"address": "6.text", "value": value}])
+
+    override = calls[0]["cmd"][4:][3]
+    assert override == f"6.text={encoded}"
+    # ...and comfy-cli's own parse of that entry yields the value we were sent.
+    assert json.loads(override.partition("=")[2]) == value
+
+
+def test_set_workflow_slot_string_override_still_passes_through_verbatim(patched_run):
+    """Regression: the string form is untouched, coercion and all.
+
+    `"6.text=true"` still reaches argv byte-for-byte (and so still sets the
+    BOOLEAN downstream) — the structured form is additive, not a rewrite of the
+    existing one.
+    """
+    calls = patched_run(envelope(data={"modified": True}))
+
+    server.set_workflow_slot("/tmp/flux.json", ["6.text=true", "3.seed=42"])
+
+    assert calls[0]["cmd"][4:] == [
+        "workflow",
+        "set-slot",
+        "/tmp/flux.json",
+        "6.text=true",
+        "3.seed=42",
+        "--stdout",
+    ]
+
+
+def test_set_workflow_slot_mixes_string_and_structured_overrides(patched_run):
+    """Each entry is rendered on its own, so a mixed list is fine — and ordered."""
+    calls = patched_run(envelope(data={"modified": True}))
+
+    server.set_workflow_slot(
+        "/tmp/flux.json",
+        [
+            "3.seed=42",
+            {"address": "6.text", "value": "true"},
+            "4.ckpt=sd-xl",
+        ],
+        stdout=False,
+    )
+
+    assert calls[0]["cmd"][4:] == [
+        "workflow",
+        "set-slot",
+        "/tmp/flux.json",
+        "3.seed=42",
+        '6.text="true"',
+        "4.ckpt=sd-xl",
+    ]
+
+
+def test_vary_workflow_structured_slot_serializes_values_as_json_array(patched_run):
+    """`values` is encoded as the JSON array comfy-cli's `--slot` contract wants.
+
+    That also dissolves the string form's quoting gotcha: the comma inside the
+    first prompt stays inside it with nothing for the caller to escape.
+    """
+    calls = patched_run(envelope(data={"count": 2}))
+
+    result = server.vary_workflow(
+        "/tmp/flux.json",
+        [
+            {"address": "3.seed", "values": [1, 2]},
+            {
+                "address": "1.prompt",
+                "values": ["a lighthouse at dawn, oil painting", "a cabin"],
+            },
+        ],
+    )
+    assert result == {"count": 2}
+
+    assert calls[0]["cmd"][4:] == [
+        "workflow",
+        "vary",
+        "/tmp/flux.json",
+        "--slot",
+        "3.seed=[1, 2]",
+        "--slot",
+        '1.prompt=["a lighthouse at dawn, oil painting", "a cabin"]',
+    ]
+
+
+def test_vary_workflow_structured_slot_preserves_element_types(patched_run):
+    """Same fidelity guarantee per element: `["true"]` is not `[true]`."""
+    calls = patched_run(envelope(data={"count": 2}))
+
+    server.vary_workflow(
+        "/tmp/flux.json", [{"address": "6.text", "values": ["true", 1]}]
+    )
+
+    slot = calls[0]["cmd"][4:][-1]
+    assert slot == '6.text=["true", 1]'
+    assert json.loads(slot.partition("=")[2]) == ["true", 1]
+
+
+def test_vary_workflow_mixes_string_and_structured_slots(patched_run):
+    """A mixed list works, and each entry keeps its own `--slot` flag and order."""
+    calls = patched_run(envelope(data={"count": 2}))
+
+    server.vary_workflow(
+        "/tmp/flux.json",
+        ["3.seed=[1,2]", {"address": "6.text", "values": ["a cat", "a dog"]}],
+    )
+
+    assert calls[0]["cmd"][4:] == [
+        "workflow",
+        "vary",
+        "/tmp/flux.json",
+        "--slot",
+        "3.seed=[1,2]",  # verbatim, straight through the existing pre-check
+        "--slot",
+        '6.text=["a cat", "a dog"]',
+    ]
+
+
+def test_vary_workflow_rejects_empty_structured_values(no_spawn):
+    """An empty `values` produces zero variants, so name it instead of forwarding.
+
+    comfy-cli ZIPS the lists: an empty one silently makes the whole sweep empty
+    and the run "succeeds" having generated nothing.
+    """
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.vary_workflow(
+            "/tmp/flux.json",
+            [
+                {"address": "3.seed", "values": [1, 2]},
+                {"address": "6.text", "values": []},
+            ],
+        )
+
+    message = str(excinfo.value)
+    assert "slots[1]" in message  # names the offending entry...
+    assert "6.text" in message  # ...and its address
+    assert "empty" in message
+
+
+@pytest.mark.parametrize(
+    "address, marker",
+    [
+        ("--stdout", "leading '-'"),
+        ("-6.text", "leading '-'"),
+        ("6.text=x", "contains '='"),
+        ("6.te\0xt", "embedded NUL"),
+        ("", "empty"),
+        ("   ", "empty"),
+    ],
+    ids=["option-like", "dash-leading", "equals", "nul", "empty", "whitespace-only"],
+)
+def test_structured_slot_address_is_guarded(no_spawn, address, marker):
+    """The structured `address` carries every constraint the string entry did.
+
+    It BECOMES the portion before the first `=` of an argv entry, so it gets the
+    same `_reject_option_like` / `_reject_nul` pair the string path runs — named
+    against the `address` field the caller actually sent — plus the two checks
+    only this form can express: an empty address (a bare `=value` entry) and an
+    embedded `=` (which would re-split, silently shifting the value).
+    """
+    for call in (
+        lambda: server.set_workflow_slot(
+            "/tmp/flux.json", [{"address": address, "value": "x"}]
+        ),
+        lambda: server.vary_workflow(
+            "/tmp/flux.json", [{"address": address, "values": [1]}]
+        ),
+    ):
+        with pytest.raises(server.ComfyCliError) as excinfo:
+            call()
+        message = str(excinfo.value)
+        assert marker in message
+        assert "address" in message  # the named parameter, not a generic entry
+
+
+def test_structured_slot_address_is_stripped(patched_run):
+    """Surrounding whitespace is trimmed rather than smuggled into the argv entry."""
+    calls = patched_run(envelope(data={"modified": True}))
+
+    server.set_workflow_slot("/tmp/flux.json", [{"address": "  6.text\n", "value": 1}])
+
+    assert calls[0]["cmd"][4:][3] == "6.text=1"
+
+
+def test_structured_slot_value_must_be_json_data(no_spawn):
+    """A Python object with no JSON form is named, not raised as a bare TypeError.
+
+    Unreachable over MCP (everything there is JSON already); this covers the
+    in-process caller and keeps the tool's error type uniform.
+    """
+    with pytest.raises(server.ComfyCliError, match="not JSON data"):
+        server.set_workflow_slot(
+            "/tmp/flux.json", [{"address": "6.text", "value": {1}}]
+        )
+
+    with pytest.raises(server.ComfyCliError, match="not JSON data"):
+        server.vary_workflow("/tmp/flux.json", [{"address": "6.text", "values": [{1}]}])
+
+
+def test_structured_slot_item_requires_both_fields(no_spawn):
+    """A half-filled structured item is a validation error, not a silent default."""
+    for call in (
+        lambda: server.set_workflow_slot("/tmp/flux.json", [{"address": "6.text"}]),
+        lambda: server.set_workflow_slot("/tmp/flux.json", [{"value": "a cat"}]),
+        lambda: server.vary_workflow("/tmp/flux.json", [{"address": "6.text"}]),
+        lambda: server.vary_workflow("/tmp/flux.json", [{"values": [1]}]),
+    ):
+        with pytest.raises(ValidationError):
+            call()
+
+
+def test_slot_tools_advertise_the_union_item_type():
+    """The MCP schema offers BOTH forms per item, so a client can send either.
+
+    `anyOf: [string, $ref]` is what makes the structured form discoverable at
+    all — a client reads the schema, not the docstring, to decide what to send.
+    """
+    tools = {tool.name: tool for tool in asyncio.run(server.mcp.list_tools())}
+
+    for name, param, model, value_field in (
+        ("set_workflow_slot", "overrides", "SlotOverride", "value"),
+        ("vary_workflow", "slots", "SlotVariants", "values"),
+    ):
+        schema = tools[name].inputSchema
+        item = schema["properties"][param]["items"]
+        assert {"type": "string"} in item["anyOf"]
+        assert {"$ref": f"#/$defs/{model}"} in item["anyOf"]
+
+        model_schema = schema["$defs"][model]
+        assert model_schema["properties"]["address"]["type"] == "string"
+        assert sorted(model_schema["required"]) == sorted(["address", value_field])
+
+    # No existing parameter was renamed or dropped.
+    assert set(tools["set_workflow_slot"].inputSchema["properties"]) == {
+        "workflow_path",
+        "overrides",
+        "stdout",
+    }
+    assert set(tools["vary_workflow"].inputSchema["properties"]) == {
+        "workflow_path",
+        "slots",
+        "out_dir",
+    }
+
+
+def test_structured_slot_items_deserialize_through_the_mcp_boundary(patched_run):
+    """End-to-end through FastMCP: a JSON dict lands as the model, not a stray dict.
+
+    The direct-call tests above go through the same coercion helper but not
+    through FastMCP's own argument validation, which is what a real client
+    actually exercises — and it is the union that has to hold there.
+    """
+    calls = patched_run(envelope(data={"modified": True}))
+
+    asyncio.run(
+        server.mcp.call_tool(
+            "set_workflow_slot",
+            {
+                "workflow_path": "/tmp/flux.json",
+                "overrides": ["3.seed=42", {"address": "6.text", "value": "true"}],
+            },
+        )
+    )
+    assert calls[0]["cmd"][4:] == [
+        "workflow",
+        "set-slot",
+        "/tmp/flux.json",
+        "3.seed=42",
+        '6.text="true"',
+        "--stdout",
+    ]
+
+    asyncio.run(
+        server.mcp.call_tool(
+            "vary_workflow",
+            {
+                "workflow_path": "/tmp/flux.json",
+                "slots": [{"address": "6.text", "values": ["a cat", "a dog"]}],
+            },
+        )
+    )
+    assert calls[1]["cmd"][4:] == [
+        "workflow",
+        "vary",
+        "/tmp/flux.json",
+        "--slot",
+        '6.text=["a cat", "a dog"]',
+    ]
+
+
+def test_vary_workflow_string_form_still_allows_an_empty_array(patched_run):
+    """The empty-`values` rejection is scoped to the STRUCTURED form only.
+
+    `'6.text=[]'` is a valid JSON array, so it rides through the existing
+    pre-check untouched and reaches comfy-cli exactly as it always did. Worth
+    locking in: the structured form's extra rejection is a nudge on a shape that
+    yields zero variants, NOT the removal of a way to send an empty list.
+    """
+    calls = patched_run(envelope(data={"count": 0}))
+
+    server.vary_workflow("/tmp/flux.json", ["6.text=[]"])
+
+    assert calls[0]["cmd"][4:] == [
+        "workflow",
+        "vary",
+        "/tmp/flux.json",
+        "--slot",
+        "6.text=[]",
+    ]


### PR DESCRIPTION
## ELI-5

Telling the workflow tools "set the prompt to `true`" used to actually set a **boolean**, not the word "true" — because the value rode in as text and comfy-cli guesses the type by trying to read it as JSON. Now you can hand the tool `{"address": "6.text", "value": "true"}` instead, and it arrives as the exact string you sent. The old text form still works exactly as before; this just adds a second, unambiguous way to say it.

## Summary

`set_workflow_slot` and `vary_workflow` took stringly-typed slot inputs (`overrides: list[str]` of `"ADDR=VALUE"`, `slots: list[str]` of `"ADDR=[v1,v2,...]"`) while the sibling `list_workflow_slots` returns structured per-slot objects with an `address` field — so a caller reading the slot list had to hand-serialize it back into a string to edit it. Both tools now ALSO accept a structured item per entry. Additive and non-breaking: no parameter was renamed or removed, and string items pass through byte-for-byte.

The string form's real defect is type coercion. comfy-cli splits an override on its first `=` and runs the value portion through `json.loads`, falling back to the literal string (`comfy_cli/command/workflow.py`, `_split_addr_value` → `_parse_value`). So `"6.text=true"` sets the boolean `true`, `"6.text=123"` sets the integer `123`, and there is **no way to spell the literal strings** `"true"` / `"123"` through it. The structured form is lossless precisely because `json.dumps` is the inverse of the `json.loads` comfy-cli runs: `json.dumps("true")` → `'"true"'` → parses back to the string.

## Changes

- **`set_workflow_slot`** — `overrides: list[str | SlotOverride]`, where `SlotOverride` is a pydantic model with `address: str` and `value: Any`. A structured item is serialized to `f"{address}={json.dumps(value)}"`; the CLI invocation shape is otherwise untouched.
- **`vary_workflow`** — `slots: list[str | SlotVariants]` with `address: str` and `values: list[Any]`, serialized as `f"{address}={json.dumps(values)}"`. That is exactly the wire form comfy-cli wants (it requires the value portion to parse to a JSON array), which also dissolves the string form's quoting gotcha: a comma inside a prompt no longer has to be hand-quoted to stay part of its value.
- **Address validation** — the structured `address` becomes the portion before the first `=` of an argv entry, so it carries the same `_reject_option_like` / `_reject_nul` guards the string path runs, named against the `address` field the caller actually sent. Plus two checks only this form can express: an empty/whitespace-only address, and one containing `=` (comfy-cli's `partition("=")` would silently re-split it and shift the value). Whitespace is stripped, matching comfy-cli's own `addr.strip()`.
- **Empty `values`** rejected for `vary_workflow` before the CLI is invoked, naming the offending `slots[i]` and its address.
- **Docstrings** for both tools now document both accepted forms, state which one coerces and which preserves types, and show a canonical loop feeding `list_workflow_slots`' returned `address` straight into a structured item.
- FastMCP/pydantic emits the union as an `anyOf` item schema; a test locks that in along with the unchanged parameter sets.

Mixed lists (some strings, some structured) are processed per item and work fine.

## Motivation

Two problems, one fix: the tool surface primed callers to send the structured shape `list_workflow_slots` returns and then refused it, and the only accepted form silently mistyped any value that looks like JSON.

## Testing

- [x] Existing tests pass (`pytest`) — 775 passed, 3 skipped (the 3 are the pre-existing `e2e` skips needing a live ComfyUI). Also green under `uv run pytest`.
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually — not run against a live comfy-cli; the suite mocks `_run_comfy` per this repo's convention, and the serialization contract was verified by reading comfy-cli's parser directly (see below).

New tests cover: exact argv shape for a structured override (`["workflow", "set-slot", path, '6.text="a cat"', "--stdout"]`); type fidelity across string/int/float/bool/null/object, asserting `json.loads` of the emitted entry equals what was sent; string items still verbatim (regression); mixed lists for both tools; `vary_workflow` structured `values` as a JSON array; empty `values` rejected; dash-leading / `=`-containing / NUL-bearing / empty / whitespace-only `address` rejected with the named-parameter error; a non-JSON-encodable value named as `ComfyCliError` rather than a bare `TypeError`; the `anyOf` schema plus unchanged parameter sets; and an end-to-end `mcp.call_tool` case proving the union deserializes through FastMCP's own argument validation, not just through the in-process helper.

## Additional Notes

**Negative-claim falsification.** This diff adds two new rejection paths, so I went and checked empirically that neither removes a capability, reading comfy-cli `main` rather than asserting my own premise:

- *Empty `values`.* In `comfy_cli/command/workflow.py`'s `vary_cmd`, the slot lists are zipped: with one slot whose list is empty, `n = 0` and `variations = []`, so the run "succeeds" having generated nothing; with a second non-empty slot it dies on "All --slot lists must have the same length". There is no input where an empty list produces output. Crucially, the rejection is scoped to the **structured** form only — `'6.text=[]'` as a string still rides through untouched, and there is a test locking that in. So nothing became unreachable.
- *`=` in an address.* `_split_addr_value` does `arg.partition("=")`, taking everything before the FIRST `=` as the address. An address containing `=` is therefore unrepresentable on the wire in **either** form — `{"address": "6.we=ird", ...}` would reach the engine as address `6.we`. Naming it beats silently mis-targeting a slot.

**Judgment calls.**

- *NUL asymmetry, deliberate.* The string path refuses a NUL because a raw one cannot ride in argv at all. `json.dumps` escapes it to a `` sequence, so a structured value may carry one and comfy-cli's `json.loads` decodes it on the far side. That is the encoding doing its job (argv stays clean), not a hole — the reason to refuse never applies to an encoded value. The `address` is still NUL-checked, since it lands in argv unencoded. Documented in `_slot_value_json`.
- *A plain dict is accepted in-process, not just the model.* Over MCP, FastMCP has already validated the item into the model; a bare mapping only reaches the helper from an in-process caller (the tests, a script importing the tool). It is validated through the same model rather than read key-by-key, so there is one definition of the shape and one set of error messages.
- *Structured entries still run through `_reject_non_json_array_slot`.* Redundant by construction (`json.dumps` of a list is always a JSON array), kept so every entry passes the same gate regardless of how it arrived. Costs one re-parse per structured slot.
- *Not fixed, noticed in passing:* the existing `test_list_workflow_slots_argv` fixture uses an `addr` key in its mock payload, while comfy-cli's `_extract_frontend_slots` actually emits `address`. That mock is an opaque passthrough payload the test never inspects, so it is harmless and left alone rather than swept into this diff.

Every acceptance criterion in the spec is met; none were skipped.
