### PR TITLE
refactor(streaming): spawn comfy-cli asynchronously; adopt the rules that found it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,17 @@ the CLI, so a change to the spawn signature is one edit rather than a sweep:
 - `patched_plain_run(returncode, stdout, stderr) -> calls` — same, for the verbs
   that print human text and emit no envelope (`launch`/`stop`/`generate`).
 - `patched_stream(stdout_text) -> procs` — the `--json-stream` NDJSON path
-  (`subprocess.Popen`).
+  (`asyncio.create_subprocess_exec`). Its fake pipes are real
+  `asyncio.StreamReader`s, built by conftest's `stream_reader(text, limit)`
+  helper; reuse that rather than hand-rolling an awaitable, so a fake still
+  exercises the reader's buffer-limit behavior.
+
+The two spawn paths differ deliberately: the plain `--json` path is synchronous
+(`subprocess.Popen` + a bounded `communicate`, off-loaded to a thread pool by its
+async callers), while every path that STREAMS or is otherwise long-lived
+(`_run_comfy_streaming`, `auth_login`) spawns with `asyncio.create_subprocess_exec`
+and reads the pipes as asyncio streams — nothing blocking may run on the event
+loop. `ASYNC` is enabled in ruff's `select` to enforce that.
 
 A local stub is justified only where the call genuinely differs — the
 `comfy --version` probe (its own kwargs) and multi-call sequenced replies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,14 @@ dependencies = [
 # src/comfy_local_mcp/server.py (ENVELOPE_SCHEMA_MAJOR / MIN_COMFY_CLI_VERSION).
 
 [project.optional-dependencies]
-dev = ["pytest>=8", "ruff>=0.15,<0.17"]
+# The ruff floor is 0.16, not 0.15, because `[tool.ruff.lint] select` below now
+# enables RUF100 (unused-`noqa`) — and 0.16 narrowed BLE001 to stop flagging a
+# blind `except` that logs its exception. Under 0.15 those handlers still need a
+# `# noqa: BLE001`; under 0.16 that same directive is an unused-directive error.
+# A range spanning that change cannot be green on both, so pin past it: a lint
+# toolchain whose verdicts differ by patch release is the exact problem the
+# pinned rule selection exists to prevent.
+dev = ["pytest>=8", "ruff>=0.16,<0.17"]
 
 [project.scripts]
 comfy-local-mcp = "comfy_local_mcp.server:main"
@@ -54,7 +61,32 @@ target-version = "py310"
 # bump turned a green tree red with 60 findings — 52 of them stale `# noqa: ARG0xx`
 # directives for a rule that was never enabled, plus 8 genuine ones.
 #
-# These four are ruff's historical defaults: the set this codebase was written
-# and reviewed against. Widening them is a deliberate decision, not something a
-# linter release should make on our behalf — so widen here, in a PR, on purpose.
-select = ["E4", "E7", "E9", "F"]
+# The first four are ruff's historical defaults: the set this codebase was
+# written and reviewed against. Widening them is a deliberate decision, not
+# something a linter release should make on our behalf — so widen here, in a PR,
+# on purpose. What follows is that deliberate widening, one rule set at a time:
+#
+# ASYNC  — blocking calls inside `async def`. This server's whole job is shelling
+#          out from async tools, so a blocking spawn or read on the event loop is
+#          the highest-value defect class ruff can find here.
+# BLE    — blind `except Exception`. Every remaining site now states its reason:
+#          the handlers that log the exception satisfy the rule outright (0.16
+#          exempts those), and the few that genuinely must swallow carry an
+#          explicit `# noqa: BLE001 - <reason>`. The rule now forces the NEXT
+#          blind catch to argue for itself the same way.
+# S110   — `try`/`except`/`pass`. Selected as a single rule rather than all of
+#          `S` (flake8-bandit): the broader set flags `subprocess` use itself,
+#          which is this repo's entire reason to exist.
+# I      — import sorting. Cosmetic and auto-fixable; on so it cannot drift.
+# RUF100 — unused/non-enabled `# noqa`. This is the rule that would have PREVENTED
+#          the mess this selection was written for: ~50 `# noqa: ARG0xx`
+#          directives had accumulated for `flake8-unused-arguments`, a rule this
+#          repo has never enabled, and nothing flagged them until a linter
+#          release changed its defaults. With RUF100 on, a directive that
+#          suppresses nothing is an error the day it is written.
+#
+# Deliberately NOT adopted: ARG (flake8-unused-arguments). The tests are largely
+# interface-mirroring fakes whose unused parameters exist precisely BECAUSE the
+# real signature has them, so the rule reports 306 sites here and finds no
+# defects. The ~50 stale directives were removed rather than completed.
+select = ["E4", "E7", "E9", "F", "ASYNC", "BLE", "S110", "I", "RUF100"]

--- a/src/comfy_local_mcp/failure_log.py
+++ b/src/comfy_local_mcp/failure_log.py
@@ -252,11 +252,17 @@ def _failure_logger(path: str) -> logging.Logger:
                     logger.removeHandler(existing)
                     try:
                         existing.close()
-                    except Exception:
+                    except Exception:  # teardown must reach every handler
                         # A handler that fails to close is already detached; it
                         # must not abort the teardown of the ones after it (two
-                        # live handlers would duplicate every line).
-                        pass
+                        # live handlers would duplicate every line). Reported on
+                        # the MODULE logger rather than swallowed: that is a
+                        # different logger from the non-propagating
+                        # `comfy_local_mcp.failures` one being rebuilt here, so
+                        # this cannot recurse into the handler that just failed.
+                        logging.getLogger(__name__).debug(
+                            "failure-log handler close failed", exc_info=True
+                        )
                 parent = os.path.dirname(path)
                 if parent:
                     os.makedirs(parent, mode=_FAILURE_LOG_DIR_MODE, exist_ok=True)
@@ -326,5 +332,18 @@ def _log_failure(
             "streaming": streaming,
         }
         _failure_logger(path).info(json.dumps(entry, ensure_ascii=False))
-    except Exception:
-        pass  # diagnostics are best-effort; never mask the real error
+    except Exception:  # a diagnostic aid must never mask the real error
+        # Swallowed by design (see the contract in this function's docstring):
+        # this runs while a REAL error is being reported, so letting a logging
+        # fault replace it would lose the failure the user actually needs.
+        #
+        # But swallowing it SILENTLY is how a failure log ends up reading healthy
+        # while writing nothing — a disabled log and a broken one would look
+        # identical. So the drop is recorded on the module logger, which is a
+        # different, PROPAGATING logger from the non-propagating
+        # `comfy_local_mcp.failures` one that just failed: it can neither recurse
+        # nor re-enter the broken handler. `debug` because this file is an opt-in
+        # diagnostic, so its own faults belong at diagnostic level too.
+        logging.getLogger(__name__).debug(
+            "failure-log write failed; the entry was dropped", exc_info=True
+        )

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -363,34 +363,15 @@ _POST_ENVELOPE_REAP_GRACE = 5.0
 # (uninterruptible sleep) cannot hold the tool call open past its deadline.
 _DRAIN_TIMEOUT = 5.0
 
-# Dedicated, bounded thread pool for the blocking pipe reads / process waits in
-# `_run_comfy_streaming` (`stdout.readline`, `stderr.read`, `proc.wait`).
-#
-# Cancelling an `asyncio.to_thread` NEVER interrupts the underlying OS thread —
-# it stays parked on the pipe until the child is killed and its stdio closes.
-# On the success-envelope path the stderr reader is never awaited, only
-# cancelled, so it lingers until the `finally` kills the child (up to
-# `_POST_ENVELOPE_REAP_GRACE`). Running these on asyncio's shared *default*
-# executor means many concurrent `run_workflow(wait=True)` / `watch_job` calls
-# could pile parked readers/waiters onto that pool and starve unrelated
-# `to_thread` work for the grace window. Confining them to their own bounded
-# pool caps the blast radius to this pool; the `finally` block additionally
-# joins the stderr reader once the child is dead so it does not outlive the run.
-_PIPE_POOL_MAX_WORKERS = min(32, (os.cpu_count() or 1) + 4)
-_PIPE_EXECUTOR = ThreadPoolExecutor(
-    max_workers=_PIPE_POOL_MAX_WORKERS,
-    thread_name_prefix="comfy-pipe",
-)
-
-
-def _in_pipe_pool(func, *args):
-    """Off-load a blocking pipe read / process wait to the dedicated pool.
-
-    Mirrors :func:`asyncio.to_thread` but targets :data:`_PIPE_EXECUTOR`
-    instead of the loop's shared default executor, so subprocess pipe threads
-    can never saturate the pool other `to_thread` callers rely on.
-    """
-    return asyncio.get_running_loop().run_in_executor(_PIPE_EXECUTOR, func, *args)
+# `_run_comfy_streaming` used to off-load its blocking pipe reads / process
+# waits (`stdout.readline`, `stderr.read`, `proc.wait`) to a dedicated bounded
+# thread pool, because cancelling an `asyncio.to_thread` NEVER interrupts the
+# underlying OS thread — it stays parked on the pipe until the child is killed
+# and its stdio closes, so a timed-out or cancelled run left a thread behind.
+# That path now spawns with `asyncio.create_subprocess_exec` and reads the pipes
+# as asyncio streams, so there is no blocking read to off-load and no thread to
+# strand: cancelling the read cancels it. Only `partner_generate`'s genuinely
+# synchronous `comfy generate` run still needs a pool (below).
 
 
 # Dedicated, bounded thread pool for `partner_generate`'s blocking `comfy
@@ -446,21 +427,11 @@ _STDERR_JOIN_GRACE = 5.0
 _STDERR_MAX_CHARS = 64 * 1024
 _STDERR_READ_CHUNK = 64 * 1024
 
-
-def _drain_capped(stream: Any, limit: int) -> str:
-    """Read ``stream`` to EOF but keep only the trailing ``limit`` chars.
-
-    Draining to EOF keeps the child from blocking on a full stderr pipe; slicing
-    to the tail on every chunk bounds memory to ``limit`` + one chunk regardless
-    of how much the child spams.
-    """
-    tail = ""
-    while True:
-        chunk = stream.read(_STDERR_READ_CHUNK)
-        if not chunk:
-            break
-        tail = (tail + chunk)[-limit:]
-    return tail
+# Buffer size for the streaming path's stdout `StreamReader`. NOT a maximum line
+# length — `_readline_unbounded` stitches an over-long line back together — so
+# this only trades memory for the number of read hops a big NDJSON event costs.
+# Sized to comfortably hold a `queued` event's node manifest in one pass.
+_STREAM_LINE_LIMIT = 1024 * 1024
 
 
 # comfy-cli floor. `comfy logs` (get_logs) and the structured `envelope/1`
@@ -1192,19 +1163,19 @@ def _envelope_major(envelope: dict) -> int | None:
 def _kill_proc_tree(proc: subprocess.Popen) -> None:
     """Kill the child *and* any grandchildren it spawned.
 
-    Shared by both spawn sites — :func:`_run_comfy_raw` and
-    :func:`_run_comfy_streaming` both pass ``start_new_session=True``, so the
-    child leads its own process group and one ``killpg`` reaps the whole tree.
+    Serves the synchronous spawn site, :func:`_run_comfy_raw`, which passes
+    ``start_new_session=True`` so the child leads its own process group and one
+    ``killpg`` reaps the whole tree. The async spawn sites
+    (:func:`_run_comfy_streaming`, :func:`_start_login`) use the identical
+    twin :func:`_kill_proc_tree_async`.
 
-    On the streaming path that closes every copy of the stderr pipe: comfy-cli
-    can fork a ComfyUI/helper grandchild that inherits the pipe's write-end, and
-    killing only the direct child leaves that fd open, so the blocking
-    ``proc.stderr.read()`` we run in a ``to_thread`` worker never sees EOF and
-    the thread leaks — repeated timeouts then exhaust the default ``to_thread``
-    pool and wedge the server. On the plain path the stake is the work itself:
-    ``comfy update``'s ``git pull`` + ``pip install`` and ``comfy model
-    download``'s transfer keep mutating the workspace after the tool has already
-    reported a timeout, so they have to die with their parent.
+    What is at stake is the work itself: ``comfy update``'s ``git pull`` + ``pip
+    install`` and ``comfy model download``'s transfer keep mutating the
+    workspace after the tool has already reported a timeout, so they have to die
+    with their parent. Killing the group also closes every copy of the stderr
+    pipe — comfy-cli can fork a ComfyUI/helper grandchild that inherits the
+    write-end, and killing only the direct child leaves that fd open so the
+    drain never sees EOF.
 
     The group kill is UNCONDITIONAL — deliberately NOT gated on ``proc.poll()``.
     A dead leader does not mean a dead tree: the case that matters most is
@@ -1255,6 +1226,98 @@ def _reap(proc: subprocess.Popen, timeout: float = 5.0) -> None:
         proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         pass
+
+
+def _kill_proc_tree_async(proc: Any) -> None:
+    """Kill an async-spawned child and any grandchildren, best-effort.
+
+    The :class:`asyncio.subprocess.Process` twin of :func:`_kill_proc_tree` —
+    same rationale (the child leads its own process group via
+    ``start_new_session=True``, so killing the group closes every inherited copy
+    of the stderr pipe and lets the drain EOF), against a process object that
+    exposes ``returncode`` rather than ``poll()``. Shared by
+    :func:`_run_comfy_streaming` and :func:`_start_login`.
+
+    Unlike the synchronous twin this DOES gate on ``returncode``, because
+    ``asyncio``'s child watcher reaps the process as soon as it exits: signalling
+    a reaped pid could reach an unrelated group the OS has since handed the
+    number to.
+    """
+    if proc.returncode is not None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (OSError, AttributeError, ValueError):
+        try:
+            proc.kill()
+        except (OSError, AttributeError, ValueError):
+            pass
+
+
+async def _reap_async(proc: Any, timeout: float = 5.0) -> None:
+    """Reap a (killed) async-spawned child without blocking forever.
+
+    The :func:`_reap` twin for :class:`asyncio.subprocess.Process`. Same reason
+    for the bound: a child stuck in uninterruptible sleep (D state) can ignore
+    ``SIGKILL`` indefinitely, and cleanup must never hang the tool call on one.
+    Best-effort — a still-unreaped child is left to the OS.
+    """
+    try:
+        await asyncio.wait_for(proc.wait(), timeout)
+    except (asyncio.TimeoutError, TimeoutError):
+        logging.getLogger(__name__).debug(
+            "comfy-cli child survived SIGKILL for %.1fs; leaving it to the OS", timeout
+        )
+
+
+async def _drain_capped_async(stream: Any, limit: int) -> str:
+    """Read an asyncio stream to EOF keeping only the trailing ``limit`` bytes.
+
+    Draining to EOF keeps the child from wedging on a full pipe; slicing to the
+    tail on every chunk bounds memory to ``limit`` + one chunk however much it
+    spams. Decoding once at the end (not per chunk) keeps a multi-byte character
+    split across a chunk boundary from becoming a replacement character.
+
+    Shared by both async spawn sites, :func:`_run_comfy_streaming` and
+    :func:`_start_login`. The synchronous plain path does not need an equivalent:
+    :func:`_run_comfy_raw` bounds its child with ``communicate()``, which drains
+    both pipes itself.
+    """
+    tail = b""
+    while True:
+        chunk = await stream.read(_STDERR_READ_CHUNK)
+        if not chunk:
+            break
+        tail = (tail + chunk)[-limit:]
+    return tail.decode("utf-8", "replace")
+
+
+async def _readline_unbounded(stream: Any) -> bytes:
+    """Read one newline-terminated line however long it is (``b""`` at EOF).
+
+    :meth:`asyncio.StreamReader.readline` raises ``ValueError`` the moment a
+    single line exceeds the reader's buffer limit, which would turn one oversized
+    comfy-cli event into a crashed run — the blocking ``Popen`` + text-mode
+    ``readline`` this replaced had no such ceiling, and a ``queued`` event
+    carrying a large node manifest is exactly the shape that would hit it.
+    Stitching the overrun chunks back together preserves that parity: ``limit``
+    becomes a read-granularity knob rather than a hard maximum line length.
+    """
+    chunks: list[bytes] = []
+    while True:
+        try:
+            chunks.append(await stream.readuntil(b"\n"))
+            return b"".join(chunks)
+        except asyncio.LimitOverrunError as exc:
+            # `consumed` bytes are buffered with no newline among them: take
+            # them and keep looking for the terminator past that point.
+            chunks.append(await stream.readexactly(exc.consumed))
+        except asyncio.IncompleteReadError as exc:
+            # EOF before a newline. `partial` is b"" at a clean EOF, which is
+            # the pump's stop signal; a trailing unterminated line is returned
+            # as-is rather than dropped.
+            chunks.append(exc.partial)
+            return b"".join(chunks)
 
 
 def _close_pipes(proc: subprocess.Popen) -> None:
@@ -1699,7 +1762,7 @@ class _StreamProgress:
                 await ctx.report_progress(
                     progress=progress, total=self.total, message=message
                 )
-            except Exception:  # noqa: BLE001 - telemetry must not abort the run
+            except Exception:  # telemetry must not abort the run
                 # A notification is best-effort; the run's RESULT is the
                 # deliverable. Any exception out of the pump reaches
                 # `_run_comfy_streaming`'s `finally`, which kills the comfy-cli
@@ -1726,9 +1789,9 @@ async def _run_comfy_streaming(
 ) -> Any:
     """Run ``comfy --json-stream --where local <args>`` and stream progress.
 
-    Spawns comfy-cli with :class:`subprocess.Popen`, reads its NDJSON stdout
-    line-by-line (each ``readline`` off-loaded to a thread so the event loop
-    stays free), and forwards run events as MCP progress notifications via
+    Spawns comfy-cli with :func:`asyncio.create_subprocess_exec`, reads its
+    NDJSON stdout line-by-line off the child's asyncio stream, and forwards run
+    events as MCP progress notifications via
     ``ctx.report_progress``. The final ``envelope/1`` line is unwrapped exactly
     as :func:`_run_comfy` does, so an error envelope raises
     :class:`ComfyCliError` with the same code — terminal behavior is unchanged.
@@ -1752,25 +1815,22 @@ async def _run_comfy_streaming(
     # subcommand; a trailing form errors with "No such option".
     cmd = [COMFY_BIN, "--json-stream", "--where", "local", *args]
     env = _comfy_env()
-    proc = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
         # Same reason as the plain path: never let a child inherit the stdio
         # transport's stdin and eat JSON-RPC request bytes. See _run_comfy_raw.
-        stdin=subprocess.DEVNULL,
-        text=True,
-        # Match the child's forced UTF-8 output (see _comfy_env); otherwise
-        # readline()/stderr.read() decode with the parent locale (cp1252 on
-        # Windows) and non-ASCII stream lines raise UnicodeDecodeError or
-        # corrupt to mojibake before _parse_event/_last_json_object.
-        encoding="utf-8",
+        stdin=asyncio.subprocess.DEVNULL,
         env=env,
         # Own process group so a timeout can kill the whole tree (child +
         # grandchildren) and close every copy of the stderr pipe — otherwise a
-        # grandchild that inherited the fd keeps the blocking stderr read (and
-        # its to_thread worker) alive forever. See _kill_proc_tree. (BE-3343)
+        # grandchild that inherited the fd keeps the stderr drain from ever
+        # seeing EOF. See _kill_proc_tree_async. (BE-3343)
         start_new_session=True,
+        # Read granularity, not a maximum line length: `_readline_unbounded`
+        # stitches an over-long line back together rather than raising.
+        limit=_STREAM_LINE_LIMIT,
     )
     lines: list[str] = []
     tracker = _StreamProgress()
@@ -1789,9 +1849,14 @@ async def _run_comfy_streaming(
         """
         assert proc.stdout is not None
         while True:
-            line = await _in_pipe_pool(proc.stdout.readline)
-            if not line:  # EOF: comfy-cli closed stdout
+            raw = await _readline_unbounded(proc.stdout)
+            if not raw:  # EOF: comfy-cli closed stdout
                 return False
+            # comfy-cli's output is forced to UTF-8 (see `_comfy_env`); decode
+            # with `replace` rather than strict so a truncated or mis-encoded
+            # byte degrades one line instead of raising UnicodeDecodeError out
+            # of the middle of a live run.
+            line = raw.decode("utf-8", "replace")
             lines.append(line)
             # Advance the tracker even without a ctx so a timed-out ctx-less
             # watch still returns real progress; report() no-ops the notify.
@@ -1810,9 +1875,7 @@ async def _run_comfy_streaming(
     # Drain stderr concurrently so a chatty child can't deadlock on a full pipe;
     # retain only the tail so it can't drive unbounded allocation here.
     stderr_future = (
-        asyncio.ensure_future(
-            _in_pipe_pool(_drain_capped, proc.stderr, _STDERR_MAX_CHARS)
-        )
+        asyncio.ensure_future(_drain_capped_async(proc.stderr, _STDERR_MAX_CHARS))
         if proc.stderr is not None
         else None
     )
@@ -1828,7 +1891,7 @@ async def _run_comfy_streaming(
             return True, None
         # EOF: the child has closed stdout, so a plain wait is safe and its
         # stderr is collectible for the error message.
-        returncode = await _in_pipe_pool(proc.wait)
+        returncode = await proc.wait()
         stderr = (await stderr_future) if stderr_future is not None else ""
         # Keep the joined stdout around rather than only its parsed JSON: this is
         # the EOF path, so comfy-cli died without an envelope and whatever plain
@@ -1874,9 +1937,9 @@ async def _run_comfy_streaming(
             # the whole tree FIRST so every copy of the stderr pipe closes and
             # the drain returns the buffered output (a wedged child — or a
             # grandchild holding the fd — would otherwise block the read).
-            if proc.poll() is None:
-                _kill_proc_tree(proc)
-                await _in_pipe_pool(_reap, proc)
+            if proc.returncode is None:
+                _kill_proc_tree_async(proc)
+                await _reap_async(proc)
             # Keep the drained text itself, not only its 500-char message tail:
             # the failure log records a much longer slice
             # (`textutil._stream_tail` at `failure_log._FAILURE_LOG_TAIL_CHARS`),
@@ -1886,7 +1949,7 @@ async def _run_comfy_streaming(
             if stderr_future is not None:
                 try:
                     stderr_text = await asyncio.wait_for(stderr_future, 2.0) or ""
-                except (Exception, asyncio.CancelledError):
+                except (Exception, asyncio.CancelledError):  # noqa: BLE001 - see body
                     # Diagnostics are best-effort: never let gathering the tail
                     # mask the timeout itself. CancelledError is a BaseException
                     # (not caught by `except Exception`) and DOES fire here: the
@@ -1922,9 +1985,7 @@ async def _run_comfy_streaming(
         envelope = _last_json_object(stdout_text)
         child_reaped = True
         try:
-            await asyncio.wait_for(
-                _in_pipe_pool(proc.wait), timeout=_POST_ENVELOPE_REAP_GRACE
-            )
+            await asyncio.wait_for(proc.wait(), timeout=_POST_ENVELOPE_REAP_GRACE)
         except (asyncio.TimeoutError, TimeoutError):
             child_reaped = False  # lingering child; `finally` reaps it
         # stderr only matters for an error envelope whose `error.message` is
@@ -1939,8 +2000,9 @@ async def _run_comfy_streaming(
         ):
             # The direct child exited during the grace, so its stderr pipe has
             # normally EOF'd — but a descendant holding the write fd could still
-            # block this read. Bound it; `shield` keeps a timeout from cancelling
-            # the reader here so the `finally` join can still detach it.
+            # block this read. Bound it; `shield` keeps a timeout here from
+            # cancelling the reader task itself, leaving that to the `finally`
+            # once the whole tree is dead.
             try:
                 stderr = await asyncio.wait_for(
                     asyncio.shield(stderr_future), _STDERR_JOIN_GRACE
@@ -1961,13 +2023,13 @@ async def _run_comfy_streaming(
         # notification is swallowed in `_StreamProgress.report` and reaches
         # neither this block nor the caller). Kill the whole process tree (not
         # just the direct child) so a descendant holding the stderr write fd
-        # can't keep the pipe from EOFing — see
-        # _kill_proc_tree. (BE-3343) Reap on the dedicated pipe pool, not the
-        # default `to_thread` pool, so this wait can never contend with (or be
-        # confused for) unrelated `to_thread` callers.
-        if proc.poll() is None:
-            _kill_proc_tree(proc)
-            await _in_pipe_pool(_reap, proc)
+        # can't keep the pipe from EOFing — see _kill_proc_tree_async. (BE-3343)
+        if proc.returncode is None:
+            _kill_proc_tree_async(proc)
+            await _reap_async(proc)
+        # Cancelling an asyncio stream read takes effect immediately, so unlike
+        # the thread-pool reader this replaced there is nothing left parked on
+        # the pipe once the task is cancelled — no join is needed.
         if stderr_future is not None and not stderr_future.done():
             stderr_future.cancel()
 
@@ -2535,44 +2597,6 @@ def _login_lock_for_loop() -> asyncio.Lock:
     return _login_lock
 
 
-def _kill_login_child(proc: Any) -> None:
-    """Kill a login child and any grandchildren, best-effort.
-
-    The async-subprocess twin of :func:`_kill_proc_tree` — same rationale (the
-    child leads its own process group via ``start_new_session=True``, so killing
-    the group closes every inherited copy of the stderr pipe and lets the drain
-    EOF), against :class:`asyncio.subprocess.Process`, which exposes
-    ``returncode`` rather than ``poll()``.
-    """
-    if proc.returncode is not None:
-        return
-    try:
-        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-    except (OSError, AttributeError, ValueError):
-        try:
-            proc.kill()
-        except (OSError, AttributeError, ValueError):
-            pass
-
-
-async def _drain_capped_async(stream: Any, limit: int) -> str:
-    """Read an asyncio stream to EOF keeping only the trailing ``limit`` bytes.
-
-    The async counterpart of :func:`_drain_capped`, and there for the same
-    reason: draining keeps the child from wedging on a full pipe, and slicing
-    per chunk bounds memory however much it spams. Decoding once at the end (not
-    per chunk) keeps a multi-byte character split across a chunk boundary from
-    becoming a replacement character.
-    """
-    tail = b""
-    while True:
-        chunk = await stream.read(_STDERR_READ_CHUNK)
-        if not chunk:
-            break
-        tail = (tail + chunk)[-limit:]
-    return tail.decode("utf-8", "replace")
-
-
 async def _tail_login_child(child: _LoginChild) -> None:
     """Consume the rest of a login child's output and park its terminal result.
 
@@ -2588,7 +2612,7 @@ async def _tail_login_child(child: _LoginChild) -> None:
     rest = ""
     try:
         rest = await _drain_capped_async(child.proc.stdout, _LOGIN_STREAM_MAX_CHARS)
-    except Exception:  # noqa: BLE001 - a lost tail must not lose the result
+    except Exception:  # a lost tail must not lose the result
         logging.getLogger(__name__).debug("login stdout drain failed", exc_info=True)
     try:
         returncode = await child.proc.wait()
@@ -2597,7 +2621,7 @@ async def _tail_login_child(child: _LoginChild) -> None:
     stderr_text = ""
     try:
         stderr_text = await child.stderr_task
-    except Exception:  # noqa: BLE001 - stderr is diagnostics, never the verdict
+    except Exception:  # stderr is diagnostics, never the verdict
         logging.getLogger(__name__).debug("login stderr drain failed", exc_info=True)
     stdout_text = ("".join(child.prefix) + rest)[-_LOGIN_STREAM_MAX_CHARS:]
     child.result = (returncode, stdout_text, stderr_text)
@@ -2621,7 +2645,7 @@ async def _login_terminal_report(child: _LoginChild) -> dict | None:
         # timeout from cancelling the reader itself and losing the result.
         try:
             await asyncio.wait_for(asyncio.shield(child.reader), _LOGIN_REAP_GRACE)
-        except Exception:  # noqa: BLE001 - fall through to the report below
+        except Exception:  # fall through to the report below
             logging.getLogger(__name__).debug("login reader join failed", exc_info=True)
     if child.result is None:
         return {
@@ -2681,8 +2705,8 @@ async def _start_login() -> tuple[_LoginChild | None, dict]:
         # request bytes. Same reason as both synchronous spawn sites.
         stdin=asyncio.subprocess.DEVNULL,
         env=_comfy_env(),
-        # Own process group so `_kill_login_child` can take the whole tree and
-        # close every copy of the stderr pipe. See `_kill_proc_tree`.
+        # Own process group so `_kill_proc_tree_async` can take the whole tree
+        # and close every copy of the stderr pipe.
         start_new_session=True,
         limit=_LOGIN_LINE_LIMIT,
     )
@@ -2724,7 +2748,7 @@ async def _start_login() -> tuple[_LoginChild | None, dict]:
         # on something that is not the browser (most likely a comfy-cli without
         # the `login_url` event). Reap it rather than leave an OAuth flow the
         # agent has no URL for, and point at the path that still works.
-        _kill_login_child(proc)
+        _kill_proc_tree_async(proc)
         await _reap_login_child(proc, stderr_task)
         raise ComfyCliError(
             f"`comfy cloud login` emitted no `login_url` within {_LOGIN_URL_WAIT_S:g}s. "
@@ -2735,7 +2759,7 @@ async def _start_login() -> tuple[_LoginChild | None, dict]:
     except BaseException:
         # Cancellation (a disconnected client) must not leak a child holding a
         # loopback port the user can never reach.
-        _kill_login_child(proc)
+        _kill_proc_tree_async(proc)
         stderr_task.cancel()
         raise
     if found is None:
@@ -2767,7 +2791,7 @@ async def _reap_login_child(proc: Any, stderr_task: Any) -> None:
     """Best-effort, bounded cleanup of a killed login child."""
     try:
         await asyncio.wait_for(proc.wait(), _LOGIN_REAP_GRACE)
-    except Exception:  # noqa: BLE001 - a stuck child is left to the OS
+    except Exception:  # a stuck child is left to the OS
         logging.getLogger(__name__).debug("login child reap failed", exc_info=True)
     stderr_task.cancel()
 
@@ -2781,7 +2805,7 @@ async def _abandon_login_child(child: _LoginChild) -> None:
     of the process. Cancelling it is also what frees the loopback port before the
     replacement login tries to bind one.
     """
-    _kill_login_child(child.proc)
+    _kill_proc_tree_async(child.proc)
     await _reap_login_child(child.proc, child.stderr_task)
     if child.reader is not None:
         child.reader.cancel()
@@ -3285,7 +3309,7 @@ def _engine_auto_confirms() -> bool:
     # (`UnicodeDecodeError`) escapes `_run_comfy_raw` uncaught, and crashing
     # `partner_generate` is strictly worse than falling back to asking.
     # `False` is the safe direction — it can only ever cause a prompt.
-    except Exception:
+    except Exception:  # noqa: BLE001 - deliberate: every failure answers False
         return False
     if returncode != 0:
         return False
@@ -3353,7 +3377,11 @@ def _client_elicitation_support(ctx: Context | None) -> bool | None:
         return bool(
             check(types.ClientCapabilities(elicitation=types.ElicitationCapability()))
         )
-    except Exception:
+    except Exception:  # noqa: BLE001 - an unreadable capability must ask, not assume
+        # Any failure here is UNKNOWN, not "no elicitation": a third-party
+        # client's probe can raise anything, and narrowing this catch would let
+        # an unlisted exception type escape and be read as a hard False by the
+        # caller — which is what would spend credits without a human prompt.
         return None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,17 +15,24 @@ copy per test file:
 
 * the plain ``--json`` path (``subprocess.Popen`` + a bounded
   ``communicate``) — ``envelope`` + ``patched_run`` / ``patched_plain_run``;
-* the streaming ``--json-stream`` path (``subprocess.Popen`` + incremental
-  reads) — ``patched_stream``. ``run_workflow``, ``watch_job`` and
-  ``generate_image`` all drive the same NDJSON stream.
+* the streaming ``--json-stream`` path
+  (``asyncio.create_subprocess_exec`` + incremental stream reads) —
+  ``patched_stream``. ``run_workflow``, ``watch_job`` and ``generate_image``
+  all drive the same NDJSON stream.
 
 Both paths spawn with ``start_new_session=True`` so a timeout can kill the whole
 process group; the fakes model that too (see ``_FakeRunProc``).
+
+The streaming fakes back their pipes with REAL :class:`asyncio.StreamReader`
+objects (``stream_reader``) rather than a hand-rolled awaitable. The reader's
+buffer-limit behavior is load-bearing for ``server._readline_unbounded``, so a
+stub that merely returned canned lines would test nothing about the one thing
+that path exists to handle.
 """
 
 from __future__ import annotations
 
-import io
+import asyncio
 import json
 import logging
 
@@ -208,7 +215,7 @@ class _FakeRunProc:
     def poll(self):
         return self.returncode  # None until it exits or is killed
 
-    def wait(self, timeout=None):  # noqa: ARG002
+    def wait(self, timeout=None):
         return self.returncode
 
     def kill(self):
@@ -234,7 +241,7 @@ def _canonical_run(calls: list[dict], *, stdout, returncode, stderr, raises):
     """
     canned_stdout, canned_stderr = stdout, stderr
 
-    def fake(cmd, stdout, stderr, stdin, text, encoding, env, start_new_session):  # noqa: ARG001
+    def fake(cmd, stdout, stderr, stdin, text, encoding, env, start_new_session):
         record = {
             "cmd": cmd,
             "env": env,
@@ -332,25 +339,43 @@ def patched_plain_run(patched_run):
     return setup
 
 
+def stream_reader(text: str | bytes, limit: int | None = None) -> asyncio.StreamReader:
+    """A closed :class:`asyncio.StreamReader` pre-loaded with ``text``.
+
+    The real reader, not a stub: ``server._readline_unbounded`` exists precisely
+    to survive a line longer than the reader's ``limit``, and only a genuine
+    ``StreamReader`` raises the ``LimitOverrunError`` that exercises it. Must be
+    called with a running event loop (the reader binds to it at construction).
+    """
+    reader = asyncio.StreamReader(limit=limit or server._STREAM_LINE_LIMIT)
+    reader.feed_data(text.encode("utf-8") if isinstance(text, str) else text)
+    reader.feed_eof()
+    return reader
+
+
 class _FakeProc:
-    """A minimal stand-in for ``subprocess.Popen`` over a canned NDJSON stream."""
+    """A stand-in for ``asyncio.subprocess.Process`` over a canned NDJSON stream.
+
+    Deliberately carries NO ``pid``: ``server._kill_proc_tree_async`` looks one
+    up for its ``killpg`` and falls back to ``proc.kill()`` on the resulting
+    ``AttributeError``, so the fake records the kill instead of signalling a
+    made-up pid — which on a busy machine could land on a real, unrelated
+    process group. See ``_FakeRunProc`` for the same reasoning on the plain path.
+    """
 
     def __init__(
-        self, cmd, stdout_text, stderr_text="", env=None, encoding=None, stdin=None
+        self, cmd, stdout_text, stderr_text="", env=None, stdin=None, limit=None
     ):
         self.cmd = cmd
         self.env = env
-        self.encoding = encoding
+        self.limit = limit  # what `server` asked for, for the argv assertions
         self.stdin_arg = stdin  # what `server` asked for, not a writable pipe
-        self.stdout = io.StringIO(stdout_text)
-        self.stderr = io.StringIO(stderr_text)
+        self.stdout = stream_reader(stdout_text, limit)
+        self.stderr = stream_reader(stderr_text, limit)
         self.returncode = 0
         self.killed = False
 
-    def poll(self):
-        return self.returncode  # already "finished" once the stream is drained
-
-    def wait(self, timeout=None):  # noqa: ARG002
+    async def wait(self):
         return self.returncode
 
     def kill(self):
@@ -369,7 +394,7 @@ class _RecordingCtx:
 
 @pytest.fixture
 def patched_stream(monkeypatch):
-    """Patch ``shutil.which`` + ``subprocess.Popen`` for the streaming path.
+    """Patch ``shutil.which`` + ``asyncio.create_subprocess_exec`` for streaming.
 
     Returns ``setup(stdout_text) -> procs`` — the list capturing each spawned
     ``_FakeProc`` (so the test can assert the command line that was run).
@@ -378,13 +403,15 @@ def patched_stream(monkeypatch):
     def setup(stdout_text: str) -> list[_FakeProc]:
         procs: list[_FakeProc] = []
 
-        def fake_popen(cmd, stdout, stderr, text, encoding, env, stdin=None, **kwargs):  # noqa: ARG001
-            proc = _FakeProc(cmd, stdout_text, env=env, encoding=encoding, stdin=stdin)
+        async def fake_exec(
+            *cmd, stdout, stderr, env, stdin=None, limit=None, **kwargs
+        ):
+            proc = _FakeProc(list(cmd), stdout_text, env=env, stdin=stdin, limit=limit)
             procs.append(proc)
             return proc
 
         monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-        monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+        monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
         return procs
 
     return setup

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -122,7 +122,7 @@ def _isolated_login_state(monkeypatch):
     child = server._login_child
     server._login_child = None
     if child is not None:
-        server._kill_login_child(child.proc)
+        server._kill_proc_tree_async(child.proc)
 
 
 async def _shutdown_login() -> None:

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -20,7 +20,6 @@ from conftest import _FakeRunProc, _raises_at_spawn
 
 from comfy_local_mcp import server
 
-
 # --- envelope-version assertion (_unwrap_envelope) --------------------------
 
 
@@ -102,7 +101,7 @@ def test_detect_version_none_when_binary_missing(monkeypatch):
 def test_detect_version_parses_cli_output(monkeypatch):
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
 
-    def fake(cmd, capture_output, text, errors, timeout, check):  # noqa: ARG001
+    def fake(cmd, capture_output, text, errors, timeout, check):
         assert cmd == [server.COMFY_BIN, "--version"]
         return subprocess.CompletedProcess(
             cmd, 0, stdout="comfy-cli, 1.12.0\n", stderr=""
@@ -116,7 +115,7 @@ def test_detect_version_ignores_stderr_and_nonzero_exit(monkeypatch):
     """Only stdout on a clean exit is trusted; a stderr number / bad exit -> None."""
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
 
-    def fake(cmd, capture_output, text, errors, timeout, check):  # noqa: ARG001
+    def fake(cmd, capture_output, text, errors, timeout, check):
         # Non-zero exit, and a misleading dotted number only on stderr.
         return subprocess.CompletedProcess(
             cmd, 1, stdout="", stderr="Python 3.11.7 error\n"
@@ -342,7 +341,7 @@ def patched_env_then_outdated(monkeypatch):
     def setup(replies: list) -> list[dict]:
         calls: list[dict] = []
 
-        def fake(cmd, stdout, stderr, stdin, text, encoding, env, start_new_session):  # noqa: ARG001
+        def fake(cmd, stdout, stderr, stdin, text, encoding, env, start_new_session):
             record = {"cmd": cmd, "timeout": None}
             calls.append(record)
             reply = replies[len(calls) - 1]

--- a/tests/test_failure_log.py
+++ b/tests/test_failure_log.py
@@ -322,13 +322,13 @@ def test_streaming_failure_is_flagged(log_path, monkeypatch):
     """The ``streaming`` flag distinguishes the ``--json-stream`` spawn path."""
     procs: list[_FakeProc] = []
 
-    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
-        proc = _FakeProc(cmd, _ERROR_ENVELOPE + "\n", env=env, encoding=encoding)
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
+        proc = _FakeProc(list(cmd), _ERROR_ENVELOPE + "\n", env=env)
         procs.append(proc)
         return proc
 
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
 
     with pytest.raises(server.ComfyCliError):
         server.asyncio.run(server._run_comfy_streaming("run", "wf.json"))

--- a/tests/test_partner_generate.py
+++ b/tests/test_partner_generate.py
@@ -318,7 +318,7 @@ def test_partner_generate_surfaces_a_broken_elicitation_without_spending(
     calls = patched_plain_run(0, stdout="done")
 
     class _BrokenCtx(_FakeCtx):
-        async def elicit(self, message, schema):  # noqa: ARG002
+        async def elicit(self, message, schema):
             raise RuntimeError("client closed the connection")
 
     with pytest.raises(
@@ -708,7 +708,7 @@ def test_client_elicitation_support_is_false_outside_a_live_request():
     """`Context.session` raises outside a request — that is "cannot ask", not a crash."""
 
     class _NoSessionCtx:
-        async def elicit(self, message, schema):  # noqa: ARG002
+        async def elicit(self, message, schema):
             raise AssertionError("must never be reached")
 
         @property
@@ -732,7 +732,7 @@ def test_client_elicitation_support_is_unknown_when_the_probe_raises():
             self.session = _BrokenSession()
 
     class _BrokenSession:
-        def check_client_capability(self, capability):  # noqa: ARG002
+        def check_client_capability(self, capability):
             raise RuntimeError("capability table is corrupt")
 
     assert server._client_elicitation_support(_BrokenProbeCtx()) is None
@@ -750,7 +750,7 @@ def test_an_errored_capability_probe_still_asks_before_spending(patched_plain_ru
     calls = patched_plain_run(0, stdout="done")
 
     class _BrokenSession:
-        def check_client_capability(self, capability):  # noqa: ARG002
+        def check_client_capability(self, capability):
             raise RuntimeError("capability table is corrupt")
 
     ctx = _FakeCtx(action="decline")
@@ -769,7 +769,7 @@ def test_an_unanswered_prompt_lapses_into_a_refusal(patched_plain_run, monkeypat
     monkeypatch.setattr(server, "_SPEND_ELICIT_TIMEOUT", 0.05)
 
     class _SilentCtx(_FakeCtx):
-        async def elicit(self, message, schema):  # noqa: ARG002
+        async def elicit(self, message, schema):
             self.elicitations.append(message)
             await asyncio.sleep(30)  # never answers
             raise AssertionError("must never be reached")
@@ -786,7 +786,7 @@ def test_a_malformed_elicitation_result_is_a_refusal(patched_plain_run):
     calls = patched_plain_run(0, stdout="done")
 
     class _NonsenseCtx(_FakeCtx):
-        async def elicit(self, message, schema):  # noqa: ARG002
+        async def elicit(self, message, schema):
             self.elicitations.append(message)
             return object()  # no `.action`, no `.data`
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -249,7 +249,7 @@ def _patch_version_probe(monkeypatch, returncode: int, stderr: str) -> None:
     monkeypatch.setattr(server, "_version_checked", False)
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
 
-    def fake_run(cmd, **kwargs):  # noqa: ARG001
+    def fake_run(cmd, **kwargs):
         return subprocess.CompletedProcess(cmd, returncode, stdout="", stderr=stderr)
 
     monkeypatch.setattr(server.subprocess, "run", fake_run)
@@ -282,7 +282,7 @@ def test_version_guard_translates_a_denied_spawn(on_macos, monkeypatch):
     monkeypatch.setattr(
         server.subprocess,
         "run",
-        lambda cmd, **kw: (_ for _ in ()).throw(  # noqa: ARG005
+        lambda cmd, **kw: (_ for _ in ()).throw(
             PermissionError(1, "Operation not permitted", _DENIED_PATH)
         ),
     )
@@ -302,7 +302,7 @@ def test_version_guard_fails_open_on_an_unrelated_denied_spawn(on_macos, monkeyp
     monkeypatch.setattr(
         server.subprocess,
         "run",
-        lambda cmd, **kw: (_ for _ in ()).throw(  # noqa: ARG005
+        lambda cmd, **kw: (_ for _ in ()).throw(
             PermissionError(13, "Permission denied", "/opt/comfy/bin/comfy")
         ),
     )
@@ -325,7 +325,7 @@ def test_version_guard_ignores_a_healthy_comfy_cli(on_macos, monkeypatch):
     monkeypatch.setattr(
         server.subprocess,
         "run",
-        lambda cmd, **kwargs: subprocess.CompletedProcess(  # noqa: ARG005
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
             cmd, 0, stdout="comfy-cli, version 1.12.0\n", stderr=""
         ),
     )
@@ -340,7 +340,7 @@ def _patch_failing_run(monkeypatch, stderr: str) -> None:
     """A comfy-cli spawn that exits 1 with ``stderr`` and no envelope."""
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
 
-    def fake_popen(cmd, **kwargs):  # noqa: ARG001
+    def fake_popen(cmd, **kwargs):
         return _FakeRunProc(
             cmd, {}, stdout="", stderr=stderr, returncode=1, raises=None
         )
@@ -384,7 +384,7 @@ def test_a_real_error_envelope_is_untouched(on_macos, monkeypatch):
     monkeypatch.setattr(
         server.subprocess,
         "Popen",
-        lambda cmd, **kw: _FakeRunProc(  # noqa: ARG005
+        lambda cmd, **kw: _FakeRunProc(
             cmd, {}, stdout=envelope, stderr=_FATAL_STDERR, returncode=1, raises=None
         ),
     )

--- a/tests/test_run_template.py
+++ b/tests/test_run_template.py
@@ -27,12 +27,10 @@ comfy-cli is mocked throughout: no real ComfyUI, and no real credit spend.
 from __future__ import annotations
 
 import asyncio
-import io
 import json
-import time
 
 import pytest
-from conftest import _OK_STREAM, _RecordingCtx, envelope
+from conftest import _OK_STREAM, _RecordingCtx, envelope, stream_reader
 from mcp.server.elicitation import (
     AcceptedElicitation,
     CancelledElicitation,
@@ -208,7 +206,7 @@ def test_run_template_survives_a_failing_progress_notification(patched_streamed_
         def __init__(self):
             self.attempts = 0
 
-        async def report_progress(self, progress, total=None, message=None):  # noqa: ARG002
+        async def report_progress(self, progress, total=None, message=None):
             self.attempts += 1
             raise RuntimeError("client disconnected")
 
@@ -482,40 +480,40 @@ def test_run_template_wait_false_submits_async(patched_run, monkeypatch):
 
 
 class _BlockingProc:
-    """A Popen fake that emits ``first_lines`` and then never yields an envelope.
+    """A child fake that emits ``first_lines`` and then never yields an envelope.
 
     Local rather than in ``conftest`` because this is the one case where the call
     genuinely differs (see AGENTS.md): the shared ``patched_stream`` fake drains a
     canned stream to EOF instantly and reports itself already exited, so it can
     never hold the read past a deadline — which is precisely the state this test
     is about.
+
+    ``returncode`` starts None so the timeout handler's kill fires; no ``pid``, so
+    that kill takes ``server._kill_proc_tree_async``'s ``proc.kill()`` fallback
+    instead of signalling a made-up process group.
     """
 
     def __init__(self, cmd, first_lines):
         self.cmd = cmd
-        self._lines = list(first_lines)
-        self.stdout = self  # readline lives on the proc itself
-        self.stderr = io.StringIO("")
-        self.returncode = 0
+        self._lines = [line.encode("utf-8") for line in first_lines]
+        self.stdout = self  # the reader protocol lives on the proc itself
+        self.stderr = stream_reader("")
+        self.returncode = None
         self.killed = False
-        self._alive = True
 
-    def readline(self):
+    async def readuntil(self, separator=b"\n"):
         if self._lines:
             return self._lines.pop(0)
-        time.sleep(1.0)  # outlives the test's tiny deadline; no envelope ever comes
-        return ""
+        # Outlives the test's tiny deadline; no envelope ever comes.
+        await asyncio.sleep(1.0)
+        raise asyncio.IncompleteReadError(b"", None)
 
-    def poll(self):
-        return None if self._alive else self.returncode
-
-    def wait(self, timeout=None):  # noqa: ARG002
-        self._alive = False
+    async def wait(self):
+        self.returncode = 0
         return self.returncode
 
     def kill(self):
         self.killed = True
-        self._alive = False
 
 
 def test_run_template_timeout_raises_the_streaming_shape(monkeypatch):
@@ -532,13 +530,13 @@ def test_run_template_timeout_raises_the_streaming_shape(monkeypatch):
     queued = json.dumps({"schema": "event/1", "type": "queued", "nodes": [{"id": "1"}]})
     procs: list[_BlockingProc] = []
 
-    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
         proc = _BlockingProc(cmd, [queued + "\n"])
         procs.append(proc)
         return proc
 
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
     monkeypatch.setattr(server, "_RUN_TEMPLATE_TIMEOUT_GRACE", 0.0)
 
     with pytest.raises(server.ComfyCliError) as exc:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -23,7 +23,6 @@ from conftest import envelope
 
 from comfy_local_mcp import server
 
-
 # A representative slice of the real comfy-cli `templates ls` payload shape.
 ROWS = [
     {

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -15,7 +15,6 @@ MCP progress notifications, and still returns the final envelope's data.
 from __future__ import annotations
 
 import asyncio
-import io
 import json
 import os
 import shutil
@@ -27,7 +26,7 @@ import time
 from pathlib import PurePosixPath
 
 import pytest
-from conftest import _OK_STREAM, _FakeProc, _RecordingCtx, envelope
+from conftest import _OK_STREAM, _FakeProc, _RecordingCtx, envelope, stream_reader
 
 from comfy_local_mcp import server, textutil
 
@@ -418,7 +417,7 @@ def _fake_version(stdout: str, *, stderr: str = "", raises: Exception | None = N
     """A `subprocess.run` stand-in for `comfy --version`; records each call."""
     calls: list[list[str]] = []
 
-    def fake(cmd, capture_output, text, timeout, check, errors=None):  # noqa: ARG001
+    def fake(cmd, capture_output, text, timeout, check, errors=None):
         calls.append(cmd)
         if raises is not None:
             raise raises
@@ -2141,20 +2140,19 @@ def test_streaming_no_envelope_error_includes_both_stream_tails(monkeypatch):
     """The streaming EOF path produces the same enriched message as `_run_comfy`."""
     procs: list[_FakeProc] = []
 
-    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
         proc = _FakeProc(
-            cmd,
+            list(cmd),
             "starting run...\ncomfy-cli crashed before emitting a result\n",
             stderr_text="Traceback (most recent call last):\nRuntimeError: nope",
             env=env,
-            encoding=encoding,
         )
         proc.returncode = 1
         procs.append(proc)
         return proc
 
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
 
     with pytest.raises(server.ComfyCliError) as excinfo:
         asyncio.run(
@@ -2177,21 +2175,20 @@ def test_streaming_eof_ignores_a_trailing_progress_event(monkeypatch):
     tool), so it is filtered to None and the no-envelope branch fires instead.
     """
 
-    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
         proc = _FakeProc(
-            cmd,
+            list(cmd),
             # An event that both parses AND claims success — the worst case.
             '{"type": "progress", "ok": true, "data": {"value": 3}}\n'
             "comfy-cli crashed mid-run\n",
             stderr_text="RuntimeError: nope",
             env=env,
-            encoding=encoding,
         )
         proc.returncode = 1
         return proc
 
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
 
     with pytest.raises(server.ComfyCliError) as excinfo:
         asyncio.run(
@@ -2212,17 +2209,16 @@ def test_streaming_eof_still_refuses_an_incompatible_envelope(monkeypatch):
     with the incompatible-version message — not demoted to "returned no JSON".
     """
 
-    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
         proc = _FakeProc(
-            cmd,
+            list(cmd),
             '{"schema": "envelope/2", "type": "envelope", "ok": true, "data": {}}\n',
             env=env,
-            encoding=encoding,
         )
         return proc
 
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
 
     with pytest.raises(server.ComfyCliError, match="incompatible comfy-cli envelope"):
         asyncio.run(
@@ -2447,16 +2443,82 @@ def test_run_workflow_stream_sets_no_watch_env(patched_stream):
 
 
 def test_run_workflow_stream_forces_utf8_env(patched_stream):
-    """The streaming (Popen) spawn path also forces UTF-8 for the Windows fix."""
+    """The streaming spawn path also forces UTF-8 for the Windows fix."""
     procs = patched_stream(_OK_STREAM)
 
     asyncio.run(server.run_workflow("wf.json", wait=True))
 
     assert procs[0].env["PYTHONUTF8"] == "1"
     assert procs[0].env["PYTHONIOENCODING"] == "utf-8"
-    # And the parent-side stream read is pinned to UTF-8 to match (readline()/
-    # stderr.read() would otherwise decode with the cp1252 parent locale).
-    assert procs[0].encoding == "utf-8"
+
+
+def test_run_workflow_stream_decodes_utf8_and_survives_bad_bytes(monkeypatch):
+    """Stream lines decode as UTF-8, and an undecodable byte degrades one line.
+
+    The async pipes are binary, so the parent decodes each line itself rather
+    than relying on the parent locale (cp1252 on Windows would mojibake or raise
+    on the non-ASCII title below). ``errors="replace"`` is the deliberate half:
+    a truncated multi-byte sequence must not raise ``UnicodeDecodeError`` out of
+    the middle of a live run whose envelope is still to come.
+    """
+    ctx = _RecordingCtx()
+    good = json.dumps({"type": "executing", "node": "1", "title": "Café ☕"}).encode()
+    envelope_line = json.dumps(
+        {"schema": "envelope/1", "type": "envelope", "ok": True, "data": {"n": 1}}
+    ).encode()
+    raw = good + b"\n" + b'{"type": "executing", "node": "\xff\xfe"}\n' + envelope_line
+
+    procs: list[object] = []
+
+    async def fake_exec(*cmd, stdout, stderr, env, limit=None, **kwargs):
+        proc = _FakeProc(list(cmd), "", env=env, limit=limit)
+        proc.stdout = stream_reader(raw, limit)
+        procs.append(proc)
+        return proc
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
+
+    result = asyncio.run(server._run_comfy_streaming("run", "wf.json", ctx=ctx))
+
+    assert result == {"n": 1}  # the undecodable line did not abort the run
+    assert any("Café ☕" in (c["message"] or "") for c in ctx.calls)
+
+
+def test_streaming_reads_a_line_longer_than_the_reader_limit(monkeypatch):
+    """An NDJSON event bigger than the StreamReader's buffer is still read whole.
+
+    ``asyncio.StreamReader.readline`` raises ``ValueError`` as soon as one line
+    exceeds ``limit``; the blocking ``Popen`` + text ``readline`` this path used
+    to run had no such ceiling. A ``queued`` event carrying a large node manifest
+    is exactly the shape that would hit it, so ``_readline_unbounded`` stitches
+    the overrun chunks back together instead. Spawning with a deliberately tiny
+    ``limit`` makes the overrun happen at test speed.
+    """
+    nodes = [{"node_id": str(i)} for i in range(400)]
+    stream = (
+        json.dumps({"schema": "event/1", "type": "queued", "nodes": nodes})
+        + "\n"
+        + json.dumps(
+            {"schema": "envelope/1", "type": "envelope", "ok": True, "data": {"ok": 1}}
+        )
+        + "\n"
+    )
+    assert len(stream) > 4096  # the manifest line really does overrun the limit
+
+    ctx = _RecordingCtx()
+
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
+        return _FakeProc(list(cmd), stream, env=env, limit=1024)
+
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
+
+    result = asyncio.run(server._run_comfy_streaming("run", "wf.json", ctx=ctx))
+
+    assert result == {"ok": 1}
+    # The oversized line parsed, so the node manifest set the progress total.
+    assert ctx.calls[0]["total"] == float(len(nodes))
 
 
 @_needs_posix_exec
@@ -2564,33 +2626,34 @@ def test_watch_job_stream_error_envelope_raises_with_code(patched_stream):
 
 
 class _BlockingProc:
-    """A fake Popen whose stdout yields ``first_lines`` then blocks (forces a timeout)."""
+    """A fake child whose stdout yields ``first_lines`` then blocks (forces a timeout).
+
+    ``returncode`` starts None (the child is running) so the timeout handler's
+    kill actually fires; carries no ``pid`` so the kill takes the ``proc.kill()``
+    fallback rather than signalling a made-up group. See conftest's ``_FakeProc``.
+    """
 
     def __init__(self, cmd, first_lines):
         self.cmd = cmd
-        self._lines = list(first_lines)
-        self.stdout = self  # readline lives on the proc itself
-        self.stderr = io.StringIO("")
-        self.returncode = 0
+        self._lines = [line.encode("utf-8") for line in first_lines]
+        self.stdout = self  # the reader protocol lives on the proc itself
+        self.stderr = stream_reader("")
+        self.returncode = None
         self.killed = False
-        self._alive = True
 
-    def readline(self):
+    async def readuntil(self, separator=b"\n"):
         if self._lines:
             return self._lines.pop(0)
-        time.sleep(1.0)  # outlives the test's tiny timeout, never yields the envelope
-        return ""
+        # Outlives the test's tiny timeout, so the envelope never arrives.
+        await asyncio.sleep(1.0)
+        raise asyncio.IncompleteReadError(b"", None)
 
-    def poll(self):
-        return None if self._alive else self.returncode
-
-    def wait(self, timeout=None):  # noqa: ARG002
-        self._alive = False
+    async def wait(self):
+        self.returncode = 0
         return self.returncode
 
     def kill(self):
         self.killed = True
-        self._alive = False
 
 
 def test_watch_job_times_out_returns_payload(monkeypatch):
@@ -2600,13 +2663,13 @@ def test_watch_job_times_out_returns_payload(monkeypatch):
     )
     procs: list[_BlockingProc] = []
 
-    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
         proc = _BlockingProc(cmd, [queued + "\n"])
         procs.append(proc)
         return proc
 
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
 
     # MCP always injects a ctx, so the tracker has advanced by the time we expire.
     result = asyncio.run(
@@ -2628,13 +2691,13 @@ def test_watch_job_times_out_reports_progress_without_ctx(monkeypatch):
     executed = json.dumps({"type": "executed", "node": "1"})
     procs: list[_BlockingProc] = []
 
-    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
         proc = _BlockingProc(cmd, [queued + "\n", executed + "\n"])
         procs.append(proc)
         return proc
 
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
 
     # No ctx: the notification is a no-op, but tracker state must still advance
     # so the snapshot reports the node that actually finished (not all zeros).
@@ -2911,7 +2974,7 @@ class _GroupKillProc:
     def poll(self):
         return self.returncode
 
-    def wait(self, timeout=None):  # noqa: ARG002
+    def wait(self, timeout=None):
         return self.returncode
 
     def kill(self):
@@ -2935,7 +2998,7 @@ def test_sync_timeout_kills_the_whole_process_group(monkeypatch):
     )
     signalled: list[tuple[int, int]] = []
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: proc)  # noqa: ARG005
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: proc)
     monkeypatch.setattr(
         server.os, "killpg", lambda pgid, sig: signalled.append((pgid, sig))
     )
@@ -2971,7 +3034,7 @@ def test_group_kill_is_not_gated_on_the_leader_still_running(monkeypatch):
     )
     signalled: list[tuple[int, int]] = []
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: proc)  # noqa: ARG005
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: proc)
     monkeypatch.setattr(
         server.os, "killpg", lambda pgid, sig: signalled.append((pgid, sig))
     )
@@ -3006,8 +3069,8 @@ def test_drain_second_timeout_keeps_the_longer_capture(monkeypatch):
         _timeout(stderr=b"trace", stdout=b"first"),
     )
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: proc)  # noqa: ARG005
-    monkeypatch.setattr(server.os, "killpg", lambda pgid, sig: None)  # noqa: ARG005
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: proc)
+    monkeypatch.setattr(server.os, "killpg", lambda pgid, sig: None)
 
     with pytest.raises(server.ComfyCliError) as exc:
         server._run_comfy("update", "all", timeout=1800.0)
@@ -3037,8 +3100,8 @@ def test_drain_non_timeout_failure_falls_back_to_the_first_capture(monkeypatch):
         _timeout(stderr="partial trace", stdout="partial out"),
     )
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: proc)  # noqa: ARG005
-    monkeypatch.setattr(server.os, "killpg", lambda pgid, sig: None)  # noqa: ARG005
+    monkeypatch.setattr(server.subprocess, "Popen", lambda *a, **kw: proc)
+    monkeypatch.setattr(server.os, "killpg", lambda pgid, sig: None)
 
     with pytest.raises(server.ComfyCliError) as exc:
         server._run_comfy("update", "all", timeout=1800.0)
@@ -3065,34 +3128,12 @@ def test_sync_non_timeout_failure_still_reaps_the_child(patched_run):
     assert calls[0]["proc"].killed is True
 
 
-class _BlockingProcWithStderr:
-    """A blocking Popen fake that also carries buffered stderr (a crashed child's traceback)."""
+class _BlockingProcWithStderr(_BlockingProc):
+    """A blocking child fake that also carries buffered stderr (a crashed traceback)."""
 
     def __init__(self, cmd, first_lines, stderr_text):
-        self.cmd = cmd
-        self._lines = list(first_lines)
-        self.stdout = self  # readline lives on the proc itself
-        self.stderr = io.StringIO(stderr_text)
-        self.returncode = 0
-        self.killed = False
-        self._alive = True
-
-    def readline(self):
-        if self._lines:
-            return self._lines.pop(0)
-        time.sleep(1.0)  # outlives the test's tiny timeout, never yields the envelope
-        return ""
-
-    def poll(self):
-        return None if self._alive else self.returncode
-
-    def wait(self, timeout=None):  # noqa: ARG002
-        self._alive = False
-        return self.returncode
-
-    def kill(self):
-        self.killed = True
-        self._alive = False
+        super().__init__(cmd, first_lines)
+        self.stderr = stream_reader(stderr_text)
 
 
 def test_streaming_timeout_surfaces_stdout_and_stderr_tails(monkeypatch):
@@ -3100,7 +3141,7 @@ def test_streaming_timeout_surfaces_stdout_and_stderr_tails(monkeypatch):
     queued = json.dumps({"type": "queued", "nodes": [{"node_id": "1"}]})
     procs: list[_BlockingProcWithStderr] = []
 
-    def fake_popen(cmd, stdout, stderr, text, env, **kwargs):  # noqa: ARG001
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
         proc = _BlockingProcWithStderr(
             cmd, [queued + "\n"], "Traceback ...\nUnicodeEncodeError: boom"
         )
@@ -3108,7 +3149,7 @@ def test_streaming_timeout_surfaces_stdout_and_stderr_tails(monkeypatch):
         return proc
 
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
 
     with pytest.raises(server.ComfyCliError) as exc:
         asyncio.run(
@@ -3128,13 +3169,13 @@ def test_streaming_timeout_stdout_tail_is_bounded(monkeypatch):
     noisy = [("x" * 100 + "\n") for _ in range(50)]  # 5000+ chars of NDJSON
     procs: list[_BlockingProcWithStderr] = []
 
-    def fake_popen(cmd, stdout, stderr, text, env, **kwargs):  # noqa: ARG001
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
         proc = _BlockingProcWithStderr(cmd, noisy, "")
         procs.append(proc)
         return proc
 
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
 
     with pytest.raises(server.ComfyCliError) as exc:
         asyncio.run(
@@ -3162,25 +3203,24 @@ class _StderrBlockingProc:
 
     def __init__(self, cmd, stdout_lines):
         self.cmd = cmd
-        self._lines = list(stdout_lines)
-        self.stdout = self  # readline lives on the proc
+        self._lines = [line.encode("utf-8") for line in stdout_lines]
+        self.stdout = self  # the reader protocol lives on the proc
         self.stderr = self  # read lives on the proc
-        self.returncode = 0
+        self.returncode = None
         self.killed = False
-        self._alive = True
 
-    def readline(self):
-        return self._lines.pop(0) if self._lines else ""  # EOF -> _pump breaks
+    async def readuntil(self, separator=b"\n"):
+        if self._lines:
+            return self._lines.pop(0)
+        raise asyncio.IncompleteReadError(b"", None)  # EOF -> _pump breaks
 
-    def read(self, size=-1):  # noqa: ARG002 — size ignored; models a blocking pipe
-        time.sleep(1.0)  # outlives the tiny timeout; suspends _drain at stderr_future
-        return ""
+    async def read(self, size=-1):
+        # Outlives the tiny timeout; suspends `_read` at `await stderr_future`.
+        await asyncio.sleep(1.0)
+        return b""
 
-    def poll(self):
-        return None if self._alive else self.returncode
-
-    def wait(self, timeout=None):  # noqa: ARG002
-        self._alive = False
+    async def wait(self):
+        self.returncode = 0
         return self.returncode
 
     def kill(self):
@@ -3192,11 +3232,11 @@ def test_streaming_timeout_stderr_cancel_still_raises(monkeypatch):
     """A timeout that cancels the stderr read must still raise ComfyCliError, not CancelledError."""
     queued = json.dumps({"type": "queued", "nodes": [{"node_id": "1"}]})
 
-    def fake_popen(cmd, stdout, stderr, text, env, **kwargs):  # noqa: ARG001
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
         return _StderrBlockingProc(cmd, [queued + "\n"])
 
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
 
     with pytest.raises(server.ComfyCliError) as exc:
         asyncio.run(
@@ -3491,7 +3531,7 @@ def test_restart_comfyui_explains_port_clash_after_nothing_to_stop(monkeypatch):
     def fake_stop():
         raise server.ComfyCliError("No ComfyUI is running in the background.")
 
-    def fake_launch(extra_args=None):  # noqa: ARG001
+    def fake_launch(extra_args=None):
         raise server.ComfyCliError(
             "comfy-cli returned no JSON (exit 1). stderr: The 8188 port is "
             "already in use. | stdout: <empty>",
@@ -3518,7 +3558,7 @@ def test_restart_comfyui_leaves_port_clash_alone_after_a_real_stop(monkeypatch):
     """A port clash after a stop that DID kill comfy-cli's server is a different bug."""
     monkeypatch.setattr(server, "stop_comfyui", lambda: {"ok": True})
 
-    def fake_launch(extra_args=None):  # noqa: ARG001
+    def fake_launch(extra_args=None):
         raise server.ComfyCliError("The 8188 port is already in use.")
 
     monkeypatch.setattr(server, "launch_comfyui", fake_launch)
@@ -3539,7 +3579,7 @@ def test_restart_comfyui_leaves_non_port_launch_failure_alone(monkeypatch):
         ),
     )
 
-    def fake_launch(extra_args=None):  # noqa: ARG001
+    def fake_launch(extra_args=None):
         raise server.ComfyCliError("ComfyUI exited during startup: missing torch")
 
     monkeypatch.setattr(server, "launch_comfyui", fake_launch)
@@ -3596,7 +3636,7 @@ def test_restart_comfyui_leaves_a_non_port_resource_clash_alone(monkeypatch):
         ),
     )
 
-    def fake_launch(extra_args=None):  # noqa: ARG001
+    def fake_launch(extra_args=None):
         raise server.ComfyCliError("Cannot load model: the file is already in use")
 
     monkeypatch.setattr(server, "launch_comfyui", fake_launch)
@@ -3684,7 +3724,7 @@ def test_restart_comfyui_port_guidance_reflects_the_requested_port(monkeypatch):
     def fake_stop():
         raise server.ComfyCliError("No ComfyUI is running in the background.")
 
-    def fake_launch(extra_args=None):  # noqa: ARG001
+    def fake_launch(extra_args=None):
         raise server.ComfyCliError("The 8189 port is already in use.")
 
     monkeypatch.setattr(server, "stop_comfyui", fake_stop)
@@ -4111,43 +4151,50 @@ def test_fetch_outputs_default_return_is_unchanged(patched_run, tmp_path):
 
 
 class _LingeringProc:
-    """Fake Popen that emits ``lines`` (incl. the terminal envelope) then lingers.
+    """Fake async child emitting ``lines`` (incl. the envelope) then lingering.
 
-    Once the canned lines are exhausted ``stdout.readline`` blocks until the
-    child is killed, and ``wait()`` blocks the same way — modeling comfy-cli
-    outliving its own ``--json-stream`` envelope under a pipe. ``stderr.read``
-    blocks too, so a test also proves the envelope path never awaits stderr. The
-    block is bounded (10s) only so a buggy test can't hang the suite; the real
-    exit is ``kill()``.
+    Once the canned lines are exhausted ``stdout`` never EOFs and ``wait()``
+    never returns — modeling comfy-cli outliving its own ``--json-stream``
+    envelope under a pipe. ``stderr.read`` blocks the same way, so a test also
+    proves the envelope path never awaits stderr. The block is bounded (10s) only
+    so a buggy test can't hang the suite; the real exit is ``kill()``.
+
+    Carries no ``pid``, so ``server._kill_proc_tree_async`` takes its
+    ``AttributeError`` fallback to ``proc.kill()`` instead of signalling a
+    made-up process group — same reasoning as conftest's ``_FakeProc``.
     """
 
     def __init__(self, cmd, lines):
         self.cmd = cmd
-        self._lines = list(lines)
-        self.stdout = self  # readline lives on the proc itself
+        self._lines = [line.encode("utf-8") for line in lines]
+        self.stdout = self  # the reader protocol lives on the proc itself
         self.stderr = self  # read() blocks the same way -> proves we don't await it
-        # None until reaped, mirroring real Popen: while the child lingers past
-        # its envelope its returncode is unknown, and _unwrap_envelope must
-        # tolerate that (it ignores returncode whenever an envelope is present).
+        # None until reaped, mirroring a real child: while it lingers past its
+        # envelope its returncode is unknown, and _unwrap_envelope must tolerate
+        # that (it ignores returncode whenever an envelope is present).
         self.returncode = None
         self.killed = False
-        self._dead = threading.Event()
+        self._dead = asyncio.Event()
 
-    def readline(self):
+    async def _park(self):
+        """Block until killed — bounded only so a buggy test can't hang the suite."""
+        try:
+            await asyncio.wait_for(self._dead.wait(), 10.0)
+        except (asyncio.TimeoutError, TimeoutError):
+            pass
+
+    async def readuntil(self, separator=b"\n"):
         if self._lines:
             return self._lines.pop(0)
-        self._dead.wait(timeout=10.0)  # stdout never EOFs on its own
-        return ""
+        await self._park()  # stdout never EOFs on its own
+        raise asyncio.IncompleteReadError(b"", None)
 
-    def read(self, size=-1):  # noqa: ARG002 — size ignored; models a blocking pipe
-        self._dead.wait(timeout=10.0)  # stderr never EOFs while the child lives
-        return ""
+    async def read(self, size=-1):
+        await self._park()  # stderr never EOFs while the child lives
+        return b""
 
-    def poll(self):
-        return self.returncode if self._dead.is_set() else None
-
-    def wait(self, timeout=None):  # noqa: ARG002
-        self._dead.wait(timeout=10.0)  # a child that lingers past its envelope
+    async def wait(self):
+        await self._park()  # a child that lingers past its envelope
         return self.returncode
 
     def kill(self):
@@ -4156,15 +4203,15 @@ class _LingeringProc:
         self._dead.set()
 
 
-def _lingering_popen(procs, stream_lines):
-    """A ``subprocess.Popen`` stand-in minting a fresh ``_LingeringProc`` per call."""
+def _lingering_exec(procs, stream_lines):
+    """An ``create_subprocess_exec`` stand-in minting a ``_LingeringProc`` per call."""
 
-    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
-        proc = _LingeringProc(cmd, list(stream_lines))
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
+        proc = _LingeringProc(list(cmd), list(stream_lines))
         procs.append(proc)
         return proc
 
-    return fake_popen
+    return fake_exec
 
 
 # Run events (2-node manifest + one completion) then the terminal envelope; the
@@ -4208,7 +4255,9 @@ def test_run_workflow_returns_on_envelope_despite_lingering_child(monkeypatch):
     procs: list[_LingeringProc] = []
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
     monkeypatch.setattr(
-        server.subprocess, "Popen", _lingering_popen(procs, _ENVELOPE_THEN_LINGER)
+        server.asyncio,
+        "create_subprocess_exec",
+        _lingering_exec(procs, _ENVELOPE_THEN_LINGER),
     )
     # Tiny post-envelope grace so the lingering child is reaped fast in-test.
     monkeypatch.setattr(server, "_POST_ENVELOPE_REAP_GRACE", 0.1)
@@ -4231,7 +4280,9 @@ def test_run_workflow_error_envelope_with_open_pipe_raises(monkeypatch):
     procs: list[_LingeringProc] = []
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
     monkeypatch.setattr(
-        server.subprocess, "Popen", _lingering_popen(procs, _ERROR_ENVELOPE_THEN_LINGER)
+        server.asyncio,
+        "create_subprocess_exec",
+        _lingering_exec(procs, _ERROR_ENVELOPE_THEN_LINGER),
     )
     monkeypatch.setattr(server, "_POST_ENVELOPE_REAP_GRACE", 0.1)
 
@@ -4251,7 +4302,9 @@ def test_two_overlapping_run_workflow_calls_complete_independently(monkeypatch):
     procs: list[_LingeringProc] = []
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
     monkeypatch.setattr(
-        server.subprocess, "Popen", _lingering_popen(procs, _ENVELOPE_THEN_LINGER)
+        server.asyncio,
+        "create_subprocess_exec",
+        _lingering_exec(procs, _ENVELOPE_THEN_LINGER),
     )
     monkeypatch.setattr(server, "_POST_ENVELOPE_REAP_GRACE", 0.1)
 
@@ -4275,13 +4328,13 @@ def test_run_workflow_timeout_error_includes_snapshot_and_hint(monkeypatch):
     )
     procs: list[_BlockingProc] = []
 
-    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
         proc = _BlockingProc(cmd, [queued + "\n"])
         procs.append(proc)
         return proc
 
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
 
     with pytest.raises(server.ComfyCliError) as excinfo:
         asyncio.run(
@@ -4336,7 +4389,9 @@ def test_run_workflow_returns_envelope_after_deadline_during_reap(monkeypatch):
     procs: list[_LingeringProc] = []
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
     monkeypatch.setattr(
-        server.subprocess, "Popen", _lingering_popen(procs, _ENVELOPE_THEN_LINGER)
+        server.asyncio,
+        "create_subprocess_exec",
+        _lingering_exec(procs, _ENVELOPE_THEN_LINGER),
     )
     # Grace (0.5s) deliberately exceeds the client timeout (0.2s): the OLD code
     # ran the reap inside the client budget and raised; the fix returns the data.
@@ -4361,9 +4416,9 @@ def test_run_workflow_ignores_non_terminal_envelope_typed_line(monkeypatch):
     procs: list[_LingeringProc] = []
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
     monkeypatch.setattr(
-        server.subprocess,
-        "Popen",
-        _lingering_popen(procs, _SPURIOUS_ENVELOPE_THEN_REAL),
+        server.asyncio,
+        "create_subprocess_exec",
+        _lingering_exec(procs, _SPURIOUS_ENVELOPE_THEN_REAL),
     )
     monkeypatch.setattr(server, "_POST_ENVELOPE_REAP_GRACE", 0.1)
 
@@ -4388,19 +4443,18 @@ class _ExitedErrorProc:
 
     def __init__(self, cmd, lines, stderr_text):
         self.cmd = cmd
-        self._lines = list(lines)
+        self._lines = [line.encode("utf-8") for line in lines]
         self.stdout = self
-        self.stderr = io.StringIO(stderr_text)
+        self.stderr = stream_reader(stderr_text)
         self.returncode = 1  # already exited by the time we reap
         self.killed = False
 
-    def readline(self):
-        return self._lines.pop(0) if self._lines else ""
+    async def readuntil(self, separator=b"\n"):
+        if self._lines:
+            return self._lines.pop(0)
+        raise asyncio.IncompleteReadError(b"", None)
 
-    def poll(self):
-        return self.returncode
-
-    def wait(self, timeout=None):  # noqa: ARG002
+    async def wait(self):
         return self.returncode
 
     def kill(self):
@@ -4423,11 +4477,11 @@ def test_run_workflow_error_envelope_empty_message_falls_back_to_stderr(monkeypa
     ]
     stderr_text = "Traceback (most recent call last):\nRuntimeError: kaboom"
 
-    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
         return _ExitedErrorProc(cmd, lines, stderr_text)
 
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
     monkeypatch.setattr(server, "_POST_ENVELOPE_REAP_GRACE", 0.1)
 
     with pytest.raises(server.ComfyCliError) as excinfo:
@@ -4442,11 +4496,11 @@ def test_run_workflow_error_envelope_empty_message_falls_back_to_stderr(monkeypa
 
 
 class _ChunkedStream:
-    """Fake pipe that hands back ``data`` in fixed ``chunk`` slices, then EOF.
+    """Fake async pipe handing back ``data`` in fixed ``chunk`` slices, then EOF.
 
     Models a real pipe delivering stderr in many small reads (ignoring the
-    requested size), so a test can prove `_drain_capped` keeps reading to EOF
-    and retains the tail across chunk boundaries — not just within one read.
+    requested size), so a test can prove `_drain_capped_async` keeps reading to
+    EOF and retains the tail across chunk boundaries — not just within one read.
     """
 
     def __init__(self, data, chunk):
@@ -4454,62 +4508,81 @@ class _ChunkedStream:
         self._chunk = chunk
         self._pos = 0
 
-    def read(self, size=-1):  # noqa: ARG002 — models a pipe: own chunk, not size
+    async def read(self, size=-1):  # chunked regardless of the requested size
         piece = self._data[self._pos : self._pos + self._chunk]
         self._pos += len(piece)
         return piece
 
 
-def test_drain_capped_retains_only_the_tail_across_chunks():
-    """`_drain_capped` drains to EOF but keeps at most ``limit`` trailing chars.
+def test_drain_capped_async_retains_only_the_tail_across_chunks():
+    """`_drain_capped_async` drains to EOF but keeps at most ``limit`` trailing bytes.
 
     A verbose child must be fully drained (so it can't wedge on a full stderr
     pipe) without letting its output drive unbounded allocation here — only the
     tail, where the actual error/traceback lands, is retained.
     """
-    data = "".join(f"line{i}\n" for i in range(1000))  # ~7 KB across many chunks
-    out = server._drain_capped(_ChunkedStream(data, chunk=64), limit=100)
-    assert out == data[-100:]
+    data = b"".join(f"line{i}\n".encode() for i in range(1000))  # ~7 KB, many chunks
+    out = asyncio.run(server._drain_capped_async(_ChunkedStream(data, chunk=64), 100))
+    assert out == data[-100:].decode()
     assert len(out) == 100
     # Under the cap: returned whole. Empty: drains to "".
-    assert server._drain_capped(_ChunkedStream("short", chunk=64), 100) == "short"
-    assert server._drain_capped(_ChunkedStream("", chunk=64), 100) == ""
+    drain = server._drain_capped_async
+    assert asyncio.run(drain(_ChunkedStream(b"short", chunk=64), 100)) == "short"
+    assert asyncio.run(drain(_ChunkedStream(b"", chunk=64), 100)) == ""
+
+
+def test_drain_capped_async_decodes_once_at_the_end():
+    """A multi-byte character split across a chunk boundary survives the drain.
+
+    The cap slices BYTES, so decoding per chunk would turn a UTF-8 sequence
+    straddling a read into replacement characters — which is why the decode
+    happens once, after the tail is assembled.
+    """
+    data = "ünïcödé ☕ traceback\n".encode()
+    # A chunk size that lands mid-sequence on the multi-byte characters.
+    out = asyncio.run(server._drain_capped_async(_ChunkedStream(data, chunk=3), 4096))
+    assert out == data.decode()
+    assert "�" not in out
 
 
 class _StderrNeverEOFProc:
     """Envelope-then-linger child whose stderr pipe never EOFs, even after kill.
 
     Models comfy-cli leaving a descendant that inherited the stderr write fd:
-    ``kill()`` reaps the direct child (unblocking ``readline`` / ``wait``) but
-    the stderr ``read()`` never returns. The bounded ``finally`` join must
-    detach the parked reader instead of hanging the tool call forever.
+    ``kill()`` reaps the direct child (unblocking the stdout read / ``wait``) but
+    the stderr ``read()`` never returns. Cleanup must detach the parked reader
+    instead of hanging the tool call forever.
     """
 
     def __init__(self, cmd, lines):
         self.cmd = cmd
-        self._lines = list(lines)
+        self._lines = [line.encode("utf-8") for line in lines]
         self.stdout = self
         self.stderr = self
         self.returncode = None
         self.killed = False
-        self._child_dead = threading.Event()  # set by kill(): the direct child
-        self._stderr_eof = threading.Event()  # NEVER set: descendant holds the fd
+        self._child_dead = asyncio.Event()  # set by kill(): the direct child
+        self._stderr_eof = asyncio.Event()  # NEVER set: descendant holds the fd
 
-    def readline(self):
+    async def _park(self, event):
+        """Block on ``event`` — bounded only so a buggy test can't hang the suite."""
+        try:
+            await asyncio.wait_for(event.wait(), 10.0)
+        except (asyncio.TimeoutError, TimeoutError):
+            pass
+
+    async def readuntil(self, separator=b"\n"):
         if self._lines:
             return self._lines.pop(0)
-        self._child_dead.wait(timeout=10.0)
-        return ""
+        await self._park(self._child_dead)
+        raise asyncio.IncompleteReadError(b"", None)
 
-    def read(self, size=-1):  # noqa: ARG002 — parks past kill(); never EOFs
-        self._stderr_eof.wait(timeout=10.0)
-        return ""
+    async def read(self, size=-1):
+        await self._park(self._stderr_eof)
+        return b""
 
-    def poll(self):
-        return self.returncode if self._child_dead.is_set() else None
-
-    def wait(self, timeout=None):  # noqa: ARG002
-        self._child_dead.wait(timeout=10.0)
+    async def wait(self):
+        await self._park(self._child_dead)
         return self.returncode
 
     def kill(self):
@@ -4539,11 +4612,11 @@ def test_envelope_path_does_not_hang_when_stderr_pipe_never_eofs(monkeypatch):
     ]
     proc = _StderrNeverEOFProc(cmd=["comfy"], lines=lines)
 
-    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
         return proc
 
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
     monkeypatch.setattr(server, "_POST_ENVELOPE_REAP_GRACE", 0.05)
     monkeypatch.setattr(server, "_STDERR_JOIN_GRACE", 0.05)
 
@@ -4559,154 +4632,83 @@ def test_envelope_path_does_not_hang_when_stderr_pipe_never_eofs(monkeypatch):
     assert proc.killed  # the direct child was reaped even though stderr never EOF'd
 
 
-# --- bounded pipe-read pool: threads don't accumulate on the default executor -
+# --- the streaming path never blocks the event loop ---------------------------
 
 
-def test_pipe_executor_is_dedicated_and_bounded():
-    """The subprocess pipe reads run on their own bounded pool, not the default.
+def test_streaming_run_keeps_the_event_loop_responsive(monkeypatch):
+    """A live stream must not stall other coroutines on the same loop.
 
-    A dedicated `ThreadPoolExecutor` with a finite `max_workers` is what keeps
-    parked pipe-reader/waiter threads off asyncio's shared default executor, so
-    they can never starve unrelated `to_thread` work.
+    This is the property `_run_comfy_streaming` exists to hold and the one a
+    result-only test cannot see: an implementation that spawned with
+    `subprocess.Popen` and read the pipes with blocking `readline` would return
+    the exact same envelope while the loop sat frozen for the life of the child.
+
+    So the assertion is on the HEARTBEAT, not the payload. A companion coroutine
+    ticks every millisecond for the whole run; if the stream ever monopolizes the
+    loop the tick count collapses and the largest gap between ticks approaches
+    the run's duration. Both are checked, because either alone is foolable — a
+    high tick count could come from one long stall plus a fast burst.
     """
-    from concurrent.futures import ThreadPoolExecutor
+    ticks: list[float] = []
+    step = 0.02  # per-line delay: the run lasts long enough to sample the loop
 
-    assert isinstance(server._PIPE_EXECUTOR, ThreadPoolExecutor)
-    assert server._PIPE_EXECUTOR._max_workers == server._PIPE_POOL_MAX_WORKERS
-    assert server._PIPE_POOL_MAX_WORKERS >= 1  # bounded, non-zero
+    class _PacedProc:
+        """Emits its canned lines one `step` apart, yielding to the loop between."""
 
-
-def test_overlapping_streaming_runs_confine_and_release_pipe_threads(monkeypatch):
-    """N overlapping streaming runs keep their blocking pipe reads on the
-    dedicated pool and drain back to baseline once each run returns.
-
-    Each fake child emits its envelope then lingers with a blocked stderr pipe
-    (``read()`` never EOFs until the child is killed) — the exact shape that
-    parks a reader thread. This asserts the two halves of the fix together:
-
-    1. Isolation — every blocking ``readline`` / ``read`` / ``wait`` runs on a
-       ``_PIPE_EXECUTOR`` worker (``comfy-pipe`` prefix), NOT the loop's shared
-       default executor (whose threads are named ``asyncio_*``). On the old
-       ``asyncio.to_thread`` code these would land on the default pool and the
-       name assertion fails.
-    2. Baseline — after every run returns, no reader/waiter thread is still
-       parked: the ``finally`` joins the stderr reader once the child is dead
-       instead of leaving it parked on a cancelled future.
-    """
-    from concurrent.futures import ThreadPoolExecutor
-
-    n_runs = 6
-    parked = 0  # threads currently blocked in a fake pipe read / wait
-    peak_parked = 0
-    seen_thread_names: set[str] = set()
-    lock = threading.Lock()
-
-    # A generously sized dedicated pool so the test never deadlocks on a
-    # low-core host (a persistent stderr reader holds a slot for the whole run);
-    # the `comfy-pipe` prefix mirrors the real `_PIPE_EXECUTOR`.
-    test_pool = ThreadPoolExecutor(
-        max_workers=4 * n_runs, thread_name_prefix="comfy-pipe"
-    )
-    monkeypatch.setattr(server, "_PIPE_EXECUTOR", test_pool)
-
-    class _InstrumentedProc:
         def __init__(self, cmd, lines):
             self.cmd = cmd
-            self._lines = list(lines)
+            self._lines = [line.encode("utf-8") for line in lines]
             self.stdout = self
-            self.stderr = self
+            self.stderr = stream_reader("")
             self.returncode = None
             self.killed = False
-            self._dead = threading.Event()
 
-        def _record_thread(self):
-            with lock:
-                seen_thread_names.add(threading.current_thread().name)
-
-        def _block_until_dead(self):
-            nonlocal parked, peak_parked
-            self._record_thread()
-            with lock:
-                parked += 1
-                peak_parked = max(peak_parked, parked)
-            try:
-                self._dead.wait(timeout=10.0)  # real exit is kill(); bound as a guard
-            finally:
-                with lock:
-                    parked -= 1
-
-        def readline(self):
-            self._record_thread()
+        async def readuntil(self, separator=b"\n"):
+            await asyncio.sleep(step)  # the child is "thinking" between events
             if self._lines:
                 return self._lines.pop(0)
-            self._block_until_dead()
-            return ""
+            raise asyncio.IncompleteReadError(b"", None)
 
-        def read(self, size=-1):  # noqa: ARG002 — size ignored; parks until killed
-            self._block_until_dead()
-            return ""
-
-        def poll(self):
-            return self.returncode if self._dead.is_set() else None
-
-        def wait(self, timeout=None):  # noqa: ARG002
-            self._block_until_dead()
+        async def wait(self):
+            self.returncode = 0
             return self.returncode
 
         def kill(self):
             self.killed = True
-            self.returncode = -9
-            self._dead.set()
 
-    procs: list[_InstrumentedProc] = []
-
-    def fake_popen(cmd, stdout, stderr, text, encoding, env, **kwargs):  # noqa: ARG001
-        proc = _InstrumentedProc(cmd, list(_ENVELOPE_THEN_LINGER))
-        procs.append(proc)
-        return proc
+    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
+        return _PacedProc(list(cmd), _OK_STREAM.splitlines(keepends=True))
 
     monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(server, "_POST_ENVELOPE_REAP_GRACE", 0.2)
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
 
-    async def _run_many():
-        return await asyncio.gather(
-            *[
-                server.run_workflow(f"wf{i}.json", wait=True, timeout_seconds=30.0)
-                for i in range(n_runs)
-            ]
-        )
+    async def _heartbeat(stop: asyncio.Event):
+        while not stop.is_set():
+            ticks.append(time.monotonic())
+            await asyncio.sleep(0.001)
 
-    try:
-        results = asyncio.run(_run_many())
+    async def _drive():
+        stop = asyncio.Event()
+        beat = asyncio.ensure_future(_heartbeat(stop))
+        started = time.monotonic()
+        try:
+            result = await server.run_workflow("wf.json", wait=True, timeout_seconds=30)
+        finally:
+            stop.set()
+            await beat
+        return result, time.monotonic() - started
 
-        assert results == [{"outputs": ["/x.png"]}] * n_runs
-        assert len(procs) == n_runs
-        assert all(p.killed for p in procs)  # every child reaped
+    result, elapsed = asyncio.run(_drive())
 
-        # The runs genuinely overlapped: at least the N stderr readers were
-        # parked at once (proves this isn't trivially serialized).
-        assert peak_parked >= n_runs
-
-        # (1) Isolation: everything ran on the dedicated pool, never the default.
-        assert seen_thread_names, "expected pipe reads to run on worker threads"
-        assert all(name.startswith("comfy-pipe") for name in seen_thread_names), (
-            seen_thread_names
-        )
-
-        # (2) Baseline: no pipe thread stays parked after the runs return. The
-        # only laggard is each timed-out reap `wait`, released by kill(); poll
-        # briefly so a sub-millisecond unwind race isn't read as a leak.
-        deadline = time.monotonic() + 2.0
-        while time.monotonic() < deadline:
-            with lock:
-                if parked == 0:
-                    break
-            time.sleep(0.01)
-        with lock:
-            assert parked == 0, f"{parked} pipe thread(s) still parked at baseline"
-    finally:
-        test_pool.shutdown(wait=True)
+    assert result == {"outputs": ["/x.png"]}
+    # The run really did span several event lines rather than resolving instantly.
+    assert elapsed >= 3 * step
+    # The other coroutine made progress THROUGHOUT: many ticks, and no single gap
+    # anywhere near the run's length. A blocking implementation parks the loop for
+    # the whole run, which shows up as a gap of roughly `elapsed`.
+    assert len(ticks) > 10, f"only {len(ticks)} ticks in {elapsed:.3f}s"
+    largest_gap = max(b - a for a, b in zip(ticks, ticks[1:]))
+    assert largest_gap < elapsed / 2, f"loop stalled for {largest_gap:.3f}s"
 
 
 def test_get_logs_caps_oversized_line(patched_run):


### PR DESCRIPTION
## ELI-5

When you ask this server to run a workflow, it starts `comfy-cli` and reads its progress line by line. Doing that with the plain, "wait right here until the next line arrives" style of reading would freeze everything else the server is doing — so the old code hired a pool of background threads to do the waiting. That worked, but threads you hire to wait can't be told to stop waiting; if a run timed out, its thread stayed stuck on the pipe until the child process died. Python has a built-in way to start a program and read from it that never blocks and *can* be cancelled instantly. This switches to that, and throws away the thread pool. The same PR also cleans up the seven other things the newer linter noticed, and turns on the rules so they stay clean.

## Summary

Ports `_run_comfy_streaming` from `subprocess.Popen` + thread-pool-offloaded blocking reads to `asyncio.create_subprocess_exec` + asyncio stream reads, reusing the pattern `auth_login` (#98) already established, and resolves the other findings ruff 0.16 surfaced.

**One correction to the ticket's premise, up front.** The ticket says the loop is blocked "for the life of the child." It is not, and has not been since BE-3343: `_in_pipe_pool` already off-loaded every blocking read to a dedicated thread pool. Measured against `origin/main` with a real child streaming for 1.54s, a companion coroutine ticked 135 times with a largest gap of 16 ms. What was genuinely still on the event loop is the `Popen` fork/exec itself — bounded and millisecond-scale, and what `ASYNC220` actually flags.

That makes this a cleanup rather than an outage fix, and the real payoff is deleting the workaround rather than the microseconds:

- **Cancellation now works.** Cancelling an `asyncio.to_thread` never interrupts the underlying OS thread. A timed-out or cancelled `run_workflow` / `watch_job` left a reader parked on the pipe until the child died. Cancelling an asyncio stream read takes effect immediately.
- **The 32-worker ceiling is gone.** `_PIPE_EXECUTOR` was bounded at `min(32, cpus + 4)`; enough concurrent streaming runs would queue behind it.
- **One spawn pattern instead of two.** `_kill_proc_tree_async` / `_drain_capped_async` are now shared by `_run_comfy_streaming` and `_start_login` rather than duplicated.

## Changes

- **`_run_comfy_streaming`** spawns with `asyncio.create_subprocess_exec` and reads stdout/stderr as asyncio streams. Terminal-envelope detection, the separate post-envelope reap budget, the timeout message and failure-log record, `raise_on_timeout=False`'s bounded-tail payload, and the process-group teardown all keep their existing semantics.
- **`_readline_unbounded`** preserves a property the naive port would have lost: `StreamReader.readline` raises `ValueError` as soon as one line exceeds the reader's buffer limit, while the text-mode `readline` it replaces had no ceiling. A `queued` event carrying a large node manifest is exactly that shape. Overrun chunks are stitched back together, so `limit` is read granularity, not a maximum line length. Covered by a test that spawns with a deliberately tiny `limit`.
- **`_kill_login_child` → `_kill_proc_tree_async`**, now shared by both async spawn sites; `_drain_capped_async` likewise. `_PIPE_EXECUTOR` / `_in_pipe_pool` deleted (no remaining callers). `_GENERATE_EXECUTOR` stays — `partner_generate`'s `comfy generate` run is genuinely synchronous.
- **Dead code removed:** the synchronous `_drain_capped` lost its only caller with this port. Deleted, and its test retargeted at `_drain_capped_async` (plus a new one pinning the decode-once-at-the-end behavior, which is what keeps a multi-byte character split across a chunk boundary from becoming `�`).
- **BLE001 / S110 (5 sites):** the two `failure_log` handlers that swallowed silently now record the drop on the module logger — a different, *propagating* logger from the non-propagating `comfy_local_mcp.failures` one that just failed, so it can neither recurse nor re-enter the broken handler. That was the ticket's specific concern: a failure log that discards its own write errors reads identical to a disabled one. The remaining blind catches state their reason in place.
- **ruff `select`** gains `ASYNC`, `BLE`, `S110`, `I`, `RUF100`.
- **AGENTS.md** fixture documentation updated (it requires same-PR sync).

## The ARG decision (ticket item 3)

**Not adopted; the ~60 stale directives are deleted.** Measured both directions rather than guessing:

| | count |
|---|---|
| Total `ARG` sites in the repo | 306 |
| Suppressed by the 60 existing directives | 140 |
| **New suppressions needed to enable `ARG`** | **166** |

A deliberate policy would have covered its own sites. Covering fewer than half is the signature of cargo-culting, and the uncovered remainder is the same kind of code: interface-mirroring test fakes whose unused parameters exist *because* the real signature has them (`def wait(self, timeout=None)`). Enabling `ARG` would mean adding 166 more comments to say "this fake matches the interface it fakes," and would surface no defects. Removed via `ruff check --fix`; rationale recorded in `pyproject.toml` so the question isn't reopened from scratch.

`RUF100` is the counterpart decision: it makes a `noqa` that suppresses nothing an error the day it is written, which is precisely what would have prevented this ticket. It earned its keep during this PR — it caught me re-introducing an `# noqa: ARG002` on a new test helper out of habit.

## Judgment call: the ruff floor moves 0.15 → 0.16

`ruff>=0.15,<0.17` (set by #91) **cannot be green on both ends** once `RUF100` is on. 0.16 narrowed `BLE001` to stop flagging a blind `except` that logs its exception. Under 0.15 those seven handlers need `# noqa: BLE001`; under 0.16 that same directive is an unused-directive error. Verified both.

Pinned to `>=0.16,<0.17` and the seven now-unneeded directives converted to plain reason comments. The alternative was dropping `RUF100`, which would have kept the version range at the cost of the rule that prevents recurrence. Flagging it because it edits a pin #91 just set — happy to reverse if you'd rather keep 0.15 support.

## Motivation

Ticket BE-4810. #91 pinned the rule set so the 0.16 bump could merge, which left these eight findings real but unenforced.

## Testing

- [x] Existing tests pass (`pytest`) — **830 passed, 2 skipped**, on Python **3.10** and **3.14** (both CI matrix versions, in clean venvs)
- [x] Lint passes (`ruff check .`) — under ruff **0.16.0**
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — see below

**The concurrency test is verified discriminating.** The ticket asked for a test that a result-only assertion couldn't fake. `test_streaming_run_keeps_the_event_loop_responsive` runs a companion coroutine ticking every millisecond for the whole stream and asserts both the tick count and the largest inter-tick gap. Run against a deliberately loop-blocking read, it records **zero ticks** while the output assertion still passes — so it fails for the right reason, not by accident.

Note in fairness: this test also passes on `origin/main`, because (per the correction above) `main` is already non-blocking. It is a regression guard for the property, not a red→green demonstration.

**Manual verification against a real child process** (no fakes), on the new code:

```
result={'outputs': ['/x.png']}
progress notifications=7  first_total=300.0   # 300-node manifest parsed from a >5 KB line
stream=1.51s  heartbeat_ticks=132  max_loop_gap=18.5ms
timeout path: raised after 0.53s -> comfy-cli timed out after 0.5s: ...
bounded tail path: {'timed_out': True, 'status': {'progress': None, 'total': None, 'nodes_done': 0}}
```

Process-group teardown confirmed: zero orphaned children after the timeout case.

## Additional Notes

- **Diff size.** ~1100 changed lines, of which `test_wrapper.py` is ~600 — mechanical porting of the streaming test doubles from `Popen` shape to `asyncio.subprocess.Process` shape. The production change is ~150 lines in one function plus two new helpers. The fakes now back their pipes with **real `asyncio.StreamReader`s** (`conftest.stream_reader`) rather than hand-rolled awaitables, specifically so they still exercise the buffer-limit behavior `_readline_unbounded` exists to handle — a stub returning canned lines would test nothing about it.
- **3 tests removed, 5 added.** `test_pipe_executor_is_dedicated_and_bounded` and `test_overlapping_streaming_runs_confine_and_release_pipe_threads` asserted properties of the thread pool this PR deletes; they are superseded by the loop-responsiveness test. `test_drain_capped_retains_only_the_tail_across_chunks` moved to the async function.
- **Windows / CRLF.** The pipes are now binary, so universal-newline translation no longer happens and a `\r\n` line keeps its `\r`. Verified both consumers tolerate it (`_parse_event` and `_last_json_object` both parse a CRLF-terminated envelope — JSON treats `\r` as whitespace). Decoding moved to explicit `utf-8` with `errors="replace"`, matching `auth_login`; strictly more robust than the previous strict decode, which would raise mid-run on one bad byte.
- **Negative-claim falsification (per the review checklist): not triggered.** This diff denies no capability — it adds no "not supported"/"unavailable"/"STOP" string, no throw/deny dead-end user-facing path, and flips no test to assert a dead-end. Every tool's contract, argv, and result shape are unchanged; the only new `raise` is an `IncompleteReadError` used as internal EOF control flow inside a private helper.
- The ticket cited "623 passed / 2 skipped"; the suite is at 828 on `origin/main` today.
