### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfy-local-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "Local MCP server for ComfyUI — a thin wrapper over comfy-cli."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/comfy_local_mcp/__init__.py
+++ b/src/comfy_local_mcp/__init__.py
@@ -1,3 +1,3 @@
 """comfy-local-mcp: a thin MCP wrapper over comfy-cli."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"


### PR DESCRIPTION
## ELI-5

The version number in `pyproject.toml` is the only thing standing between `main` and a tagged `v0.4.0` release. This bumps it (and the matching `__version__`), so the tag can be cut.

## Why 0.4.0

31 commits since `v0.3.0`. Minor bump: five new capabilities, **no removals and no changed tool signatures**, so nothing a client calls today breaks.

The headline is **`auth_login`** (#98) — an agent can now sign a user in to Comfy Cloud by starting `comfy cloud login` and handing back the OAuth URL, instead of telling the user to go run the CLI by hand. comfy-cli keeps the whole PKCE flow and the loopback callback; this only lifts the URL out of the machine stream.

Also new: `update_comfyui` (#92), structured `{address, value}` workflow slots (#100), live progress on `run_template(wait=True)` (#82), and the opt-in rotating failure log (#77). The rest is 16 fixes — mostly the argv-injection hardening sweep (#83–#89, #94) — plus docs and refactors.

The comfy-cli floor stays `>= 1.12.0`: verified `comfy cloud login --no-browser --timeout` exists there, so `auth_login` does not raise the requirement.

## Verification

- `ruff check src tests scripts` — all checks passed (with the pinned `ruff 0.16`; a stale local `ruff 0.15` reports BLE001 on handlers 0.16 deliberately exempts, which is exactly the patch-release divergence the pinned rule selection was written for).
- `ruff format --check .` — 49 files already formatted.
- `pytest -q` — 829 passed, 1 skipped (e2e excluded; it needs a real ComfyUI + comfy-cli).
- No other file in the tree carries a `0.3.0` string.
