### PR TITLE
feat(templates): flag templates the local install can't actually run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,14 @@ Hard guardrails — a PR that breaks any of these should be rejected:
   — none of which apply here. This repo is local-only, single-process, and has no
   filesystem/multi-tenancy concerns to design around.
 
+A tool may COMPOSE more than one passthrough when the value is in the sequence
+rather than in new logic — `fetch_template` runs `templates fetch` and then
+`validate` to tell the caller whether the template it just wrote can actually
+run on this install. That stays inside the rule: every call still goes through
+`_run_comfy`, the verdict is comfy-cli's own, and this repo adds no product
+behavior of its own. What would breach it is deriving the answer here (parsing
+the graph, keeping a table of what is "supported") instead of asking the engine.
+
 The one thing that legitimately lives here rather than in comfy-cli is **MCP
 protocol surface** — capabilities that only exist between this server and its
 client, and that comfy-cli has no way to express. Today that is the per-call

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Cloud MCP** — comfy-cli is the engine.
 - [Prerequisites](#prerequisites)
 - [Partner-API nodes](#partner-api-nodes)
 - [Spending credits on partner models](#spending-credits-on-partner-models)
+- [Templates your install can't run](#templates-your-install-cant-run)
 - [Driving a remote ComfyUI](#driving-a-remote-comfyui)
 - [Targeting a non-default ComfyUI address](#targeting-a-non-default-comfyui-address)
 - [Install](#install)
@@ -206,6 +207,28 @@ some embed partner-API nodes and bill through them.
 
 Unlike `partner_generate`, there is no up-front gate probe: `run-template` carries its spend gate
 inside the verb itself, so a comfy-cli that has the verb has the gate.
+
+## Templates your install can't run
+
+The template gallery is served fresh from `Comfy-Org/workflow_templates`, while your ComfyUI is
+whatever version you installed. So the catalog can legitimately offer a template your install
+cannot run yet — it references a node class you don't have, or a *model option inside* a node you
+do have (a partner model key added in a later release is the common one). Discovery succeeds, the
+run fails, and you get to work out why.
+
+`get_template` and `fetch_template` cross-check the template against your install and report it
+as a `local_check` block. Under the hood it is `comfy validate` — the same engine
+[`validate_workflow`](#workflow-building) uses, reading the **live `object_info`** of your running
+ComfyUI, so it sees your custom nodes and your model options, not a bundled catalog.
+
+| `local_check` | Means |
+|---|---|
+| `{"checked": true, "runnable": true, …}` | Every node class and input option the template uses exists in your install. Necessary, not sufficient — `validate_workflow`'s documented blind spots still apply. |
+| `{"checked": true, "runnable": false, "errors": [...], …}` | Running it will fail as-is: the `errors` name what is missing (and, where comfy-cli can, what your install offers instead). Update ComfyUI and its custom nodes, or pick another template. |
+| `{"checked": false, "reason": …, …}` | The comparison could **not** be made — almost always because ComfyUI isn't running, so there is no live catalog to compare against. This is not a verdict about the template. |
+
+The check is advisory and fails open: the workflow file is written either way, `path` always comes
+back, and nothing is ever refused on its account. Pass `check_local=False` to skip it.
 
 ## Driving a remote ComfyUI
 
@@ -432,7 +455,9 @@ Zero to a generated image:
    Under the hood the agent calls `server_info` to confirm ComfyUI is up, `run_workflow` to
    execute your workflow JSON (API-format or a UI export), and `fetch_outputs` to collect the
    result. No hand-authored workflow? Ask it to start from a template instead — it can
-   `search_templates`, `fetch_template` to write a runnable JSON, and run that.
+   `search_templates`, `fetch_template` to write a runnable JSON, and run that — and
+   `fetch_template` tells it up front if [your install can't run that
+   template](#templates-your-install-cant-run) yet.
 
 **Where the images land.** ComfyUI writes generated files into your ComfyUI **workspace's
 `output/` directory** (part of the workspace `comfy install` created). On top of that,
@@ -491,8 +516,8 @@ handle is `prompt_id`.
 | Tool | Wraps | What it does |
 |---|---|---|
 | `search_templates(query="", limit=25, offset=0, tag="", type="", model="", provider="", exclude_api=False)` | `comfy templates ls [--tag/--type/--model/--provider …]` | Find a built-in workflow template: free-text `query` (client-side over name/title/description/tags/models), paged via `limit`/`offset`, narrowed by the `tag`/`type`/`model`/`provider` gallery filters or `exclude_api=True`. Returns `{total, shown, offset, rows:[{name,title,description,output_type}]}`. |
-| `get_template(name)` | `comfy templates show <name>` | Show one template's details/schema before fetching it. |
-| `fetch_template(name, out_path)` | `comfy templates fetch <name> --out <path>` | Write a template's runnable workflow JSON to `out_path`; returns the absolute path for `run_workflow`. |
+| `get_template(name, check_local=True)` | `comfy templates show <name>` (+ `comfy validate`) | Show one template's details/schema before fetching it, plus a `local_check` block cross-checking its graph against the live `object_info` of your install — see [Templates your install can't run](#templates-your-install-cant-run). `check_local=False` skips the check (metadata only, one call). |
+| `fetch_template(name, out_path, check_local=True)` | `comfy templates fetch <name> --out <path>` (+ `comfy validate`) | Write a template's runnable workflow JSON to `out_path`; returns `{path, local_check}` — `path` is the absolute path for `run_workflow`, `local_check` is the same cross-check run on the file just written. The file is written either way. |
 | `search_nodes(query)` | `comfy nodes search <query>` | Find node classes in the **live local** `object_info` (includes installed custom nodes). |
 | `get_node(name)` | `comfy nodes show <ClassName>` | Full input/output schema for one node class — what you need to author/repair a graph. |
 | `list_nodes(produces="", accepts="", category="", pack="", label="")` | `comfy nodes ls [--produces/--accepts/--category/--pack/--label …]` | List node classes, filtered by output/input type, category, pack, or label; bare call lists all. Reads the **live install**. |

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -50,6 +50,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -79,7 +80,14 @@ This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
   search, paged 25 at a time via `limit`/`offset`; narrow with `tag`/`type`/
   `model`/`provider`, or `exclude_api=True` for templates that run without a
   hosted-API key), `fetch_template` to save its workflow JSON, then `run_workflow`
-  on that file. To change the prompt / seed
+  on `result["path"]`. `fetch_template` and `get_template` also return a
+  `local_check` block comparing the template against the live node catalog of the
+  installed ComfyUI — the gallery is served fresh, so a template can need a node
+  or model option this install does not have yet. On
+  `{"checked": true, "runnable": false}` tell the USER what is missing (update
+  ComfyUI / custom nodes, or pick another template) instead of running it and
+  hitting the failure deep in execution; `{"checked": false}` is "could not
+  compare", not a verdict. To change the prompt / seed
   / steps / model of a fetched template before running, inspect its tweakable slots
   with `list_workflow_slots` and edit them with `set_workflow_slot` (non-destructive
   by default) — the loop is `fetch_template` -> `set_workflow_slot` -> `run_workflow`.
@@ -584,6 +592,15 @@ class ComfyCliError(RuntimeError):
     can then tell its own deadline firing from a genuine comfy-cli error without
     matching on the message — :func:`wait_for_job`, which caps each poll to the
     time left on the caller's bound, is exactly that caller.
+
+    ``data`` is the failed envelope's own ``data`` payload, for the commands that
+    carry a STRUCTURED result alongside a negative verdict: ``comfy validate``
+    emits its full ``{valid, errors, warnings}`` report as ``data`` and sets the
+    envelope's ``ok`` to ``valid``, so "the workflow does not fit this install"
+    arrives here as an error whose payload is the actual answer. It is ``None``
+    for every failure that has no payload, which is what lets a caller tell a
+    real verdict from a check that could not run at all
+    (:func:`_local_template_check`).
     """
 
     def __init__(
@@ -593,12 +610,14 @@ class ComfyCliError(RuntimeError):
         no_envelope: bool = False,
         returncode: int | None = None,
         timed_out: bool = False,
+        data: Any = None,
     ) -> None:
         super().__init__(*args)
         self.code = code
         self.no_envelope = no_envelope
         self.returncode = returncode
         self.timed_out = timed_out
+        self.data = data
 
 
 def _comfy_bin_candidates() -> list[str]:
@@ -1570,7 +1589,13 @@ def _unwrap_envelope(
         # `_is_missing_verb_error`'s Click-usage-exit condition stays genuinely
         # independent of its `no_envelope` provenance condition rather than
         # being a proxy for it (an envelope-borne failure can also exit 2).
-        raise ComfyCliError(text, code=code, returncode=returncode)
+        # `data` rides along because a failed envelope is not always empty: the
+        # commands whose negative verdict IS a structured report (`comfy
+        # validate`) put that report in `data` and set `ok` to the verdict. See
+        # `ComfyCliError.data`.
+        raise ComfyCliError(
+            text, code=code, returncode=returncode, data=envelope.get("data")
+        )
     return envelope.get("data")
 
 
@@ -5125,37 +5150,253 @@ def search_templates(
     }
 
 
+# Cap on how many validator findings ride back in a template's `local_check` —
+# enough to act on, bounded so a wildly-mismatched template can't build a
+# response that trips the MCP client's tool-output cap (same reasoning as
+# `_TEMPLATE_LIST_MAX_LIMIT`).
+_TEMPLATE_CHECK_MAX_FINDINGS = 10
+
+
+def _validation_report(result: Any) -> dict | None:
+    """``result`` if it is a ``comfy validate`` report, else ``None``.
+
+    A report is only a report when comfy-cli actually compared the workflow
+    against the live ``object_info``: it carries a boolean ``valid`` and an
+    ``errors`` list. Anything else — the ``None`` a load failure raises with, a
+    drifted payload shape — means the comparison never happened, and the caller
+    must say so rather than invent a verdict. Wrongly telling a user their
+    template cannot run is worse than telling them it could not be checked.
+    """
+    if not isinstance(result, dict):
+        return None
+    if not isinstance(result.get("valid"), bool):
+        return None
+    if not isinstance(result.get("errors"), list):
+        return None
+    return result
+
+
+def _finding_line(finding: Any) -> str:
+    """Render one validator error/warning as a single readable clause."""
+    if not isinstance(finding, dict):
+        return str(finding)[:_MAX_ERROR_FIELD_CHARS]
+    message = str(finding.get("message") or finding.get("code") or "")[
+        :_MAX_ERROR_FIELD_CHARS
+    ]
+    node_id = finding.get("node_id")
+    line = f"node {node_id}: {message}" if node_id else message
+    suggestions = finding.get("suggestions")
+    if isinstance(suggestions, list) and suggestions:
+        line += f" (this install has: {', '.join(str(s) for s in suggestions[:3])})"
+    return line
+
+
+def _unchecked(summary: str, reason: str) -> dict:
+    """A ``local_check`` block for "the comparison did not happen"."""
+    return {"checked": False, "reason": reason, "summary": summary}
+
+
+def _local_template_check(workflow_path: str) -> dict:
+    """Cross-check a fetched template against the LOCAL install's ``object_info``.
+
+    The gallery is served fresh from ``Comfy-Org/workflow_templates`` while the
+    user's ComfyUI is whatever they installed, so a template can legitimately
+    reference a node class — or an input option inside one, e.g. a partner
+    model key added in a later release — that this install does not expose yet.
+    Discovery then succeeds and the RUN fails, which is a bad place to find out.
+    This runs ``comfy validate --workflow <path>`` (the same engine
+    ``validate_workflow`` exposes: class_types, input shapes, enum values, edge
+    wiring, all read from the running server's live ``object_info``) and turns
+    its report into a block the agent can relay.
+
+    Advisory only, and deliberately fail-OPEN: the template is already written
+    and every caller still gets its path, a negative verdict is comfy-cli's own
+    (never a hardcoded list of "unsupported" things here), and anything that
+    stops the comparison from happening — no ComfyUI running, so no
+    ``object_info`` — comes back ``checked: False`` rather than a denial.
+    """
+    try:
+        result = _run_comfy("validate", "--workflow", workflow_path, timeout=60.0)
+    except ComfyCliError as exc:
+        # `comfy validate` reports an invalid workflow as an envelope whose `ok`
+        # mirrors `valid` and whose `data` is the full report, so this except
+        # branch covers BOTH "the template does not fit this install" and "the
+        # check could not run at all". The payload is what tells them apart.
+        result = exc.data
+        if _validation_report(result) is None:
+            return _unchecked(
+                "could not check this template against your ComfyUI install "
+                "(the live node catalog was unreachable — the server may not be "
+                "running). The template was still written. Start ComfyUI with "
+                "`launch_comfyui`, then re-check with "
+                "`validate_workflow(workflow_path=...)`. "
+                f"Details: {str(exc)[:_MAX_ERROR_FIELD_CHARS]}",
+                "check_unavailable",
+            )
+
+    report = _validation_report(result)
+    if report is None:
+        return _unchecked(
+            "could not check this template against your ComfyUI install: "
+            "`comfy validate` returned an unexpected payload, so its output "
+            "shape may have drifted. The template was still written.",
+            "unexpected_payload",
+        )
+
+    errors = report["errors"]
+    warnings = report.get("warnings")
+    warnings = warnings if isinstance(warnings, list) else []
+    # A comfy-cli too old to lower a UI-export workflow to API format checks ZERO
+    # nodes on one and calls it valid (`validate_workflow`'s blind spot 3), and
+    # gallery templates are UI exports — so that vacuous pass must not be
+    # reported as a clean bill of health.
+    converted = bool(report.get("converted_from_ui"))
+    vacuous = (
+        report["valid"]
+        and not converted
+        and any(
+            isinstance(w, dict) and w.get("code") == "non_node_key" for w in warnings
+        )
+    )
+    if vacuous:
+        return _unchecked(
+            "could not check this template against your ComfyUI install: this "
+            "comfy-cli did not convert the template's UI-format graph, so no "
+            "node was actually compared against the live catalog. Upgrade "
+            "comfy-cli for a real check. The template was still written.",
+            "workflow_not_converted",
+        )
+
+    if report["valid"]:
+        summary = (
+            "every node class and input option this template uses is present in "
+            "your ComfyUI install. A clean check is necessary, not sufficient — "
+            "see `validate_workflow` for what it cannot see."
+        )
+    else:
+        summary = (
+            f"{len(errors)} problem(s): this template needs a node class or an "
+            "input option your ComfyUI install does not have — a template served "
+            "from the gallery can be newer than your install. Update ComfyUI and "
+            "its custom nodes (`update_comfyui`), or pick another template. "
+            f"First: {_finding_line(errors[0])}"
+            if errors
+            else (
+                "this template did not validate against your ComfyUI install, "
+                "though comfy-cli listed no specific problem."
+            )
+        )
+
+    check = {
+        "checked": True,
+        "runnable": report["valid"],
+        "summary": summary,
+        "error_count": len(errors),
+        "errors": [_finding_line(e) for e in errors[:_TEMPLATE_CHECK_MAX_FINDINGS]],
+    }
+    if warnings:
+        check["warnings"] = [
+            _finding_line(w) for w in warnings[:_TEMPLATE_CHECK_MAX_FINDINGS]
+        ]
+    return check
+
+
+def _check_template_by_name(name: str) -> dict:
+    """``_local_template_check`` for a template that is not on disk yet.
+
+    ``comfy templates show`` returns gallery metadata only — no graph — so the
+    workflow has to be materialized before it can be compared against the local
+    catalog. It goes to a scratch directory that is removed either way, leaving
+    the caller's filesystem untouched (``fetch_template`` is the tool that
+    writes a file the user keeps).
+    """
+    scratch = tempfile.mkdtemp(prefix="comfy-local-mcp-template-")
+    try:
+        path = os.path.join(scratch, "template.json")
+        try:
+            _run_comfy("templates", "fetch", name, "--out", path, timeout=60.0)
+        except ComfyCliError as exc:
+            return _unchecked(
+                "could not check this template against your ComfyUI install: "
+                "fetching its workflow failed. "
+                f"Details: {str(exc)[:_MAX_ERROR_FIELD_CHARS]}",
+                "template_fetch_failed",
+            )
+        return _local_template_check(path)
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+
+_CHECK_NOT_REQUESTED = _unchecked(
+    "not checked against your ComfyUI install (check_local=False).",
+    "not_requested",
+)
+
+
 @mcp.tool()
-def get_template(name: str) -> Any:
-    """Show one template's details/schema (inputs, description, node graph).
+def get_template(name: str, check_local: bool = True) -> Any:
+    """Show one template's details/schema, and whether your install can run it.
 
     Wraps ``comfy templates show <name>``, using a ``name`` from
     ``search_templates``. Step 2 of the on-ramp: inspect a template before
     fetching it, then ``fetch_template(name, out_path)`` writes the runnable JSON
     for ``run_workflow``.
+
+    With ``check_local=True`` (the default) the response also carries a
+    ``local_check`` block: the template's graph is compared against the LIVE
+    ``object_info`` of the running local ComfyUI, because the gallery is served
+    fresh while the user's install is whatever they installed — a template can
+    reference a node class, or a model option inside one, that only a newer
+    ComfyUI exposes. ``{"checked": true, "runnable": false, ...}`` means running
+    it will fail until the install is updated; ``{"checked": false, ...}`` means
+    the comparison could not be made (usually: ComfyUI is not running) and says
+    nothing either way. The check costs an extra gallery fetch plus a validate —
+    pass ``check_local=False`` to skip it when you only want the metadata.
     """
     # Bare positional: a leading-dash name is read by comfy-cli as an option
     # rather than the template to show (argument injection).
     _reject_option_like("name", name, expected="a template name (e.g. 'image_flux2')")
     _reject_nul("name", name)
-    return _run_comfy("templates", "show", name, timeout=60.0)
+    data = _run_comfy("templates", "show", name, timeout=60.0)
+    if not isinstance(data, dict):
+        # comfy-cli emits `{"template": {...}}`; on a drifted shape there is no
+        # object to attach to, so hand the payload back untouched rather than
+        # re-wrap it into something the caller does not expect.
+        return data
+    return {
+        **data,
+        "local_check": _check_template_by_name(name)
+        if check_local
+        else _CHECK_NOT_REQUESTED,
+    }
 
 
 @mcp.tool()
-def fetch_template(name: str, out_path: str) -> str:
-    """Write a template's runnable workflow JSON to ``out_path``; return its absolute path.
+def fetch_template(name: str, out_path: str, check_local: bool = True) -> dict:
+    """Write a template's runnable workflow JSON to ``out_path``; report if it can run here.
 
     Wraps ``comfy templates fetch <name> --out <path>``, which materializes the
-    template as a workflow JSON file on disk. Returns the ABSOLUTE path so it can
-    be passed straight to ``run_workflow(workflow_path=...)``, completing the
-    template on-ramp::
+    template as a workflow JSON file on disk. Returns
+    ``{"path": <absolute path>, "local_check": {...}}`` — ``path`` is what
+    ``run_workflow(workflow_path=...)`` takes, completing the template
+    on-ramp::
 
         search_templates("flux")               # find a template
         get_template("flux_dev")               # inspect it
-        path = fetch_template("flux_dev", "/tmp/flux.json")
-        run_workflow(path)                      # generate — no hand-authored JSON
+        result = fetch_template("flux_dev", "/tmp/flux.json")
+        run_workflow(result["path"])           # generate — no hand-authored JSON
 
     so an agent reaches a working generation without hand-authoring workflow JSON.
+
+    ``local_check`` is the same cross-check ``get_template`` reports, run against
+    the file just written: the gallery serves templates that can be newer than
+    the user's ComfyUI, so one may reference a node class or an input option
+    this install does not expose. ``{"checked": true, "runnable": false, ...}``
+    means the run will fail until the install is updated — RELAY that to the
+    user instead of running it and letting the failure surface deep in
+    execution. ``{"checked": false, ...}`` means the comparison could not be made
+    (usually: ComfyUI is not running) and is NOT a verdict. The file is written
+    either way; pass ``check_local=False`` to skip the check.
     """
     # `name` is a bare positional, so a leading-dash value is read as an option
     # and every later token shifts up a slot. `out_path` rides behind `--out` as
@@ -5171,7 +5412,13 @@ def fetch_template(name: str, out_path: str) -> str:
     _reject_nul("name", name)
     _reject_nul("out_path", out_path)
     _run_comfy("templates", "fetch", name, "--out", out_path, timeout=60.0)
-    return os.path.abspath(out_path)
+    path = os.path.abspath(out_path)
+    return {
+        "path": path,
+        "local_check": _local_template_check(path)
+        if check_local
+        else _CHECK_NOT_REQUESTED,
+    }
 
 
 @mcp.tool()

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -5327,10 +5327,16 @@ def _check_template_by_name(name: str) -> dict:
         shutil.rmtree(scratch, ignore_errors=True)
 
 
-_CHECK_NOT_REQUESTED = _unchecked(
-    "not checked against your ComfyUI install (check_local=False).",
-    "not_requested",
-)
+def _check_not_requested() -> dict:
+    """The ``local_check`` block for ``check_local=False``.
+
+    A function, not a module constant: every caller gets its own dict, so
+    nothing downstream can mutate a shared one out from under the next call.
+    """
+    return _unchecked(
+        "not checked against your ComfyUI install (check_local=False).",
+        "not_requested",
+    )
 
 
 @mcp.tool()
@@ -5367,7 +5373,7 @@ def get_template(name: str, check_local: bool = True) -> Any:
         **data,
         "local_check": _check_template_by_name(name)
         if check_local
-        else _CHECK_NOT_REQUESTED,
+        else _check_not_requested(),
     }
 
 
@@ -5417,7 +5423,7 @@ def fetch_template(name: str, out_path: str, check_local: bool = True) -> dict:
         "path": path,
         "local_check": _local_template_check(path)
         if check_local
-        else _CHECK_NOT_REQUESTED,
+        else _check_not_requested(),
     }
 
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -11,7 +11,9 @@ comfy-cli's real ``templates ls`` payload:
    the CLI's own ``--tag/--type/--model/--provider`` gallery filters, drops
    API-tagged rows on ``exclude_api``, and pages via ``limit``/``offset``.
 2. A payload with no ``rows`` list is a shape drift -> raise, never a raw dump.
-3. ``fetch_template`` returns the ABSOLUTE output path for ``run_workflow``.
+3. ``fetch_template`` returns ``{"path": <ABSOLUTE path>, "local_check": {...}}``
+   — the path for ``run_workflow``, and the cross-check of the template against
+   the live local ``object_info`` (``get_template`` reports the same block).
 """
 
 from __future__ import annotations
@@ -289,8 +291,26 @@ def test_get_template_argv(patched_run):
     """Passthrough: `comfy --json --where local templates show <name>`."""
     calls = patched_run(envelope(data={"name": "flux_dev", "nodes": 12}))
 
-    assert server.get_template("flux_dev") == {"name": "flux_dev", "nodes": 12}
+    result = server.get_template("flux_dev", check_local=False)
+
     assert calls[0]["cmd"][4:] == ["templates", "show", "flux_dev"]
+    # The metadata rides through untouched; only `local_check` is added.
+    assert {k: v for k, v in result.items() if k != "local_check"} == {
+        "name": "flux_dev",
+        "nodes": 12,
+    }
+    assert result["local_check"] == {
+        "checked": False,
+        "reason": "not_requested",
+        "summary": "not checked against your ComfyUI install (check_local=False).",
+    }
+    assert len(calls) == 1  # `check_local=False` costs exactly one call
+
+
+def test_get_template_returns_drifted_payload_untouched(monkeypatch):
+    """A non-dict `templates show` payload has nowhere to attach a check."""
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: ["not", "a", "dict"])
+    assert server.get_template("flux_dev") == ["not", "a", "dict"]
 
 
 # `get_template` / `fetch_template` leading-dash + NUL rejection is covered by
@@ -304,19 +324,21 @@ def test_fetch_template_argv_and_returns_abspath(patched_run, tmp_path):
     calls = patched_run(envelope(data=None))
 
     out = tmp_path / "flux.json"
-    result = server.fetch_template("flux_dev", str(out))
+    result = server.fetch_template("flux_dev", str(out), check_local=False)
 
     assert calls[0]["cmd"][4:] == ["templates", "fetch", "flux_dev", "--out", str(out)]
-    assert result == str(out)  # tmp_path is already absolute
-    assert os.path.isabs(result)
+    assert result["path"] == str(out)  # tmp_path is already absolute
+    assert os.path.isabs(result["path"])
+    assert result["local_check"]["reason"] == "not_requested"
+    assert len(calls) == 1  # no validate call when the check is skipped
 
 
 def test_fetch_template_resolves_relative_path(monkeypatch):
     """A relative out_path is returned as an absolute path (ready for run_workflow)."""
     monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: None)
-    result = server.fetch_template("flux_dev", "flux.json")
-    assert result == os.path.abspath("flux.json")
-    assert os.path.isabs(result)
+    result = server.fetch_template("flux_dev", "flux.json", check_local=False)
+    assert result["path"] == os.path.abspath("flux.json")
+    assert os.path.isabs(result["path"])
 
 
 def test_get_template_rejects_option_like_name(monkeypatch):
@@ -367,3 +389,210 @@ def test_template_tools_reject_embedded_nul(monkeypatch):
     ):
         with pytest.raises(server.ComfyCliError, match="embedded NUL"):
             call()
+
+
+# --- local_check: does the user's install actually support this template? ----
+#
+# The gallery is served fresh while the install is whatever the user has, so a
+# template can reference a node class — or a model option inside one — that this
+# ComfyUI does not expose yet. The tools cross-check via `comfy validate` against
+# the LIVE object_info and report it; the checks below pin the three outcomes
+# that matter, especially the two that must NOT read as "your install can't run
+# this": a check that could not run, and a vacuous pass.
+
+
+def _fake_comfy(monkeypatch, handler):
+    """Dispatch `_run_comfy` per subcommand; returns the recorded arg tuples."""
+    calls: list[tuple] = []
+
+    def fake(*args, **kwargs):
+        calls.append(args)
+        return handler(args)
+
+    monkeypatch.setattr(server, "_run_comfy", fake)
+    return calls
+
+
+def _report(*, valid: bool, errors=(), warnings=(), **extra) -> dict:
+    """A `comfy validate` payload, shaped like cmdline.py's `validate` emits."""
+    return {
+        "valid": valid,
+        "error_count": len(errors),
+        "warning_count": len(warnings),
+        "errors": list(errors),
+        "warnings": list(warnings),
+        **extra,
+    }
+
+
+def test_fetch_template_reports_a_clean_local_check(monkeypatch, tmp_path):
+    """A valid workflow: `validate` runs on the written file, verdict is runnable."""
+    out = tmp_path / "flux.json"
+    calls = _fake_comfy(
+        monkeypatch,
+        lambda args: (
+            _report(valid=True, converted_from_ui=True)
+            if args[0] == "validate"
+            else None
+        ),
+    )
+
+    result = server.fetch_template("flux_dev", str(out))
+
+    assert calls[0] == ("templates", "fetch", "flux_dev", "--out", str(out))
+    # Checked against the file just written, by absolute path.
+    assert calls[1] == ("validate", "--workflow", str(out))
+    assert result["path"] == str(out)
+    assert result["local_check"]["checked"] is True
+    assert result["local_check"]["runnable"] is True
+    assert result["local_check"]["error_count"] == 0
+
+
+def test_fetch_template_warns_when_the_install_lacks_a_model_option(
+    monkeypatch, tmp_path
+):
+    """The reported case: the template names a model key this install has never seen.
+
+    comfy-cli reports an invalid workflow as an envelope whose `ok` mirrors
+    `valid` and whose `data` is the full report, so it reaches us as a raised
+    `ComfyCliError` carrying that report — the verdict, not a failure to check.
+    """
+    out = tmp_path / "seedream.json"
+    error = {
+        "node_id": "12",
+        "code": "invalid_enum_value",
+        "message": "'seedream-5.0-pro' is not a valid value for input 'model'",
+        "suggestions": ["seedream-5.0-lite", "seedream-4.0"],
+    }
+
+    def handler(args):
+        if args[0] != "validate":
+            return None
+        raise server.ComfyCliError(
+            "comfy validate --workflow x failed [unknown]: ",
+            data=_report(valid=False, errors=[error], converted_from_ui=True),
+        )
+
+    _fake_comfy(monkeypatch, handler)
+    result = server.fetch_template("seedream_5_pro", str(out))
+
+    check = result["local_check"]
+    assert check["checked"] is True
+    assert check["runnable"] is False
+    assert check["error_count"] == 1
+    assert check["errors"] == [
+        "node 12: 'seedream-5.0-pro' is not a valid value for input 'model' "
+        "(this install has: seedream-5.0-lite, seedream-4.0)"
+    ]
+    assert "update comfyui" in check["summary"].lower()
+    # Advisory, never a refusal: the file is still written and still handed back.
+    assert result["path"] == str(out)
+
+
+def test_fetch_template_does_not_deny_when_the_check_cannot_run(monkeypatch, tmp_path):
+    """No live object_info (ComfyUI down) is `checked: false`, NOT `runnable: false`.
+
+    An unreachable node catalog says nothing about the template. Reporting it as
+    an incompatibility would send the user chasing an install problem that may
+    not exist.
+    """
+    out = tmp_path / "flux.json"
+
+    def handler(args):
+        if args[0] != "validate":
+            return None
+        raise server.ComfyCliError(
+            "comfy validate --workflow x failed [cql_no_graph]: no object_info",
+            code="cql_no_graph",
+        )
+
+    _fake_comfy(monkeypatch, handler)
+    check = server.fetch_template("flux_dev", str(out))["local_check"]
+
+    assert check == {
+        "checked": False,
+        "reason": "check_unavailable",
+        "summary": check["summary"],
+    }
+    assert "runnable" not in check
+    assert "launch_comfyui" in check["summary"]
+    assert "cql_no_graph" in check["summary"]  # the cause survives for the user
+
+
+def test_fetch_template_does_not_report_a_vacuous_pass(monkeypatch, tmp_path):
+    """An un-converted UI-format graph validates zero nodes — not a clean bill.
+
+    Gallery templates are UI exports; a comfy-cli too old to lower one to API
+    format emits `non_node_key` warnings, checks nothing, and calls it valid.
+    """
+    out = tmp_path / "flux.json"
+    _fake_comfy(
+        monkeypatch,
+        lambda args: (
+            _report(
+                valid=True,
+                warnings=[{"code": "non_node_key", "message": "ignored key 'links'"}],
+            )
+            if args[0] == "validate"
+            else None
+        ),
+    )
+
+    check = server.fetch_template("flux_dev", str(out))["local_check"]
+
+    assert check["checked"] is False
+    assert check["reason"] == "workflow_not_converted"
+
+
+def test_fetch_template_survives_a_drifted_validate_payload(monkeypatch, tmp_path):
+    """A payload that is not a validate report is `checked: false`, never a verdict."""
+    out = tmp_path / "flux.json"
+    _fake_comfy(
+        monkeypatch,
+        lambda args: {"something": "else"} if args[0] == "validate" else None,
+    )
+
+    check = server.fetch_template("flux_dev", str(out))["local_check"]
+
+    assert check["checked"] is False
+    assert check["reason"] == "unexpected_payload"
+
+
+def test_get_template_checks_via_a_scratch_copy_and_cleans_up(monkeypatch):
+    """`templates show` has no graph, so the check fetches one — to scratch space."""
+    fetched: list[str] = []
+
+    def handler(args):
+        if args[0] == "templates" and args[1] == "show":
+            return {"template": {"name": "flux_dev"}}
+        if args[0] == "templates" and args[1] == "fetch":
+            fetched.append(args[4])
+            return None
+        return _report(valid=True, converted_from_ui=True)
+
+    calls = _fake_comfy(monkeypatch, handler)
+    result = server.get_template("flux_dev")
+
+    assert result["template"] == {"name": "flux_dev"}
+    assert result["local_check"]["runnable"] is True
+    # Fetched to a scratch path (never the caller's cwd) and validated there...
+    assert calls[1][:4] == ("templates", "fetch", "flux_dev", "--out")
+    assert calls[2][:2] == ("validate", "--workflow")
+    assert calls[2][2] == fetched[0]
+    # ...and the scratch directory is gone afterwards.
+    assert not os.path.exists(os.path.dirname(fetched[0]))
+
+
+def test_get_template_reports_an_unfetchable_template_as_unchecked(monkeypatch):
+    """A failed scratch fetch is a check that did not happen, not a bad template."""
+
+    def handler(args):
+        if args[0] == "templates" and args[1] == "show":
+            return {"template": {"name": "flux_dev"}}
+        raise server.ComfyCliError("template fetch failed [template_fetch_failed]")
+
+    _fake_comfy(monkeypatch, handler)
+    check = server.get_template("flux_dev")["local_check"]
+
+    assert check["checked"] is False
+    assert check["reason"] == "template_fetch_failed"

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -410,6 +410,29 @@ def test_error_envelope_carries_structured_code(patched_run):
     assert excinfo.value.code == "server_not_running"
 
 
+def test_error_envelope_carries_its_data_payload(patched_run):
+    """A negative verdict that IS a structured report reaches the caller intact.
+
+    ``comfy validate`` emits its full report as the envelope's ``data`` and sets
+    ``ok`` to the verdict, so "this workflow does not fit the install" arrives as
+    an error whose payload is the actual answer. Dropping it would leave a caller
+    unable to tell a real verdict from a check that never ran — which is exactly
+    what the template ``local_check`` branches on.
+    """
+    report = {"valid": False, "errors": [{"node_id": "3", "message": "nope"}]}
+    patched_run({"type": "envelope", "ok": False, "data": report})
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("validate", "--workflow", "wf.json")
+
+    assert excinfo.value.data == report
+    # Failures with nothing structured to carry keep `data` at None.
+    patched_run({"type": "envelope", "ok": False, "error": {"code": "boom"}})
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("env")
+    assert excinfo.value.data is None
+
+
 # --- comfy-cli version guard -------------------------------------------------
 
 


### PR DESCRIPTION
## ELI-5

The template gallery is served fresh from the web; your ComfyUI is whatever version you installed. So the catalog can hand you a template your install can't actually run — it needs a node you don't have, or (the reported case) a model option *inside* a node you do have, where your install only knows the older keys. Fetching worked, running blew up, and you got to figure out why. Now `get_template` and `fetch_template` ask your running ComfyUI whether it has everything the template uses, and tell you before you run it.

## Summary

`get_template` and `fetch_template` cross-check a template against the LIVE `object_info` of the local install and return the result as a `local_check` block. The check is `comfy validate` — the same engine `validate_workflow` already exposes, which compares class_types, input shapes and enum values against the running server's own catalog — so the verdict is comfy-cli's about *this machine*, never a table of "unsupported" things kept in this repo.

## Changes

- **`fetch_template(name, out_path, check_local=True)`** now returns `{"path": <absolute path>, "local_check": {...}}` and runs the check on the file it just wrote. **Breaking:** it used to return the bare path string.
- **`get_template(name, check_local=True)`** adds the same `local_check` to its payload. `templates show` returns gallery metadata with no graph, so the check materializes the workflow into a scratch dir and removes it — the caller's filesystem is untouched.
- `local_check` is `{checked, runnable, summary, error_count, errors[, warnings]}` on a real verdict, and `{checked: false, reason, summary}` when the comparison could not be made. Findings are capped at 10 (`error_count` still reports the true total) so a wildly-mismatched template can't blow the client's output cap.
- `ComfyCliError` carries the failed envelope's `data`. `comfy validate` reports an invalid workflow as `ok:false` **with the full report as `data`**, so without this the structured verdict was dropped on the floor and a real "doesn't fit your install" was indistinguishable from "couldn't check".
- Handshake INSTRUCTIONS, README (new [Templates your install can't run](https://github.com/Comfy-Org/comfy-local-mcp/blob/matt/be-3786-template-compat/README.md#templates-your-install-cant-run) section + tool table), and AGENTS.md (where composing two passthroughs inside one tool sits against the thin-wrapper rule) updated in the same PR.

## Motivation

Reported from a survey: the catalog listed a Seedream 5.0 Pro template while the installed node only exposed `seedream 5.0 lite` + 4.x — the Pro model key appeared only after a full ComfyUI core update. Template discovery succeeded, the run failed, and the time went into discovering why. Nothing in `get_template` / `fetch_template` compared the template against the live install.

## Testing

- [x] Existing tests pass (`pytest` — 839 passed, 2 skipped; 10 new)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — see the falsification run below

### Falsifying the "can't run this" verdict against the real engine

This PR's user-facing outcome can say a capability is unavailable, so the premise was checked against comfy-cli itself (built from `main`, driven offline with `--input <object_info.json>` so no ComfyUI was needed) rather than only against tests that assert my own premise. A UI-format template pinning `seedream-5.0-pro`, run against two synthetic installs:

| Install's `object_info` | Result |
|---|---|
| `model: [seedream-4.0, seedream-5.0-lite]` | `ok:false`, `valid:false`, one error: `'seedream-5.0-pro' not in 2 known options for model`, `suggestions: [seedream-4.0, seedream-5.0-lite]` |
| **same template**, catalog updated to include `seedream-5.0-pro` | `ok:true`, `valid:true`, **zero errors** |
| no catalog reachable (nothing running) | `data: null`, `error.code: cql_no_graph` |

So (1) the reported failure class really is detected — including the enum/model-key case, not just missing node classes; (2) the negative verdict is a property of the *install*, and evaporates the moment the install has the key, so this cannot become a standing denial of something that works; and (3) an unreachable catalog produces no payload at all, which is exactly what the code branches on to report `checked: false` instead of a denial.

## Additional Notes

**Fails open, by construction.** The workflow file is written either way, `path` always comes back, nothing is ever refused, and every path that can't produce a verdict reports `checked: false` with the reason — including three the code checks for explicitly: no live catalog (server down), a drifted `validate` payload, and a **vacuous pass** (a comfy-cli too old to lower the template's UI-format graph to API format checks zero nodes and calls it valid — reporting that as a clean bill of health would be worse than saying nothing). Wrongly telling someone their template can't run is a worse failure than telling them it couldn't be checked.

**Judgment calls, flagged:**

1. **`fetch_template`'s return type is a breaking change.** A warning that arrives after the caller has already fed a bare string into `run_workflow` isn't a warning. Judged acceptable on the precedent set by the `partner_generate` `download` → `out_path` rename (#101): MCP clients introspect tool schemas fresh each session. Every doc surface that showed `path = fetch_template(...)` was updated in this PR.
2. **The warning names the missing node/option, not a ComfyUI version.** The ticket suggested wording like "requires ComfyUI >= X". Neither the gallery index nor `object_info` carries a minimum-version field, so a version number would have to be invented; what the engine can prove is the concrete missing class or option, plus what the install offers instead. The summary points at `update_comfyui`.
3. **`check_local=True` is the default, and costs an extra call** (`get_template`: a gallery fetch + a validate; `fetch_template`: a validate). Defaulting it off would leave the reported bug exactly where it is for anyone who doesn't know to ask. `check_local=False` skips it.
4. **`get_template` fetches the template's graph to check it.** `templates show` has no graph to check. It goes to a scratch dir removed in a `finally`, so nothing lands in the caller's cwd.

**Not covered:** `search_templates` doesn't check its rows — that would be one validate per row against a 558-row catalog. The check lives at the inspect/fetch step, where the user has picked one.
