### PR TITLE
fix(compat): raise the comfy-cli floor to 1.13.0, the release carrying `login_url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,13 @@ Cloud MCP** — comfy-cli is the engine.
 ## Prerequisites
 
 - **Python ≥ 3.10.**
-- **comfy-cli ≥ 1.12.0** on your `PATH`: `pip install 'comfy-cli>=1.12.0'`. This is the engine
+- **comfy-cli ≥ 1.13.0** on your `PATH`: `pip install 'comfy-cli>=1.13.0'`. This is the engine
   every tool wraps; the server refuses to run against an older comfy-cli with an upgrade message.
-  The `server_info` `freshness` block additionally needs the first comfy-cli release **after**
-  1.12.0 that ships the `comfy outdated` verb; on a comfy-cli without it the block degrades to
+  1.13.0 is the first release carrying everything this server needs — the `comfy logs` verb, the
+  `envelope/1` contract, the `comfy outdated` verb behind `server_info`'s `freshness` block, and
+  the machine-readable `login_url` event `auth_login` waits for. On a comfy-cli that slips past
+  the version guard (it fails open on a `--version` it can't parse — a source build, a fork) and
+  lacks `outdated`, the `freshness` block degrades to
   `freshness: {"error": "freshness unavailable: …", "unsupported": true}` — update checks are
   skipped, nothing is broken, and everything else works unchanged.
 - **A ComfyUI workspace.** If you don't have one, `comfy-cli` can create it: `comfy install`
@@ -303,9 +306,10 @@ breaking the call.
 resolves the local address by the same rules, so the server URL it reports *is* the resolved
 address. Seeing `:8189` there (and the server reported running) confirms the override is live.
 
-**Requires a comfy-cli newer than 1.12.0.** `COMFY_LOCAL_URL` landed after the 1.12.0 release and
-is not in a published version yet — install comfy-cli from `main` to use it. On 1.12.0 or older the
-variable is simply ignored (no error) and every tool keeps targeting `127.0.0.1:8188`.
+**Requires comfy-cli ≥ 1.13.0.** `COMFY_LOCAL_URL` landed after the 1.12.0 release and first
+shipped in 1.13.0 — which is also this server's enforced floor, so any comfy-cli it accepts
+honors the variable. On 1.12.0 or older the variable is simply ignored (no error) and every tool
+keeps targeting `127.0.0.1:8188`.
 
 **Still reporting `:8188`?** Three causes, all silent, in the order worth checking:
 
@@ -433,7 +437,7 @@ Zero to a generated image:
 1. **Install the pieces.**
 
    ```bash
-   pip install 'comfy-cli>=1.12.0'  # the engine (>= 1.12.0 required)
+   pip install 'comfy-cli>=1.13.0'  # the engine (>= 1.13.0 required)
    comfy install                  # create a ComfyUI workspace (skip if you have one)
    pip install .                  # this MCP server → the `comfy-local-mcp` command
    ```

--- a/README.md
+++ b/README.md
@@ -307,9 +307,13 @@ resolves the local address by the same rules, so the server URL it reports *is* 
 address. Seeing `:8189` there (and the server reported running) confirms the override is live.
 
 **Requires comfy-cli ≥ 1.13.0.** `COMFY_LOCAL_URL` landed after the 1.12.0 release and first
-shipped in 1.13.0 — which is also this server's enforced floor, so any comfy-cli it accepts
-honors the variable. On 1.12.0 or older the variable is simply ignored (no error) and every tool
-keeps targeting `127.0.0.1:8188`.
+shipped in 1.13.0 — which is also this server's enforced floor, so every *published* comfy-cli
+this server accepts honors the variable. The floor is not a guarantee, though: the version guard
+fails OPEN on a `--version` it can't parse, that errors, or that times out, so a source build or
+fork older than 1.13.0 can still slip past it and silently ignore the variable. On any comfy-cli
+without the support the variable is simply ignored (no error) and every tool keeps targeting
+`127.0.0.1:8188` — which is why the `server_info` check above is the way to confirm it took
+effect, rather than the version alone.
 
 **Still reporting `:8188`?** Three causes, all silent, in the order worth checking:
 

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -28,9 +28,10 @@ it for that call — asked per call over MCP elicitation, or pre-authorized in
 comfy-cli's own config. The durable "always proceed" stays engine-side, so this
 server holds no spend state of its own.
 
-Requires comfy-cli >= 1.12.0 (the ``comfy logs`` verb + the ``envelope/1``
-contract): :func:`_run_comfy` guards this once, up front, with an actionable
-upgrade error so a stale install fails clearly rather than cryptically.
+Requires comfy-cli >= 1.13.0 (the ``comfy logs`` verb, the ``envelope/1``
+contract, and the ``login_url`` event ``auth_login`` depends on):
+:func:`_run_comfy` guards this once, up front, with an actionable upgrade error
+so a stale install fails clearly rather than cryptically.
 
 NOTE: the exact ``comfy`` invocation + envelope shape still need a smoke test
 against a real comfy-cli install and a running local ComfyUI.
@@ -442,12 +443,17 @@ _STDERR_READ_CHUNK = 64 * 1024
 _STREAM_LINE_LIMIT = 1024 * 1024
 
 
-# comfy-cli floor. `comfy logs` (get_logs) and the structured `envelope/1`
-# contract this server relies on require comfy-cli >= 1.12.0; against an older
-# install `comfy logs` doesn't exist and would surface as a cryptic "No such
-# command", so `_run_comfy` guards this once, up front, with an upgrade message.
-_MIN_COMFY_CLI = (1, 12, 0)
-_MIN_COMFY_CLI_STR = "1.12.0"
+# comfy-cli floor. Three things this server relies on require comfy-cli
+# >= 1.13.0: `comfy logs` (get_logs), the structured `envelope/1` contract, and
+# the machine-readable `login_url` event `comfy cloud login --json` emits, which
+# `auth_login` blocks on. Against an older install the first two surface as a
+# cryptic "No such command", and `auth_login` burns its whole
+# `_LOGIN_URL_WAIT_S` budget before it can say why — so `_run_comfy` guards this
+# once, up front, with an upgrade message. `auth_login` keeps its own timeout
+# branch as the backstop for an install that slips past the guard (which fails
+# OPEN on a `--version` it cannot read).
+_MIN_COMFY_CLI = (1, 13, 0)
+_MIN_COMFY_CLI_STR = "1.13.0"
 
 # The version guard shells out to `comfy --version`; memoize so it runs at most
 # once per process (it sits on the hot path of every _run_comfy call).
@@ -708,7 +714,7 @@ def _spawn_comfy_version() -> subprocess.CompletedProcess:
     """Run ``comfy --version`` and return the completed process.
 
     The single spawn site shared by the two ``--version`` probes —
-    :func:`_check_comfy_version` (the hard ``>= 1.12.0`` floor) and
+    :func:`_check_comfy_version` (the hard ``>= 1.13.0`` floor) and
     :func:`_detect_comfy_cli_version` (the opt-in ``COMFY_CLI_MIN_VERSION``
     report). It deliberately does NOT catch anything: the two callers have
     different, load-bearing failure policies (fail-open with a latched timeout
@@ -731,7 +737,7 @@ def _check_comfy_version() -> None:
     Runs ``comfy --version`` once per process (memoized via ``_version_checked``).
     If the reported version is below the floor, raises a clear, actionable
     :class:`ComfyCliError` telling the user to upgrade — so a stale install fails
-    with "upgrade comfy-cli to >= 1.12.0" instead of a cryptic "No such command:
+    with "upgrade comfy-cli to >= 1.13.0" instead of a cryptic "No such command:
     logs" deep inside a tool call. Fails OPEN on anything it can't positively read
     as too-old (an unparseable ``--version``, a ``--version`` that errors) so a
     future comfy-cli output-format change can never wedge a working install.
@@ -2247,11 +2253,14 @@ def _freshness_report() -> Any:
     the probe can never take ``server_info`` down with it; it degrades to one of
     two shapes instead.
 
-    The MISSING-VERB degrade is its own shape: ``comfy outdated`` does not exist
-    on any released comfy-cli (through 1.12.0), so on those installs this probe
-    fails every time — and Click/Typer's raw ``No such command 'outdated'.``
-    usage dump, relayed verbatim, reads like a broken MCP rather than the benign
-    capability gap it is. That case returns
+    The MISSING-VERB degrade is its own shape: ``comfy outdated`` ships in
+    comfy-cli 1.13.0 (:data:`_MIN_COMFY_CLI`, the floor this server enforces), so
+    a compliant install answers this probe. It stays as a degrade because the
+    version guard fails OPEN — an install whose ``comfy --version`` can't be
+    parsed (a source build, a fork) reaches here below the floor, and
+    Click/Typer's raw ``No such command 'outdated'.`` usage dump, relayed
+    verbatim, reads like a broken MCP rather than the benign capability gap it
+    is. That case returns
     ``{"error": "freshness unavailable: ...", "unsupported": True}``, with
     ``unsupported`` machine-readable so a client can branch on it without
     matching strings. :func:`_is_missing_verb_error` decides that case, and is
@@ -2282,7 +2291,7 @@ def _freshness_report() -> Any:
             return {
                 "error": (
                     "freshness unavailable: the installed comfy-cli does not support "
-                    "'comfy outdated' (the verb ships in releases after 1.12.0). "
+                    f"'comfy outdated' (the verb ships in comfy-cli >= {_MIN_COMFY_CLI_STR}). "
                     "Workflows are unaffected; update checks were skipped."
                 ),
                 "unsupported": True,
@@ -2343,8 +2352,10 @@ def server_info() -> Any:
     (``target="comfy"`` for core, ``target="all"`` for the node packs; the
     per-pack form is terminal-only), and ``restart_comfyui`` afterwards is what
     makes the updated code take effect. The probe is best-effort and degrades
-    two ways — ``server_info`` itself still succeeds either way. On a comfy-cli
-    that lacks the ``outdated`` verb (no release through 1.12.0 has it), ``freshness`` is
+    two ways — ``server_info`` itself still succeeds either way. The verb ships
+    in comfy-cli 1.13.0, this server's enforced floor, so a compliant install
+    answers it; on a comfy-cli that lacks it anyway (the version guard fails
+    OPEN, so a source build or fork can slip past the floor), ``freshness`` is
     ``{"error": "freshness unavailable: ...", "unsupported": true}``:
     ``unsupported: true`` means SKIP staleness advice entirely and do NOT tell
     the user anything is broken — nothing failed, this comfy-cli just cannot
@@ -3263,11 +3274,12 @@ def _require_spend_gate() -> None:
     """Refuse to run a spending call unless comfy-cli's spend gate is installed.
 
     This tool's core safety claim is that ``confirm_spend=False`` spends nothing
-    because comfy-cli fails CLOSED. That interlock landed in comfy-cli AFTER the
-    ``>= 1.12.0`` floor :data:`_MIN_COMFY_CLI` enforces (which was chosen for
-    ``comfy logs`` / ``envelope/1``), so the version check cannot prove it is
-    present — and against a comfy-cli without it the default call would silently
-    charge the user's card.
+    because comfy-cli fails CLOSED. That interlock ships in comfy-cli 1.13.0, so
+    the ``>= 1.13.0`` floor :data:`_MIN_COMFY_CLI` enforces now covers it — but
+    the floor check fails OPEN (an unparseable ``--version``, a source build, a
+    fork), so it still cannot PROVE the gate is present, and against a comfy-cli
+    without it the default call would silently charge the user's card. This
+    probe stays as the load-bearing check; the floor is not a substitute for it.
 
     ``comfy generate consent`` is the gate's OWN configuration surface and ships
     with it, so a clean exit is the capability signal; on an older CLI

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -83,7 +83,7 @@ def test_incompatible_envelope_propagates_through_run_comfy(patched_run):
 @pytest.mark.parametrize(
     "text,expected",
     [
-        ("comfy-cli 1.12.0", (1, 12, 0)),
+        ("comfy-cli 1.13.0", (1, 13, 0)),
         ("comfy version 1.5", (1, 5, 0)),
         ("v2.0.3\n", (2, 0, 3)),
         ("no version here", None),
@@ -104,11 +104,11 @@ def test_detect_version_parses_cli_output(monkeypatch):
     def fake(cmd, capture_output, text, errors, timeout, check):
         assert cmd == [server.COMFY_BIN, "--version"]
         return subprocess.CompletedProcess(
-            cmd, 0, stdout="comfy-cli, 1.12.0\n", stderr=""
+            cmd, 0, stdout="comfy-cli, 1.13.0\n", stderr=""
         )
 
     monkeypatch.setattr(server.subprocess, "run", fake)
-    assert server._detect_comfy_cli_version() == "1.12.0"
+    assert server._detect_comfy_cli_version() == "1.13.0"
 
 
 def test_detect_version_ignores_stderr_and_nonzero_exit(monkeypatch):
@@ -141,11 +141,11 @@ def test_detect_version_none_on_subprocess_error(monkeypatch):
 def test_check_reports_version_without_floor(monkeypatch):
     """No floor configured: report the version, no warning, never raise."""
     monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", None)
-    monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.12.0")
+    monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.13.0")
 
     report = server._check_comfy_cli_version()
 
-    assert report["comfy_cli_version"] == "1.12.0"
+    assert report["comfy_cli_version"] == "1.13.0"
     assert report["min_comfy_cli_version"] is None
     assert report["envelope_schema_major"] == server.ENVELOPE_SCHEMA_MAJOR
     assert report["warnings"] == []
@@ -163,7 +163,7 @@ def test_check_warns_when_version_unknown_and_no_floor(monkeypatch):
 
 def test_check_passes_when_version_meets_floor(monkeypatch):
     monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", "1.5.0")
-    monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.12.0")
+    monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.13.0")
 
     report = server._check_comfy_cli_version()
 
@@ -183,7 +183,7 @@ def test_check_raises_when_version_below_floor(monkeypatch):
 def test_check_warns_when_floor_is_unparseable(monkeypatch, bad_floor):
     """A misconfigured floor must not silently no-op: warn instead of failing open."""
     monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", bad_floor)
-    monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.12.0")
+    monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.13.0")
 
     report = server._check_comfy_cli_version()
 
@@ -209,7 +209,7 @@ def test_check_warns_but_does_not_raise_when_floor_set_and_version_unknown(monke
 def patched_env(monkeypatch, patched_run):
     """Patch comfy-cli so ``server_info`` sees a given ``comfy env`` envelope."""
 
-    def setup(payload: dict, version: str | None = "1.12.0") -> list[dict]:
+    def setup(payload: dict, version: str | None = "1.13.0") -> list[dict]:
         calls = patched_run(payload)
         monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: version)
         return calls
@@ -232,7 +232,7 @@ def test_server_info_attaches_compatibility_block(patched_env, monkeypatch):
 
     assert result["running"] is True  # original comfy env data preserved
     compat = result["compatibility"]
-    assert compat["comfy_cli_version"] == "1.12.0"
+    assert compat["comfy_cli_version"] == "1.13.0"
     assert compat["envelope_schema"] == "envelope/1"
     assert compat["envelope_schema_major"] == server.ENVELOPE_SCHEMA_MAJOR
     assert calls[0]["cmd"][4:] == ["env"]  # still `comfy env`
@@ -255,7 +255,7 @@ def test_server_info_raises_on_version_below_floor(patched_env, monkeypatch):
             "ok": True,
             "data": {"running": False},
         },
-        version="1.12.0",
+        version="1.13.0",
     )
 
     with pytest.raises(server.ComfyCliError, match="older than the required minimum"):
@@ -360,7 +360,7 @@ def patched_env_then_outdated(monkeypatch):
 
         monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
         monkeypatch.setattr(server.subprocess, "Popen", fake)
-        monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.12.0")
+        monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.13.0")
         monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", None)
         return calls
 
@@ -394,11 +394,14 @@ def test_server_info_attaches_freshness_block(patched_env_then_outdated):
 def test_server_info_freshness_degrades_on_missing_verb(patched_env_then_outdated):
     """A comfy-cli without `outdated` -> the purpose-built `unsupported` degrade.
 
-    Every released comfy-cli (through 1.12.0) lacks the verb, so this is the
-    COMMON path, not an edge case. It must read as a capability gap rather than
-    a failure of this server: no raw Click/Typer usage dump, no "returned no
-    JSON" wrapper text, and a machine-readable `unsupported` flag so a client
-    can branch without string-matching.
+    `comfy outdated` ships in comfy-cli 1.13.0, this server's enforced floor, so
+    a compliant install answers the probe and this is now the RARE path — it
+    survives because the version guard fails OPEN, letting an install with an
+    unparseable `--version` (a source build, a fork) reach here below the floor.
+    It must still read as a capability gap rather than a failure of this server:
+    no raw Click/Typer usage dump, no "returned no JSON" wrapper text, and a
+    machine-readable `unsupported` flag so a client can branch without
+    string-matching.
     """
     import json
 

--- a/tests/test_partner_generate.py
+++ b/tests/test_partner_generate.py
@@ -656,10 +656,11 @@ def test_partner_generate_refuses_when_comfy_cli_has_no_spend_gate(
 ):
     """No `comfy generate consent` -> no interlock -> refuse BEFORE spending.
 
-    The fail-closed guarantee is comfy-cli's, and it landed after the >= 1.12.0
-    floor this server enforces, so the version check cannot prove it is there.
-    Against an older CLI a default `confirm_spend=False` call would charge the
-    user with nothing to stop it.
+    The fail-closed guarantee is comfy-cli's. It ships in 1.13.0, the floor this
+    server enforces, but the floor check fails OPEN (an unparseable `--version`,
+    a source build, a fork), so the version check still cannot PROVE the gate is
+    there. Against a CLI without it a default `confirm_spend=False` call would
+    charge the user with nothing to stop it.
     """
     monkeypatch.setattr(server, "_spend_gate_probed", False)
     # An older comfy-cli reads `consent` as a model name and exits non-zero.

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -326,7 +326,7 @@ def test_version_guard_ignores_a_healthy_comfy_cli(on_macos, monkeypatch):
         server.subprocess,
         "run",
         lambda cmd, **kwargs: subprocess.CompletedProcess(
-            cmd, 0, stdout="comfy-cli, version 1.12.0\n", stderr=""
+            cmd, 0, stdout="comfy-cli, version 1.13.0\n", stderr=""
         ),
     )
     server._check_comfy_version()

--- a/tests/test_remote_host.py
+++ b/tests/test_remote_host.py
@@ -297,7 +297,7 @@ def _patch_env_for_server_info(monkeypatch, patched_run):
     """Stub `comfy env` + the version detection so `server_info()` runs offline."""
     patched_run(envelope(data={"running": False}))
     monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", None)
-    monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.12.0")
+    monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.13.0")
 
 
 def test_server_info_reports_remote_target(monkeypatch, patched_run):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -455,7 +455,7 @@ def test_version_guard_raises_on_old_comfy_cli(monkeypatch):
     fake, calls = _fake_version("comfy-cli, version 1.11.0")
     monkeypatch.setattr(server.subprocess, "run", fake)
 
-    with pytest.raises(server.ComfyCliError, match=r"too old.*1\.12\.0"):
+    with pytest.raises(server.ComfyCliError, match=r"too old.*1\.13\.0"):
         server._check_comfy_version()
 
     assert calls[0] == [server.COMFY_BIN, "--version"]
@@ -477,7 +477,7 @@ def test_version_guard_blocks_run_comfy_on_old_cli(monkeypatch):
 def test_version_guard_allows_new_comfy_cli_and_memoizes(monkeypatch):
     """A comfy-cli at/above the floor passes and shells out only once."""
     monkeypatch.setattr(server, "_version_checked", False)
-    fake, calls = _fake_version("comfy-cli, version 1.12.0")
+    fake, calls = _fake_version("comfy-cli, version 1.13.0")
     monkeypatch.setattr(server.subprocess, "run", fake)
 
     server._check_comfy_version()
@@ -485,6 +485,68 @@ def test_version_guard_allows_new_comfy_cli_and_memoizes(monkeypatch):
 
     server._check_comfy_version()  # memoized: no second `comfy --version`
     assert len(calls) == 1
+
+
+def test_version_guard_floor_is_exactly_the_login_url_release(monkeypatch):
+    """Pin the boundary: 1.12.0 is rejected, 1.13.0 is accepted.
+
+    1.13.0 is the first published comfy-cli carrying the machine-readable
+    `login_url` event `auth_login` blocks on (1.12.0 has no `login_url` anywhere
+    in the wheel). Without this floor, a 1.12.0 install sails past the guard and
+    only learns it cannot log in after `auth_login` burns its whole
+    `_LOGIN_URL_WAIT_S` budget spawning and reaping a child process. Pinning
+    both sides of the boundary is what stops the constant drifting back to the
+    version that gives that slow, late "no".
+    """
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+
+    # The immediately-prior release: rejected, up front, with the upgrade line.
+    monkeypatch.setattr(server, "_version_checked", False)
+    prior, _ = _fake_version("comfy-cli, version 1.12.0")
+    monkeypatch.setattr(server.subprocess, "run", prior)
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._check_comfy_version()
+    assert "1.12.0 is too old" in str(excinfo.value)
+    assert "comfy-cli>=1.13.0" in str(excinfo.value)
+
+    # The floor itself: accepted.
+    monkeypatch.setattr(server, "_version_checked", False)
+    floor, _ = _fake_version("comfy-cli, version 1.13.0")
+    monkeypatch.setattr(server.subprocess, "run", floor)
+    server._check_comfy_version()  # no raise
+    assert server._version_checked is True
+
+    assert server._MIN_COMFY_CLI == (1, 13, 0)
+    assert server._MIN_COMFY_CLI_STR == "1.13.0"
+
+
+def test_auth_login_is_refused_up_front_on_a_cli_without_login_url(monkeypatch):
+    """`auth_login` below the floor fails at the guard, not after the 15s wait.
+
+    The whole point of raising the floor: on a comfy-cli with no `login_url`
+    event the old behavior was to spawn `comfy cloud login`, wait the full
+    `_LOGIN_URL_WAIT_S` budget, reap the child, and only then say "upgrade
+    comfy-cli". The guard now answers on the first tool call — so no child is
+    ever spawned.
+    """
+    monkeypatch.setattr(server, "_version_checked", False)
+    monkeypatch.setattr(server, "_login_child", None)  # no pending flow to resume
+    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+    fake, _ = _fake_version("comfy-cli, version 1.12.0")
+    monkeypatch.setattr(server.subprocess, "run", fake)
+
+    spawned: list = []
+
+    async def never(*args, **kwargs):  # pragma: no cover - must not be reached
+        spawned.append(args)
+        raise AssertionError("auth_login spawned a child below the version floor")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", never)
+
+    with pytest.raises(server.ComfyCliError, match=r"too old.*1\.13\.0"):
+        asyncio.run(server.auth_login())
+
+    assert spawned == []  # refused before any `comfy cloud login` spawn
 
 
 def test_version_guard_fails_open_on_unparseable_version(monkeypatch):
@@ -561,14 +623,14 @@ def test_both_version_probes_go_through_the_shared_spawn(monkeypatch):
         return subprocess.CompletedProcess(
             [server.COMFY_BIN, "--version"],
             0,
-            stdout="comfy-cli, version 1.12.0\n",
+            stdout="comfy-cli, version 1.13.0\n",
             stderr="",
         )
 
     monkeypatch.setattr(server, "_spawn_comfy_version", fake_spawn)
 
     server._check_comfy_version()  # no raise: at the floor
-    assert server._detect_comfy_cli_version() == "1.12.0"
+    assert server._detect_comfy_cli_version() == "1.13.0"
     assert len(calls) == 2
 
 


### PR DESCRIPTION
## ELI-5

This server refuses to run against a comfy-cli that's too old. That cutoff was set to `1.12.0` — but `1.12.0` is missing the one thing the `auth_login` tool needs: a machine-readable "here's your sign-in URL" message. So someone on `1.12.0` got waved through the front door, called `auth_login`, sat there for 15 seconds while a login process started and got killed, and *then* got told "upgrade comfy-cli." Now the cutoff is `1.13.0` (published, and the first release that has it), so they get told immediately instead. Bumping the cutoff also made a bunch of "no released comfy-cli has this yet" notes around the repo untrue — those are corrected too.

## Summary

Raises the hard comfy-cli floor from `1.12.0` to `1.13.0` and sweeps the in-repo claims about unreleased comfy-cli capabilities that go stale with it.

`1.13.0` is now published on PyPI (it is `latest`) and is the first release carrying the `login_url` event `auth_login` blocks on. It also carries three other things this repo documented as unreleased: the `comfy outdated` verb, `COMFY_LOCAL_URL` support, and the `generate consent` spend interlock. All four were verified against the actual published wheels, not assumed — evidence below.

## Changes

- **`_MIN_COMFY_CLI` / `_MIN_COMFY_CLI_STR` → `(1, 13, 0)` / `"1.13.0"`.** The remediation string (`pip install --upgrade 'comfy-cli>=1.13.0'`) interpolates the constants, so it follows automatically.
- **The floor comment now names `login_url` / `auth_login`** as a reason for the floor alongside `comfy logs` and `envelope/1`, and records that `auth_login`'s own timeout branch stays as the backstop for an install that slips past the guard (which fails OPEN by design).
- **`server_info` freshness — the three "no release has `comfy outdated`" claims are now false and are corrected.** `comfy outdated` ships in `1.13.0`. The `unsupported: true` degrade is **kept, not removed**: the version guard fails open on a `--version` it can't parse, so a source build or a fork can still reach that branch below the floor. Its rationale in `_freshness_report` and `server_info` now says that, and the user-facing guidance string interpolates `_MIN_COMFY_CLI_STR` instead of hardcoding a number that can drift.
- **`_require_spend_gate` docstring** no longer claims the interlock post-dates the floor (it ships in `1.13.0`). The probe itself is untouched and stays load-bearing — same fail-open reason. No runtime change.
- **README:** prerequisites and Quickstart quote `>= 1.13.0`; the `COMFY_LOCAL_URL` section no longer tells users to install comfy-cli from `main`.
- **Tests:** fixtures pinning `1.12.0` as a floor-*satisfying* version move to `1.13.0` across `test_compat.py`, `test_wrapper.py`, `test_permissions.py`, `test_remote_host.py`; two stale docstrings (`test_compat.py` "every released comfy-cli lacks the verb", `test_partner_generate.py` "landed after the floor") are corrected. Two new tests pin the boundary.

## Motivation

`auth_login`'s graceful-degradation path worked exactly as designed — it was just a slow, late "no" where the existing guard could give an instant one on the first tool call. Raising the floor to the release that actually carries `login_url` is the fix; the stale-release claims are collateral that had to move with it.

## Negative-claim falsification

This diff **denies a capability** (the server now refuses comfy-cli `1.12.0`), so per the falsification discipline I went and empirically attempted the denied capability against the real published artifact rather than only asserting it in a test. Both published wheels were downloaded from PyPI and installed into throwaway venvs, then driven with the exact invocation `_start_login` uses.

**1.12.0 — the capability genuinely does not exist, via any path:**

```
$ comfy --version
{"schema": "envelope/1", ..., "data": {"version": "1.12.0"}}

$ comfy --json cloud login --no-browser --timeout 5
{"schema": "envelope/1", "type": "envelope", "ok": false, "command": "cloud", "version": "1.12.0",
 "data": null, "error": {"code": "oauth_timeout",
 "message": "timed out waiting for browser callback after 5s", ...}}
# login_url occurrences on stdout+stderr: 0
```

Nothing is emitted at all until the OAuth callback times out — precisely the late-failure the ticket describes. Confirmed at source level too: `login_url` appears **nowhere** in the 1.12.0 wheel, and the complete set of renderer events it can emit is `converted, executed, executing, execution_error, output, prompt_preview, queued, settled, state`. Its `login_cmd._on_url` callback returns early whenever the renderer is not pretty — i.e. under `--json` the URL is never surfaced by any code path. There is no alternate path to redirect users to.

**1.13.0 — the same invocation succeeds:**

```
$ comfy --json cloud login --no-browser --timeout 5
{"schema": "event/1", "type": "login_url", "url": "https://cloud.comfy.org/oauth/authorize?...", "timeout_s": 5}
{"schema": "envelope/1", ... "error": {"code": "oauth_timeout", ...}}
```

The shape matches what `_await_url` parses exactly (`type: "login_url"`, `url`, `timeout_s`), so the floor lands on a release that genuinely satisfies the consumer.

**The other three claims, same method:**

| Claim | 1.12.0 | 1.13.0 |
|---|---|---|
| `comfy outdated` | `No such command 'outdated'. Did you mean 'update'?` | valid `envelope/1` with `core` / `packs` / `checked_at` — the shape `_freshness_report` passes through |
| `COMFY_LOCAL_URL` | no `local_address.py`, zero occurrences in the wheel | `comfy_cli/local_address.py` with `ENV_LOCAL_URL = "COMFY_LOCAL_URL"` + `host_port.py` precedence |
| `generate consent` spend gate | no `consent` branch in the generate command | `comfy_cli/command/generate/app.py` dispatches `target == "consent"` |

## Testing

- [x] Existing tests pass (`pytest`) — **841 passed, 2 skipped**
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — the live comfy-cli 1.12.0 / 1.13.0 runs above

New tests:

- `test_version_guard_floor_is_exactly_the_login_url_release` — asserts the guard rejects the immediately-prior `1.12.0` (with the exact upgrade line) and accepts `1.13.0`, and pins both constants.
- `test_auth_login_is_refused_up_front_on_a_cli_without_login_url` — patches `asyncio.create_subprocess_exec` to fail loudly if reached, then asserts `auth_login()` on a `1.12.0` CLI raises at the guard with **no child ever spawned**. This is the acceptance criterion expressed as a test rather than as prose.

Both were confirmed to genuinely gate the change: reverting `_MIN_COMFY_CLI` to `(1, 12, 0)` makes both fail.

## Additional Notes

**Judgment calls, flagged for review:**

1. **The `unsupported: true` freshness branch is kept, not deleted.** The literal reading of "if `outdated` now ships, update the branch to match" could be read as "remove the dead branch." I kept it: the version guard deliberately fails OPEN (unparseable `--version`, source build, fork), so the branch is rare rather than dead, and deleting it would regress a source-build user from a benign capability-gap message back to a raw Click/Typer usage dump. Both docstrings and the test now describe it as the rare path with that reason, so it can't be mistaken for common again.
2. **`_require_spend_gate`'s runtime is untouched** — only its docstring. The interlock now sits at the floor, but the fail-open guard means the floor still cannot *prove* the gate is present, and the cost of guessing wrong there is the user's money. Same reasoning as (1); called out because the docstring change could read as an invitation to drop the probe. It should not be dropped.
3. **Three `1.12.0` mentions are deliberately left in `server.py`** (and two in `test_wrapper.py`): the `--json-stream` reap-grace note, the `cmdline.stop` no-envelope note, and the `_parse_version` doc example / parser unit cases. Those describe observed behavior of that specific version or exercise arbitrary version strings — they are not floor claims, and rewriting them would make the history wrong.
4. **`comfy-cli` is still not a declared `pyproject.toml` dependency**, per the existing comment in `[project] dependencies` — runtime enforcement is the design, and that was explicitly out of scope.
5. **No feature flag.** This changes a compatibility floor and its error text, not user-visible product behavior.

**Every acceptance criterion is met.** The one worth naming explicitly is the "read the actual PyPI version — do not guess" instruction: `1.13.0` was read from the PyPI JSON API (`info.version`), and both wheels were downloaded and executed rather than inferred.
