### PR TITLE
docs: teach agents that subgraph templates are fully supported

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -108,6 +108,15 @@ This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
   gated by the same `confirm_spend` flag as `partner_generate` (free templates ignore it).
   For the quickest path from text to an image, `generate_image(prompt)` runs the
   default local text-to-image template through that same verb — free, no API key.
+- Templates that use the frontend's "subgraph" feature (UUID-typed nodes plus a
+  `definitions.subgraphs` block in the workflow JSON) are FULLY supported:
+  `run_workflow` and `run_template` expand them client-side via comfy-cli, and
+  `list_workflow_slots` surfaces their interior inputs as slot addresses like
+  `115/75.strength` (subgraph instance node 115 -> interior node 75) alongside
+  proxy-widget slots on the instance node itself (`130.text`). Never refuse or
+  swap a template because it contains subgraphs, and never hand-edit
+  `definitions.subgraphs` — tweak it through `set_workflow_slot` /
+  `run_template(params=...)` like any other template.
 - When custom nodes or models may be missing, pre-flight with `validate_workflow`
   before running.
 - Manage in-flight work with `get_queue` (list jobs) and `cancel_job`.
@@ -4108,7 +4117,11 @@ async def run_template(
     ``params`` fills the template's parameterized slots — ``{slot: value}`` where
     a slot is an address (``"6.text"``) or a unique name (``"prompt"``). List a
     template's slots by fetching it (``fetch_template``) and inspecting the graph.
-    Values are forwarded verbatim for comfy-cli to accept or reject.
+    Values are forwarded verbatim for comfy-cli to accept or reject. Subgraph
+    slot addresses work here too: a template built with the frontend's subgraph
+    feature exposes interior inputs as ``A/B.name`` addresses (e.g.
+    ``"115/75.strength"``) — pass them in ``params`` like any other slot; the
+    engine expands ``definitions.subgraphs`` for you.
 
     SPEND CONSENT — most gallery templates are free OSS graphs that run entirely
     on the user's own machine. SOME embed partner-API (paid) nodes, and running
@@ -5530,6 +5543,13 @@ def fetch_template(name: str, out_path: str, check_local: bool = True) -> dict:
     execution. ``{"checked": false, ...}`` means the comparison could not be made
     (usually: ComfyUI is not running) and is NOT a verdict. The file is written
     either way; pass ``check_local=False`` to skip the check.
+
+    The written JSON may contain a ``definitions.subgraphs`` block and nodes
+    whose ``type`` is a UUID (the frontend's "subgraph" feature). That is NORMAL
+    and fully supported — ``run_workflow`` / ``run_template`` expand it via
+    comfy-cli — so never refuse or swap a template over it. Do not hand-edit
+    ``definitions.subgraphs``; route edits through ``list_workflow_slots`` /
+    ``set_workflow_slot``, which address subgraph-interior inputs too.
     """
     # `name` is a bare positional, so a leading-dash value is read as an option
     # and every later token shifts up a slot. `out_path` rides behind `--out` as
@@ -6499,6 +6519,14 @@ def list_workflow_slots(workflow_path: str) -> Any:
     ``run_workflow`` accepts — ``list_workflow_slots(workflow_path=...)``. Pass
     a slot's ``ADDR`` back to ``set_workflow_slot`` (or ``vary_workflow``) to
     change it.
+
+    For a workflow that uses subgraphs (``definitions.subgraphs`` + UUID-typed
+    instance nodes), slots INSIDE a subgraph are addressed as ``A/B.name`` —
+    e.g. ``115/75.strength`` is input ``strength`` of interior node ``75`` inside
+    subgraph instance node ``115`` — alongside plain ``A.name`` slots for
+    proxy widgets promoted onto the instance node itself (e.g. ``130.text``).
+    Both forms come back in the slot's ``address`` field and are set the same
+    way; subgraphs never need hand-editing.
     """
     # Bare positional, same as `set_workflow_slot` — a leading-dash path is read
     # as a flag rather than the path comfy-cli is meant to read.

--- a/tests/test_subgraph_templates.py
+++ b/tests/test_subgraph_templates.py
@@ -1,0 +1,139 @@
+"""Regression tests: subgraph templates flow through the MCP layer untouched.
+
+A gallery template built with the frontend's "subgraph" feature carries
+UUID-typed instance nodes plus a ``definitions.subgraphs`` block in its
+workflow JSON. The whole stack supports that shape — comfy-cli expands
+``definitions.subgraphs`` client-side, and ``comfy workflow slots`` addresses
+subgraph-interior inputs as ``A/B.name`` — so this server must stay a pure
+passthrough: no tool may inspect the JSON and reject or block on subgraphs.
+(The reported failure mode was informational, not code: an agent preemptively
+refused a subgraph template as "can't unpack", so the INSTRUCTIONS now say the
+shape is supported, and these tests pin the passthrough behavior itself.)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from conftest import envelope
+
+from comfy_local_mcp import server
+
+# The UUID doubles as the instance node's `type` — the discriminator that makes
+# a workflow "subgraphed" in the frontend format.
+SUBGRAPH_ID = "8e9c5f5a-4a4f-4bde-9d7a-2f27c1c4a2b1"
+
+# A minimal frontend-format workflow using a subgraph: one top-level UUID-typed
+# instance node (115) and one interior node (75) inside the definition.
+SUBGRAPH_WORKFLOW = {
+    "nodes": [
+        {
+            "id": 115,
+            "type": SUBGRAPH_ID,
+            "inputs": [],
+            "widgets_values": ["a photo of a fox"],
+        },
+    ],
+    "links": [],
+    "definitions": {
+        "subgraphs": [
+            {
+                "id": SUBGRAPH_ID,
+                "name": "Style pack",
+                "nodes": [
+                    {
+                        "id": 75,
+                        "type": "LoraLoaderModelOnly",
+                        "widgets_values": ["style.safetensors", 0.7],
+                    },
+                ],
+                "links": [],
+            },
+        ],
+    },
+}
+
+
+def test_instructions_teach_that_subgraph_templates_are_supported():
+    """The word "subgraph" must appear in INSTRUCTIONS — the guidance that stops
+    an agent from preemptively refusing a subgraph template. A rewrite that
+    drops it silently reintroduces the refusal failure mode."""
+    assert "subgraph" in server.INSTRUCTIONS.lower()
+
+
+def test_fetch_template_writes_subgraph_json_untouched(monkeypatch, tmp_path):
+    """The subgraphed JSON comfy-cli writes reaches disk byte-identical.
+
+    ``fetch_template`` composes ``templates fetch`` + ``validate`` and must not
+    parse, rewrite, or veto the file in between — ``definitions.subgraphs``
+    included.
+    """
+    out = tmp_path / "subgraph_template.json"
+    raw = json.dumps(SUBGRAPH_WORKFLOW, indent=2)
+    calls: list[tuple] = []
+
+    def fake(*args, **kwargs):
+        calls.append(args)
+        if args[0] == "templates":
+            # comfy-cli materializes the template at --out; the wrapper only
+            # forwards the path.
+            out.write_text(raw, encoding="utf-8")
+            return None
+        assert args[0] == "validate"
+        return {
+            "valid": True,
+            "error_count": 0,
+            "warning_count": 0,
+            "errors": [],
+            "warnings": [],
+            "converted_from_ui": True,
+        }
+
+    monkeypatch.setattr(server, "_run_comfy", fake)
+
+    result = server.fetch_template("subgraph_style", str(out))
+
+    assert calls[0] == ("templates", "fetch", "subgraph_style", "--out", str(out))
+    assert result["path"] == str(out)
+    assert result["local_check"]["runnable"] is True
+    # Byte-identical: the MCP layer never opened, reserialized, or edited it.
+    assert out.read_text(encoding="utf-8") == raw
+    assert json.loads(out.read_text(encoding="utf-8")) == SUBGRAPH_WORKFLOW
+
+
+def test_run_workflow_submits_subgraph_workflow_without_inspection(
+    patched_run, tmp_path
+):
+    """`comfy run --workflow <path>` is invoked verbatim — no pre-inspection
+    rejection of the on-disk ``definitions.subgraphs`` content."""
+    path = tmp_path / "subgraph_template.json"
+    path.write_text(json.dumps(SUBGRAPH_WORKFLOW), encoding="utf-8")
+    calls = patched_run(envelope(data={"prompt_id": "abc123"}))
+
+    result = asyncio.run(server.run_workflow(str(path), wait=False))
+
+    assert result == {"prompt_id": "abc123"}
+    cmd = calls[0]["cmd"]
+    assert cmd[1:4] == ["--json", "--where", "local"]
+    assert cmd[4:] == ["run", "--workflow", str(path)]
+
+
+def test_list_workflow_slots_passes_subgraph_workflow_verbatim(patched_run, tmp_path):
+    """The path goes to `comfy workflow slots` as-is, and subgraph-interior
+    slot addresses (``115/75.strength``) come back unfiltered."""
+    path = tmp_path / "subgraph_template.json"
+    path.write_text(json.dumps(SUBGRAPH_WORKFLOW), encoding="utf-8")
+    slots = [
+        # Interior input: instance node 115 -> interior node 75.
+        {"address": "115/75.strength", "value": 0.7},
+        # Proxy widget promoted onto the instance node itself.
+        {"address": "115.text", "value": "a photo of a fox"},
+    ]
+    calls = patched_run(envelope(data=slots))
+
+    assert server.list_workflow_slots(str(path)) == slots
+
+    cmd = calls[0]["cmd"]
+    assert cmd[1:4] == ["--json", "--where", "local"]
+    assert cmd[4:] == ["workflow", "slots", str(path)]


### PR DESCRIPTION
## ELI-5

Some gallery templates are built with the ComfyUI frontend's "subgraph" feature — the workflow JSON has nodes whose `type` is a UUID plus a `definitions.subgraphs` block. The whole stack already runs these fine, but nothing in this repo said so, and an agent was seen refusing to run one, telling the user it "can't unpack" it. This PR just writes the truth down where agents read it (the server INSTRUCTIONS and three tool docstrings) and adds tests so the guidance and the passthrough behavior can't silently regress.

## Summary

Documentation + tests only — no tool behavior changes. Before this change `git grep -i subgraph` over the repo returned zero hits, so an agent had no signal that subgraph templates are supported; the observed failure mode was a preemptive refusal in agent prose, not a code bug (comfy-cli expands `definitions.subgraphs` client-side, and `comfy workflow slots` addresses subgraph-interior inputs as `A/B.name`, e.g. `115/75.strength`).

## Changes

- **INSTRUCTIONS**: new bullet in the template on-ramp stating subgraph templates are fully supported, how their slots are addressed (`115/75.strength` interior form + proxy-widget slots on the instance node), and to never refuse/swap a template over subgraphs or hand-edit `definitions.subgraphs`.
- **Docstrings**: `fetch_template` (the written JSON may contain `definitions.subgraphs` / UUID-typed nodes — normal; route edits through the slot tools), `list_workflow_slots` (documents the `A/B.name` subgraph-interior address form), `run_template` (`params` accepts subgraph slot addresses).
- **Tests** (`tests/test_subgraph_templates.py`, canned-subprocess fixtures, no real comfy-cli): a minimal subgraphed workflow goes through the canonical flow — `fetch_template` leaves the file byte-identical, `run_workflow` invokes `comfy run --workflow <path>` with no pre-inspection rejection, `list_workflow_slots` passes the path verbatim and returns `115/75.strength` addresses unfiltered. Plus an assertion that the word "subgraph" appears in INSTRUCTIONS, so a future instructions rewrite can't silently drop the guidance.

## Motivation

The supported-capability information existed nowhere agents could see it, so the refusal failure mode could recur on any subgraph template. The claim itself is safe to assert: comfy-cli's converter has expanded `definitions.subgraphs` since 1.8.0, and this repo's compatibility floor is already 1.13.0.

## Testing

- [x] Existing tests pass (`pytest` — 904 passed, 2 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually (not needed — docs/tests only, no behavior change)

## Additional Notes

No test previously asserted INSTRUCTIONS content, so the coverage assertion lives in the new test file rather than extending an existing one.
