### PR TITLE
fix(deps): cap mcp below 2.0, which deleted `mcp.server.fastmcp`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,17 @@ dependencies = [
     # crash at import on this server's `ctx: Context | None` tool parameters
     # (`issubclass() arg 1 must be a class`). Verified by running the suite
     # against each release; the floor was previously understated at 1.2.0.
-    "mcp>=1.14.0",
+    #
+    # < 2 because the SDK's 2.0.0 (2026-07-28) DELETED `mcp.server.fastmcp`
+    # outright — no shim, no deprecation window. This server's single SDK import
+    # (`from mcp.server.fastmcp import Context, FastMCP, Image`, server.py) is
+    # therefore an ImportError on 2.x, which takes the whole suite down at
+    # conftest collection rather than at any one test. The ceiling is what makes
+    # that upgrade a reviewable Dependabot PR instead of an unrelated PR's CI
+    # turning red hours after a release nobody here asked for. Removing it is
+    # the LAST step of the 2.x migration (FastMCP -> `mcp.server.mcpserver`.
+    # MCPServer, elicitation types moved alongside it), never a prerequisite.
+    "mcp>=1.14.0,<2",
     # Already an mcp dependency; declared explicitly because this server now
     # imports it directly for the elicitation response schema.
     "pydantic>=2",


### PR DESCRIPTION
## ELI-5

The MCP Python SDK shipped a 2.0 today. It deleted the exact module this server imports, and our dependency said `mcp>=1.14.0` with no upper limit — so every CI run since then has been installing a version this code cannot import. The tests aren't broken; the floor moved. This puts a `<2` ceiling on it.

## Summary

`mcp` 2.0.0 was published **2026-07-28 13:45 UTC**. It removes `mcp.server.fastmcp` with no shim and no deprecation window — the package is gone, replaced by `mcp.server.mcpserver`.

This server's only SDK import is `src/comfy_local_mcp/server.py:60`:

```python
from mcp.server.fastmcp import Context, FastMCP, Image
```

On 2.x that raises at module load. `tests/conftest.py` imports `server`, so the failure lands during pytest **collection**, not in any test:

```
ImportError while loading conftest '/home/runner/.../tests/conftest.py'.
tests/conftest.py:41: in <module>
    from comfy_local_mcp import failure_log, server
src/comfy_local_mcp/server.py:62: in <module>
    from mcp.server.fastmcp import Context, FastMCP, Image
E   ModuleNotFoundError: No module named 'mcp.server.fastmcp'
##[error]Process completed with exit code 4.
```

That traceback points at conftest, which is why this reads as "the tests are broken" rather than "a dependency moved." Note the job installed `mcp-2.0.0` a few lines earlier, and `ruff check` / `ruff format --check` both passed in the same job — only `pytest` fell over.

## Why it hits every PR

`mcp>=1.14.0` had no ceiling, so every fresh CI install after 13:45 UTC resolves to 2.0.0. Main's last green run was **09:28 UTC**; nothing in this repo changed in between. #107 is docs-and-tests only and is red for a reason entirely unrelated to its diff — as any PR opened today would be. This is a wall-clock boundary, not a code one.

## Changes

- `pyproject.toml`: `mcp>=1.14.0` → `mcp>=1.14.0,<2`, with a comment recording what 2.0 removed, why the break presents as a conftest error, and that lifting the ceiling is the **last** step of the 2.x migration rather than a prerequisite.

The ceiling is what converts "an unrelated PR goes red hours after an upstream release" into "Dependabot opens a reviewable PR" — the same argument the ruff pin a few lines down already makes for the same reason.

## Follow-up (not this PR)

Migrating to 2.x is a real port, not a version bump: `FastMCP` → `mcp.server.mcpserver.MCPServer`, and the elicitation types (`AcceptedElicitation` / `DeclinedElicitation` / `CancelledElicitation`) move with it — and elicitation is load-bearing here, it is the spend-confirmation interlock on `partner_generate` and `run_template`. Tracked separately so this unblock stays a one-line diff.

## Testing

- [x] Clean `pip install -e '.[dev]'` in a fresh venv resolves `mcp==1.29.0` (verified the pre-2.0 line still exports `Context, FastMCP, Image`)
- [x] `pytest -q -m "not e2e"` — 899 passed, 1 skipped
- [x] `ruff check src tests` — All checks passed
- [x] `ruff format --check src tests` — 22 files already formatted
- [ ] Tested manually (not needed — dependency constraint only, no code change)

## Additional Notes

Merge this first, then rebase #107; its own diff needs no changes.