### PR TITLE
ci: enroll this repo in the shared groom sweep (finds-only)

### DIFF
--- a/.github/workflows/groom.yml
+++ b/.github/workflows/groom.yml
@@ -84,9 +84,15 @@ jobs:
       # Manual dispatch may dry-run; the schedule always files live
       # (github.event.inputs is null on a schedule -> '' != 'true' -> false).
       dry_run: ${{ github.event.inputs.dry_run == 'true' }}
-      # Effective cadence, re-read every run, so retuning weekly -> every-3-days
-      # needs no edit to this file:
-      #   gh variable set GROOM_INTERVAL_DAYS --repo Comfy-Org/comfy-local-mcp --body 3
+      # Effective cadence, re-read every run, so retuning needs no edit to this
+      # file:
+      #   gh variable set GROOM_INTERVAL_DAYS --repo Comfy-Org/comfy-local-mcp --body 7
+      # `|| '7'` is ONLY the fallback for a MISSING variable — it is NOT the
+      # effective cadence and does not mean "weekly by default". This repo
+      # already defines GROOM_INTERVAL_DAYS, so the variable governs the spend,
+      # not this line. It is set to 1 (= a real audit every day the repo had a
+      # merge) as of this PR. Read it before assuming weekly:
+      #   gh variable get GROOM_INTERVAL_DAYS --repo Comfy-Org/comfy-local-mcp
       interval_days: ${{ vars.GROOM_INTERVAL_DAYS || '7' }}
       # Match the volume-gate window to the EFFECTIVE cadence above, not the
       # daily base cron, so "did anything merge since the last real run?" spans

--- a/.github/workflows/groom.yml
+++ b/.github/workflows/groom.yml
@@ -1,0 +1,107 @@
+name: Groom
+
+# Thin caller for the shared reusable code-cleanup sweep. All the logic (the
+# two-phase finder -> independent verifier audit, the durable dedup ledger, the
+# GitHub-issue sink) lives in Comfy-Org/github-workflows — this repo carries
+# only the pin, exactly like agents-md-integrity.yml and ci-cursor-review.yml.
+# Keep `workflows_ref` equal to the `uses:` SHA so a run always loads the briefs
+# and ledger that match the workflow filing the issues; the upstream bump
+# dispatcher (GROOM_CALLERS) opens SHA-bump PRs automatically once registered.
+#
+# FINDS-ONLY. The opt-in auto-builder (`builder: true`, which turns findings
+# into review-gated PRs) is deliberately left OFF here. This repo's whole
+# contract is the thin-wrapper rule in AGENTS.md — "every tool is a
+# `comfy --json --where local` passthrough" — and that is a judgement a
+# refactor agent cannot make from the code alone: the most "duplicated" -looking
+# passthroughs are duplicated ON PURPOSE, because collapsing them would move
+# behavior out of comfy-cli and into this repo. Groom files issues a human
+# triages; it opens no PRs, writes no commits, and never merges.
+#
+# PREREQUISITE (operator): `secrets.ANTHROPIC_API_KEY` must reach this repo (org-
+# or repo-level) — the finder and verifier agents bill through it, and the
+# reusable declares it `required: true`. If it is absent the run fails LOUD at
+# the agent step by design, so the sweep is never silently inert. `vars.APP_ID` +
+# `secrets.CLOUD_CODE_BOT_PRIVATE_KEY` are optional here: with them, issues are
+# filed as cloud-code-bot; without, the reusable degrades to github-actions[bot]
+# rather than failing.
+
+on:
+  schedule:
+    # DAILY base tick — deliberately NOT the effective cadence. GitHub Actions
+    # cron is static in the file, so "every N days" is implemented as a frequent
+    # base tick plus the reusable's runtime interval gate: a tick within
+    # GROOM_INTERVAL_DAYS of the last real run no-ops cheaply, before the finder
+    # ever spins up. Never fires on a PR. 10:41 UTC is off-peak and off the hour
+    # to dodge top-of-hour scheduler congestion, and staggered from the other
+    # groom callers so the org's runs do not all land in one minute.
+    - cron: '41 10 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: >-
+          Run the full audit + dedup but do NOT open issues — print what WOULD be
+          filed to the job summary. Use this for the first run to confirm the
+          agent credentials resolve and to eyeball finding quality before
+          trusting live filing.
+        type: boolean
+        default: false
+
+# NOTE: intentionally NO caller-level `concurrency:`. The reusable already
+# declares `concurrency: groom-${{ github.repository }}` (cancel-in-progress:
+# false), which is the real TOCTOU guard for the read-then-file dedup ledger.
+# Repeating that same group here would DEADLOCK the run — the caller would hold
+# the group while its `uses:` job waits on the identical group, and with
+# cancel-in-progress:false the nested job never gets the slot.
+
+jobs:
+  groom:
+    permissions:
+      # REQUIRED UNION, and it is not optional paperwork: a reusable's nested
+      # jobs cannot request more GITHUB_TOKEN scope than the caller grants, and
+      # GitHub validates that at STARTUP — before any job runs. A short grant
+      # fails the whole run with an opaque "workflow file issue" and zero jobs,
+      # not a clean error. At the pinned SHA: `file` needs issues: write;
+      # `build_select` needs issues: read + pull-requests: read; `gate` needs
+      # actions: read to find the last real run in this workflow's history.
+      # Omitting `actions: read` REJECTS the run outright ("requesting
+      # 'actions: read', but is only allowed 'actions: none'") — it does not
+      # quietly degrade to running every tick. The agent jobs need nothing
+      # beyond contents: read: they invoke the Claude CLI directly and mint no
+      # GitHub token, so `id-token: write` is not required at this SHA (verified
+      # against ece4c3e — grep finds no `id-token` outside a comment).
+      contents: read
+      issues: write
+      pull-requests: read
+      actions: read
+    uses: Comfy-Org/github-workflows/.github/workflows/groom.yml@ece4c3eaa71812a5a665f48d5d1f4bb0ff5f655e # github-workflows main (ece4c3e)
+    with:
+      # Keep the assets ref (finder/verifier briefs, interval gate, dedup ledger)
+      # in lock-step with the `uses:` SHA above. Bump both together.
+      workflows_ref: ece4c3eaa71812a5a665f48d5d1f4bb0ff5f655e
+      # File as cloud-code-bot so groom's issues are a distinct, queryable actor
+      # rather than github-actions[bot]. Unset -> reusable falls back gracefully.
+      bot_app_id: ${{ vars.APP_ID }}
+      # Manual dispatch may dry-run; the schedule always files live
+      # (github.event.inputs is null on a schedule -> '' != 'true' -> false).
+      dry_run: ${{ github.event.inputs.dry_run == 'true' }}
+      # Effective cadence, re-read every run, so retuning weekly -> every-3-days
+      # needs no edit to this file:
+      #   gh variable set GROOM_INTERVAL_DAYS --repo Comfy-Org/comfy-local-mcp --body 3
+      interval_days: ${{ vars.GROOM_INTERVAL_DAYS || '7' }}
+      # Match the volume-gate window to the EFFECTIVE cadence above, not the
+      # daily base cron, so "did anything merge since the last real run?" spans
+      # the right window. Wired to the one variable so the two gates cannot drift.
+      cadence: ${{ vars.GROOM_INTERVAL_DAYS || '7' }}
+      # A dry-run is the pre-trust spot-check, so it must always reach the audit:
+      # bypass the volume gate when dispatched with dry_run:true, or a quiet week
+      # would gate it to nothing and print no summary — defeating the point. Live
+      # runs keep the gate on so a quiescent repo still skips the spend.
+      volume_gate: ${{ github.event.inputs.dry_run != 'true' }}
+      # Below the default of 12. This is a ~30-file repo whose entire source is
+      # one server module plus three leaves, so a cap sized for a large service
+      # would mostly buy restatements of the same few observations. Raise it if
+      # real findings start hitting the ceiling.
+      max_findings: 5
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BOT_APP_PRIVATE_KEY: ${{ secrets.CLOUD_CODE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## ELI-5

There's a shared workflow in `Comfy-Org/github-workflows` that periodically reads a repo, has one agent propose cleanups, has a *second independent* agent double-check them, and files the survivors as GitHub issues. This adds the ~10 lines that enroll this repo in it. It files issues only — it never writes code here.

## Summary

Adds `.github/workflows/groom.yml`, a thin caller for the reusable groom sweep, pinned to `ece4c3e` — the same SHA cursor-review was just bumped to in #109, so all three shared workflows in this repo now load from one commit.

The shape follows the reusable's documented caller pattern and the two callers already here (`agents-md-integrity.yml`, `ci-cursor-review.yml`): the pin, `workflows_ref` at the same SHA, and nothing else. The audit logic, the finder/verifier briefs, and the dedup ledger all stay upstream.

## Configuration choices (and why)

**Finds-only — `builder: true` is deliberately off.** The reusable can turn confirmed findings into review-gated PRs. Not here. This repo's contract is the thin-wrapper rule in `AGENTS.md`, and that's precisely the judgement a refactor agent can't make from the code alone: the passthroughs that look most duplicated are duplicated *on purpose*, because collapsing them would move behavior out of comfy-cli and into this repo. A groom issue costs a human 30 seconds to close; a groom PR that quietly violates the architecture rule costs a review cycle and risks landing. Issues only.

**`max_findings: 5`, below the default 12.** This is a ~30-file repo whose source is one server module plus three leaves. A cap sized for a large service mostly buys restatements of the same few observations. Easy to raise if real findings start hitting the ceiling.

**Cadence: daily base cron + runtime interval gate.** Actions cron is static in the file, so "every N days" is a frequent tick plus the reusable's gate — a tick within `GROOM_INTERVAL_DAYS` of the last real run no-ops before the finder spins up. Both `interval_days` and `cadence` are wired to that one variable so the two gates can't drift, and retuning weekly → every-3-days needs no edit to this file:

```
gh variable set GROOM_INTERVAL_DAYS --repo Comfy-Org/comfy-local-mcp --body 3
```

Cron is `41 10 * * *` — off-peak, off the hour, and staggered from the other groom callers.

**No caller-level `concurrency:`.** The reusable already declares `groom-${{ github.repository }}` with `cancel-in-progress: false`. Repeating it here would *deadlock* the run: the caller would hold the group while its `uses:` job waits on the identical group.

## Verification

Validated against the reusable **at the pinned SHA** (not main — I re-fetched `groom.yml?ref=ece4c3e` and diffed to confirm I reviewed the same bytes the caller will run):

- [x] Every `with:` key resolves to a declared `workflow_call` input — no unknown inputs (an unknown key rejects the run at startup)
- [x] Both secret names resolve; `ANTHROPIC_API_KEY`, the only `required: true` secret, is passed
- [x] `workflows_ref` equals the `uses:` SHA
- [x] The `permissions` block is **exactly** the union of the reusable's per-job grants — `contents: read`, `issues: write`, `pull-requests: read`, `actions: read`. No short grant, no over-grant.
- [x] Confirmed no `id-token` declaration survives at this SHA (only a comment mentions it), so the shorter grant is safe — the BE-4214 CLI migration is in
- [x] YAML parses

`actions: read` is the easy one to miss: without it GitHub **rejects the whole run** at startup with an opaque "workflow file issue" — it does not degrade to running every tick.

## Operator prerequisites (before the first live run)

1. **`secrets.ANTHROPIC_API_KEY` must reach this repo** (org- or repo-level). I could not verify this from here — enumerating org secrets needs `admin:org`, which returns 403 for me. This repo has no repo-level copy. If it's absent the run fails loudly at the agent step by design, so it will never be silently inert — but it *will* fail.
2. **Register this caller in `GROOM_CALLERS`** on `Comfy-Org/github-workflows` so the pin gets auto-bumped like the other three. It currently lists `cloud`, `comfy-cloud-mcp-server`, and `github-workflows`. Without it this pin silently goes stale.

`vars.APP_ID` + `secrets.CLOUD_CODE_BOT_PRIVATE_KEY` are **optional** — with them issues file as cloud-code-bot; without, the reusable degrades to `github-actions[bot]` rather than failing.

## Suggested first run

Dispatch manually with `dry_run: true` before trusting live filing. That bypasses the interval gate, bypasses the volume gate, runs the full audit + dedup, and prints what *would* be filed to the job summary — which also confirms the credentials in (1) actually resolve.

## Testing

- [x] YAML parses; structure, inputs, secrets, and permissions all validated against the pinned reusable
- [ ] Tested manually — not possible pre-merge: `workflow_dispatch` only becomes available once the workflow is on the default branch. See "Suggested first run" above.

## Additional Notes

No `AGENTS.md` change. That file documents the contributor loop (the three commands CI runs per PR); groom is a scheduled sweep that files issues and touches none of it, and `AGENTS.md` is explicitly meant to stay thin.