### PR TITLE
refactor: port to MCP Python SDK 2.x and require mcp>=2,<3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,20 @@ dependencies = [
     #
     # < 3 for the same reason the `< 2` cap existed before this port: a major
     # release must arrive as a reviewable Dependabot PR, not as unrelated PRs'
-    # CI turning red hours after a release nobody here asked for. `mcp-types`
-    # is deliberately NOT declared — `mcp.types` still ships inside the `mcp`
-    # distribution on 2.x, and the split-out package comes in transitively.
+    # CI turning red hours after a release nobody here asked for.
+    #
+    # `mcp-types` is deliberately NOT declared, and the two facts behind that
+    # only look like a contradiction: 2.x split the wire types out into a
+    # standalone `mcp-types` distribution, AND kept `mcp.types` inside the `mcp`
+    # distribution as a module that mirrors it (every name is the same object),
+    # which is the spelling `server.py` imports. The version is bounded either
+    # way — `mcp` 2.0.0 requires `mcp-types==2.0.0`, an EXACT pin, so a breaking
+    # `mcp-types` major cannot arrive except via an `mcp` release, which this
+    # `< 3` ceiling already gates into a reviewable Dependabot PR.
+    #
+    # `requires-python = ">=3.10"` above still holds: `mcp` 2.0.0 and
+    # `mcp-types` 2.0.0 both declare `Requires-Python: >=3.10`, so the major
+    # bump did not raise the floor out from under the 3.10 CI leg.
     "mcp>=2,<3",
     # Already an mcp dependency; declared explicitly because this server now
     # imports it directly for the elicitation response schema.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,22 +7,20 @@ requires-python = ">=3.10"
 license = "Apache-2.0"
 authors = [{ name = "Comfy Org" }]
 dependencies = [
-    # >= 1.10 for elicitation (`Context.elicit`, used by `partner_generate` to
-    # confirm a credit spend per call); >= 1.14 because earlier FastMCP builds
-    # crash at import on this server's `ctx: Context | None` tool parameters
-    # (`issubclass() arg 1 must be a class`). Verified by running the suite
-    # against each release; the floor was previously understated at 1.2.0.
+    # >= 2 because that is where `mcp.server.mcpserver` exists: the SDK's 2.0.0
+    # DELETED `mcp.server.fastmcp` outright — no shim, no deprecation window —
+    # and this server's single SDK import (`from mcp.server.mcpserver import
+    # Context, Image, MCPServer`, server.py) resolves on 2.x only. On 1.x it is
+    # an ImportError that takes the whole suite down at conftest collection
+    # rather than at any one test. (Historical floors this supersedes: >= 1.10
+    # for elicitation, >= 1.14 to survive `ctx: Context | None` tool parameters.)
     #
-    # < 2 because the SDK's 2.0.0 (2026-07-28) DELETED `mcp.server.fastmcp`
-    # outright — no shim, no deprecation window. This server's single SDK import
-    # (`from mcp.server.fastmcp import Context, FastMCP, Image`, server.py) is
-    # therefore an ImportError on 2.x, which takes the whole suite down at
-    # conftest collection rather than at any one test. The ceiling is what makes
-    # that upgrade a reviewable Dependabot PR instead of an unrelated PR's CI
-    # turning red hours after a release nobody here asked for. Removing it is
-    # the LAST step of the 2.x migration (FastMCP -> `mcp.server.mcpserver`.
-    # MCPServer, elicitation types moved alongside it), never a prerequisite.
-    "mcp>=1.14.0,<2",
+    # < 3 for the same reason the `< 2` cap existed before this port: a major
+    # release must arrive as a reviewable Dependabot PR, not as unrelated PRs'
+    # CI turning red hours after a release nobody here asked for. `mcp-types`
+    # is deliberately NOT declared — `mcp.types` still ships inside the `mcp`
+    # distribution on 2.x, and the split-out package comes in transitively.
+    "mcp>=2,<3",
     # Already an mcp dependency; declared explicitly because this server now
     # imports it directly for the elicitation response schema.
     "pydantic>=2",

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -7050,7 +7050,12 @@ def main() -> None:
     :func:`_require_comfy_bin` do for the child process we spawn.
     """
     try:
-        mcp.run()
+        # Name the transport rather than inheriting the SDK's default: the whole
+        # stdio design rests on it — `failure_log`'s rule that stdout is the
+        # JSON-RPC channel and must never be written to is only true under
+        # stdio. 2.x defaults to "stdio" today, but a default is a thing a
+        # future SDK is free to change, and this one is load-bearing.
+        mcp.run(transport="stdio")
     except PermissionError as exc:
         # Prefer the exception's structured `filename` over re-parsing its text:
         # it is the authoritative path, and it is present for errnos the text

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -59,7 +59,7 @@ from typing import Any, TypeVar
 from urllib.parse import urlparse
 
 from mcp import types
-from mcp.server.fastmcp import Context, FastMCP, Image
+from mcp.server.mcpserver import Context, Image, MCPServer
 from pydantic import BaseModel, Field
 
 from . import failure_log, tcc, textutil
@@ -163,7 +163,7 @@ tool takes a bare `path` or `workflow` argument.
 Everything targets the LOCAL server only — there is no cloud access here.
 """
 
-mcp = FastMCP("comfy-local-mcp", instructions=INSTRUCTIONS)
+mcp = MCPServer("comfy-local-mcp", instructions=INSTRUCTIONS)
 
 # Allow overriding the binary (e.g. a venv path) without touching code. The
 # companion address override needs no constant here: a LOCAL ComfyUI on a
@@ -4599,7 +4599,7 @@ def get_queue() -> Any:
 
 
 # Image suffixes we return inline from ``fetch_outputs`` — kept to the formats
-# ``mcp.server.fastmcp.Image`` maps to a real ``image/*`` MIME type (an unknown
+# ``mcp.server.mcpserver.Image`` maps to a real ``image/*`` MIME type (an unknown
 # suffix would fall back to ``application/octet-stream`` and not render).
 _INLINE_IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg", ".gif", ".webp")
 
@@ -4984,7 +4984,7 @@ _UPDATE_TARGETS = ("all", "comfy", "cli")
 # network fetch that must not be killed halfway).
 _UPDATE_TIMEOUT = 1800.0
 
-# Only one `comfy update` may be in flight per server process. FastMCP dispatches
+# Only one `comfy update` may be in flight per server process. MCPServer dispatches
 # sync tools onto a worker thread pool, so a client is free to issue a second
 # `update_comfyui` while the first is still running — and both would drive `git`
 # and `pip` against the SAME workspace and Python environment at once (a fight
@@ -5054,7 +5054,7 @@ def update_comfyui(target: str = "comfy") -> Any:
             "('comfy' = ComfyUI core, 'all' = installed custom node packs, "
             "'cli' = comfy-cli itself)."
         )
-    # Refuse rather than queue: blocking would park a FastMCP worker thread for
+    # Refuse rather than queue: blocking would park an MCPServer worker thread for
     # up to 30 minutes behind an update the caller cannot see, and present as a
     # hang. Failing immediately names what is happening and leaves retrying to
     # the caller. Acquired AFTER target validation so a bad target is still
@@ -6664,7 +6664,7 @@ _SlotModel = TypeVar("_SlotModel", bound=BaseModel)
 def _as_slot_model(item: Any, model: type[_SlotModel]) -> _SlotModel:
     """Coerce one structured slot item to its model.
 
-    Over MCP, FastMCP has already validated the item into ``model``. A plain
+    Over MCP, MCPServer has already validated the item into ``model``. A plain
     mapping only reaches here from an in-process caller (this module's own
     tests, a script importing the tool), so it is validated through the same
     model rather than read key-by-key — one definition of the shape, one set of

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -383,7 +383,7 @@ class _FakeProc:
 
 
 class _RecordingCtx:
-    """A fake FastMCP Context that records each ``report_progress`` call."""
+    """A fake MCPServer Context that records each ``report_progress`` call."""
 
     def __init__(self):
         self.calls: list[dict] = []

--- a/tests/test_partner_generate.py
+++ b/tests/test_partner_generate.py
@@ -55,7 +55,7 @@ class _FakeSession:
 
 
 class _FakeCtx:
-    """A fake FastMCP ``Context`` that answers the elicitation with ``action``.
+    """A fake MCPServer ``Context`` that answers the elicitation with ``action``.
 
     Records every elicitation raised so a test can assert the prompt happened
     (and what it said), and can be told to have no elicitation capability at all
@@ -912,7 +912,7 @@ def test_instructions_warn_that_partner_generate_spends_credits():
 
 
 def test_partner_generate_takes_an_injected_context():
-    """FastMCP must recognise `ctx` — or the spend prompt silently never fires.
+    """MCPServer must recognise `ctx` — or the spend prompt silently never fires.
 
     The elicitation path is reachable only if the server injects the request
     context; a rename or a retype would quietly degrade every call to the

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -399,10 +399,29 @@ def test_a_real_error_envelope_is_untouched(on_macos, monkeypatch):
 # --- process startup ---------------------------------------------------------
 
 
+def test_main_serves_stdio_explicitly(monkeypatch):
+    """The transport is NAMED, never inherited from whatever the SDK defaults to.
+
+    Everything downstream assumes stdio: `failure_log`'s rule that stdout is the
+    JSON-RPC channel and must never be written to, and every child spawn that
+    withholds the parent's stdin so a subprocess cannot eat protocol traffic. A
+    default is a thing an SDK major is free to change; this contract is not.
+    """
+    seen = {}
+
+    def record(transport):
+        seen["transport"] = transport
+
+    monkeypatch.setattr(server.mcp, "run", record)
+    server.main()
+
+    assert seen["transport"] == "stdio"
+
+
 def test_main_reports_a_startup_denial_instead_of_a_traceback(
     on_macos, monkeypatch, capsys
 ):
-    def boom():
+    def boom(transport):
         raise PermissionError(1, "Operation not permitted", _DENIED_PATH)
 
     monkeypatch.setattr(server.mcp, "run", boom)
@@ -419,7 +438,7 @@ def test_main_reports_a_startup_denial_instead_of_a_traceback(
 def test_main_handles_a_bytes_filename(on_macos, monkeypatch, capsys):
     """A denial on a bytes path carries a bytes `filename` — decode, don't crash."""
 
-    def boom():
+    def boom(transport):
         raise PermissionError(1, "Operation not permitted", os.fsencode(_DENIED_PATH))
 
     monkeypatch.setattr(server.mcp, "run", boom)
@@ -433,7 +452,7 @@ def test_main_handles_a_bytes_filename(on_macos, monkeypatch, capsys):
 
 
 def test_main_propagates_an_unrelated_permission_error(on_macos, monkeypatch):
-    def boom():
+    def boom(transport):
         raise PermissionError(13, "Permission denied", "/etc/shadow")
 
     monkeypatch.setattr(server.mcp, "run", boom)
@@ -443,7 +462,7 @@ def test_main_propagates_an_unrelated_permission_error(on_macos, monkeypatch):
 
 
 def test_main_propagates_on_non_macos(on_linux, monkeypatch):
-    def boom():
+    def boom(transport):
         raise PermissionError(1, "Operation not permitted", _DENIED_PATH)
 
     monkeypatch.setattr(server.mcp, "run", boom)

--- a/tests/test_run_template.py
+++ b/tests/test_run_template.py
@@ -61,7 +61,7 @@ class _FakeSession:
 
 
 class _FakeCtx:
-    """A fake FastMCP ``Context`` that answers the elicitation with ``action``.
+    """A fake MCPServer ``Context`` that answers the elicitation with ``action``.
 
     Deliberately a local copy of ``test_partner_generate``'s fake rather than a
     shared one: the two tools' consent paths are asserted independently, so a

--- a/tests/test_sdk_conformance.py
+++ b/tests/test_sdk_conformance.py
@@ -1,0 +1,106 @@
+"""The test doubles for MCP ``Context``/``ServerSession`` must match the real SDK.
+
+Every consent and progress test in this suite drives a hand-rolled fake rather
+than a live MCP session, so those fakes ARE the contract those tests check
+against. That makes them a blind spot precisely where it costs the most: the
+production call sites pass by keyword (``ctx.elicit(message=..., schema=...)``)
+inside broad ``except`` handlers, so an SDK signature change lands as a
+``TypeError`` that surfaces as "could not confirm the credit spend with the
+user" on every paid call — or, on the progress path, as silently dropped
+notifications — while the fakes keep the suite green.
+
+These tests close that loop by asserting each fake against the REAL signature
+imported from the installed SDK. They are cheap, and they are the reason a
+future major bump fails loudly here instead of quietly in production.
+"""
+
+import inspect
+
+import conftest
+import pytest
+import test_partner_generate
+import test_run_template
+from mcp.server.mcpserver import Context
+from mcp.server.session import ServerSession
+
+
+def _params(func) -> list[tuple[str, bool]]:
+    """``(name, has_default)`` per bindable parameter, ``self`` dropped.
+
+    Annotations are deliberately ignored: what the call sites depend on is the
+    NAME (they pass by keyword) and whether an argument may be omitted, not the
+    type spelling — which the SDK is free to restate without breaking anyone.
+    """
+    kinds = (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+    return [
+        (name, param.default is not inspect.Parameter.empty)
+        for name, param in inspect.signature(func).parameters.items()
+        if name != "self" and param.kind in kinds
+    ]
+
+
+# Every fake standing in for the real `Context.elicit`, named by where it lives
+# so a failure says which module to fix.
+_ELICIT_FAKES = [
+    ("test_partner_generate._FakeCtx", test_partner_generate._FakeCtx),
+    ("test_run_template._FakeCtx", test_run_template._FakeCtx),
+]
+
+_PROGRESS_FAKES = [
+    ("conftest._RecordingCtx", conftest._RecordingCtx),
+    ("test_run_template._FakeCtx", test_run_template._FakeCtx),
+]
+
+_SESSION_FAKES = [
+    ("test_partner_generate._FakeSession", test_partner_generate._FakeSession),
+    ("test_run_template._FakeSession", test_run_template._FakeSession),
+]
+
+
+@pytest.mark.parametrize("label,fake", _ELICIT_FAKES, ids=[n for n, _ in _ELICIT_FAKES])
+def test_fake_elicit_matches_the_real_context_signature(label, fake):
+    """A renamed ``elicit`` keyword must fail HERE, not as a spend-path TypeError."""
+    assert _params(fake.elicit) == _params(Context.elicit), label
+    assert inspect.iscoroutinefunction(fake.elicit) == inspect.iscoroutinefunction(
+        Context.elicit
+    ), label
+
+
+@pytest.mark.parametrize(
+    "label,fake", _PROGRESS_FAKES, ids=[n for n, _ in _PROGRESS_FAKES]
+)
+def test_fake_report_progress_matches_the_real_context_signature(label, fake):
+    """The production call only debug-logs on failure, so drift is silent there."""
+    assert _params(fake.report_progress) == _params(Context.report_progress), label
+    assert inspect.iscoroutinefunction(
+        fake.report_progress
+    ) == inspect.iscoroutinefunction(Context.report_progress), label
+
+
+@pytest.mark.parametrize(
+    "label,fake", _SESSION_FAKES, ids=[n for n, _ in _SESSION_FAKES]
+)
+def test_fake_check_client_capability_matches_the_real_session_signature(label, fake):
+    """The capability probe decides whether a human is asked before money moves."""
+    real = ServerSession.check_client_capability
+    assert _params(fake.check_client_capability) == _params(real), label
+    assert inspect.iscoroutinefunction(
+        fake.check_client_capability
+    ) == inspect.iscoroutinefunction(real), label
+
+
+def test_the_spend_prompt_keywords_bind_to_the_real_elicit():
+    """`_elicit_spend_approval` passes `message=`/`schema=` — they must still bind.
+
+    The fakes above are checked against the real signature, but this asserts the
+    other direction directly on the SDK: the exact keywords server.py sends are
+    accepted by `Context.elicit` as installed.
+    """
+    signature = inspect.signature(Context.elicit)
+    signature.bind(object(), message="ask", schema=type("S", (), {}))
+
+
+def test_the_progress_keywords_bind_to_the_real_report_progress():
+    """The progress pump sends all three by keyword — `progress=` included."""
+    signature = inspect.signature(Context.report_progress)
+    signature.bind(object(), progress=0.5, total=1.0, message="half")

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -848,7 +848,7 @@ def test_slot_tools_advertise_the_union_item_type():
         ("set_workflow_slot", "overrides", "SlotOverride", "value"),
         ("vary_workflow", "slots", "SlotVariants", "values"),
     ):
-        schema = tools[name].inputSchema
+        schema = tools[name].input_schema
         item = schema["properties"][param]["items"]
         assert {"type": "string"} in item["anyOf"]
         assert {"$ref": f"#/$defs/{model}"} in item["anyOf"]
@@ -858,12 +858,12 @@ def test_slot_tools_advertise_the_union_item_type():
         assert sorted(model_schema["required"]) == sorted(["address", value_field])
 
     # No existing parameter was renamed or dropped.
-    assert set(tools["set_workflow_slot"].inputSchema["properties"]) == {
+    assert set(tools["set_workflow_slot"].input_schema["properties"]) == {
         "workflow_path",
         "overrides",
         "stdout",
     }
-    assert set(tools["vary_workflow"].inputSchema["properties"]) == {
+    assert set(tools["vary_workflow"].input_schema["properties"]) == {
         "workflow_path",
         "slots",
         "out_dir",
@@ -871,10 +871,10 @@ def test_slot_tools_advertise_the_union_item_type():
 
 
 def test_structured_slot_items_deserialize_through_the_mcp_boundary(patched_run):
-    """End-to-end through FastMCP: a JSON dict lands as the model, not a stray dict.
+    """End-to-end through MCPServer: a JSON dict lands as the model, not a stray dict.
 
     The direct-call tests above go through the same coercion helper but not
-    through FastMCP's own argument validation, which is what a real client
+    through MCPServer's own argument validation, which is what a real client
     actually exercises — and it is the union that has to hold there.
     """
     calls = patched_run(envelope(data={"modified": True}))

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -2533,7 +2533,7 @@ def test_fetch_outputs_omits_url_only_by_default(patched_run):
 def test_server_instructions_cover_canonical_flows():
     """Instructions ride the handshake and teach submit->poll->fetch + templates."""
     instructions = server.mcp.instructions
-    assert instructions  # present on the FastMCP instance
+    assert instructions  # present on the MCPServer instance
 
     # Call-server-info-first + the async submit -> poll -> fetch generation loop.
     for tool in ("server_info", "run_workflow", "wait_for_job", "fetch_outputs"):
@@ -4740,7 +4740,7 @@ def test_update_comfyui_is_non_interactive(patched_plain_run):
 def test_update_comfyui_refuses_a_concurrent_update(monkeypatch, patched_plain_run):
     """A second update while one is in flight is refused, not run in parallel.
 
-    FastMCP dispatches sync tools onto a worker thread pool, so two calls really
+    MCPServer dispatches sync tools onto a worker thread pool, so two calls really
     can overlap — and both would then drive git/pip against the same checkout and
     Python environment. A real second thread here, pinned inside the first
     update's subprocess (i.e. while the lock is held).
@@ -4824,7 +4824,7 @@ def test_fetch_outputs_inline_images_returns_image_content(patched_run, tmp_path
 
     content = images[0].to_image_content()
     assert content.type == "image"
-    assert content.mimeType == "image/png"
+    assert content.mime_type == "image/png"
     import base64
 
     assert base64.b64decode(content.data) == _FAKE_PNG  # the real file bytes
@@ -4850,7 +4850,7 @@ def test_fetch_outputs_inline_images_resolves_nested_absolute_paths(
 
     images = [r for r in result if isinstance(r, server.Image)]
     assert len(images) == 1
-    assert images[0].to_image_content().mimeType == "image/jpeg"
+    assert images[0].to_image_content().mime_type == "image/jpeg"
 
 
 def test_fetch_outputs_inline_images_rejects_paths_outside_out_dir(


### PR DESCRIPTION
## ELI-5

The MCP Python SDK just shipped 2.0.0, and it **deleted** the module this server imports (`mcp.server.fastmcp`) — no shim, no deprecation window. The server class also got renamed `FastMCP` → `MCPServer` and moved to `mcp.server.mcpserver`. On 2.x this repo would not even start: it is an ImportError at `import`, which takes the whole test suite down at collection rather than at any one test. A recent PR bought time by capping `mcp<2`; this PR does the actual port and then lifts the cap.

Nothing about what the server *does* changes. Same 42 tools, same arguments, same wire format, same credit-spend confirmation. The only things that move are the name of the module we import from and two Python attribute names that the 2.x protocol models renamed.

## Changes

Two commits, deliberately ordered so the port is reviewable on its own and the dependency range moves last:

**1. `refactor:` port the server off the deleted module**

- `from mcp.server.fastmcp import Context, FastMCP, Image` → `from mcp.server.mcpserver import Context, Image, MCPServer`, and `FastMCP("comfy-local-mcp", instructions=…)` → `MCPServer(…)` (the constructor takes the same positional name + `instructions=` kwarg).
- `from mcp import types` is left alone on purpose: `mcp.types` still ships inside the `mcp` distribution on 2.x and re-exports the **same class objects** the SDK itself compares against — `mcp.types.ClientCapabilities is mcp_types._types.ClientCapabilities` → `True`. This matters more than it looks; see "Riskiest line" below.
- 2.x protocol models are **snake_case attributes with camelCase serialization aliases**, so attribute access via the alias now raises `AttributeError` while the JSON on the wire is unchanged. Fixed: `tool.inputSchema` → `tool.input_schema` (3 sites) and `content.mimeType` → `content.mime_type` (2 sites).
- Comment/docstring references to the old class name renamed alongside, so the repo carries no pointer to a module that no longer exists.

**2. `build:` require the 2.x SDK**

- `"mcp>=1.14.0,<2"` → `"mcp>=2,<3"`, with the comment block rewritten: floor 2 because that is where `mcp.server.mcpserver` exists; ceiling `<3` for exactly the reason the `<2` cap existed — a major release should arrive as a reviewable Dependabot PR, not as an unrelated PR's CI turning red hours after a release nobody here asked for.
- `mcp-types` is deliberately **not** declared: `mcp.types` still resolves through the `mcp` distribution and the split-out package arrives transitively, so declaring it would pin a second copy of the same models.
- `pydantic>=2` unchanged — still imported directly for the elicitation response schema.

Explicitly **not** in scope: no 2.x feature adoption (middleware, extensions, caching, `custom_route`, streamable-HTTP), no change to the thin-wrapper architecture, the `_run_comfy` passthrough contract, or the spend-consent design.

## Motivation

`mcp.server.fastmcp` no longer exists on the 2.x line, and `mcp.server.mcpserver` does not exist on the 1.x line — the two are mutually exclusive across the major boundary, so the code and the version range have to move together. Verified in two throwaway environments rather than assumed:

| Environment | `import mcp.server.mcpserver` | `import mcp.server.fastmcp` |
|---|---|---|
| `mcp 1.29.0` (latest 1.x) | `ModuleNotFoundError` | ✅ resolves |
| `mcp 2.0.0` | ✅ resolves | `ModuleNotFoundError` |

That is also why the floor is a hard `>=2` and not a wider range: there is no version of the SDK where both imports work, so no compatibility shim is possible without a `try/except ImportError` the repo does not want.

## Testing

Fresh resolve on **both CI legs**, confirming the 2.x SDK is what actually got installed (`mcp 2.0.0` + `mcp-types 2.0.0` in `uv pip list` on each):

| Leg | pytest | `ruff check` | `ruff format --check` |
|---|---|---|---|
| Python 3.14.6 | 904 passed, 2 skipped | clean | clean |
| Python 3.10.20 | 904 passed, 2 skipped | clean | clean |

(The 2 skips are the `e2e` tests, which self-skip without a live ComfyUI.)

- [x] Existing tests pass (`pytest`)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually (below)

**Manual: a live in-memory 2.0.0 client↔server session against the real server module.** Unit tests drive the consent path through fakes, which by construction cannot tell you whether a *real* 2.x client's capability advertisement still satisfies the server's probe. So the session was stood up for real (`mcp.shared.memory` streams + a real `ClientSession` + the real low-level server) and the money path exercised end to end:

- Handshake: server name and instructions ride the initialize result; **42 tools** list over the wire.
- Wire format unchanged: the serialized tool still carries the JSON key `inputSchema`; only the Python attribute is now `input_schema`. `ctx` stays out of the public input schema.
- Spend interlock, all four branches: **accept** → prompt raised, `--yes` forwarded to comfy-cli; **decline** → refused, nothing spent; **cancel** → refused, nothing spent; **client with no elicitation capability** → no prompt raised and no `--yes` forwarded, so comfy-cli's own gate holds. The `_require_spend_gate` fail-closed refusal also still fires ahead of all of this when comfy-cli predates the gate.

## Additional Notes

**Riskiest line, and why it is safe.** Not the import — it is the *unchanged* `from mcp import types` feeding the elicitation capability probe in `_client_elicitation_support` (`server.py`). That probe builds a `types.ClientCapabilities(elicitation=types.ElicitationCapability())` and hands it to `ServerSession.check_client_capability`. If `mcp.types` on 2.x re-exported *look-alike* classes rather than the identical ones the SDK compares against, the probe would quietly return `False`, the spend prompt would silently never fire, and a `confirm_spend=True` call would spend credits with no human in the loop — the exact outcome that interlock exists to prevent, and a failure no fake-based unit test can see. Checked both ways: class identity is `True`, and the live session above confirms a real 2.x client's advertisement still resolves to a raised prompt.

**Judgment call — `mimeType` was not in the migration plan.** The plan called out `inputSchema` only; `content.mimeType` is the same class of rename and surfaced only by actually running the suite (2 failures in `test_wrapper.py`). Fixed the same way. I then swept the whole repo for every other camelCase protocol attribute (`isError`, `structuredContent`, `nextCursor`, `outputSchema`, `uriTemplate`, `serverInfo`, …) and for any `.someCamelCase` attribute access at all — the only remaining hits are stdlib `logging` (`removeHandler`, `maxBytes`, `backupCount`, `baseFilename`), which are unaffected.

**Judgment call — the spend-interlock suites.** `test_partner_generate.py` / `test_run_template.py` pass with **every assertion byte-for-byte unmodified** (121 passed). The only edit in those two files is three words of docstring prose (`FastMCP` → `MCPServer`), so that the repo does not ship references to a class that no longer exists. If you would rather those two files be literally untouched, say so and I will revert those three words — no assertion, fixture, or behavior depends on them.

**Judgment call — no lockfile regeneration.** The migration plan asked for a `uv lock` regen "(repo has `uv.lock`)". It does not: `uv.lock` is **gitignored** here, and `AGENTS.md` says so explicitly — comfy-cli bundles `uv` and can drop a stray `uv.lock` into the working directory, and that file is deliberately not ours. CI installs via `pip install -e '.[dev]'` and resolves fresh. So there is no lockfile to regenerate and none was added; adding one would contradict a documented repo convention. This is the one instruction from the plan not carried out, and it is a no-op rather than a gap.

**One surviving `fastmcp` string, on purpose.** `grep -ri fastmcp src/ tests/` is empty. The name still appears once in the `pyproject.toml` dependency comment, where it names the deleted module as the reason the floor is 2 — removing it would make the rationale unreadable.
