### PR TITLE
fix(emit_partner_workflow): gate on a comfy-cli that actually has --emit-workflow

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -4264,6 +4264,77 @@ async def partner_generate(
 # deadline would be a dial with nothing behind it.
 _EMIT_WORKFLOW_TIMEOUT = 120.0
 
+# Whether the installed comfy-cli's `comfy generate` recognises `--emit-workflow`
+# as a run-level flag, established once per process by
+# `_require_emit_workflow_capability`. Latched only on a positive result — same
+# posture as `_spend_gate_probed`: a probe that fails for a transient reason
+# (a hung binary, a bad spawn) must not wedge the tool for the life of the
+# process.
+_emit_workflow_capability_probed = False
+
+
+def _require_emit_workflow_capability() -> None:
+    """Refuse ``emit_partner_workflow`` unless this comfy-cli actually has ``--emit-workflow``.
+
+    ``emit_partner_workflow``'s whole safety claim is that ``comfy generate
+    <model> --emit-workflow <path>`` returns before any partner-proxy call, so it
+    deliberately skips :func:`_require_spend_gate` — spending nothing means there
+    is nothing to gate. That is true only if the INSTALLED comfy-cli recognises
+    ``--emit-workflow`` as a run-level flag at all. ``comfy generate`` is
+    registered with Click's ``ignore_unknown_options``/``allow_extra_args``, so on
+    a comfy-cli that predates the flag it is instead forwarded as a MODEL
+    PARAMETER and the real, spending proxy call runs — silently, from a tool
+    whose contract says it spends nothing and which therefore never raises the
+    per-call consent prompt :func:`partner_generate` does.
+
+    :data:`_MIN_COMFY_CLI` is the release that added the SPEND GATE, not
+    necessarily the release that added ``--emit-workflow`` (they are unrelated
+    features that happened to land in the same command), and
+    :func:`_check_comfy_version` fails OPEN on a ``--version`` it cannot read (a
+    fork, a source build) — so neither the floor nor the version guard can PROVE
+    the flag exists. This probe can.
+
+    The probe runs ``comfy generate --help`` — no model, no params — and checks
+    its printed usage for ``--emit-workflow``. That specific invocation is safe
+    on ANY comfy-cli, capable or not: with no target positional, ``comfy
+    generate``'s own entry point takes the built-in "print help and exit" branch
+    before it ever reaches model dispatch or the meta-flag/param split that would
+    treat an unrecognised flag as a proxy call. Probing with the real
+    ``--emit-workflow`` flag against a live model, by contrast, would on an
+    incapable install BE the unguarded spending call this function exists to
+    prevent — so this deliberately does not do that.
+
+    Fails CLOSED, like :func:`_require_spend_gate` and unlike
+    :func:`_check_comfy_version`: the cost of guessing wrong here is the user's
+    money, not an error message.
+    """
+    global _emit_workflow_capability_probed
+    if _emit_workflow_capability_probed:
+        return
+    try:
+        _, stdout, _, returncode, _ = _run_comfy_raw("generate", "--help", timeout=30.0)
+    # Broad on purpose, exactly like `_require_spend_gate`: the probe must fail
+    # CLOSED with THIS explanation, not leak a raw OSError/UnicodeDecodeError
+    # from a present-but-unusable binary.
+    except Exception as exc:
+        raise ComfyCliError(
+            "could not confirm this comfy-cli's `comfy generate` supports "
+            "`--emit-workflow` — refusing emit_partner_workflow rather than risk "
+            "a comfy-cli without the flag silently running a real, spending "
+            f"partner generation. (probe: {exc})"
+        ) from exc
+    if returncode != 0 or "--emit-workflow" not in stdout:
+        raise ComfyCliError(
+            "this comfy-cli's `comfy generate` does not recognise "
+            "`--emit-workflow`, so emit_partner_workflow would forward it as a "
+            "MODEL PARAMETER instead of the run-level flag it needs to be — "
+            "running a real, spending partner generation with no consent "
+            "interlock. Upgrade comfy-cli (`pip install --upgrade "
+            f"'comfy-cli>={_MIN_COMFY_CLI_STR}'`) to a release with "
+            "`--emit-workflow`, or use partner_generate if you intend to spend."
+        )
+    _emit_workflow_capability_probed = True
+
 
 @mcp.tool()
 async def emit_partner_workflow(
@@ -4332,6 +4403,13 @@ async def emit_partner_workflow(
     exist. RUNNING the emitted graph can still spend — a partner API node bills
     the user's Comfy account when it executes — so the spend happens at
     ``run_workflow`` time, under that tool's own posture, not here.
+
+    That "spends nothing" claim holds only on a comfy-cli that actually
+    recognises ``--emit-workflow`` as a flag — see
+    :func:`_require_emit_workflow_capability`, which this checks (once per
+    process) before ever building the call, and which raises rather than fall
+    through to a comfy-cli that would silently treat it as a model parameter
+    and run a real, spending generation instead.
     """
     _validate_generate_model(model)
     if not out_path:
@@ -4359,6 +4437,11 @@ async def emit_partner_workflow(
         # `--flag=value` so a path beginning with `-` stays the value.
         f"--emit-workflow={out_path}",
     ]
+    # Prove the installed comfy-cli actually treats `--emit-workflow` as a
+    # run-level flag BEFORE running the call above — on a comfy-cli that does
+    # not, this exact argv would instead run a real, spending proxy generation.
+    # See `_require_emit_workflow_capability`.
+    await asyncio.to_thread(_require_emit_workflow_capability)
     # No `plain_ok`: `generate emit-workflow` DOES emit an `envelope/1` (unlike
     # the proxy path this shares a verb with), so the normal contract applies —
     # `data` on success, and a failure raises with comfy-cli's structured

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,9 @@ the comfy-cli spawn to emit canned envelopes and assert the exact argv — a str
 `comfy --version` call would consume that stub and pollute those assertions. So
 by default we mark the guard "already checked" for every test; the dedicated
 guard tests (`test_wrapper.py`) re-enable it explicitly and mock `--version`.
-``partner_generate``'s spend-gate probe is a second such once-per-process
-shell-out and is neutralized the same way.
+``partner_generate``'s spend-gate probe and ``emit_partner_workflow``'s
+capability probe are two more such once-per-process shell-outs, each
+neutralized the same way.
 
 This module also holds the shared test helpers for both comfy-cli spawn paths,
 so a change to how ``server`` shells out lands in ONE fake rather than in a
@@ -57,6 +58,19 @@ def _skip_spend_gate_probe(monkeypatch):
     The dedicated probe tests (`test_partner_generate.py`) re-enable it.
     """
     monkeypatch.setattr(server, "_spend_gate_probed", True)
+
+
+@pytest.fixture(autouse=True)
+def _skip_emit_workflow_capability_probe(monkeypatch):
+    """Neutralize ``emit_partner_workflow``'s once-per-process capability probe.
+
+    Same reason as the spend-gate probe above: it shells out to ``comfy
+    generate --help`` before the first emit call, which would consume the
+    stubbed spawn and shift every exact-argv assertion in the emit-workflow
+    tests. The dedicated probe tests (`test_emit_partner_workflow.py`) restore
+    it explicitly.
+    """
+    monkeypatch.setattr(server, "_emit_workflow_capability_probed", True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_emit_partner_workflow.py
+++ b/tests/test_emit_partner_workflow.py
@@ -16,6 +16,9 @@ ComfyUI. What the wrapper is responsible for, and what these lock in:
    ``--emit-workflow`` DOES emit an ``envelope/1``, so ``data`` comes back
    structured and a failure surfaces comfy-cli's ``emit_workflow_failed``
    message intact, supported-model list and all.
+5. The capability gate — this tool's "spends nothing" claim only holds on a
+   comfy-cli that actually recognises ``--emit-workflow`` as a flag, so it must
+   REFUSE (not silently run a spending proxy call) against one that does not.
 
 comfy-cli is mocked throughout: nothing here runs a real CLI or writes a graph.
 """
@@ -23,6 +26,7 @@ comfy-cli is mocked throughout: nothing here runs a real CLI or writes a graph.
 from __future__ import annotations
 
 import asyncio
+import json
 
 import pytest
 from conftest import envelope
@@ -264,6 +268,103 @@ def test_emit_takes_no_confirm_spend_argument():
 
     assert "confirm_spend" not in tool.parameters["properties"]
     assert set(tool.parameters["required"]) == {"model", "out_path"}
+
+
+# --- comfy-cli must actually support --emit-workflow (BE-4971) -------------
+#
+# `emit_partner_workflow`'s whole safety claim is that `--emit-workflow`
+# returns before any partner-proxy call, so it deliberately skips the spend
+# gate above. That is true only on a comfy-cli that recognises the flag —
+# `comfy generate` is registered with Click's `ignore_unknown_options` /
+# `allow_extra_args`, so on an older install `--emit-workflow` is instead
+# forwarded as a MODEL PARAMETER and a real, spending proxy call runs. These
+# lock in the capability probe that stands between this tool and that outcome.
+
+
+def test_emit_refuses_when_comfy_cli_lacks_the_emit_workflow_flag(
+    monkeypatch, patched_run
+):
+    """No `--emit-workflow` in `comfy generate --help` -> refuse, never run.
+
+    This is the regression the ticket is about: on an incapable comfy-cli, the
+    argv this tool builds would run a real, spending partner generation with no
+    consent interlock — from a tool whose contract says it spends nothing and
+    so raises no prompt. Refusing is what stands in for the missing prompt.
+    """
+    monkeypatch.setattr(server, "_emit_workflow_capability_probed", False)
+    # An older comfy-cli's `generate --help` text never mentions the flag.
+    calls = patched_run(
+        "comfy generate — call ComfyUI partner nodes\n\n"
+        "Usage:\n"
+        "  comfy generate <model> [--<param> value]... [--download PATH] [--yes]\n"
+    )
+
+    with pytest.raises(server.ComfyCliError, match="does not recognise"):
+        _emit("flux-pro", "/tmp/flux.json", params={"prompt": "a cat"})
+
+    assert len(calls) == 1  # only the probe ran — never the spending call
+    assert calls[0]["cmd"][4:] == ["generate", "--help"]
+    assert server._emit_workflow_capability_probed is False  # not latched
+
+
+def test_emit_capability_probe_uses_generate_help_not_a_real_emit_call(
+    monkeypatch, patched_run
+):
+    """The probe itself must not be the spending call it exists to prevent.
+
+    Probing with a real `comfy generate <model> --emit-workflow <path>` would,
+    on the exact incapable install this guards against, BE an unguarded
+    spending call — reproducing the hazard instead of catching it. The probe
+    argv must carry no model and no `--emit-workflow`.
+    """
+    monkeypatch.setattr(server, "_emit_workflow_capability_probed", False)
+    calls = patched_run("--emit-workflow")
+
+    server._require_emit_workflow_capability()
+
+    assert len(calls) == 1
+    probe_argv = calls[0]["cmd"][4:]
+    assert probe_argv == ["generate", "--help"]
+    assert "flux-pro" not in probe_argv
+
+
+def test_emit_capability_probe_failure_is_not_latched(monkeypatch, patched_run):
+    """A probe that cannot even run fails CLOSED, and does not wedge the process.
+
+    Mirrors `_require_spend_gate`'s posture: a transient spawn failure must not
+    be latched as "no capability" forever, so a later, healthy call can still
+    succeed.
+    """
+    monkeypatch.setattr(server, "_emit_workflow_capability_probed", False)
+    patched_run(raises=OSError("no such file or directory: comfy"))
+
+    with pytest.raises(server.ComfyCliError, match="could not confirm"):
+        _emit("flux-pro", "/tmp/flux.json")
+
+    assert server._emit_workflow_capability_probed is False
+
+
+def test_emit_probes_the_capability_once_then_emits(monkeypatch, patched_run):
+    """A CLI that HAS the flag is probed once; every later emit call skips it."""
+    monkeypatch.setattr(server, "_emit_workflow_capability_probed", False)
+    # One canned stdout that answers BOTH calls the fake cannot tell apart: a
+    # help line carrying the flag (what the probe greps for), followed by the
+    # envelope the real emit call parses — `_last_json_object` keeps the last
+    # JSON line on stdout and ignores the leading prose ahead of it.
+    calls = patched_run(
+        '  comfy generate flux-pro --prompt "a fox" --emit-workflow flux.json\n'
+        + json.dumps(envelope(data=_EMIT_DATA))
+    )
+
+    _emit("flux-pro", "/tmp/flux.json")
+    _emit("flux-pro", "/tmp/flux.json")
+
+    assert [c["cmd"][4:6] for c in calls] == [
+        ["generate", "--help"],  # probed once...
+        ["generate", "flux-pro"],
+        ["generate", "flux-pro"],  # ...not again on the second call
+    ]
+    assert server._emit_workflow_capability_probed is True
 
 
 # --- result contract (emit-workflow DOES emit an envelope) ------------------


### PR DESCRIPTION
## ELI-5

`emit_partner_workflow` writes a runnable ComfyUI graph instead of calling a paid partner API, and its whole "spends nothing" promise rests on the installed `comfy` CLI actually recognizing the `--emit-workflow` flag it passes. If the CLI is old enough not to know that flag, `comfy generate` silently treats it as just another model input and runs the real, paid generation instead — with no heads-up, because this tool's contract says it never needs one. This PR adds a one-time, read-only check (`comfy generate --help`) before the tool ever builds that call, so an install that can't back the "spends nothing" promise gets a clear refusal instead of a surprise charge.

## Summary

Adds a capability gate to `emit_partner_workflow` so it refuses to run against a comfy-cli that does not actually support `--emit-workflow`, instead of silently letting the flag fall through as a model parameter and triggering a real, spending partner generation.

## Changes

- New `_require_emit_workflow_capability()` in `server.py`, mirroring `_require_spend_gate`'s shape: memoized in a module global (`_emit_workflow_capability_probed`), latched only on success, fails CLOSED.
- The probe runs `comfy generate --help` (no model, no params) and checks the printed usage text for `--emit-workflow`. That specific invocation never reaches model dispatch or the meta-flag/param split, so it cannot itself be the unguarded spending call it exists to prevent — unlike probing with the real flag against a live model would be on an incapable install.
- `emit_partner_workflow` now calls this (once per process, off the event loop via `asyncio.to_thread`) right before it runs the built `comfy generate <model> ... --emit-workflow=<path>` call.
- Tests in `tests/test_emit_partner_workflow.py`: refuses and never spends when the flag is absent from `--help`, the probe itself uses no model/flag (so it can't be the hazard), a probe spawn failure fails closed without latching, and a capable CLI is probed once then skipped on subsequent calls.
- `tests/conftest.py` gets an autouse fixture neutralizing the new probe by default (matching the existing `_spend_gate_probed` pattern), so the rest of the emit-workflow test suite's exact-argv assertions are unaffected.

## Motivation

Deferred from a review thread on #113 (https://github.com/Comfy-Org/comfy-local-mcp/pull/113#discussion_r3669581732): `emit_partner_workflow` deliberately skips `_require_spend_gate` because `--emit-workflow` returns before any partner-proxy call. That's only true if the INSTALLED comfy-cli recognizes the flag — `comfy generate` is registered with Click's `ignore_unknown_options`/`allow_extra_args`, so on a comfy-cli that predates the flag it is forwarded as a model parameter and the real proxy generation runs. The server's version floor (`_MIN_COMFY_CLI = 1.13.0`) is the release that added the spend gate, not necessarily the release that added `--emit-workflow`, and `_check_comfy_version` fails OPEN on a `--version` it cannot read (a fork, a source build) — so neither can prove the flag exists. This is reachable today specifically when a user has set comfy-cli's durable always-proceed (`comfy generate consent always`), which skips the interlock that would otherwise fail closed.

I checked the first part of the ticket's proposed fix — which release actually shipped `--emit-workflow` — against a local clone of `Comfy-Org/comfy-cli`'s real history: the flag was added in the same commit that introduced the whole agent-CLI feature set, tagged `v1.11.0`, well before the spend-gate commit that will ship as `1.13.0`. So any install that passes the *existing* version floor already has the flag — the only real gap is exactly the fail-open case the ticket calls out (an unparseable `--version`, a fork, a source build), which a numeric floor bump can't close. That's why this ships the capability probe (the ticket's preferred option) rather than a version assertion.

## Testing

- [x] Existing tests pass (`pytest` — 995 passed, 3 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually (describe below)

Manual verification against real comfy-cli builds (not just mocks), since this PR's whole point is a live-CLI safety property:

- Built a throwaway venv from a local clone of `Comfy-Org/comfy-cli` at HEAD (current, has `--emit-workflow`) and confirmed `comfy --json --where local generate --help` exits 0 and includes `--emit-workflow` in its output, with no ANSI codes and the flag token intact (not word-wrapped).
- Built a second venv from the exact parent commit of the one that introduced `--emit-workflow` (a genuine pre-flag comfy-cli, from the real repo history) and confirmed its `generate --help` output does NOT mention `--emit-workflow` — the probe correctly identifies this as incapable. (That old build also predates the `--json`/`--where` global flags, so the full server invocation fails even earlier with a non-zero exit — the probe's `returncode != 0` branch catches that too, so it still fails closed.)

## Additional Notes

- The probe is a substring check on Rich-rendered help prose rather than a structured flag list (comfy-cli exposes no "list recognized flags" command), so it's a heuristic tied to the current wording of `_print_top_help()`. If that text is ever reworded to drop the literal `--emit-workflow` example while the flag still works, the probe would false-negative — failing CLOSED (blocking a capable install) rather than open, which is the correct direction for a spend-safety check but worth knowing about.
- Did not bump `_MIN_COMFY_CLI` / add a second version constant, per the ticket's own reasoning: `--emit-workflow` shipped before the release that will become the spend-gate floor, so a numeric floor can't close the actual gap (fail-open forks/source builds) that a runtime probe can.
- No Linear ticket reference in this PR per the repo's destined-public hygiene guardrail (`AGENTS.md`); this was sourced from a deferred review thread on #113, linked above.
