### PR TITLE
docs(search_models): document cross-folder query search + per-mode response shapes

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -6530,12 +6530,27 @@ def search_models(query: str = "", folder: str = "") -> Any:
 
     Thin passthrough with three modes, in precedence order:
 
-    - ``query`` given → ``comfy models search --text <query>`` (match model
-      filenames). ``--text`` is required: comfy-cli's ``search`` takes the query
-      as an option, not a positional (a positional exits 2 with a usage error).
+    - ``query`` given → ``comfy models search --text <query>`` — a
+      case-insensitive substring match on model FILENAMES across ALL local
+      model folders (``checkpoints``, ``diffusion_models``, ``loras``, ``vae``,
+      …), so a LoRA or VAE is findable by name without knowing its folder.
+      ``--text`` is required: comfy-cli's ``search`` takes the query as an
+      option, not a positional (a positional exits 2 with a usage error).
+      The cross-folder walk needs a comfy-cli release NEWER than v1.13.0 — the
+      fix landed in Comfy-Org/comfy-cli#603, after v1.13.0 was cut. On v1.13.0
+      and older this mode searches ``checkpoints`` only, and anything outside
+      that folder is reachable via ``folder`` mode below.
     - else ``folder`` given → ``comfy models list-folder <folder>`` (list one
       model folder, e.g. ``checkpoints``, ``loras``).
     - else (both empty) → ``comfy models list-folders`` (list the folder names).
+
+    RESPONSE SHAPE DIFFERS BY MODE — this split is by design in comfy-cli, not a
+    bug, so parse per mode: ``query`` returns the cloud-asset row projection
+    ``{mode, filters, total, shown, rows: [{name, type, tags, ...}]}`` (on local
+    ``type``/``tags`` carry the source folder and the enrichment fields are
+    ``null``), while ``folder`` returns the raw listing ``{mode, url, folder,
+    total, shown, files: [{name, pathIndex}]}``. Model names live under ``rows``
+    for a query and under ``files`` for a folder.
 
     LOCAL DEGRADATION: unlike the cloud catalog, this returns only what is on
     disk — filenames, with no enrichment (no base-model / hash / description /


### PR DESCRIPTION
## ELI-5

`search_models(query=...)` used to say only "match model filenames". It didn't say *where* it looks. comfy-cli just fixed its local search so it walks **every** model folder instead of only `checkpoints` — so a LoRA or VAE is now findable by name. This PR updates the docstring to say that, names the comfy-cli release you need for it, and spells out that the two modes return **different-shaped** JSON (`rows` vs `files`) so an agent reading the tool output parses the right key. Docstring only — no code changed.

## Summary

Truth-up the `search_models` tool docstring in `src/comfy_local_mcp/server.py` after comfy-cli's cross-folder local-search fix (Comfy-Org/comfy-cli#603). The passthrough argv (`models search --text <query>`) was already correct and is unchanged.

## Changes

- **Query mode**: now documented as a case-insensitive substring match on model filenames **across all local model folders** (`checkpoints`, `diffusion_models`, `loras`, `vae`, …), with the release boundary it requires and the fallback path on older releases.
- **Response shapes**: new paragraph documenting the intentional per-mode split — `query` returns the cloud-asset row projection `{mode, filters, total, shown, rows: [{name, type, tags, ...}]}` (on local, `type`/`tags` carry the source folder and the enrichment fields are `null`); `folder` returns the raw listing `{mode, url, folder, total, shown, files: [{name, pathIndex}]}`. Stated explicitly as by-design in comfy-cli, not a bug.
- **LOCAL DEGRADATION** paragraph kept verbatim — it remains accurate.

## Motivation

The tool docstring is the description MCP clients hand to agents, so an understated one directly costs recall: an agent told only "match model filenames" has no way to know the query used to be scoped to `checkpoints`, and no way to know the two modes key their results differently. Both are now stated.

## Testing

- [x] Existing tests pass (`pytest`) — **1007 passed, 3 skipped**
- [x] Lint passes (`ruff check .`) — **All checks passed!**
- [x] Format check passes (`ruff format --check .`) — **33 files already formatted**

Run against `ruff 0.16.0` (the floor `pyproject.toml` declares, `ruff>=0.16,<0.17`) via `uvx ruff@0.16.0`; the ambient venv carries 0.15.20, which reports 7 pre-existing `BLE001` findings that 0.16 deliberately narrowed away — exactly the version skew the `pyproject.toml` comment above the pin describes.

## Additional Notes

### Judgment call: the version boundary is **v1.13.0**, not the ticket's suggested "1.12.x"

The plan said to name the release once cut, and otherwise fall back to "comfy-cli newer than 1.12.x". That fallback would be **wrong today**: `v1.13.0` was cut 2026-07-28, and the fix (#603) merged 2026-07-29 — *after* it. A reader on `v1.13.0` satisfies "newer than 1.12.x" but does **not** have cross-folder search. So the docstring says **newer than v1.13.0** and cites the PR. Verified directly:

- `gh release list -R Comfy-Org/comfy-cli` → latest release is `v1.13.0` (2026-07-28); no release contains #603 yet.
- `git show v1.13.0:comfy_cli/command/models/search.py` → `_local_search` still hardcodes `folder = "checkpoints"` when no `--type` is given. Same at `v1.12.0`.
- `origin/main` (997fda5, the #603 merge) → `_local_search` walks `_local_folder_names(target)`.

This phrasing also stays correct once a release is cut, since any such release is by definition newer than `v1.13.0`.

Worth flagging for reviewers: this server *enforces* a comfy-cli floor of `>= 1.13.0` (`_MIN_COMFY_CLI`), so the minimum-supported install is precisely the one that still gets checkpoints-only search. The caveat is load-bearing, not hypothetical.

### Shape keys: `mode` / `url` included beyond the plan's enumeration

The plan enumerated `{filters, total, shown, rows}` and `{folder, total, shown, files}`. comfy-cli's actual payloads also carry `mode` on both and `url` on the folder listing (`search.py` lines 333–339 and 613–617 on `origin/main`), and `_run_comfy` returns the envelope's `data` verbatim, so those keys do reach the caller. Documented them rather than shipping a knowingly-partial shape.

### Negative-claim falsification (self-review clause (e))

The diff carries a capability caveat ("on v1.13.0 and older this mode searches `checkpoints` only"), so it gets the falsification pass:

- **The limitation is real, not assumed** — confirmed by reading the released tag's source, not by inference: `v1.13.0` and `v1.12.0` both hardcode `folder = "checkpoints"`.
- **It is not a dead-end.** The docstring names a working path rather than denying the capability: `folder` mode (`comfy models list-folder <folder>`) reaches every other folder on every supported release, and comfy-cli's `--type` scoping works there too. Nothing in this diff refuses, throws, or removes a capability — it is additive prose, and no test was flipped to assert a dead-end.
- **Limit of the evidence, stated honestly:** a live end-to-end run was not possible on this machine — the `comfy` binary is not installed and no local ComfyUI is listening on `:8188`. The falsification here is source-level against the exact released tags plus the merged upstream PR, which settles the version claim conclusively; the behavioral claims about `rows`/`files` shapes are likewise read from comfy-cli's emit sites.

### Deliberate scope call

`README.md:609`'s one-line table entry for `search_models` ("List/search model files on disk. **Local:** filenames only, no cloud enrichment.") is left untouched — it is still accurate, and the ticket scoped this to the docstring. Flagging it in case a reviewer would rather see the cross-folder detail mirrored there too.

### Acceptance criteria

All met. No criterion was skipped or partially delivered.
