### PR TITLE
docs(security): document the threat model in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,38 @@ If you discover a security vulnerability in this project, **please report it res
 
 We will keep you informed of our progress throughout the process. If the issue is accepted, we will coordinate disclosure with you and credit you in the advisory (unless you prefer to remain anonymous).
 
+## Threat model
+
+This section says what this server assumes, what it deliberately allows, and what it actually defends — so a reader can tell a real bug from working-as-intended. The short version: this is a thin wrapper that lets an agent drive a ComfyUI install running as you, on your machine. It is **not** a sandbox, and it does not try to be one. The interesting question is therefore not "can the agent touch my files" (it can) but "can a malicious *input* make the wrapper do something the agent was never given permission to do" — and that is what the guards below are for.
+
+### Trust boundaries
+
+**Trusted: the host environment and the MCP client registration.** `COMFY_BIN` (resolved on the `PATH` through `shutil.which`), `COMFYUI_URL` / `COMFYUI_HOST` / `COMFYUI_PORT` (see `_comfy_target`), and `COMFY_API_KEY` are read from the environment the user configured in their MCP client *before* the server starts. No tool can change any of them at runtime. An attacker who can set this process's environment — or edit the MCP client's config file — can already run arbitrary code as the user, so a malicious `COMFY_BIN` is **outside** this threat model: the server intentionally does not try to authenticate the binary it was told to run. It only checks that the binary exists, is readable, and is new enough (`_require_comfy_bin`, `_check_comfy_version`).
+
+**Trusted: the local install.** comfy-cli, ComfyUI, and whatever custom nodes and models the user chose to install all run with the user's own privileges. This server is a wrapper over that install, not a sandbox around it.
+
+**Semi-trusted: the agent / MCP client driving the tools.** Tool *inputs* are treated as adversarial — the working assumption is a prompt-injected agent. That assumption is what the argument guards (`_reject_nul`, `_reject_option_like`, `_guard_prompt_id`, `_guard_download_id`) and the consent gates exist for.
+
+**Untrusted: content.** Workflow JSON files, registry and template metadata, workflow note text (`list_workflow_notes` — the README already says to treat it as data, not as instructions), and strings inside comfy-cli's result envelopes.
+
+### What a compromised agent can do — by design
+
+These are accepted capabilities, not defects. A prompt-injected agent holding this server's tools can do all of the following, mediated only by the agent host's own tool-permission UX:
+
+- **Read and write files as the user.** `run_workflow(workflow_path)` and `validate_workflow(workflow_path)` read a path you name; `upload_file(paths)` copies any user-readable file into ComfyUI's `input` directory; `fetch_outputs(out_dir)`, `fetch_template(out_path)`, and `emit_partner_workflow(out_path)` write to a path you name. Paths are forwarded to comfy-cli verbatim once they pass the input-hygiene guards. The server does not sandbox the filesystem.
+- **Execute arbitrary workflows.** A workflow is a program. With custom nodes installed, running one is arbitrary code execution inside the local ComfyUI's trust domain.
+- **Control the ComfyUI lifecycle.** `launch_comfyui`, `stop_comfyui`, `restart_comfyui`, and `update_comfyui` start, stop, and mutate the install (`update_comfyui` runs a `git pull` plus a dependency reinstall). Note that `launch_comfyui(extra_args)` and `restart_comfyui(extra_args)` forward their arguments to ComfyUI **verbatim** after a `--` separator — including `--listen`, which exposes the unauthenticated ComfyUI API to the network.
+- **Cause a local denial of service.** A workflow that passes every validation layer can still request an impossible total allocation and get the local ComfyUI process OOM-killed mid-run; this is documented in `run_workflow`'s `CAUTION` block.
+
+### What this server defends against
+
+- **Shell injection — structurally absent.** Every spawn is an argv list: `_run_comfy_raw` (`subprocess.Popen`), `_run_comfy_streaming` and `_start_login` (`asyncio.create_subprocess_exec`), and the `comfy --version` probe `_spawn_comfy_version`. `shell=True` appears nowhere in the repository. The three sites that run a real subcommand also pass `stdin=DEVNULL`, so a child can never read JSON-RPC protocol bytes out from under the client on this stdio transport; the `--version` probe reads no input and is bounded by its own timeout.
+- **Argument and flag injection into comfy-cli.** Leading-dash positionals are rejected (`_reject_option_like` — e.g. `upload_file(paths=["--overwrite"])` is refused rather than silently becoming the overwrite flag), NUL bytes are rejected wherever they ride (`_reject_nul`), job and download handles are format-bounded (`_guard_prompt_id`, `_guard_download_id`), and `update_comfyui`'s `target` is validated against an allowlist so only the matched value — never the caller's raw string — reaches the command line.
+- **Silent credit spend.** `partner_generate` requires comfy-cli's spend interlock and fails **closed** if it cannot prove the interlock is installed (`_require_spend_gate`). On a client that can be prompted, the human is elicited per call and the agent's own `confirm_spend=True` grants nothing; `confirm_spend` is only the documented fallback for a client that cannot show a prompt. `run_template` applies the same gate on the narrower terms the engine uses for it.
+- **Silent destructive version switch.** `switch_comfyui_version` elicits the user on every call, and `confirm_switch=True` grants nothing on a client that can be prompted (`_resolve_switch_consent`). An unknown elicitation capability counts as *capable*, so a failed probe cannot demote a real client onto the caller's own say-so.
+- **Model downloads escaping the models tree.** `download_model(relative_path)` is lexically traversal-checked and must name the `models` directory or a subfolder of it — specifically so a download cannot land in `custom_nodes/`, which ComfyUI would execute on its next start. **Stated limitation:** that check is lexical, so it cannot see a symlink or junction that *already* exists inside the models tree; if `models/link` already points at `custom_nodes`, then `models/link/pwn` passes. Planting such a link already requires write access to the models tree.
+- **Resource exhaustion of the server itself.** Timeouts are bounded with hard ceilings (`_bounded_timeout`), output drains are capped to a trailing window (`_drain_capped_async`), a timeout kills the whole process tree rather than orphaning a `git pull` or a multi-GB transfer (`_kill_proc_tree`), and inline image previews are capped at 8 files / 16 MiB aggregate so a large batch cannot blow up a reply.
+
 ### What counts as a vulnerability
 
 This server is a thin wrapper that shells out to the local [`comfy-cli`](https://github.com/Comfy-Org/comfy-cli) binary. The most relevant classes here are:
@@ -38,7 +70,10 @@ This server is a thin wrapper that shells out to the local [`comfy-cli`](https:/
 
 ### Out of scope
 
-- Defects within third-party software itself (comfy-cli, ComfyUI, MCP clients) — please report those to the respective maintainers. Vulnerabilities in **this repository's integration logic** — e.g. how tool inputs are turned into `comfy` arguments, or how comfy-cli's responses are validated and handled — are in scope and should be reported here.
+- Defects within third-party software itself (comfy-cli, ComfyUI, custom nodes, MCP clients) — please report those to the respective maintainers. Vulnerabilities in **this repository's integration logic** — e.g. how tool inputs are turned into `comfy` arguments, or how comfy-cli's responses are validated and handled — are in scope and should be reported here.
+- An attacker who already controls this server's environment, the MCP client's configuration, or the machine's user account. Each of those already implies arbitrary code execution as the user (see "Trust boundaries" above).
+- Malicious custom nodes or models the user chose to install. Workflows execute in ComfyUI's trust domain, and this server does not sandbox them.
+- The agent host's own permission and consent UX. This server raises elicitation wherever it can, but it cannot force a client to render a prompt; the code treats "cannot prompt" as a distinct case with documented `confirm_*` fallbacks whose defaults are the safe ones.
 - Social engineering or phishing
 - Reports from automated scanners without a demonstrated exploit
 


### PR DESCRIPTION
## ELI-5

`SECURITY.md` used to only say *how to report a bug*. It never said *what this server actually lets an agent do*. That's a problem, because the first outside security reader will immediately ask: this thing runs a binary named by an environment variable, takes file paths from an AI agent, and executes workflow JSON — what happens if the agent goes rogue? This PR writes down the answer. The honest answer is that a prompt-injected agent can read and write your files and run arbitrary workflows, because this is a wrapper around your own ComfyUI, not a sandbox — and that's stated plainly instead of glossed over. What the server *does* defend is the narrower thing it can actually defend: a malicious *input* tricking the wrapper into doing something the agent was never granted. All of it was already written down as docstrings in `server.py`; this just surfaces it where a security reader looks.

## Summary

Adds a `## Threat model` section to `SECURITY.md`. Docs only — no code changes, no behavior change.

It sits between the reporting timeline and the existing scope subsections, and folds those subsections (`What counts as a vulnerability`, `Out of scope`) in as its closing parts, so the file reads reporting → threat model → what counts → out of scope, with no duplicated headings and no existing content dropped.

## Changes

- **Trust boundaries** — trusted (the host environment + MCP client registration; the local install), semi-trusted (the driving agent, whose *inputs* are treated as adversarial), untrusted (workflow JSON, registry/template metadata, note text, comfy-cli envelope strings). States explicitly that a malicious `COMFY_BIN` is out of scope: anyone who can set this process's environment can already run code as the user, so the server deliberately does not try to authenticate the binary it was told to run.
- **What a compromised agent can do — by design** — accepted capabilities, stated without hedging: file read/write as the user, arbitrary workflow execution inside ComfyUI's trust domain, lifecycle control (including `launch_comfyui`/`restart_comfyui` forwarding `extra_args` verbatim after `--`, `--listen` included), and local OOM denial of service.
- **What this server defends against** — argv-only spawns with no `shell=True`, argument/flag injection guards, the fail-closed spend interlock, the version-switch consent gate, the models-tree traversal check *with its stated symlink limitation*, and the resource-exhaustion bounds.
- **Out of scope** — extended with the environment/config/account attacker, user-installed custom nodes and models, and the agent host's own consent UX. The existing sentence keeping *this repo's integration logic* in scope is preserved verbatim (`custom nodes` added to its third-party list).

## Motivation

`SECURITY.md` was a reporting policy with no threat model, so there was no written basis for a reader to tell a real vulnerability from working-as-intended. That ambiguity cuts both ways: it invites noise reports about accepted capabilities, and it hides the genuinely interesting attack surface (input-driven argument injection, traversal, silent spend) behind the uninteresting one.

## Testing

- [x] Existing tests pass (`pytest`) — 1133 passed, 3 skipped
- [x] Lint passes (`ruff check .`) — all checks passed
- [x] Format check passes (`ruff format --check .`) — 35 files already formatted
- [x] Tested manually (described below)

Every claim in the new section was cross-checked against this branch's `server.py` before writing — the point of the exercise was that a threat model asserting something the code doesn't do is worse than no threat model. Manual verification was reading the cited symbols directly and grepping for the absolute claims (`shell=True` repo-wide, every `subprocess`/`create_subprocess_exec` spawn site, the preview cap constants, the `confirm_*` defaults).

**Toolchain note for whoever runs this locally:** the shared clone's `.venv` has **ruff 0.15.20**, but `pyproject.toml` pins `ruff>=0.16,<0.17` — and 0.15 misreads the explicit `[tool.ruff.lint] select` block, reporting **7 phantom `BLE001` errors** on files this PR doesn't touch. I reproduced those same 7 on a pristine `origin/main` checkout, confirming they're a toolchain-version artifact and not a regression. The green results above are from a fresh venv installed from this worktree with the pinned ruff 0.16.0. Worth fixing that venv separately.

## Additional Notes

**Judgment call — symbol names instead of line numbers.** The spec for this change cited claims positionally (`server.py:309`, `:7740`, …). I verified against every one of those, but wrote the published doc to cite **stable symbol names** (`_reject_option_like`, `_require_spend_gate`, `download_model`) instead. `server.py` is ~8,800 lines and moves fast — the spec itself noted the numbers would rot — and a public `SECURITY.md` full of stale line numbers is worse than one with none. Flagging it because it's a deliberate deviation from the letter of the plan, not an oversight.

**Two claims corrected during self-review**, both cases of my own draft overclaiming:

1. I first wrote *"children are spawned with `stdin=DEVNULL`"* as a blanket statement. There are **four** spawn sites, not three: `_spawn_comfy_version` (the `comfy --version` probe) also spawns, and it does **not** pass `stdin=DEVNULL`. The bullet now names all four, scopes the `stdin=DEVNULL` claim to the three that run a real subcommand, and notes the probe reads no input and is bounded by its own timeout. Harmless in practice, but a false absolute in a security doc is exactly what a reader would test first.
2. *"resolved once through `shutil.which`"* → `shutil.which(COMFY_BIN)` is called at three sites, so "once" was wrong; now just "resolved on the `PATH` through `shutil.which`".

**Checked for a `launch_comfyui` consent gate on current `main` — there is none.** The plan said to describe a consent gate *if* a companion hardening change had landed first. It hasn't: `launch_comfyui(extra_args)` still forwards verbatim after `--`. So this documents the current, ungated behavior, including the `--listen` network-exposure consequence. If that hardening lands later, this bullet needs updating in the same PR.

**Two additions beyond the plan, both for accuracy:** `restart_comfyui(extra_args)` forwards args identically to `launch_comfyui` (the plan named only the latter), and `run_template` shares the spend gate on the narrower terms the engine uses for it.

**Negative-claim falsification — trigger does not fire.** The self-review checklist requires empirically attempting any capability a diff denies. This diff denies none: it's descriptive prose that *affirms* capabilities (the whole middle section enumerates what an agent **can** do), adds no `not supported`/`unavailable`/`STOP` string, no throw or deny path, and flips no test to assert a dead-end. The `Out of scope` bullets are vulnerability-*report* triage scope — a policy section that already existed — not a claim that any product capability is unavailable to a user.
