### PR TITLE
docs(readme): lead with Quickstart and state the local/cloud scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@
 </p>
 
 <p>
-  <a href="#install"><strong>Install</strong></a> ·
-  <a href="#quickstart">Quickstart</a> ·
-  <a href="#tools">Tools</a> ·
+  <a href="#quickstart"><strong>Quickstart</strong></a> ·
   <a href="#configure-your-ai-client">Configure your client</a> ·
+  <a href="#tools">Tools</a> ·
   <a href="#contributing">Contributing</a>
 </p>
 
@@ -39,15 +38,154 @@
 - ♻️ **Manage ComfyUI** — launch / stop / restart the server, tail its logs, and stage input assets.
 
 Each tool shells out to the `comfy` command with `--where local --json`, parses comfy-cli's
-`envelope/1` output, and returns it. There is no HTTP client and **no code shared with the Comfy
-Cloud MCP** — comfy-cli is the engine.
+`envelope/1` output, and returns it — comfy-cli is the engine, and by default everything targets
+the ComfyUI on **your** machine (`127.0.0.1:8188`).
+
+**Scope — local-first, not local-only.** A few flows already reach beyond your machine:
+[`partner_generate`](#spending-credits-on-partner-models) runs hosted partner models
+(Flux / Ideogram / Kling / …) entirely on partner infrastructure — no local ComfyUI in the
+execution path — and [partner-API nodes](#partner-api-nodes) let a locally-executed workflow call
+those same hosted models, while [`COMFYUI_URL`](#driving-a-remote-comfyui) points the run/job tools
+at a ComfyUI on another machine you control. What this server is **not** is a Comfy Cloud client:
+it shares no code with the Comfy Cloud MCP and implements none of its cloud-native feature set. If
+your workflows live in Comfy Cloud, use that MCP — alongside this one if you like.
 
 > **Status:** beta. 49 tools; core loop validated end-to-end against a live local ComfyUI
 > (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on
 > Python 3.10 and 3.14.
 
+## Quickstart
+
+Four steps take you from a fresh install to your first generated image.
+
+1. **Install the pieces.**
+
+   ```bash
+   pip install 'comfy-cli>=1.13.0'  # the engine (>= 1.13.0 required)
+   comfy install                  # create a ComfyUI workspace (skip if you have one)
+   pip install .                  # this MCP server → the `comfy-local-mcp` command
+   ```
+
+   Run that last one from a checkout of this repo (`pip install -e .` for a working copy).
+   `pip install .` puts a `comfy-local-mcp` console script on your `PATH`; that command is what you
+   point your AI client at in step 3. (A dedicated venv is fine — MCP clients may not see that
+   venv's `PATH`, which is exactly what `COMFY_BIN` is for; see [Prerequisites](#prerequisites).)
+
+2. **Launch ComfyUI** and leave it running:
+
+   ```bash
+   comfy launch
+   ```
+
+3. **Add the server to your client** using the snippet for your client in
+   [Configure your AI client](#configure-your-ai-client) just below, then restart / reload it so
+   the tools appear.
+
+4. **Ask your agent to run a workflow.** For example:
+
+   > "Confirm my local ComfyUI is running, then run the workflow at
+   > `~/workflows/txt2img.json` and show me the image."
+
+   Under the hood the agent calls `server_info` to confirm ComfyUI is up, `run_workflow` to
+   execute your workflow JSON (API-format or a UI export), and `fetch_outputs` to collect the
+   result. No hand-authored workflow? Ask it to start from a template instead — it can
+   `search_templates`, `fetch_template` to write a runnable JSON, and run that — and
+   `fetch_template` tells it up front if [your install can't run that
+   template](#templates-your-install-cant-run) yet.
+
+**Where the images land.** ComfyUI writes generated files into your ComfyUI **workspace's
+`output/` directory** (part of the workspace `comfy install` created). On top of that,
+`fetch_outputs(prompt_id, out_dir)` **copies** a finished job's outputs into any directory you
+name — so telling the agent "save them to `./outputs`" puts a copy right where you asked while
+the originals stay in the ComfyUI workspace.
+
+## Configure your AI client
+
+All three clients speak the same MCP stdio contract: run the `comfy-local-mcp` command as a
+server. Pick your client.
+
+> The `COMFY_BIN` env entry is shown in every example. Drop it if `comfy` is already on the
+> environment your client launches the server with; keep it (pointing at the absolute path) if
+> it isn't. `COMFY_API_KEY` is also shown, commented as optional — keep it only if you use
+> [partner-API nodes](#partner-api-nodes) (Seedream / Veo / Kling / Gemini / …); drop it
+> otherwise.
+
+> **On macOS, keep ComfyUI out of `~/Documents`, `~/Desktop` and `~/Downloads`** — or grant your
+> client Full Disk Access. macOS blocks apps (and everything they launch) from reading those
+> folders, so an install there fails with `Operation not permitted` before anything runs. See
+> [Troubleshooting](#troubleshooting).
+
+### Claude Code
+
+One command registers the server:
+
+```bash
+# COMFY_API_KEY is optional — add it only if you use partner-API nodes
+# (see the Partner-API nodes section).
+claude mcp add comfy-local \
+  -e COMFY_BIN=/path/to/venv/bin/comfy \
+  -e COMFY_API_KEY=<your-comfy-api-key> \
+  -- comfy-local-mcp
+```
+
+Or, to check it into a project, add a `.mcp.json` at the repo root:
+
+```json
+{
+  "mcpServers": {
+    "comfy-local": {
+      "command": "comfy-local-mcp",
+      "env": {
+        "COMFY_BIN": "/path/to/venv/bin/comfy",
+        "COMFY_API_KEY": "<your-comfy-api-key>"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Edit `claude_desktop_config.json` (Settings → Developer → Edit Config; on macOS it lives at
+`~/Library/Application Support/Claude/claude_desktop_config.json`) and add the server, then
+restart Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "comfy-local": {
+      "command": "comfy-local-mcp",
+      "env": {
+        "COMFY_BIN": "/path/to/venv/bin/comfy",
+        "COMFY_API_KEY": "<your-comfy-api-key>"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+Add the server to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` in a project:
+
+```json
+{
+  "mcpServers": {
+    "comfy-local": {
+      "command": "comfy-local-mcp",
+      "env": {
+        "COMFY_BIN": "/path/to/venv/bin/comfy",
+        "COMFY_API_KEY": "<your-comfy-api-key>"
+      }
+    }
+  }
+}
+```
+
 ## Table of contents
 
+- [Quickstart](#quickstart)
+- [Configure your AI client](#configure-your-ai-client)
 - [Prerequisites](#prerequisites)
 - [When to use this server](#when-to-use-this-server)
 - [Using with local LLMs (VRAM coordination)](#using-with-local-llms-vram-coordination)
@@ -56,9 +194,6 @@ Cloud MCP** — comfy-cli is the engine.
 - [Templates your install can't run](#templates-your-install-cant-run)
 - [Driving a remote ComfyUI](#driving-a-remote-comfyui)
 - [Targeting a non-default ComfyUI address](#targeting-a-non-default-comfyui-address)
-- [Install](#install)
-- [Configure your AI client](#configure-your-ai-client)
-- [Quickstart](#quickstart)
 - [Tools](#tools)
 - [Troubleshooting](#troubleshooting)
 - [Failure log (opt-in)](#failure-log-opt-in)
@@ -100,8 +235,9 @@ Cloud MCP** — comfy-cli is the engine.
 - **`COMFY_BIN` override (optional).** By default the server calls `comfy` from `PATH`. MCP
   clients launch the server with their own environment, which often does **not** include your
   shell's `PATH` — so if `comfy` lives in a virtualenv or a non-standard location, set
-  `COMFY_BIN` to its absolute path (e.g. `/path/to/venv/bin/comfy`). Every client example below
-  shows where it goes. Setting it is sufficient on its own — you do **not** also have to put
+  `COMFY_BIN` to its absolute path (e.g. `/path/to/venv/bin/comfy`). Every example in
+  [Configure your AI client](#configure-your-ai-client) shows where it goes. Setting it is
+  sufficient on its own — you do **not** also have to put
   that directory on the client's `PATH`. The server prepends the resolved binary's directory to
   the `PATH` it hands comfy-cli, because some comfy-cli commands (notably the background
   `launch`) re-invoke `comfy` by name and have to be able to find themselves.
@@ -110,7 +246,8 @@ Cloud MCP** — comfy-cli is the engine.
   credential, and — exactly like `COMFY_BIN` — an MCP client launches the server with its own
   minimal environment, so a key from your shell won't reach it. Set `COMFY_API_KEY` in the
   client registration `env` block. See **[Partner-API nodes](#partner-api-nodes)** below for the
-  full precedence chain; every client example shows where it goes.
+  full precedence chain; every example in
+  [Configure your AI client](#configure-your-ai-client) shows where it goes.
 - **`COMFYUI_URL` / `COMFYUI_HOST` / `COMFYUI_PORT` (optional — drive a *remote* ComfyUI).** By
   default every tool targets the local `127.0.0.1:8188`. Set `COMFYUI_URL`
   (e.g. `http://gpu-box:8188`) — or the `COMFYUI_HOST` (+ optional `COMFYUI_PORT`, default `8188`)
@@ -198,7 +335,8 @@ Option 2 does not have to be typed into a terminal: the agent can call **`auth_l
 
 Because an MCP client spawns the server with its own minimal environment (the same reason
 `COMFY_BIN` exists), a `COMFY_API_KEY` from your interactive shell is **not** inherited — put it
-in the client registration `env` block (shown in every example below). If a run fails with
+in the client registration `env` block (shown in every
+[client example](#configure-your-ai-client)). If a run fails with
 `partner_node_requires_credential`, the error now carries comfy-cli's hint verbatim, including
 the `comfy auth set comfy-cloud-api-key --key …` fallback and the list of offending nodes; the
 server also retries a transient credential failure briefly before surfacing it.
@@ -405,140 +543,6 @@ effect, rather than the version alone.
 > `COMFYUI_URL` while every other verb followed `COMFY_LOCAL_URL`. For a non-default address on
 > *this* machine prefer `COMFY_LOCAL_URL` alone: it also covers the verbs that accept no
 > `--host`/`--port` (`comfy env`, templates, models, download), which `COMFYUI_URL` cannot reach.
-
-## Install
-
-From a checkout of this repo:
-
-```bash
-pip install .          # or `pip install -e .` for a working copy
-comfy-local-mcp        # serves the MCP over stdio
-```
-
-`pip install` puts a `comfy-local-mcp` console script on your `PATH`; that command is what you
-point your AI client at below. (Installing into a dedicated venv is fine — just remember MCP
-clients may not see that venv's `PATH`, which is exactly what `COMFY_BIN` is for.)
-
-## Configure your AI client
-
-All three clients speak the same MCP stdio contract: run the `comfy-local-mcp` command as a
-server. Pick your client.
-
-> The `COMFY_BIN` env entry is shown in every example. Drop it if `comfy` is already on the
-> environment your client launches the server with; keep it (pointing at the absolute path) if
-> it isn't. `COMFY_API_KEY` is also shown, commented as optional — keep it only if you use
-> [partner-API nodes](#partner-api-nodes) (Seedream / Veo / Kling / Gemini / …); drop it
-> otherwise.
-
-> **On macOS, keep ComfyUI out of `~/Documents`, `~/Desktop` and `~/Downloads`** — or grant your
-> client Full Disk Access. macOS blocks apps (and everything they launch) from reading those
-> folders, so an install there fails with `Operation not permitted` before anything runs. See
-> [Troubleshooting](#troubleshooting).
-
-### Claude Code
-
-One command registers the server:
-
-```bash
-# COMFY_API_KEY is optional — add it only if you use partner-API nodes (see above).
-claude mcp add comfy-local \
-  -e COMFY_BIN=/path/to/venv/bin/comfy \
-  -e COMFY_API_KEY=<your-comfy-api-key> \
-  -- comfy-local-mcp
-```
-
-Or, to check it into a project, add a `.mcp.json` at the repo root:
-
-```json
-{
-  "mcpServers": {
-    "comfy-local": {
-      "command": "comfy-local-mcp",
-      "env": {
-        "COMFY_BIN": "/path/to/venv/bin/comfy",
-        "COMFY_API_KEY": "<your-comfy-api-key>"
-      }
-    }
-  }
-}
-```
-
-### Claude Desktop
-
-Edit `claude_desktop_config.json` (Settings → Developer → Edit Config; on macOS it lives at
-`~/Library/Application Support/Claude/claude_desktop_config.json`) and add the server, then
-restart Claude Desktop:
-
-```json
-{
-  "mcpServers": {
-    "comfy-local": {
-      "command": "comfy-local-mcp",
-      "env": {
-        "COMFY_BIN": "/path/to/venv/bin/comfy",
-        "COMFY_API_KEY": "<your-comfy-api-key>"
-      }
-    }
-  }
-}
-```
-
-### Cursor
-
-Add the server to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` in a project:
-
-```json
-{
-  "mcpServers": {
-    "comfy-local": {
-      "command": "comfy-local-mcp",
-      "env": {
-        "COMFY_BIN": "/path/to/venv/bin/comfy",
-        "COMFY_API_KEY": "<your-comfy-api-key>"
-      }
-    }
-  }
-}
-```
-
-## Quickstart
-
-Zero to a generated image:
-
-1. **Install the pieces.**
-
-   ```bash
-   pip install 'comfy-cli>=1.13.0'  # the engine (>= 1.13.0 required)
-   comfy install                  # create a ComfyUI workspace (skip if you have one)
-   pip install .                  # this MCP server → the `comfy-local-mcp` command
-   ```
-
-2. **Launch ComfyUI** and leave it running:
-
-   ```bash
-   comfy launch
-   ```
-
-3. **Add the server to your client** using the snippet for your client above, then restart /
-   reload it so the tools appear.
-
-4. **Ask your agent to run a workflow.** For example:
-
-   > "Confirm my local ComfyUI is running, then run the workflow at
-   > `~/workflows/txt2img.json` and show me the image."
-
-   Under the hood the agent calls `server_info` to confirm ComfyUI is up, `run_workflow` to
-   execute your workflow JSON (API-format or a UI export), and `fetch_outputs` to collect the
-   result. No hand-authored workflow? Ask it to start from a template instead — it can
-   `search_templates`, `fetch_template` to write a runnable JSON, and run that — and
-   `fetch_template` tells it up front if [your install can't run that
-   template](#templates-your-install-cant-run) yet.
-
-**Where the images land.** ComfyUI writes generated files into your ComfyUI **workspace's
-`output/` directory** (part of the workspace `comfy install` created). On top of that,
-`fetch_outputs(prompt_id, out_dir)` **copies** a finished job's outputs into any directory you
-name — so telling the agent "save them to `./outputs`" puts a copy right where you asked while
-the originals stay in the ComfyUI workspace.
 
 ## Tools
 


### PR DESCRIPTION
## ELI-5

The README made newcomers scroll past ~460 lines of advanced guidance before finding how to install and run the thing. This PR moves the 4-step Quickstart and client setup to the top (like playwright-mcp's README), turns the confusing "Zero to a generated image:" fragment into a real sentence, and adds one paragraph stating plainly what the server is: local-first, with a few hosted-partner flows, and **not** a Comfy Cloud client. No behavior changes — docs only.

## What changed

**Scope paragraph (intro).** The "each tool shells out to `comfy`" paragraph now says up front that by default everything targets the ComfyUI on *your* machine (`127.0.0.1:8188`), followed by a **Scope — local-first, not local-only** paragraph naming the three flows that already reach off-machine, each anchor-linked to the section that documents it: `partner_generate` (runs entirely on partner infrastructure), partner-API nodes (a locally-executed workflow calling those same hosted models), and `COMFYUI_URL` (run/job tools pointed at another machine you control). It closes by stating what the server is *not* — a Comfy Cloud client — and redirects Comfy Cloud users to that MCP.

**Quickstart + Configure moved to the top.** Both sections (and the three `###` client sections) now sit directly under the Status blockquote. The `Table of contents` follows them and re-lists every section in the new page order. Resulting top-level order: header/nav → What it does → scope → Status → **Quickstart** → **Configure your AI client** → Table of contents → Prerequisites → … (unchanged from there down).

**`Install` merged into Quickstart step 1.** Its `pip install .` was already duplicated in step 1, so the standalone section is gone and its console-script/venv note is appended to that step (with a link to [Prerequisites](README.md#prerequisites) for the `COMFY_BIN` explanation). The nav bar's `#install` link became `#quickstart`, and the ToC entry was dropped.

**Lead-in fixed.** "Zero to a generated image:" → "Four steps take you from a fresh install to your first generated image."

**Directional prose replaced with anchor links, not flipped words.** Four places said "below"/"above" about sections that moved: the `COMFY_BIN` and `COMFY_API_KEY` bullets in Prerequisites, the Partner-API-nodes paragraph, and Quickstart step 3. Each now links to [Configure your AI client](README.md#configure-your-ai-client) instead of asserting a direction that a future reorder would break again. The one inside a bash code block (the Claude Code snippet's `COMFY_API_KEY` comment) uses plain text — "(see the Partner-API nodes section)" — since a Markdown link would render literally there.

## Verification

- `pytest` — **1133 passed, 3 skipped**. `test_routing_instructions.py` is the one that matters here: it asserts the handshake and README carry the same routing rows, so I checked programmatically that the `When to use this server` section body is **byte-identical** to `origin/main` apart from its position.
- `ruff check .` / `ruff format --check .` — clean (no Python touched; run against a fresh `pip install -e '.[dev]'` venv on the pinned ruff 0.16).
- **Anchor check** — every `](#…)` and `href="#…"` target in the final README resolves to a real heading (code fences excluded from heading extraction), and no two headings collide into a duplicate anchor.
- **Render check** — `## Quickstart` is at line 57.
- `server.py:2806` points users at "the README's *Accepted values*"; that heading and its bold `**Accepted values.**` label are untouched. No other file in the repo links to a README anchor.

## Judgment calls

- **Dropped one line from the old `Install` body:** `comfy-local-mcp        # serves the MCP over stdio`. Running the console script by hand blocks on stdio with no output, which reads as a hang to a first-time user, and step 3 hands the command to the client anyway. The console-script fact itself survives in the step-1 note. Say the word and I'll put it back.
- **"There is no HTTP client" left the intro paragraph** (the replacement text supplied for that paragraph doesn't carry it). The claim still appears in [When to use this server](README.md#when-to-use-this-server) and as a hard guardrail in `AGENTS.md`, so it isn't lost.
- **Client sections were *not* wrapped in `<details>`** — deliberate, per the plan: it keeps the anchors stable and the diff readable.
- **Remaining "above"/"below" prose was left alone.** I swept the final file; every survivor is intra-section (VRAM-coordination steps, the Tools table, the `Accepted values` back-reference, the failure-log table) or points at a section that is still genuinely below it, so the reorder didn't flip any of them.

## Negative-claim falsification

The new paragraph makes a capability-denying claim — "not a Comfy Cloud client: it … implements none of its cloud-native feature set" — so I went and looked rather than asserting it:

- All **49** `@mcp.tool()` definitions in `server.py` were enumerated; none exposes cloud workflow, job, or asset management. Every `cloud`-named string in the file is either the auth path (`comfy cloud login` / `whoami`, documented under Partner-API nodes as the credential for partner nodes) or guidance text.
- `server.py:5421` `_drop_cloud_jobs` actively **strips** cloud-tracked rows out of `comfy jobs ls` results, with the docstring reason "This server is local-only … jobs it cannot act on" — the codebase already treats cloud jobs as out of scope.

The paragraph also **redirects** rather than dead-ends: Comfy Cloud users are pointed at the Comfy Cloud MCP, alongside this one.
