### PR TITLE
docs(tools): state a per-surface Freshness policy on every catalog tool

### DIFF
--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -106,15 +106,21 @@ This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
 - Start from a template: `search_templates(query=...)` to find one (free-text
   search, paged 25 at a time via `limit`/`offset`; narrow with `tag`/`type`/
   `model`/`provider`, or `exclude_api=True` for templates that run without a
-  hosted-API key), `fetch_template` to save its workflow JSON, then `run_workflow`
-  on `result["path"]`. `fetch_template` and `get_template` also return a
-  `local_check` block comparing the template against the live node catalog of the
-  installed ComfyUI — the gallery is served fresh, so a template can need a node
-  or model option this install does not have yet. On
+  hosted-API key), `fetch_template` to save its workflow JSON, then — only once
+  the check below has CLEARED — `run_workflow` on `result["path"]`.
+  `fetch_template` and `get_template` return a `local_check` block comparing the
+  template against the live node catalog of the installed ComfyUI. The gallery
+  catalog is CACHED by comfy-cli and maintained independently of the install (it
+  is not read from it at all), so a template can need a node or model option this
+  install does not have yet — clearing `local_check` is MANDATORY, not advisory,
+  and "the fetch succeeded" is not a substitute. On
   `{"checked": true, "runnable": false}` tell the USER what is missing (update
   ComfyUI / custom nodes, or pick another template) instead of running it and
   hitting the failure deep in execution; `{"checked": false}` is "could not
-  compare", not a verdict. To change the prompt / seed
+  compare", not a verdict — it leaves the gate UNDONE, so run
+  `validate_workflow(result["path"])` yourself before running anything. Read that
+  block with `.get("runnable")`: a `checked: false` block has no `runnable` key.
+  To change the prompt / seed
   / steps / model of a fetched template before running, inspect its tweakable slots
   with `list_workflow_slots` and edit them with `set_workflow_slot` (non-destructive
   by default) — the loop is `fetch_template` -> `set_workflow_slot` -> `run_workflow`.
@@ -4600,9 +4606,13 @@ def list_partner_models(
     - A model absent from these rows is NOT evidence it does not exist. It may be
       live upstream and simply not allowlisted in this comfy-cli — an old install
       is the likeliest reason something you expected is missing. Say "the
-      installed comfy-cli does not list it" and point at
-      ``comfy generate refresh`` / a comfy-cli upgrade; do not tell the user the
-      model does not exist.
+      installed comfy-cli does not list it"; do not tell the user the model does
+      not exist. The remedy for that likeliest cause is a comfy-cli UPGRADE, not
+      a refresh: the allowlist is code, so no spec re-pull can add a row it does
+      not name. (``comfy generate refresh`` helps only in the narrower case where
+      the endpoint IS allowlisted but the vendored spec lacks its path, which the
+      allowlist walk skips silently.) Where refresh genuinely is the fix is
+      ``partner_model_schema``'s variant enums, which are spec-derived.
     - One row can stand for a whole FAMILY of dated model variants. The variants
       live in ``partner_model_schema``'s ``model`` enum, not here, so this list
       cannot tell you which one a run would use. Read that schema before
@@ -8050,10 +8060,16 @@ def get_template(name: str, check_local: bool = True) -> Any:
     ``{"checked": true, "runnable": false, ...}`` means running it will fail
     until the install is updated; ``{"checked": false, ...}`` means the
     comparison could not be made (usually: ComfyUI is not running) and says
-    nothing either way. The check costs an extra gallery fetch plus a validate —
-    pass ``check_local=False`` to skip it when you only want the metadata, but
+    nothing either way — that block carries no ``runnable`` key, so read it with
+    ``.get("runnable")``. The check costs an extra gallery fetch plus a validate
+    — pass ``check_local=False`` to skip it when you only want the metadata, but
     then the validation still has to happen before the run (see
     ``fetch_template``).
+
+    ``local_check`` is CONDITIONAL, like ``server_info``'s ``hardware`` block: it
+    is attached to comfy-cli's payload, and on a drifted payload shape (anything
+    that is not a JSON object) the payload is handed back untouched with no
+    ``local_check`` key at all. Reach it defensively rather than by indexing.
 
     Freshness: CACHED, not live — the template metadata comes from comfy-cli's
     gallery cache at ``~/.cache/comfy-cli/gallery/index.json``, with a 24h TTL on
@@ -8094,12 +8110,18 @@ def fetch_template(name: str, out_path: str, check_local: bool = True) -> dict:
 
         search_templates("flux")               # 1. find a template
         get_template("flux_dev")               # 2. inspect it
-        result = fetch_template("flux_dev", "/tmp/flux.json")   # 3. write it
+        out_path = os.path.expanduser("~/comfy-workflows/flux.json")
+        result = fetch_template("flux_dev", out_path)          # 3. write it
         # 4. REQUIRED gate. `local_check` already ran it here; where it did not
-        #    (see below), validate_workflow(result["path"]) is the same gate.
-        if not result["local_check"]["runnable"]:
-            ...   # relay what is missing + offer update_comfyui; skip step 5
-        run_workflow(result["path"])           # 5. generate
+        #    (see below), validate_workflow(result["path"]) stands in for it.
+        #    `.get`, NOT `[...]`: a `{"checked": false, ...}` block carries no
+        #    `runnable` key at all, so indexing it raises KeyError on exactly
+        #    the paths this docstring documents as normal.
+        if result["local_check"].get("runnable"):
+            run_workflow(result["path"])       # 5. generate
+        else:
+            ...   # relay what is missing + offer update_comfyui, or validate
+                  # first — do NOT reach step 5
 
     so an agent reaches a working generation without hand-authoring workflow JSON.
 
@@ -8107,6 +8129,13 @@ def fetch_template(name: str, out_path: str, check_local: bool = True) -> dict:
     been compared to this install (see Freshness below), so "it downloaded" says
     nothing about whether it can run. Do not go from step 3 to step 5 on any
     template, however ordinary it looks.
+
+    Pick an ``out_path`` only the user can write — a directory under their home,
+    as above — rather than a fixed name in a world-writable one (``/tmp/flux.json``).
+    Step 4 validates the FILE, so on a shared host another local user who can
+    pre-create that path as a symlink, or rewrite it between the check and the
+    run, turns the gate into a TOCTOU where the validated bytes are not the
+    executed bytes.
 
     ``local_check`` is the same cross-check ``get_template`` reports, run against
     the file just written, and it IS step 4 when ``check_local`` is left at its
@@ -8119,8 +8148,21 @@ def fetch_template(name: str, out_path: str, check_local: bool = True) -> dict:
     ComfyUI is not running) and is NOT a verdict — it leaves step 4 UNDONE, so
     treat it like ``check_local=False``: run ``validate_workflow(result["path"])``
     yourself once ComfyUI is up, and do not call ``run_workflow`` until something
-    has actually validated the file. The file is written either way; passing
-    ``check_local=False`` moves the gate onto you, it does not remove it.
+    has actually validated the file. That block has no ``runnable`` key, so read
+    it with ``.get("runnable")`` and treat a missing value as "not cleared". The
+    file is written either way; passing ``check_local=False`` moves the gate onto
+    you, it does not remove it.
+
+    Standing in for ``local_check`` with a raw ``validate_workflow`` is WEAKER,
+    not equivalent, and on one install shape it is not a gate at all: gallery
+    templates are UI-format exports, and a comfy-cli too old to lower one to API
+    format checks ZERO nodes and calls it valid (``validate_workflow``'s blind
+    spot 3). ``local_check`` detects that vacuous pass and downgrades it to
+    ``{"checked": false, "reason": "workflow_not_converted"}``; a bare
+    ``validate_workflow`` call reports ``valid: true``. So when you run it
+    yourself, a pass that arrives with ``non_node_key`` warnings and no UI
+    conversion means nothing was compared — upgrade comfy-cli, or leave
+    ``check_local`` at its default and let this tool make that distinction.
 
     The written JSON may contain a ``definitions.subgraphs`` block and nodes
     whose ``type`` is a UUID (the frontend's "subgraph" feature). That is NORMAL
@@ -8415,9 +8457,20 @@ def search_models(query: str = "", folder: str = "") -> Any:
     "which model files does this install have?", not "tell me about this model".
 
     Freshness: LIVE — the model files on the target install's disk, re-read on
-    every call; filenames only, no registry metadata. So an absent name means
-    "not downloaded here", never "no such model" — ``download_model`` is the way
-    to add one, and the hosted partner catalog is ``list_partner_models``.
+    every call; filenames only, no registry metadata. So an absent name never
+    means "no such model". It means one of two things, and the SCOPE of the call
+    decides which, so rule that out before concluding anything:
+
+    - present but outside what this call searched. Each mode looks somewhere
+      narrower than "the install": the no-argument mode lists folder NAMES and no
+      files at all, ``folder`` mode reads one folder, and on the v1.13.0 floor
+      ``query`` mode reads ``checkpoints`` only (see the mode list above). A LoRA
+      or VAE already on disk is simply absent from those results — re-check with
+      ``folder="loras"`` / ``folder="vae"`` (or list the folders first) before
+      telling the user anything, since acting on this reading triggers a
+      redundant multi-GB download of a file they already have.
+    - genuinely "not downloaded here" — ``download_model`` is the way to add one,
+      and the hosted partner catalog is ``list_partner_models``.
     """
     # The guards sit INSIDE their branch so an empty value keeps meaning "mode
     # not selected" (the precedence above) rather than becoming an error.

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -4588,6 +4588,25 @@ def list_partner_models(
     ``partner_generate`` to run it (which SPENDS credits) or
     ``emit_partner_workflow`` for the few aliases that can run on the local
     install instead.
+
+    Freshness: PINNED, not live — this is comfy-cli's own catalog, not a registry
+    query. The rows come from a curated endpoint allowlist in the INSTALLED
+    comfy-cli's code, resolved against an OpenAPI spec vendored into that same
+    wheel (``comfy generate refresh`` — a terminal command this server does not
+    wrap — re-pulls the live spec into a 7-day cache at
+    ``~/.comfy/openapi-cache.yml``). Two consequences to caveat to the user
+    rather than swallow:
+
+    - A model absent from these rows is NOT evidence it does not exist. It may be
+      live upstream and simply not allowlisted in this comfy-cli — an old install
+      is the likeliest reason something you expected is missing. Say "the
+      installed comfy-cli does not list it" and point at
+      ``comfy generate refresh`` / a comfy-cli upgrade; do not tell the user the
+      model does not exist.
+    - One row can stand for a whole FAMILY of dated model variants. The variants
+      live in ``partner_model_schema``'s ``model`` enum, not here, so this list
+      cannot tell you which one a run would use. Read that schema before
+      committing to a variant in front of a user.
     """
     if limit < 0:
         raise ComfyCliError(f"invalid limit: {limit} (must be >= 0)")
@@ -4688,6 +4707,20 @@ def partner_model_schema(model: str) -> Any:
 
     An unknown alias raises with comfy-cli's own ``generate_model_unknown``
     error; ``list_partner_models()`` is the list of what is spelled how.
+
+    Freshness: PINNED, not live — the parameters, and every ``enum`` inside them,
+    come from the OpenAPI spec vendored into the INSTALLED comfy-cli wheel,
+    refreshed only by ``comfy generate refresh`` (a terminal command this server
+    does not wrap, which caches the live spec for 7 days at
+    ``~/.comfy/openapi-cache.yml``). This is nonetheless the finest-grained view
+    of what a partner currently offers — a ``model`` enum here typically
+    enumerates the dated variants that ``list_partner_models`` collapses into one
+    row — so read it before naming a specific variant to a user. But an outdated
+    comfy-cli reports an outdated variant set, so if a user asks for a variant
+    this enum lacks, say the installed comfy-cli does not list it and point at
+    ``comfy generate refresh``: do NOT assert the variant does not exist, and do
+    NOT quietly substitute a nearby one (silently swapping a ``pro`` for a
+    ``lite`` is a downgrade the user never agreed to).
     """
     if not model:
         raise ComfyCliError(
@@ -7733,8 +7766,19 @@ def search_templates(
 
     Step 1 of the template on-ramp: pick a ``name`` from the results, inspect it
     with ``get_template(name)``, then ``fetch_template(name, out_path)`` to write
-    a runnable workflow JSON and pass that path straight to ``run_workflow`` — a
-    working generation without hand-authoring workflow JSON.
+    a runnable workflow JSON. Step 4 — validating that JSON against this install
+    before ``run_workflow`` — is MANDATORY, not a nicety; see ``fetch_template``.
+
+    Freshness: CACHED, not live — comfy-cli serves the gallery out of
+    ``~/.cache/comfy-cli/gallery/index.json``, with a 24h TTL on a comfy-cli
+    NEWER than v1.13.0 (the TTL landed in Comfy-Org/comfy-cli#559, after v1.13.0
+    was cut) and NO expiry at all on v1.13.0 and older, where the first fetch is
+    kept indefinitely until ``comfy templates refresh`` is run in a terminal
+    (this server does not wrap that verb). And the catalog is NOT read from the
+    local install: a listed template may need node classes this install lacks.
+    Nothing on these rows has been checked against the install — the check is
+    ``get_template`` / ``fetch_template``'s ``local_check``, and clearing it is
+    required before running anything from here.
     """
     if limit < 0:
         raise ComfyCliError(f"invalid limit: {limit} (must be >= 0)")
@@ -8000,14 +8044,25 @@ def get_template(name: str, check_local: bool = True) -> Any:
 
     With ``check_local=True`` (the default) the response also carries a
     ``local_check`` block: the template's graph is compared against the LIVE
-    ``object_info`` of the running local ComfyUI, because the gallery is served
-    fresh while the user's install is whatever they installed — a template can
-    reference a node class, or a model option inside one, that only a newer
-    ComfyUI exposes. ``{"checked": true, "runnable": false, ...}`` means running
-    it will fail until the install is updated; ``{"checked": false, ...}`` means
-    the comparison could not be made (usually: ComfyUI is not running) and says
+    ``object_info`` of the running local ComfyUI, because the gallery catalog is
+    maintained independently of the user's install — a template can reference a
+    node class, or a model option inside one, that only a newer ComfyUI exposes.
+    ``{"checked": true, "runnable": false, ...}`` means running it will fail
+    until the install is updated; ``{"checked": false, ...}`` means the
+    comparison could not be made (usually: ComfyUI is not running) and says
     nothing either way. The check costs an extra gallery fetch plus a validate —
-    pass ``check_local=False`` to skip it when you only want the metadata.
+    pass ``check_local=False`` to skip it when you only want the metadata, but
+    then the validation still has to happen before the run (see
+    ``fetch_template``).
+
+    Freshness: CACHED, not live — the template metadata comes from comfy-cli's
+    gallery cache at ``~/.cache/comfy-cli/gallery/index.json``, with a 24h TTL on
+    a comfy-cli NEWER than v1.13.0 (the TTL landed in Comfy-Org/comfy-cli#559,
+    after v1.13.0 was cut) and NO expiry at all on v1.13.0 and older, where the
+    first fetch is kept indefinitely until ``comfy templates refresh`` is run in
+    a terminal (this server does not wrap that verb). The template fields are also
+    NOT read from the local install — only the ``local_check`` half of this
+    response is, which is exactly why that check exists.
     """
     # Bare positional: a leading-dash name is read by comfy-cli as an option
     # rather than the template to show (argument injection).
@@ -8037,22 +8092,35 @@ def fetch_template(name: str, out_path: str, check_local: bool = True) -> dict:
     ``run_workflow(workflow_path=...)`` takes, completing the template
     on-ramp::
 
-        search_templates("flux")               # find a template
-        get_template("flux_dev")               # inspect it
-        result = fetch_template("flux_dev", "/tmp/flux.json")
-        run_workflow(result["path"])           # generate — no hand-authored JSON
+        search_templates("flux")               # 1. find a template
+        get_template("flux_dev")               # 2. inspect it
+        result = fetch_template("flux_dev", "/tmp/flux.json")   # 3. write it
+        # 4. REQUIRED gate. `local_check` already ran it here; where it did not
+        #    (see below), validate_workflow(result["path"]) is the same gate.
+        if not result["local_check"]["runnable"]:
+            ...   # relay what is missing + offer update_comfyui; skip step 5
+        run_workflow(result["path"])           # 5. generate
 
     so an agent reaches a working generation without hand-authoring workflow JSON.
 
+    Step 4 is not optional. A fetched template is gallery content that has never
+    been compared to this install (see Freshness below), so "it downloaded" says
+    nothing about whether it can run. Do not go from step 3 to step 5 on any
+    template, however ordinary it looks.
+
     ``local_check`` is the same cross-check ``get_template`` reports, run against
-    the file just written: the gallery serves templates that can be newer than
-    the user's ComfyUI, so one may reference a node class or an input option
-    this install does not expose. ``{"checked": true, "runnable": false, ...}``
-    means the run will fail until the install is updated — RELAY that to the
-    user instead of running it and letting the failure surface deep in
-    execution. ``{"checked": false, ...}`` means the comparison could not be made
-    (usually: ComfyUI is not running) and is NOT a verdict. The file is written
-    either way; pass ``check_local=False`` to skip the check.
+    the file just written, and it IS step 4 when ``check_local`` is left at its
+    default: the gallery is maintained independently of the user's ComfyUI, so a
+    template may reference a node class or an input option this install does not
+    expose. ``{"checked": true, "runnable": false, ...}`` means the run will fail
+    until the install is updated — RELAY that to the user instead of running it
+    and letting the failure surface deep in execution.
+    ``{"checked": false, ...}`` means the comparison could not be made (usually:
+    ComfyUI is not running) and is NOT a verdict — it leaves step 4 UNDONE, so
+    treat it like ``check_local=False``: run ``validate_workflow(result["path"])``
+    yourself once ComfyUI is up, and do not call ``run_workflow`` until something
+    has actually validated the file. The file is written either way; passing
+    ``check_local=False`` moves the gate onto you, it does not remove it.
 
     The written JSON may contain a ``definitions.subgraphs`` block and nodes
     whose ``type`` is a UUID (the frontend's "subgraph" feature). That is NORMAL
@@ -8060,6 +8128,15 @@ def fetch_template(name: str, out_path: str, check_local: bool = True) -> dict:
     comfy-cli — so never refuse or swap a template over it. Do not hand-edit
     ``definitions.subgraphs``; route edits through ``list_workflow_slots`` /
     ``set_workflow_slot``, which address subgraph-interior inputs too.
+
+    Freshness: CACHED, not live — the template written here comes from comfy-cli's
+    gallery cache at ``~/.cache/comfy-cli/gallery/index.json``, with a 24h TTL on
+    a comfy-cli NEWER than v1.13.0 (the TTL landed in Comfy-Org/comfy-cli#559,
+    after v1.13.0 was cut) and NO expiry at all on v1.13.0 and older, where the
+    first fetch is kept indefinitely until ``comfy templates refresh`` is run in
+    a terminal (this server does not wrap that verb). The gallery is NOT read from
+    the local install, which is the whole reason step 4 above is mandatory: a
+    template this call happily writes may need node classes this install lacks.
     """
     # `name` is a bare positional, so a leading-dash value is read as an option
     # and every later token shifts up a slot. `out_path` rides behind `--out` as
@@ -8093,6 +8170,10 @@ def search_nodes(query: str) -> Any:
     static/bundled catalog. Use this to find the class name of a node (e.g.
     "KSampler", "load image") before authoring or repairing a workflow graph;
     pass the returned name to ``get_node`` for its full schema.
+
+    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
+    call; reflects exactly what THIS install has (including its staleness: an
+    outdated install lists outdated nodes).
     """
     # Bare positional: a leading-dash query is read as an option, not a search
     # term (argument injection).
@@ -8112,6 +8193,10 @@ def get_node(name: str) -> Any:
     their types and defaults, and outputs — is what an agent needs to author or
     repair a workflow graph. Reflects the user's live install, so it resolves
     custom-node classes too (not just built-ins).
+
+    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
+    call; reflects exactly what THIS install has (including its staleness: an
+    outdated install lists outdated nodes).
     """
     # Bare positional: a leading-dash name is read as an option rather than the
     # node class to show (argument injection).
@@ -8150,6 +8235,10 @@ def list_nodes(
 
     Reads the user's live install, so results include installed custom nodes —
     the broad "what nodes can do X?" companion to ``search_nodes``' name search.
+
+    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
+    call; reflects exactly what THIS install has (including its staleness: an
+    outdated install lists outdated nodes).
     """
     args = ["nodes", "ls"]
     for flag, value in (
@@ -8180,6 +8269,10 @@ def nodes_upstream(name: str, limit: int | None = None) -> Any:
     INTO this node?" — the candidates that produce the types ``name`` accepts,
     computed against the live local ``object_info`` (custom nodes included). Pass
     ``limit`` to cap the number of results; omit it for the full set.
+
+    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
+    call; reflects exactly what THIS install has (including its staleness: an
+    outdated install lists outdated nodes).
     """
     # Bare positional, and it sits beside this command's own `--limit`: a
     # leading-dash name is read as an option (argument injection).
@@ -8200,6 +8293,10 @@ def nodes_downstream(name: str, limit: int | None = None) -> Any:
     produces, computed against the live local ``object_info`` (custom nodes
     included). Pass ``limit`` to cap the number of results; omit it for the full
     set.
+
+    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
+    call; reflects exactly what THIS install has (including its staleness: an
+    outdated install lists outdated nodes).
     """
     # Bare positional, and it sits beside this command's own `--limit`: a
     # leading-dash name is read as an option (argument injection).
@@ -8222,6 +8319,10 @@ def nodes_path(
     whose wiring carries a value from ``from_type`` to ``to_type`` over the live
     local ``object_info`` graph. ``max_depth`` bounds the chain length and
     ``max_paths`` caps how many routes are returned.
+
+    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
+    call; reflects exactly what THIS install has (including its staleness: an
+    outdated install lists outdated nodes).
     """
     # Two bare positionals ahead of `--max-depth` / `--max-paths`: a leading-dash
     # type is read as an option and shifts every later token up a slot, so the
@@ -8256,6 +8357,10 @@ def nodes_types() -> Any:
     ``IMAGE``, ``LATENT``, ``CONDITIONING``, …) present across the user's
     installed nodes, ordered by how connective each is — the vocabulary you wire
     with. Reflects custom nodes, so install-specific types show up too.
+
+    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
+    call; reflects exactly what THIS install has (including its staleness: an
+    outdated install lists outdated nodes).
     """
     return _run_comfy("nodes", "types", timeout=60.0)
 
@@ -8268,6 +8373,10 @@ def nodes_categories() -> Any:
     user's installed nodes fall under — a map for browsing what is available by
     area (loaders, sampling, image, …) rather than by name. Reflects the live
     install, so custom-node categories appear too.
+
+    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
+    call; reflects exactly what THIS install has (including its staleness: an
+    outdated install lists outdated nodes).
     """
     return _run_comfy("nodes", "categories", timeout=60.0)
 
@@ -8304,6 +8413,11 @@ def search_models(query: str = "", folder: str = "") -> Any:
     disk — filenames, with no enrichment (no base-model / hash / description /
     download metadata). Agents should set expectations accordingly: it answers
     "which model files does this install have?", not "tell me about this model".
+
+    Freshness: LIVE — the model files on the target install's disk, re-read on
+    every call; filenames only, no registry metadata. So an absent name means
+    "not downloaded here", never "no such model" — ``download_model`` is the way
+    to add one, and the hosted partner catalog is ``list_partner_models``.
     """
     # The guards sit INSIDE their branch so an empty value keeps meaning "mode
     # not selected" (the precedence above) rather than becoming an error.

--- a/tests/test_freshness_docs.py
+++ b/tests/test_freshness_docs.py
@@ -1,0 +1,217 @@
+"""Guards on the per-surface ``Freshness:`` policy in the catalog tool docstrings.
+
+This server has four catalog-shaped surfaces with four genuinely different
+freshness behaviors, and a docstring is the only place a calling agent can learn
+which one it is holding:
+
+* the node tools read the running ComfyUI's ``object_info`` — **LIVE**;
+* the template tools read comfy-cli's gallery cache — **CACHED**, with a TTL that
+  depends on the installed comfy-cli;
+* ``search_models`` reads the install's disk — **LIVE**, filenames only;
+* the partner-catalog tools read a curated allowlist plus a spec vendored into
+  the comfy-cli wheel — **PINNED**.
+
+Conflating them is not hypothetical: an agent reading the pinned partner catalog
+told a user a model "does not exist" when it was merely un-allowlisted, and
+another silently substituted a cheaper variant of a model family whose variants
+live in a different tool's schema. These are prose assertions, so no functional
+test would notice the caveats being dropped in a future docstring rewrite; this
+file is that tripwire.
+
+Assertions are keyed on the load-bearing FACTS (the classification word, the
+source of truth, the escape hatch, the "absence is not non-existence" caveat)
+rather than whole sentences, so wording can be edited without test churn. Every
+docstring is whitespace-collapsed first — these are hard-wrapped, so any phrase
+long enough to matter straddles a newline.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from comfy_local_mcp import server
+
+# The node tools, all of which resolve against the live local `object_info`.
+LIVE_NODE_TOOLS = (
+    "search_nodes",
+    "get_node",
+    "list_nodes",
+    "nodes_upstream",
+    "nodes_downstream",
+    "nodes_path",
+    "nodes_types",
+    "nodes_categories",
+)
+
+# The gallery-backed template tools.
+CACHED_TEMPLATE_TOOLS = ("search_templates", "get_template", "fetch_template")
+
+# The comfy-cli-pinned partner catalog. `generate_image` is deliberately NOT
+# here: it runs one local gallery template with a local checkpoint and carries no
+# model catalog of its own, so the pinned-catalog caveat would be false on it.
+PINNED_PARTNER_TOOLS = ("list_partner_models", "partner_model_schema")
+
+ALL_CATALOG_TOOLS = (
+    *LIVE_NODE_TOOLS,
+    *CACHED_TEMPLATE_TOOLS,
+    "search_models",
+    *PINNED_PARTNER_TOOLS,
+)
+
+
+def doc(tool_name: str) -> str:
+    """One tool's docstring, whitespace-collapsed. See the module docstring."""
+    tool = getattr(server, tool_name)
+    return " ".join((tool.__doc__ or "").split())
+
+
+@pytest.mark.parametrize("tool_name", ALL_CATALOG_TOOLS)
+def test_every_catalog_tool_states_a_freshness_policy(tool_name):
+    """The whole point: an agent can read the policy off the tool it is calling.
+
+    A catalog tool without this line is one an agent can neither trust nor
+    caveat, so the marker itself is the contract — the per-class assertions below
+    only check that the right one was stated.
+    """
+    assert "Freshness:" in doc(tool_name), (
+        f"{tool_name} has no `Freshness:` line — a catalog tool must state which "
+        "of the four freshness behaviors it has."
+    )
+
+
+@pytest.mark.parametrize("tool_name", LIVE_NODE_TOOLS)
+def test_node_tools_are_documented_as_live(tool_name):
+    """LIVE, and explicitly inclusive of the install's own staleness.
+
+    The staleness clause is the non-obvious half: "live" alone reads as
+    "authoritative", when what it actually means is "authoritative about THIS
+    install" — an outdated ComfyUI truthfully reports an outdated node set.
+    """
+    text = doc(tool_name)
+    assert "Freshness: LIVE" in text
+    assert "object_info" in text
+    assert "outdated install lists outdated nodes" in text
+
+
+@pytest.mark.parametrize("tool_name", CACHED_TEMPLATE_TOOLS)
+def test_template_tools_are_documented_as_cached_with_the_version_split(tool_name):
+    """CACHED — and the TTL is comfy-cli-version-dependent, which must be stated.
+
+    The 24h TTL landed in Comfy-Org/comfy-cli#559, *after* v1.13.0 was cut, and
+    v1.13.0 is this server's hard floor (``_MIN_COMFY_CLI``). So both behaviors
+    are live in the supported range: documenting the TTL unconditionally would be
+    a false claim for every user on the floor version, where the first fetch is
+    kept until ``comfy templates refresh``. Same shape as the comfy-cli version
+    split already documented in ``search_models``.
+    """
+    text = doc(tool_name)
+    assert "Freshness: CACHED" in text
+    assert "24h TTL" in text
+    assert "v1.13.0" in text
+    assert "comfy templates refresh" in text
+    # The install-independence caveat — the reason a cached hit can be unrunnable.
+    assert "NOT read from the local install" in text
+
+
+def test_the_cached_ttl_floor_claim_still_matches_this_servers_version_floor():
+    """The version in the TTL caveat is the floor, not a number frozen in prose.
+
+    The caveat's "NEWER than v1.13.0" is only meaningful while v1.13.0 is what
+    ``_MIN_COMFY_CLI`` requires. If the floor moves past the release that carries
+    the TTL, the split disappears and these docstrings should stop hedging — this
+    is the test that says so instead of leaving stale prose behind.
+    """
+    assert server._MIN_COMFY_CLI_STR == "1.13.0", (
+        "the comfy-cli floor moved — re-check the template tools' `Freshness:` "
+        "caveat: once the floor includes comfy-cli#559 the 24h TTL is "
+        "unconditional and the v1.13.0 hedge should be dropped."
+    )
+
+
+def test_search_models_is_documented_as_live_disk_filenames():
+    """LIVE, but a *narrower* kind of live than the node tools' — and it is the
+    one surface where absence is most easily misread as non-existence."""
+    text = doc("search_models")
+    assert "Freshness: LIVE" in text
+    assert "no registry metadata" in text
+    assert "never" in text and "no such model" in text
+
+
+@pytest.mark.parametrize("tool_name", PINNED_PARTNER_TOOLS)
+def test_partner_catalog_tools_are_documented_as_pinned(tool_name):
+    """PINNED — with the refresh escape hatch, since a stale wheel under-reports.
+
+    The catalog is a curated allowlist in comfy-cli's own code resolved against a
+    spec vendored into the installed wheel, so it can lag upstream by a release.
+    Naming ``comfy generate refresh`` is what turns "I don't see it" into an
+    actionable next step for the user.
+    """
+    text = doc(tool_name)
+    assert "Freshness: PINNED" in text
+    assert "comfy generate refresh" in text
+    assert "INSTALLED comfy-cli" in text
+
+
+def test_partner_list_refuses_to_read_as_proof_of_non_existence():
+    """The "there is no such model" regression, stated as a docstring contract.
+
+    An agent asserted a model did not exist off this list; the model was real and
+    merely absent from comfy-cli's allowlist. The docstring has to say that
+    absence here is not evidence, and point at the schema for the variant level
+    this list collapses.
+    """
+    text = doc("list_partner_models")
+    assert "NOT evidence it does not exist" in text
+    assert "do not tell the user the model does not exist" in text
+    assert "partner_model_schema" in text
+
+
+def test_partner_schema_refuses_the_silent_variant_substitution():
+    """The Pro-to-Lite regression: a downgrade the user never agreed to.
+
+    The variant enum is the finest-grained thing this server can see, and it is
+    pinned — so the correct move on a miss is to report the gap, never to swap in
+    a neighbouring variant.
+    """
+    text = doc("partner_model_schema")
+    assert "do NOT quietly substitute" in text
+    assert "``lite``" in text and "``pro``" in text
+
+
+def test_fetch_template_presents_validation_as_mandatory():
+    """Step 4 of the on-ramp is a gate, not a suggestion.
+
+    The failure this guards is an agent going straight from ``fetch_template`` to
+    ``run_workflow`` because the fetch succeeded — gallery content has never been
+    compared to the install, so "it downloaded" is not "it runs". The two skip
+    paths (``check_local=False`` and a ``checked: false`` verdict) must both be
+    documented as MOVING the gate, not removing it.
+    """
+    text = doc("fetch_template")
+    assert "Step 4 is not optional" in text
+    assert "validate_workflow" in text
+    # `checked: false` is not a pass — it is the gate left undone.
+    assert "leaves step 4 UNDONE" in text
+    assert "moves the gate onto you, it does not remove it" in text
+
+
+def test_search_templates_on_ramp_flags_validation_as_mandatory():
+    """The on-ramp's step numbering starts here, so the gate has to be named here
+    too — an agent that only reads step 1 must still learn step 4 exists."""
+    text = doc("search_templates")
+    assert "MANDATORY" in text
+    assert "local_check" in text
+
+
+def test_generate_image_carries_no_pinned_catalog_caveat():
+    """``generate_image`` is not a catalog surface, and must not claim to be one.
+
+    It runs ONE local gallery template with a locally-installed checkpoint, so it
+    exposes no partner model list. Pasting the pinned-catalog caveat onto it (the
+    obvious over-application of this policy) would document a catalog it does not
+    have and point users at a ``comfy generate`` refresh that has no bearing on
+    what it runs.
+    """
+    text = doc("generate_image")
+    assert "Freshness: PINNED" not in text
+    assert "comfy generate refresh" not in text

--- a/tests/test_freshness_docs.py
+++ b/tests/test_freshness_docs.py
@@ -27,6 +27,9 @@ long enough to matter straddles a newline.
 
 from __future__ import annotations
 
+import ast
+import textwrap
+
 import pytest
 
 from comfy_local_mcp import server
@@ -61,8 +64,44 @@ ALL_CATALOG_TOOLS = (
 
 def doc(tool_name: str) -> str:
     """One tool's docstring, whitespace-collapsed. See the module docstring."""
-    tool = getattr(server, tool_name)
-    return " ".join((tool.__doc__ or "").split())
+    return " ".join(raw_doc(tool_name).split())
+
+
+def raw_doc(tool_name: str) -> str:
+    """One tool's docstring VERBATIM — for the few assertions about layout.
+
+    The example snippets are code an agent copies, so their indentation is part
+    of the contract (a gate the run sits outside of does not gate); those checks
+    need the lines the way they are written, not collapsed.
+    """
+    return getattr(server, tool_name).__doc__ or ""
+
+
+def on_ramp_snippet() -> str:
+    """``fetch_template``'s template on-ramp example, dedented and parseable.
+
+    Pulled out as real code rather than grepped as prose because its SHAPE is
+    what an agent copies: whether the run sits inside the gate's branch is a
+    structural fact, and asserting it on an AST cannot be fooled by a prose
+    sentence that happens to mention the same identifiers.
+    """
+    lines = raw_doc("fetch_template").splitlines()
+    start = next(i for i, ln in enumerate(lines) if ln.rstrip().endswith("on-ramp::"))
+    # The docstring reaches us already dedented (the tool decorator cleans it),
+    # so the block's own indent is whatever its first code line carries — read it
+    # rather than assuming a literal column.
+    body = lines[start + 1 :]
+    first = next(ln for ln in body if ln.strip())
+    indent = len(first) - len(first.lstrip())
+    assert indent, "the on-ramp example is no longer an indented literal block"
+    block: list[str] = []
+    for ln in body:
+        # Blank lines ride along; the first non-blank line back at prose level
+        # ends the block.
+        if ln.strip() and not ln.startswith(" " * indent):
+            break
+        block.append(ln)
+    return textwrap.dedent("\n".join(block)).strip("\n")
 
 
 @pytest.mark.parametrize("tool_name", ALL_CATALOG_TOOLS)
@@ -134,7 +173,24 @@ def test_search_models_is_documented_as_live_disk_filenames():
     text = doc("search_models")
     assert "Freshness: LIVE" in text
     assert "no registry metadata" in text
-    assert "never" in text and "no such model" in text
+    # The joined phrase, not two loose substrings: asserting `"never"` and
+    # `"no such model"` separately stays green if a rewrite drops the caveat
+    # while some unrelated sentence still happens to contain "never".
+    assert 'never means "no such model"' in text
+
+
+def test_search_models_absence_names_the_out_of_scope_reading_first():
+    """Absence has TWO readings here, and the wrong one costs a multi-GB download.
+
+    Each mode searches something narrower than "the install" — no-argument lists
+    folder names, ``folder`` reads one folder, and on the v1.13.0 floor ``query``
+    reads ``checkpoints`` only. A LoRA already on disk is absent from those
+    results, so "not downloaded here" cannot be the only documented reading.
+    """
+    text = doc("search_models")
+    assert "present but outside what this call searched" in text
+    assert 'folder="loras"' in text
+    assert "redundant multi-GB download" in text
 
 
 @pytest.mark.parametrize("tool_name", PINNED_PARTNER_TOOLS)
@@ -166,6 +222,22 @@ def test_partner_list_refuses_to_read_as_proof_of_non_existence():
     assert "partner_model_schema" in text
 
 
+def test_partner_list_names_the_upgrade_not_the_refresh_as_the_remedy():
+    """The two escape hatches are not interchangeable on THIS tool.
+
+    These rows are ``_ENDPOINT_ALLOWLIST`` (comfy-cli source) intersected with the
+    active spec's paths, so a model that is simply not allowlisted cannot be
+    surfaced by any spec re-pull — only a comfy-cli upgrade reaches it. Offering
+    ``comfy generate refresh`` as an equal remedy sends the user through a step
+    that cannot work for the cause the same paragraph names as likeliest.
+    ``partner_model_schema`` is the tool where refresh genuinely is the fix: its
+    variant enums are read from the spec.
+    """
+    text = doc("list_partner_models")
+    assert "comfy-cli UPGRADE, not" in text
+    assert "the allowlist is code" in text
+
+
 def test_partner_schema_refuses_the_silent_variant_substitution():
     """The Pro-to-Lite regression: a downgrade the user never agreed to.
 
@@ -193,6 +265,107 @@ def test_fetch_template_presents_validation_as_mandatory():
     # `checked: false` is not a pass — it is the gate left undone.
     assert "leaves step 4 UNDONE" in text
     assert "moves the gate onto you, it does not remove it" in text
+
+
+def test_fetch_template_example_gates_the_run_and_survives_an_unchecked_block():
+    """The SNIPPET is the contract — an LLM pattern-matches on its shape.
+
+    Two ways the example itself could teach the bug it warns about: putting
+    ``run_workflow`` after the ``if`` at the same indentation (so the run happens
+    either way), and indexing ``["runnable"]`` on a block that has no such key
+    (``_unchecked`` returns ``{"checked", "reason", "summary"}``, which is what
+    ``check_local=False`` and a not-running ComfyUI both produce). Assert the run
+    is reached only through the cleared branch.
+    """
+    tree = ast.parse(on_ramp_snippet())
+
+    gates = [n for n in ast.walk(tree) if isinstance(n, ast.If)]
+    assert len(gates) == 1, "the example should gate the run on exactly one `if`"
+    gate = gates[0]
+    # `.get("runnable")`, never `["runnable"]` — an `_unchecked` block has no
+    # such key, so a subscript raises KeyError on the documented-normal paths.
+    assert isinstance(gate.test, ast.Call), ast.dump(gate.test)
+    assert isinstance(gate.test.func, ast.Attribute) and gate.test.func.attr == "get"
+    assert [c.value for c in gate.test.args] == ["runnable"]
+
+    runs = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "run_workflow"
+    ]
+    assert len(runs) == 1, "the example should call `run_workflow` exactly once"
+    # And it must be reachable ONLY through the cleared branch: a `run_workflow`
+    # that is a sibling of the `if` rather than inside its body runs either way,
+    # which is the fetch-then-run-anyway shape the surrounding prose forbids.
+    cleared = [n for stmt in gate.body for n in ast.walk(stmt)]
+    assert runs[0] in cleared, (
+        "`run_workflow` sits outside the gate's cleared branch, so the example "
+        "runs the workflow whether or not the check passed."
+    )
+
+
+def test_fetch_template_does_not_offer_a_world_writable_example_path():
+    """The mandated gate validates a FILE, so a predictable shared path breaks it.
+
+    ``/tmp/flux.json`` is pre-creatable as a symlink by any other local user and
+    rewritable between the validate and the run — a TOCTOU where the validated
+    bytes are not the executed bytes. The server's own ``_check_template_by_name``
+    uses ``tempfile.mkdtemp`` for the same reason.
+    """
+    snippet = on_ramp_snippet()
+    assert "fetch_template(" in snippet, "the on-ramp example lost its fetch call"
+    # Only the SNIPPET is constrained — the prose below it names `/tmp/flux.json`
+    # on purpose, as the anti-pattern.
+    assert "/tmp/" not in snippet, snippet
+    assert "only the user can write" in doc("fetch_template")
+
+
+def test_fetch_template_does_not_claim_validate_workflow_is_an_equal_gate():
+    """``validate_workflow`` alone is WEAKER than ``local_check``, and says so.
+
+    Gallery templates are UI-format exports; a comfy-cli too old to lower one to
+    API format checks zero nodes and reports ``valid: true``
+    (``validate_workflow``'s blind spot 3). ``_local_template_check`` catches that
+    and downgrades it to ``workflow_not_converted``, so presenting the raw call as
+    "the same gate" would let a vacuous pass clear a mandatory check.
+    """
+    text = doc("fetch_template")
+    assert "WEAKER" in text
+    assert "non_node_key" in text
+    assert "blind spot 3" in text
+
+
+def test_get_template_documents_local_check_as_conditional():
+    """``local_check`` is attached to comfy-cli's payload, not guaranteed by it.
+
+    On a drifted (non-dict) payload ``get_template`` hands the payload back
+    untouched, so there is no ``local_check`` key at all and a caller indexing it
+    gets a ``KeyError`` — document it the way ``server_info``'s ``hardware`` block
+    already is.
+    """
+    text = doc("get_template")
+    assert "CONDITIONAL" in text
+    assert "no ``local_check`` key at all" in text
+
+
+def test_server_instructions_agree_with_the_per_tool_freshness_policy():
+    """The tripwire's blind spot: ``INSTRUCTIONS`` is sent to every client too.
+
+    The docstring assertions above cannot see it, so a policy stated on the tools
+    and contradicted in the preamble would ship green — which is exactly what
+    happened while ``INSTRUCTIONS`` still called the gallery "served fresh" and
+    walked an agent from ``fetch_template`` straight to ``run_workflow``.
+    """
+    text = " ".join(server.INSTRUCTIONS.split())
+    assert "served fresh" not in text, (
+        "INSTRUCTIONS still calls the gallery live; it is comfy-cli's CACHED "
+        "gallery (see the template tools' `Freshness:` blocks)."
+    )
+    assert "CACHED" in text
+    assert "MANDATORY, not advisory" in text
+    assert '.get("runnable")' in text
 
 
 def test_search_templates_on_ramp_flags_validation_as_mandatory():


### PR DESCRIPTION
## ELI-5

This server has four different "catalogs" an agent can ask about — the nodes your ComfyUI has installed, the workflow-template gallery, the model files on your disk, and the hosted partner models. They go stale in four completely different ways: one is read live every time, one is a cache on your machine, one is a directory listing, and one is a hardcoded list baked into whichever comfy-cli you happen to have installed. Nothing in the tool descriptions said which was which, so an agent reading any of them had no way to know whether it was looking at the truth or at a snapshot from last month — and it would confidently tell you either way. This PR writes that down, one `Freshness:` paragraph per tool. No code changes.

## Changes

Added one standard `Freshness:` paragraph to each catalog-shaped tool docstring, in four flavors:

- **LIVE** — `search_nodes`, `get_node`, `list_nodes`, `nodes_upstream`, `nodes_downstream`, `nodes_path`, `nodes_types`, `nodes_categories`. Read from the running ComfyUI's `object_info` on every call; reflects exactly what THIS install has, *including its staleness* (an outdated install truthfully lists outdated nodes). The staleness clause is the non-obvious half — "live" alone reads as "authoritative" when it actually means "authoritative about this install."
- **CACHED** — `search_templates`, `get_template`, `fetch_template`. comfy-cli serves the gallery out of `~/.cache/comfy-cli/gallery/index.json`, and the catalog is not read from the local install, so a listed template may need node classes this install lacks.
- **LIVE, narrower** — `search_models`. Filenames on the target install's disk, no registry metadata, so an absent name means "not downloaded here", never "no such model".
- **PINNED** — `list_partner_models`, `partner_model_schema`. A curated endpoint allowlist in the *installed* comfy-cli's own code, resolved against an OpenAPI spec vendored into that same wheel (`comfy generate refresh` re-pulls the live spec into a 7-day cache). Both docstrings now say explicitly that absence is not evidence of non-existence, and that a variant miss gets reported rather than substituted.

Also strengthened the template on-ramp so validation reads as the gate it is: `fetch_template`'s worked example is numbered with the validation step called out as REQUIRED, and both skip paths are documented as *moving* the gate onto the caller rather than removing it — `check_local=False`, and a `{"checked": false}` verdict, which previously read as a neutral non-answer and now reads as "step 4 is still undone."

New `tests/test_freshness_docs.py` (34 tests): every named tool carries a `Freshness:` marker, each carries the *right* classification with its load-bearing caveat, and two tests pin the specific regressions below as docstring contracts. Assertions are keyed on facts rather than whole sentences so wording can be edited without churn.

## Motivation

Two real agent failures traced back to this gap, both on the pinned partner catalog: one agent asserted a model "does not exist" when it was merely absent from comfy-cli's allowlist, and another silently absorbed a Pro-to-Lite downgrade — a variant swap the user never agreed to. Neither is a code bug; both are an agent reading a pinned snapshot as ground truth because nothing told it otherwise. Prose is the only fix available, and prose with no test is prose that gets deleted in the next docstring rewrite, hence the tripwire file.

## Testing

- [x] Existing tests pass (`pytest`) — 1337 passed, 4 skipped
- [x] Lint passes (`ruff check .`) — All checks passed
- [x] Format check passes (`ruff format --check .`) — 37 files already formatted
- [x] New `tests/test_freshness_docs.py` — 34 passed

Every factual claim in the new prose was verified against comfy-cli source rather than asserted from memory:

| Claim | Evidence |
|---|---|
| Gallery cached at `~/.cache/comfy-cli/gallery/index.json` with a 24h TTL | `comfy_cli/command/templates.py` on comfy-cli `main`: `GALLERY_TTL_SECONDS = 24 * 60 * 60`, `_cache_is_stale`, `_load_gallery` |
| No expiry at all on v1.13.0 and older | `git show v1.13.0:comfy_cli/command/templates.py` — `_load_gallery` is `if refresh or not cache.exists(): fetch`, i.e. first fetch kept forever |
| `comfy templates refresh` exists and this server does not wrap it | `templates.py` `refresh_cmd`; no `templates refresh` passthrough in `server.py` |
| Partner catalog is a curated code allowlist | `comfy_cli/command/generate/spec.py` `_ENDPOINT_ALLOWLIST` (a hardcoded list of `(endpoint_id, category, polling)` tuples) plus `_ALIASES` |
| Spec vendored into the wheel, 7-day user cache, refreshed by `comfy generate refresh` | `spec.py` `_BUNDLED_SPEC`, `_USER_CACHE`, `CACHE_TTL_SECONDS = 7 * 24 * 60 * 60`; `generate/app.py` `_refresh()` |
| One allowlist row can stand for a whole family of dated variants | The ByteDance video endpoint is **one** allowlist row (`byteplus/api/v3/contents/generations/tasks`), while the vendored `openapi.yml` `model` enum for it lists five dated variants (`…-1-5-pro-…`, `…-1-0-pro-…`, `…-1-0-pro-fast-…`, `…-1-0-lite-t2v-…`, `…-1-0-lite-i2v-…`); `generate/schema.py` surfaces that enum per-parameter, so `partner_model_schema` is where they are visible and `list_partner_models` is not |

That last row is the direct falsification of both original failures: the "missing" model family *was* allowlisted, and its variants *were* discoverable — just one tool over. So the fix is a redirect (read the schema), not a denial.

## Additional Notes

**Judgment calls, all three worth a reviewer's eye:**

1. **The pinned-catalog line went on `list_partner_models` / `partner_model_schema`, not on `generate_image`.** The original plan named `generate_image` as the code-pinned surface. That is stale: `generate_image` runs one *local* gallery template through `comfy run-template` with a locally-installed checkpoint and exposes no partner model list at all, so a "model list is code+spec pinned; run `comfy generate refresh`" caveat on it would document a catalog it does not have and point users at a refresh with no bearing on what it runs. The code+spec-pinned catalog in this repo is the `comfy generate` trio, and both real failures happened there. There is a test (`test_generate_image_carries_no_pinned_catalog_caveat`) pinning the negative, since pasting the caveat onto it is the obvious over-application of this policy.

2. **The template TTL is documented as version-split, not as a flat "24h TTL".** The plan's text was `CACHED (24h TTL)`. Unconditionally, that is false for a chunk of users: the TTL landed in comfy-cli after v1.13.0 was cut, and v1.13.0 is this server's *hard floor* (`_MIN_COMFY_CLI`), so both behaviors are live in the supported range and a v1.13.0 user's cache genuinely never expires. The docstrings state both, in the same shape `search_models` already uses for its own comfy-cli version split. `test_the_cached_ttl_floor_claim_still_matches_this_servers_version_floor` fails when the floor moves past that release, so the hedge gets dropped instead of rotting.

3. **"Always run `validate_workflow` on a fetched template" is stated as a mandatory *gate*, not as a literal always-call-this-tool.** `get_template` / `fetch_template` already run that validation themselves via `local_check` (default `check_local=True`), so instructing an agent to call `validate_workflow` even when `local_check.runnable` is already true would be a redundant instruction — and a docstring that asks for provably unnecessary work is one agents learn to discount. The wording makes the *gate* mandatory and names `validate_workflow` as the caller-side path for exactly the two cases where `local_check` did not run it.

**Deliberately not touched:** `discover` (lists this server's own tools — code-defined, but self-evidently so and not one of the four surfaces), `emit_partner_workflow` / `partner_generate` (they *consume* the pinned catalog but are not catalog surfaces; the caveat lives one hop up where the list is read), and the README tool table (the plan scoped this to docstrings, and the tool set did not change).

**One naming collision to be aware of:** `server_info` already returns a `freshness` block, which is about *install* staleness (`comfy outdated`), while this new `Freshness:` docstring line is about *catalog* staleness. They are related rather than contradictory, and the LIVE line bridges them on purpose — "reflects exactly what THIS install has, including its staleness" is precisely the case where `server_info`'s block is the follow-up question. Flagging it in case a reviewer prefers a different label for one of the two.

**No capability is denied by this diff** — it adds no throw, no dead-end path, and no "not supported" string. Its direction is the opposite: the new prose instructs against denial ("absence here is NOT evidence it does not exist", "do not tell the user the model does not exist", "do NOT assert the variant does not exist") and, where a template genuinely cannot run on this install, points at the remedy (`update_comfyui`) rather than stopping.
