### PR TITLE
chore(codeowners): route ownership to the comfy-cloud-team handle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Default owners for everything in this repo.
-* @mattmillerai
-
-/AGENTS.md @mattmillerai
+# The team must keep explicit write access on this repo for GitHub to honor this
+# (org-inherited member permissions do not count for teams in CODEOWNERS).
+* @Comfy-Org/comfy-cloud-team


### PR DESCRIPTION
## ELI-5

Right now this repo says "one person owns every file." This PR changes it to "the cloud team owns every file," so review requests go to the whole team instead of a single maintainer — which matters as the repo is prepared for OSS release. It also deletes a leftover line that named the same person for `AGENTS.md`, which the catch-all line already covered.

## Summary

Rewrites `.github/CODEOWNERS` to route all paths to `@Comfy-Org/comfy-cloud-team` instead of an individual, and drops the redundant `/AGENTS.md` entry.

## Changes

- `* @mattmillerai` → `* @Comfy-Org/comfy-cloud-team`.
- Removed `/AGENTS.md @mattmillerai` — redundant under the catch-all (last matching rule wins, and it named the same owner).
- Added a comment recording the invariant that keeps this file valid: a team in CODEOWNERS is only honored while it holds **explicit write access** on the repo.

## Motivation

GitHub silently ignores a CODEOWNERS team that lacks an explicit repo grant — org-inherited member permissions do not count — and flags the file as erroneous. Before this PR, `Comfy-Org/comfy-cloud-team` had **no** grant on this repo (`gh api repos/Comfy-Org/comfy-local-mcp/teams` returned only `comfy-bots` with `pull`).

**Out-of-band prerequisite, already applied:** the team was granted `push` on this repo (`PUT orgs/Comfy-Org/teams/comfy-cloud-team/repos/Comfy-Org/comfy-local-mcp`, `permission=push`). Verified afterwards:

```
$ gh api repos/Comfy-Org/comfy-local-mcp/teams --jq '.[] | {slug, permission}'
{"permission":"push","slug":"comfy-cloud-team"}
{"permission":"pull","slug":"comfy-bots"}
```

That grant is a repo setting, not a file, so it is not part of this diff — but it is what makes this diff work. If the grant is ever revoked, this CODEOWNERS file stops being honored; the comment in the file says so.

## Testing

- [x] Existing tests pass (`pytest`) — 1375 passed, 4 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually (below)

Manual verification against the pushed branch — GitHub parses the new file with no errors, which is the check that would fail if the team grant were missing or the handle were wrong:

```
$ gh api "repos/Comfy-Org/comfy-local-mcp/codeowners/errors?ref=matt/be-5338-codeowners-team"
{"errors":[]}
```

## Additional Notes

### This PR does not itself auto-request the team — and cannot. That is expected, not a defect.

The plan's last acceptance check was "the PR auto-requests review from `Comfy-Org/comfy-cloud-team`." It does not, and no PR that *introduces* this change could. Two independent reasons compound, both verified rather than assumed:

1. **GitHub resolves CODEOWNERS from the PR's BASE branch.** The base here is `main`, which still carries `* @mattmillerai`. The new file only governs PRs opened *after* it merges.
2. **GitHub never requests the PR author as a code owner.** This PR's author is `@mattmillerai` — the owner `main` currently names — so even under the old file there is nobody left to request.

Evidence the mechanism works in this repo (so the empty list above is author-exclusion, not a broken file): the most recent PR authored by someone *other* than the current owner, #135 by `@jojodecayz`, did get `mattmillerai` auto-requested. Every PR in the recent history authored by `mattmillerai` himself has an empty request list, exactly as here.

**How to confirm the intended behavior after merge:** the next PR opened by a non-author (or by any contributor once `main` carries this file) should show `Comfy-Org/comfy-cloud-team` under requested reviewers. Until then, `codeowners/errors == []` on this branch is the strongest available signal, and it passes.

### Other notes

- **Branch protection is deliberately untouched.** `require_code_owner_reviews` stays `false` and required approvals stay `0` on `main` — verified unchanged after this work. Turning code-owner review into an enforced gate is a separate human decision.
- **`@mattmillerai` does not lose coverage.** He is a member of `comfy-cloud-team` (verified via `gh api orgs/Comfy-Org/teams/comfy-cloud-team/members`), so the previous sole owner is still an owner, now via the team handle.
- **Blast radius today is review routing only.** Because code-owner review is not required, the worst case of a wrong owner here is that the wrong reviewers get requested — nothing can be blocked from merging.
- No other files change.
