### PR TITLE
docs(contributing): state a best-effort, no-SLA response-time policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,11 @@ drive a user's **local** ComfyUI by shelling out to
 By participating in this project you agree to abide by our
 [Code of Conduct](CODE_OF_CONDUCT.md).
 
+## Response times
+
+We review issues and pull requests on a best-effort basis and do not commit to a
+response-time SLA.
+
 ## The one architecture rule — thin wrapper only
 
 Before you write any code, read [`AGENTS.md`](AGENTS.md). The core rule:


### PR DESCRIPTION
## ELI-5

Right now `CONTRIBUTING.md` says nothing about how fast we answer issues and PRs, so a new contributor has no idea whether silence for a week means "ignored" or "normal". This adds one short section that says the honest thing: we look at things when we can, and we are not promising a deadline.

## Summary

Adds a `## Response times` section to `CONTRIBUTING.md` stating that issues and pull requests are reviewed on a best-effort basis with no response-time SLA. Docs-only — no code, tests, or tooling touched.

## Changes

- `CONTRIBUTING.md`: new `## Response times` section between the intro/Code-of-Conduct paragraph and `## The one architecture rule — thin wrapper only`.

## Motivation

Our pre-public OSS-release checklist requires `CONTRIBUTING.md` to state *either* a concrete triage SLA *or* an explicit non-commitment before the repo goes public, so that contributors know what to expect. **"Best-effort, no SLA" is the proposed default, and it is deliberately the reviewer's call.** If you would rather commit to a real number, swap the sentence for something like "we aim to triage new issues within a week" — that is a one-line change to this PR and I would rather you make it here than have us ship a non-commitment by default.

## Testing

- [x] Existing tests pass (`pytest`) — 1375 passed, 4 skipped
- [x] Lint passes (`ruff check .`) — all checks passed
- [x] Format check passes (`ruff format --check .`) — 38 files already formatted
- [ ] Tested manually — n/a (documentation only)

## Additional Notes

**Checked for a conflicting commitment before shipping the "no SLA" claim.** A statement that we *do not* promise something is only correct if we do not already promise it somewhere else, so I grepped every doc and workflow surface in the repo for existing response-time language rather than assuming. There is exactly one: `SECURITY.md` commits to concrete timelines (acknowledge within 3 business days, triage within 7, patch plan within 30 for critical/high). That is **not** a contradiction — `SECURITY.md` covers privately-reported vulnerabilities and explicitly tells reporters *not* to open a public GitHub issue, so the two policies govern disjoint channels, and the new sentence is scoped to "issues and pull requests" rather than to the project generally.

Flagging it anyway because it is a wording call you may want to make differently: if you would like `CONTRIBUTING.md` to point readers at the stronger security timeline (e.g. "security reports follow the timelines in `SECURITY.md`"), say so and I will add the pointer. I left it out because the ticket scoped this to one heading plus one sentence.

Two smaller judgment calls:

- The sentence is hard-wrapped at ~80 columns to match the surrounding prose in `CONTRIBUTING.md`; the source spec showed it as a single line. Markdown renders the two identically.
- The internal checklist that motivated this change is referenced by description rather than by tracker ID, per this repo's destined-public hygiene rule (`AGENTS.md`: no internal-tracker references in commit or PR text).

CI runs `pytest` / `ruff check` / `ruff format --check` regardless; the workflow no-ops the suite for Markdown-only PRs by design, so the required contexts still report.
