### PR TITLE
ci(secret-scanning): add weekly + on-demand full-history scan job

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,21 +1,42 @@
 name: Secret Scanning
 
+# Two jobs, one per trigger set — the TruffleHog action picks diff-vs-full-scan
+# from `github.event_name`, so they cannot be the same job:
+#   `scan`         — DIFF gate on every push/PR to main: scans only that event's
+#                    base..head range, so a new secret can never land on main.
+#   `full-history` — FULL rescan of every commit, weekly + on demand: catches
+#                    secrets that only became verifiable later, and ones that
+#                    only a newer detector recognizes. The diff gate never
+#                    re-reads history, so without this nothing ever does.
+
 on:
   pull_request:
     branches: [main]
   push:
     branches: [main]
+  schedule:
+    - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # `github.event_name` is in the key so an ordinary push to main cannot cancel
+  # an in-flight full-history rescan: both carry ref `refs/heads/main`, and a
+  # scheduled scan is minutes of work that a one-second push would otherwise
+  # kill. It changes nothing for the existing pair — a `push` to main and a
+  # `pull_request` targeting it never shared a group anyway (their refs differ:
+  # `refs/heads/main` vs `refs/pull/<n>/merge`).
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Diff gate — blocks a secret from entering main. Unchanged behavior; the `if`
+  # only keeps it off the schedule/dispatch runs that `full-history` owns.
   scan:
     name: TruffleHog
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -24,4 +45,30 @@ jobs:
 
       - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
         with:
+          extra_args: --only-verified
+
+  # Periodic full-history rescan — the reproducible form of the one-off
+  # deliberate scan run during the pre-public secret-scanning review.
+  full-history:
+    name: TruffleHog (full history)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history is the point of this job — a shallow clone would leave
+          # the scan below one commit to look at.
+          fetch-depth: 0
+
+      - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
+        with:
+          # Empty base = scan the whole branch, not a base..head diff. At this
+          # pinned SHA the action already forces base and head empty on
+          # `schedule` / `workflow_dispatch`, so this states that default out
+          # loud — it is what keeps the job a full scan if a future trigger (or
+          # action version) would otherwise infer a diff range here.
+          base: ""
+          # Keep --only-verified. An unfiltered run trips 13 unverified
+          # placeholder-URI hits that are redaction FIXTURES in the tests and in
+          # failure_log.py, which would fail this job every week, forever.
           extra_args: --only-verified

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -5,9 +5,17 @@ name: Secret Scanning
 #   `scan`         — DIFF gate on every push/PR to main: scans only that event's
 #                    base..head range, so a new secret can never land on main.
 #   `full-history` — FULL rescan of every commit, weekly + on demand: catches
-#                    secrets that only became verifiable later, and ones that
-#                    only a newer detector recognizes. The diff gate never
+#                    secrets that only became verifiable later, ones only a
+#                    newer detector recognizes, and ones nothing can verify at
+#                    all (see its two passes below). The diff gate never
 #                    re-reads history, so without this nothing ever does.
+#
+# The weekly leg is best-effort, not a guarantee: GitHub disables `schedule` on a
+# repository with no activity for 60 days, and a scheduled-run failure only
+# emails the last person to touch this file. A dormant repo — the case the
+# rescan exists for — is therefore exactly the case where it stops silently.
+# Run it by hand after a long quiet spell:
+#   gh workflow run secret-scanning.yml -R Comfy-Org/comfy-local-mcp
 
 on:
   pull_request:
@@ -22,13 +30,27 @@ permissions:
   contents: read
 
 concurrency:
-  # `github.event_name` is in the key so an ordinary push to main cannot cancel
-  # an in-flight full-history rescan: both carry ref `refs/heads/main`, and a
-  # scheduled scan is minutes of work that a one-second push would otherwise
-  # kill. It changes nothing for the existing pair — a `push` to main and a
-  # `pull_request` targeting it never shared a group anyway (their refs differ:
+  # Two things are in this key, for two different reasons.
+  #
+  # `github.event_name` — so an ordinary push to main cannot cancel an in-flight
+  # full-history rescan: both carry ref `refs/heads/main`, and a scheduled scan
+  # is minutes of work that a one-second push would otherwise kill. It changes
+  # nothing for the existing pair — a `push` to main and a `pull_request`
+  # targeting it never shared a group anyway (their refs differ:
   # `refs/heads/main` vs `refs/pull/<n>/merge`).
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  #
+  # `github.sha`, on `push` only — because a push run scans ONLY that push's own
+  # `before..after` range, and nothing ever revisits it. Two pushes to main in
+  # quick succession would otherwise share a group; cancelling the first drops
+  # its range on the floor for good (the second's range starts at the first's
+  # head), so a secret could land on main unscanned. Distinct ranges are
+  # distinct work, so they get distinct groups and all of them run. Queueing
+  # instead of cancelling would not fix it — GitHub cancels superseded *pending*
+  # runs too, even with `cancel-in-progress: false`.
+  #
+  # PR and schedule/dispatch runs are unaffected: each recomputes the whole
+  # answer for its ref, so superseding one is free and stays the default.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || 'shared' }}
   cancel-in-progress: true
 
 jobs:
@@ -38,10 +60,20 @@ jobs:
     name: TruffleHog
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    # A scan that hangs (a wedged verification request, say) would otherwise sit
+    # on a runner for the 6-hour default and report nothing. Fail visibly first.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          # The TruffleHog action bind-mounts this workspace into a container it
+          # pulls by TAG (`ghcr.io/trufflesecurity/trufflehog:latest` — the
+          # action is SHA-pinned, the image behind it is not). Checkout's default
+          # would leave the job's GITHUB_TOKEN in `.git/config` as an auth
+          # extraheader, inside that mount. Nothing here needs to push, so don't
+          # hand the scanner a credential to begin with.
+          persist-credentials: false
 
       - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
         with:
@@ -51,24 +83,67 @@ jobs:
   # deliberate scan run during the pre-public secret-scanning review.
   full-history:
     name: TruffleHog (full history)
+    # This `if` is what makes the job a full scan, and it is load-bearing, not
+    # tidiness. The action infers its scan range from `github.event_name`, and
+    # `schedule` / `workflow_dispatch` are the two names it maps to "whole
+    # branch"; every other trigger maps to some base..head diff. There is no
+    # input that can override that here — passing `base: ""` reads like a pin
+    # but is a no-op, because the action only honors explicit base/head when at
+    # least one is NON-empty, and no non-empty value means "everything". So:
+    # widen the triggers above and this job silently becomes a diff scan unless
+    # this condition is widened to match.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    # Every commit, so a longer ceiling than the diff gate's — still far under
+    # the 6-hour default a hung verification would otherwise burn silently.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Full history is the point of this job — a shallow clone would leave
           # the scan below one commit to look at.
           fetch-depth: 0
+          # Same reason as the diff gate: keep the GITHUB_TOKEN out of the
+          # `.git/config` that gets bind-mounted into the scanner container.
+          persist-credentials: false
 
+      # Two passes, because no single TruffleHog invocation covers both halves
+      # of what a rescan is for. Their union is strictly wider than
+      # --only-verified alone; either one failing fails the job.
+      #
+      # Pass 1 — every detector, but only findings TruffleHog could verify
+      # against the live provider. This is the half that catches a URI
+      # credential that is actually live.
       - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
         with:
-          # Empty base = scan the whole branch, not a base..head diff. At this
-          # pinned SHA the action already forces base and head empty on
-          # `schedule` / `workflow_dispatch`, so this states that default out
-          # loud — it is what keeps the job a full scan if a future trigger (or
-          # action version) would otherwise infer a diff range here.
-          base: ""
-          # Keep --only-verified. An unfiltered run trips 13 unverified
-          # placeholder-URI hits that are redaction FIXTURES in the tests and in
-          # failure_log.py, which would fail this job every week, forever.
           extra_args: --only-verified
+
+      # Pass 2 — UNVERIFIED findings too, minus the one detector that is pure
+      # noise here. --only-verified on its own is not just "fewer false
+      # positives": it silently drops private keys, providers TruffleHog has no
+      # verifier for, revoked-but-still-sensitive keys, and anything whose
+      # verification call merely failed. Those are exactly what a rescan of
+      # history is supposed to surface, so the weekly job cannot only run
+      # pass 1.
+      #
+      # URI is excluded rather than the fixture FILES excluded, because a
+      # path-based exclude does not actually work here. Scanning all 355
+      # commits unverified reports 24 hits; every one is the URI detector
+      # firing on the literal redaction fixture `https://user:pass@host`, they
+      # span 7 paths (including `server.py` and `textutil.py`, which no one
+      # should blind a secret scanner to), and TWO of them carry no file path
+      # at all — nothing `--exclude-paths` can name. Dropping the detector
+      # instead measures clean: 0 verified, 0 unverified across the same 355
+      # commits. Pass 1 still covers the verified-URI case this gives up.
+      #
+      # If a future detector rule starts firing on a fixture, prefer narrowing
+      # THAT fixture over widening this exclusion — every name added here is a
+      # detector switched off across all of history.
+      - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
+        # Run even if pass 1 already failed. A rescan's job is a complete
+        # inventory, and the default stop-on-failure would hide every unverified
+        # finding behind the first verified one — turning one bad week into two.
+        # Pass 1's failure still fails the job.
+        if: ${{ !cancelled() }}
+        with:
+          extra_args: --exclude-detectors=URI


### PR DESCRIPTION
## ELI-5

Our secret scanner only ever looks at the lines a push or PR changed. It has never re-read the repo's past. That matters for two reasons: a key that looked harmless when it was committed can become verifiable later, and TruffleHog ships new detectors that recognize things the old version walked straight past. So this adds a second scanner job that reads the *whole* history — automatically every Monday, and on a button press whenever you want one — while the original job keeps guarding the front door.

## Summary

`secret-scanning.yml` ran the TruffleHog action only on `push` / `pull_request` to `main`. The action derives its scan range from `github.event_name`, so both of those are a `base..head` **diff** scan — history is never rescanned. This adds a `schedule` (weekly) + `workflow_dispatch` trigger and a second job that scans the full branch, and keeps the existing job as the diff gate behind an event guard.

## Changes

- New triggers: `schedule: '0 6 * * 1'` (Monday 06:00 UTC) and `workflow_dispatch`.
- Existing `scan` job gated with `if: github.event_name == 'push' || github.event_name == 'pull_request'` — same steps, same pins, same behavior on the events it already ran on.
- New `full-history` job, `if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'`: same pinned SHAs (`actions/checkout` v7.0.0 `9c091bb`, `trufflesecurity/trufflehog` v3.95.8 `00155c9`), `fetch-depth: 0`, `base: ""` to force a whole-branch scan, `extra_args: --only-verified`.
- Concurrency group now includes `github.event_name` (see Additional Notes).
- Header comment explains what each of the two jobs is for, one entry each.

## Motivation

The one-off deliberate full-history scan run during the pre-public secret-scanning review came back clean (0 verified across all refs, with gitleaks concurring), but it was a human running a command once. Making it a CI job makes it reproducible, and making it periodic is what catches the two classes of finding a diff-only gate structurally cannot: a secret that only becomes *verifiable* after it was committed, and a secret only a newer detector ruleset recognizes.

`--only-verified` is deliberately kept on the full-history job. Without it the scan reports 13 unverified placeholder-URI hits that are redaction **fixtures** — `src/comfy_local_mcp/failure_log.py`, `tests/test_remote_host.py`, `tests/test_wrapper.py` — which would fail this job every week, forever, and train everyone to ignore it.

## Testing

- [x] Existing tests pass (`pytest` — 1375 passed, 4 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually (describe below)

**`actionlint`** passes on the changed workflow.

**The dispatch path is verified live on this branch**, not just reasoned about — run [30544067381](https://github.com/Comfy-Org/comfy-local-mcp/actions/runs/30544067381):

- `TruffleHog (full history)` → **success**; `TruffleHog` (diff gate) → **skipped**, exactly as the two `if` guards intend.
- Its log shows a full scan, not a diff: `finished scanning {"chunks": 3451, "bytes": 4012977, "verified_secrets": 0, "unverified_secrets": 0}`. A diff scan of this branch (one commit, one YAML file) would be a handful of chunks; 3451 chunks / ~4 MB is the entire history.

**Why `base: ""` is the right knob** (read from `action.yml` at the pinned SHA, not assumed): the action takes the `base`/`head` route only when at least one of them is non-empty; otherwise it switches on the event, and the `schedule` / `workflow_dispatch` arm sets both to empty — a whole-branch scan. So `base: ""` matches the action's own default for these events. It is stated explicitly anyway because it is the line that keeps this job a full scan if a future trigger or action version would otherwise infer a diff range here.

**The diff gate is verified live too**, on this PR's own Secret Scanning run [30544162343](https://github.com/Comfy-Org/comfy-local-mcp/actions/runs/30544162343): `TruffleHog` → **success**, `TruffleHog (full history)` → **skipped**. Its log reads `finished scanning {"chunks": 2, "bytes": 3847}` — a diff, against the dispatch run's 3451 chunks / ~4 MB for the same repo. Same action, same pins, two ranges: that contrast is the clearest single piece of evidence that the two jobs do what their names say.

## Additional Notes

**Judgment call — concurrency key.** I added `github.event_name` to the concurrency group. With `cancel-in-progress: true` and the old key, a scheduled or dispatched full-history run and an ordinary push to `main` share ref `refs/heads/main`, so a one-second push would cancel a multi-minute rescan — silently, and the rescan is the whole point of this PR. This changes nothing for the existing pair: a `push` to `main` and a `pull_request` targeting it already had distinct refs (`refs/heads/main` vs `refs/pull/<n>/merge`), so they never shared a group.

**Judgment call — the `scan` gate is written positively** (`event_name == 'push' || event_name == 'pull_request'`), per the plan, rather than as `!= 'schedule' && != 'workflow_dispatch'`. The tradeoff is worth naming: the positive form fails *closed*, so if someone later adds a third trigger (a `merge_group`, say) the diff gate will not run on it until its `if` is extended. The negative form would fail open. I kept the positive form because it is explicit and reads with the job comment, but whoever adds the next trigger to this file needs to touch both `if`s.

**Not required-check-affecting.** `main`'s branch protection requires only `test (py3.10)` and `test (py3.14)`, so neither the new `if` guard nor the new job can wedge a PR on a skipped context.

**Pre-existing, not introduced:** the action's `version` input defaults to `latest`, so both jobs pull `ghcr.io/trufflesecurity/trufflehog:latest` even though the *action* is SHA-pinned (this run resolved to CLI 3.96.0 while the action is v3.95.8). That is how the existing job already behaved. Pinning the CLI version too is a reasonable follow-up, but it is a change to the existing gate's behavior and out of scope here.

**Post-flip follow-through — for whoever flips this repo public.** GitHub-native secret scanning and push protection are free on public repos and are both currently **disabled**; the enable call only works *after* the repo is public, so it cannot be part of this PR. Once it is public:

```
gh api -X PATCH repos/Comfy-Org/comfy-local-mcp --input - <<< '{"security_and_analysis":{"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"}}}'
```

That is complementary to this workflow, not a replacement: GitHub's scanner has its own partner-detector set and push protection blocks at push time, while this job is the TruffleHog ruleset with verification.
