### PR TITLE
ci(secret-scanning): run the unverified pass on the diff gate too, pin the scanner image

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -3,7 +3,9 @@ name: Secret Scanning
 # Two jobs, one per trigger set — the TruffleHog action picks diff-vs-full-scan
 # from `github.event_name`, so they cannot be the same job:
 #   `scan`         — DIFF gate on every push/PR to main: scans only that event's
-#                    base..head range, so a new secret can never land on main.
+#                    base..head range, so a new secret does not reach main
+#                    unnoticed. One documented exception survives, in the URI
+#                    detector — see pass 2 on that job.
 #   `full-history` — FULL rescan of every commit, weekly + on demand: catches
 #                    secrets that only became verifiable later, ones only a
 #                    newer detector recognizes, and ones nothing can verify at
@@ -62,22 +64,41 @@ jobs:
     runs-on: ubuntu-latest
     # A scan that hangs (a wedged verification request, say) would otherwise sit
     # on a runner for the 6-hour default and report nothing. Fail visibly first.
-    timeout-minutes: 15
+    # The per-STEP budgets below are the real limits — each pass gets its own,
+    # so a slow pass 1 cannot eat the budget pass 2 needs. This job-level cap is
+    # only the backstop, set above their sum plus checkout.
+    timeout-minutes: 25
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - id: checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          # The TruffleHog action bind-mounts this workspace into a container it
-          # pulls by TAG (`ghcr.io/trufflesecurity/trufflehog:latest` — the
-          # action is SHA-pinned, the image behind it is not). Checkout's default
-          # would leave the job's GITHUB_TOKEN in `.git/config` as an auth
-          # extraheader, inside that mount. Nothing here needs to push, so don't
-          # hand the scanner a credential to begin with.
+          # The TruffleHog action bind-mounts this workspace into the scanner
+          # container. Checkout's default would leave the job's GITHUB_TOKEN in
+          # `.git/config` as an auth extraheader, inside that mount. Nothing
+          # here needs to push, so don't hand the scanner a credential at all.
           persist-credentials: false
 
+      # Same two passes as `full-history` below, for the same reason — see the
+      # long note there. The gate needs both as much as the rescan does: with
+      # only pass 1, a private key or a token for a provider TruffleHog has no
+      # verifier for sails through the gate onto main, and nothing notices until
+      # the weekly rescan up to 7 days later (and that leg is best-effort).
       - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
+        timeout-minutes: 10
         with:
+          version: 3.95.8 # keep in lockstep with the action SHA above
           extra_args: --only-verified
+
+      - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
+        # Gate on the checkout, not merely on "not cancelled": pass 2 must still
+        # run when pass 1 FAILED (that is the point — one run, whole inventory),
+        # but must not run when there is no tree to scan.
+        if: steps.checkout.outcome == 'success'
+        timeout-minutes: 10
+        with:
+          version: 3.95.8 # keep in lockstep with the action SHA above
+          extra_args: --exclude-detectors=URI
 
   # Periodic full-history rescan — the reproducible form of the one-off
   # deliberate scan run during the pre-public secret-scanning review.
@@ -94,11 +115,13 @@ jobs:
     # this condition is widened to match.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    # Every commit, so a longer ceiling than the diff gate's — still far under
+    # Every commit, so longer ceilings than the diff gate's — still far under
     # the 6-hour default a hung verification would otherwise burn silently.
-    timeout-minutes: 30
+    # As above, the per-step budgets bind first; this is the backstop.
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - id: checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Full history is the point of this job — a shallow clone would leave
           # the scan below one commit to look at.
@@ -115,35 +138,47 @@ jobs:
       # against the live provider. This is the half that catches a URI
       # credential that is actually live.
       - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
+        timeout-minutes: 20
         with:
+          version: 3.95.8 # keep in lockstep with the action SHA above
           extra_args: --only-verified
 
       # Pass 2 — UNVERIFIED findings too, minus the one detector that is pure
       # noise here. --only-verified on its own is not just "fewer false
       # positives": it silently drops private keys, providers TruffleHog has no
       # verifier for, revoked-but-still-sensitive keys, and anything whose
-      # verification call merely failed. Those are exactly what a rescan of
-      # history is supposed to surface, so the weekly job cannot only run
-      # pass 1.
+      # verification call merely failed. Those are exactly what a scan is
+      # supposed to surface, so neither job can run pass 1 alone.
       #
       # URI is excluded rather than the fixture FILES excluded, because a
-      # path-based exclude does not actually work here. Scanning all 355
-      # commits unverified reports 24 hits; every one is the URI detector
-      # firing on the literal redaction fixture `https://user:pass@host`, they
-      # span 7 paths (including `server.py` and `textutil.py`, which no one
-      # should blind a secret scanner to), and TWO of them carry no file path
-      # at all — nothing `--exclude-paths` can name. Dropping the detector
-      # instead measures clean: 0 verified, 0 unverified across the same 355
-      # commits. Pass 1 still covers the verified-URI case this gives up.
+      # path-based exclude cannot work here. Scanning all 355 commits unverified
+      # reports 24 hits; every one is the URI detector firing on the literal
+      # redaction fixture `https://user:pass@host`. They span 7 paths (including
+      # `server.py` and `textutil.py`, which no one should blind a secret
+      # scanner to), and TWO of them are in COMMIT MESSAGES — the refactor that
+      # created these modules quoted the fixture in its body — which no path or
+      # glob filter can reach, and which no future edit can remove short of
+      # rewriting history. Dropping the detector instead measures clean: 0
+      # verified, 0 unverified across the same 355 commits.
       #
-      # If a future detector rule starts firing on a fixture, prefer narrowing
-      # THAT fixture over widening this exclusion — every name added here is a
-      # detector switched off across all of history.
+      # What this gives up, precisely: an UNVERIFIABLE URI credential (a live
+      # secret for a host the runner cannot reach, so verification neither
+      # succeeds nor is retried). Pass 1 still catches a verifiable one. Closing
+      # the rest means changing the fixture so it stops matching the detector,
+      # at which point this exclusion can be dropped from the diff gate (it must
+      # stay here — history keeps the old fixture forever).
+      #
+      # If a future detector starts firing on a fixture, prefer narrowing THAT
+      # fixture over widening this exclusion — every name added here switches a
+      # detector off across all of history.
       - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
-        # Run even if pass 1 already failed. A rescan's job is a complete
-        # inventory, and the default stop-on-failure would hide every unverified
-        # finding behind the first verified one — turning one bad week into two.
-        # Pass 1's failure still fails the job.
-        if: ${{ !cancelled() }}
+        # Gate on the checkout rather than `!cancelled()`: pass 2 must still run
+        # when pass 1 FAILED — a scan's job is a complete inventory, and the
+        # default stop-on-failure would hide every unverified finding behind the
+        # first verified one, turning one bad week into two. Pass 1's failure
+        # still fails the job.
+        if: steps.checkout.outcome == 'success'
+        timeout-minutes: 20
         with:
+          version: 3.95.8 # keep in lockstep with the action SHA above
           extra_args: --exclude-detectors=URI

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -64,10 +64,11 @@ jobs:
     runs-on: ubuntu-latest
     # A scan that hangs (a wedged verification request, say) would otherwise sit
     # on a runner for the 6-hour default and report nothing. Fail visibly first.
-    # The per-STEP budgets below are the real limits — each pass gets its own,
-    # so a slow pass 1 cannot eat the budget pass 2 needs. This job-level cap is
-    # only the backstop, set above their sum plus checkout.
-    timeout-minutes: 25
+    # This has to be the JOB cap: step-level `timeout-minutes` is not enforced
+    # for a step that runs a COMPOSITE action, and the TruffleHog action is one
+    # (`runs.using: composite`). Per-pass budgets would read as limits while
+    # enforcing nothing, so both passes share this one.
+    timeout-minutes: 15
     steps:
       - id: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -85,19 +86,26 @@ jobs:
       # verifier for sails through the gate onto main, and nothing notices until
       # the weekly rescan up to 7 days later (and that leg is best-effort).
       - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
-        timeout-minutes: 10
         with:
-          version: 3.95.8 # keep in lockstep with the action SHA above
+          # tag@digest, not a bare tag: the action interpolates this straight
+          # into `docker run ghcr.io/trufflesecurity/trufflehog:${VERSION}`, and
+          # a bare tag is mutable — a re-push would be arbitrary code execution
+          # against a bind-mounted checkout. The tag is kept alongside the digest
+          # only so a human can read which release this is. Bump both together
+          # with the action SHA above.
+          version: 3.95.8@sha256:2233f7b95e2659c15de11715352e840397ce6d4553fe3d40e13e742e5b239be4
           extra_args: --only-verified
 
       - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
-        # Gate on the checkout, not merely on "not cancelled": pass 2 must still
-        # run when pass 1 FAILED (that is the point — one run, whole inventory),
-        # but must not run when there is no tree to scan.
-        if: steps.checkout.outcome == 'success'
-        timeout-minutes: 10
+        # `!cancelled()` is load-bearing and cannot be dropped: a step `if` that
+        # names no status function is implicitly wrapped in `success()`, so the
+        # checkout test ALONE would silently mean "…and every previous step
+        # passed" — skipping pass 2 exactly when pass 1 fails, which is the case
+        # it exists for. The checkout test then adds what `!cancelled()` on its
+        # own does not: don't scan a tree that was never fetched.
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         with:
-          version: 3.95.8 # keep in lockstep with the action SHA above
+          version: 3.95.8@sha256:2233f7b95e2659c15de11715352e840397ce6d4553fe3d40e13e742e5b239be4
           extra_args: --exclude-detectors=URI
 
   # Periodic full-history rescan — the reproducible form of the one-off
@@ -115,10 +123,11 @@ jobs:
     # this condition is widened to match.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    # Every commit, so longer ceilings than the diff gate's — still far under
-    # the 6-hour default a hung verification would otherwise burn silently.
-    # As above, the per-step budgets bind first; this is the backstop.
-    timeout-minutes: 45
+    # Every commit, so a longer ceiling than the diff gate's — still far under
+    # the 6-hour default a hung verification would otherwise burn silently. Job
+    # level for the same reason as above: a composite action's step budget is
+    # not enforced, so this cap covers both passes together.
+    timeout-minutes: 30
     steps:
       - id: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -138,9 +147,9 @@ jobs:
       # against the live provider. This is the half that catches a URI
       # credential that is actually live.
       - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
-        timeout-minutes: 20
         with:
-          version: 3.95.8 # keep in lockstep with the action SHA above
+          # tag@digest — see the note on the diff gate's pass 1.
+          version: 3.95.8@sha256:2233f7b95e2659c15de11715352e840397ce6d4553fe3d40e13e742e5b239be4
           extra_args: --only-verified
 
       # Pass 2 — UNVERIFIED findings too, minus the one detector that is pure
@@ -172,13 +181,15 @@ jobs:
       # fixture over widening this exclusion — every name added here switches a
       # detector off across all of history.
       - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
-        # Gate on the checkout rather than `!cancelled()`: pass 2 must still run
-        # when pass 1 FAILED — a scan's job is a complete inventory, and the
-        # default stop-on-failure would hide every unverified finding behind the
-        # first verified one, turning one bad week into two. Pass 1's failure
-        # still fails the job.
-        if: steps.checkout.outcome == 'success'
-        timeout-minutes: 20
+        # Pass 2 must still run when pass 1 FAILED — a rescan's job is a
+        # complete inventory, and the default stop-on-failure would hide every
+        # unverified finding behind the first verified one, turning one bad week
+        # into two. `!cancelled()` is what buys that: a step `if` naming no
+        # status function is implicitly wrapped in `success()`, so the checkout
+        # test alone would quietly restore stop-on-failure. The checkout test
+        # adds the other half — never scan a tree that was never fetched. Pass
+        # 1's failure still fails the job.
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         with:
-          version: 3.95.8 # keep in lockstep with the action SHA above
+          version: 3.95.8@sha256:2233f7b95e2659c15de11715352e840397ce6d4553fe3d40e13e742e5b239be4
           extra_args: --exclude-detectors=URI


### PR DESCRIPTION
Follow-up to #143. That PR merged while its review panel was still running, so the panel's findings on the final revision landed after the merge — and the consolidation job failed to post them (HTTP 422 on both the primary and fallback review POST), so they never appeared on the PR at all. I pulled them out of the run artifacts. This PR carries the ones that hold up.

## ELI5

#143 added a weekly scan of the whole git history, and made both it and the per-PR gate a bit smarter. But the *gate* — the check that runs on every PR — was still only reporting secrets it could phone home and confirm were live. That means a leaked private key, or a token for a service TruffleHog has no way to check, sailed straight through onto `main`, and nobody found out until the weekly scan up to 7 days later. This makes the gate as strict as the weekly scan. It also nails down *which* scanner runs: the action was version-locked, but the actual program it downloaded and ran was whatever `:latest` happened to be that morning.

## What changed

**The diff gate now runs both passes.** Previously `scan` ran only `--only-verified`. The classes the whole rescan exists for — private keys, providers with no verifier, revoked-but-still-sensitive keys, transient verification failures — passed the gate onto `main` and went unnoticed until the weekly job, which this file itself documents as best-effort (GitHub disables `schedule` after 60 dormant days). Six of the eight panel reviewers raised this independently; the judge rated it High. The header's completeness claim is narrowed to what is now actually true, with the one surviving exception named at its source.

**The scanner image is pinned.** The action was SHA-pinned, but its final line is:

```
docker run --rm -v .:/tmp -w /tmp ghcr.io/trufflesecurity/trufflehog:${VERSION} ...
```

with `version` defaulting to `latest` — a mutable tag, re-resolved every run, receiving the full repository history as a bind mount on every step including the merge-blocking one. Now pinned to `3.95.8` to match the action release, so the code executing against the tree is as fixed as the action referencing it and the detector set is reproducible. New detectors arrive on a deliberate bump instead of silently, which is the same contract as every other pin in this repo.

I had argued against pinning in the #143 review threads on the grounds that picking up new detectors is a reason the rescan exists. Five reviewers pushed back and they were right — that benefit survives a bump, and it did not justify running an unpinned image against full history.

**Smaller fixes from the same panel:**

- Both pass-2 steps are gated on the checkout step's `outcome` rather than `!cancelled()`, so pass 2 still runs after a pass-1 failure (one run, whole inventory) but not against a tree that was never fetched.
- Each pass carries its own `timeout-minutes`, so a slow verifying pass 1 cannot consume the budget pass 2 needs. Job-level caps are now backstops above the sum rather than the binding limit.

## What I did not change, and why

**The `URI` detector stays excluded from pass 2.** Reviewers proposed swapping it for `--exclude-paths` over the fixture files. That cannot work, and the measurement says why. Scanning all 355 commits unverified reports 24 findings, every one the URI detector firing on the literal redaction fixture `https://user:pass@host`:

| count | location |
|---|---|
| 7 | `src/comfy_local_mcp/failure_log.py` |
| 5 | `tests/test_failure_log.py` |
| 3 | `src/comfy_local_mcp/server.py` |
| 3 | `tests/test_remote_host.py` |
| 2 | `src/comfy_local_mcp/textutil.py` |
| 2 | `tests/test_wrapper.py` |
| 2 | **commit messages** (59e1333, 02da3f0) |

Two are in commit message bodies — the refactor that created these modules quoted the fixture in its own message — which no path or glob filter can reach and no future edit can remove short of rewriting history. And excluding `server.py`/`textutil.py` wholesale would blind the scanner to the two largest source modules. Dropping the detector is the only option that measures clean: 0 verified, 0 unverified across the same 355 commits.

The residual is stated precisely in the comment: an *unverifiable* URI credential is caught by nothing. Closing it means changing the fixture so it stops matching, after which the exclusion can come off the gate (it must stay on full-history regardless). Filed as a follow-up rather than done here — it touches six files' fixtures and their assertions.

**Force-push / zero-SHA gaps in the push range.** Three reviewers flagged that a push run's `before..after` range can be broken. Checked: force pushes and deletions are both disabled on `main` by branch protection, and the action maps the all-zeros `before` (first push) to an empty BASE, which is a *full* branch scan rather than a skip. Not reachable.

**Secrets echoed into job logs.** Real, but only materializes once a finding exists, and the response to a finding is rotating the credential — which moots the log copy. Not worth the complexity of routing output to a restricted artifact and losing the console signal.

## Verification

All measurements above are from the pinned image against a full clone:

```
docker run --rm -v "$PWD":/repo -w /repo ghcr.io/trufflesecurity/trufflehog:3.95.8 \
  git file:///repo/ --no-update --json
```

- unfiltered: 24 unverified, 0 verified — all `URI`, all the fixture
- `--exclude-detectors=URI`: **0 unverified, 0 verified**, same 3453 chunks scanned

Workflow YAML parses; `ruff check` and `ruff format --check` clean. No Python changed.

Note: `.github/workflows/secret-scanning.yml` is not currently a required status check on `main` (only `test (py3.10)` and `test (py3.14)` are), so this gate is advisory until someone adds it — worth doing before the repo goes public, but that is a branch-protection change, not a code one.