### PR TITLE
ci(secret-scanning): run the URI detector on the diff gate

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -4,8 +4,7 @@ name: Secret Scanning
 # from `github.event_name`, so they cannot be the same job:
 #   `scan`         — DIFF gate on every push/PR to main: scans only that event's
 #                    base..head range, so a new secret does not reach main
-#                    unnoticed. One documented exception survives, in the URI
-#                    detector — see pass 2 on that job.
+#                    unnoticed. Every detector is on here, verified and not.
 #   `full-history` — FULL rescan of every commit, weekly + on demand: catches
 #                    secrets that only became verifiable later, ones only a
 #                    newer detector recognizes, and ones nothing can verify at
@@ -85,6 +84,8 @@ jobs:
       # only pass 1, a private key or a token for a provider TruffleHog has no
       # verifier for sails through the gate onto main, and nothing notices until
       # the weekly rescan up to 7 days later (and that leg is best-effort).
+      # The two jobs' pass 2 differ in exactly one way — the URI detector — for
+      # a reason spelled out on this job's pass 2 below.
       - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
         with:
           # tag@digest, not a bare tag: the action interpolates this straight
@@ -96,6 +97,33 @@ jobs:
           version: 3.95.8@sha256:2233f7b95e2659c15de11715352e840397ce6d4553fe3d40e13e742e5b239be4
           extra_args: --only-verified
 
+      # Pass 2 — UNVERIFIED findings too, EVERY detector. `full-history`'s pass 2
+      # excludes the URI detector; this one deliberately does not, and the split
+      # is the whole point rather than drift:
+      #
+      #   * What URI catches that nothing else does is an UNVERIFIABLE URL-embedded
+      #     credential — a real secret for a host the runner cannot reach (internal
+      #     hostname, offline endpoint, blocked egress), so verification neither
+      #     succeeds nor is retried. Pass 1 drops it because it never verifies;
+      #     excluding the detector drops it too. That is precisely the case the
+      #     no-internal-hostnames rule in AGENTS.md is about.
+      #   * The reason `full-history` still excludes it is HISTORY, not the working
+      #     tree: the old `user:pass@host` redaction fixture is in ~24 places across
+      #     past commits, two of them in COMMIT MESSAGES that no path filter can
+      #     reach and no future edit can remove short of rewriting history. The
+      #     working tree no longer contains any of it — the fixtures now read
+      #     `https://<user>:<pass>@host`, which the detector does not match — so the
+      #     diff gate, which only ever reads new commits, measures clean with the
+      #     detector ON. That gives full URI coverage on all NEW code, which is the
+      #     case that matters going forward.
+      #
+      # Consequence to keep in mind when editing fixtures: a URL carrying a bare
+      # `user:pass@` userinfo, added in a PR — in code, in a test, or in a
+      # comment like this one — now FAILS this gate. That is the intent; write
+      # the placeholder form (AGENTS.md "Destined-public hygiene").
+      # No `extra_args` at all is what asks for "all detectors, verified and
+      # unverified": reporting unverified findings is the CLI's default, and
+      # `--only-verified` on pass 1 above is the opt-OUT.
       - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
         # `!cancelled()` is load-bearing and cannot be dropped: a step `if` that
         # names no status function is implicitly wrapped in `success()`, so the
@@ -106,7 +134,6 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         with:
           version: 3.95.8@sha256:2233f7b95e2659c15de11715352e840397ce6d4553fe3d40e13e742e5b239be4
-          extra_args: --exclude-detectors=URI
 
   # Periodic full-history rescan — the reproducible form of the one-off
   # deliberate scan run during the pre-public secret-scanning review.
@@ -159,23 +186,32 @@ jobs:
       # verification call merely failed. Those are exactly what a scan is
       # supposed to surface, so neither job can run pass 1 alone.
       #
+      # URI is excluded HERE ONLY — the diff gate above runs the same pass with
+      # the detector ON, and that asymmetry is deliberate. What forces it is
+      # history, which this job alone re-reads and which nothing can edit.
+      #
       # URI is excluded rather than the fixture FILES excluded, because a
       # path-based exclude cannot work here. Scanning all 355 commits unverified
-      # reports 24 hits; every one is the URI detector firing on the literal
-      # redaction fixture `https://user:pass@host`. They span 7 paths (including
-      # `server.py` and `textutil.py`, which no one should blind a secret
-      # scanner to), and TWO of them are in COMMIT MESSAGES — the refactor that
-      # created these modules quoted the fixture in its body — which no path or
-      # glob filter can reach, and which no future edit can remove short of
-      # rewriting history. Dropping the detector instead measures clean: 0
-      # verified, 0 unverified across the same 355 commits.
+      # reports 24 hits; every one is the URI detector firing on the old literal
+      # redaction fixture (a bare `user:pass@` in an https URL). They span 7
+      # paths (including `server.py` and `textutil.py`, which no one should
+      # blind a secret scanner to), and TWO of them are in COMMIT MESSAGES — the
+      # refactor that created these modules quoted the fixture in its body —
+      # which no path or glob filter can reach, and which no future edit can
+      # remove short of rewriting history. Dropping the detector instead
+      # measures clean: 0 verified, 0 unverified across the same 355 commits.
       #
-      # What this gives up, precisely: an UNVERIFIABLE URI credential (a live
-      # secret for a host the runner cannot reach, so verification neither
-      # succeeds nor is retried). Pass 1 still catches a verifiable one. Closing
-      # the rest means changing the fixture so it stops matching the detector,
-      # at which point this exclusion can be dropped from the diff gate (it must
-      # stay here — history keeps the old fixture forever).
+      # The working tree has since been fixed (the fixtures read
+      # `https://<user>:<pass>@host`, which the detector does not match), which
+      # is what let the diff gate turn the detector back on. It cannot be turned
+      # back on here as well until history is rewritten, so it will not be.
+      #
+      # What this job gives up, precisely: an UNVERIFIABLE URI credential (a
+      # live secret for a host the runner cannot reach, so verification neither
+      # succeeds nor is retried) that is already IN history. Pass 1 here still
+      # catches a verifiable one, and the diff gate catches every new one before
+      # it can become history — so the residual is bounded to what landed before
+      # that gate existed.
       #
       # If a future detector starts firing on a fixture, prefer narrowing THAT
       # fixture over widening this exclusion — every name added here switches a

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -126,18 +126,19 @@ jobs:
       # comment like this one — now FAILS this gate. That is the intent; write
       # the placeholder form (AGENTS.md "Destined-public hygiene").
       #
-      # Turning the detector on also makes this job depend on its scan RANGE
-      # staying anchored, which is worth knowing before touching either. The
-      # action derives the range from the event: `pull_request` pins it to the
-      # PR's own base/head SHAs, but `push` takes base from
-      # `github.event.before` — all-zeros on branch creation, unresolvable after
-      # a force-push — and the action maps an empty base to "scan the whole
-      # branch". That range with this detector ON re-reports the ~24 historical
-      # hits described below, failing a required check on unrelated work with no
-      # remediation short of rewriting history. What rules it out today is
-      # branch protection: `main` has force-pushes AND deletions disabled, so
-      # `before` is always a real ancestor. Re-check this before relaxing either
-      # setting, or before widening the `push` trigger past `main`.
+      # Turning the detector on also makes this job depend on something outside
+      # this file: its scan RANGE staying anchored. The action derives that range
+      # from the event — `pull_request` pins it to the PR's own base/head SHAs,
+      # but `push` takes base from `github.event.before`, which is all-zeros on
+      # branch creation and unresolvable after a force-push, and the action maps
+      # an empty base to "scan the whole branch". That range with the detector
+      # ON re-reports the ~24 historical hits described below, failing a
+      # required check on unrelated work with no remediation short of rewriting
+      # history. What rules it out today is branch protection: `main` has
+      # force-pushes AND deletions disabled, so `before` is always a real
+      # ancestor. Re-check this before relaxing either setting, or before
+      # widening the `push` trigger past `main`.
+      #
       # No `extra_args` at all is what asks for "all detectors, verified and
       # unverified": reporting unverified findings is the CLI's default, and
       # `--only-verified` on pass 1 above is the opt-OUT.

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -79,13 +79,17 @@ jobs:
           # here needs to push, so don't hand the scanner a credential at all.
           persist-credentials: false
 
-      # Same two passes as `full-history` below, for the same reason — see the
-      # long note there. The gate needs both as much as the rescan does: with
-      # only pass 1, a private key or a token for a provider TruffleHog has no
-      # verifier for sails through the gate onto main, and nothing notices until
-      # the weekly rescan up to 7 days later (and that leg is best-effort).
-      # The two jobs' pass 2 differ in exactly one way — the URI detector — for
-      # a reason spelled out on this job's pass 2 below.
+      # Two passes here as well, but NOT for `full-history`'s reason. That job's
+      # pass 2 drops a detector its pass 1 covers, so the two genuinely overlap
+      # only partly. This job's pass 2 runs EVERY detector and reports unverified
+      # findings, making its result set a strict SUPERSET of this pass's — so
+      # pass 1 can never fail while pass 2 passes, and it adds no coverage here.
+      # It is kept for the SIGNAL, not the coverage: a failure on this step names
+      # a VERIFIED live credential, the drop-everything case, distinctly from
+      # pass 2's unverified noise floor. Pass 2 is what carries the coverage —
+      # without it a private key, or a token for a provider TruffleHog has no
+      # verifier for, sails onto main and nothing notices until the weekly
+      # rescan up to 7 days later (and that leg is best-effort).
       - uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f # v3.95.8
         with:
           # tag@digest, not a bare tag: the action interpolates this straight
@@ -121,6 +125,19 @@ jobs:
       # `user:pass@` userinfo, added in a PR — in code, in a test, or in a
       # comment like this one — now FAILS this gate. That is the intent; write
       # the placeholder form (AGENTS.md "Destined-public hygiene").
+      #
+      # Turning the detector on also makes this job depend on its scan RANGE
+      # staying anchored, which is worth knowing before touching either. The
+      # action derives the range from the event: `pull_request` pins it to the
+      # PR's own base/head SHAs, but `push` takes base from
+      # `github.event.before` — all-zeros on branch creation, unresolvable after
+      # a force-push — and the action maps an empty base to "scan the whole
+      # branch". That range with this detector ON re-reports the ~24 historical
+      # hits described below, failing a required check on unrelated work with no
+      # remediation short of rewriting history. What rules it out today is
+      # branch protection: `main` has force-pushes AND deletions disabled, so
+      # `before` is always a real ancestor. Re-check this before relaxing either
+      # setting, or before widening the `push` trigger past `main`.
       # No `extra_args` at all is what asks for "all detectors, verified and
       # unverified": reporting unverified findings is the CLI's default, and
       # `--only-verified` on pass 1 above is the opt-OUT.
@@ -209,9 +226,16 @@ jobs:
       # What this job gives up, precisely: an UNVERIFIABLE URI credential (a
       # live secret for a host the runner cannot reach, so verification neither
       # succeeds nor is retried) that is already IN history. Pass 1 here still
-      # catches a verifiable one, and the diff gate catches every new one before
-      # it can become history — so the residual is bounded to what landed before
-      # that gate existed.
+      # catches a verifiable one, and the diff gate is what covers new ones — so
+      # in practice the residual is what landed before that gate existed.
+      #
+      # "The gate covers new ones" is a strong default, not an invariant: a run
+      # that never happens catches nothing. A `[skip ci]` push, a disabled or
+      # edited workflow, and an admin push that bypasses branch protection all
+      # get past it (`enforce_admins` is off). Because this job will not re-read
+      # such a commit with the detector on, anything URI-shaped that lands that
+      # way stays unseen until someone scans for it deliberately — drop the
+      # `extra_args` below on a one-off `workflow_dispatch` run to do that.
       #
       # If a future detector starts firing on a fixture, prefer narrowing THAT
       # fixture over widening this exclusion — every name added here switches a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,3 +197,12 @@ write as if it were already public:
 - **No internal-tracker references** in commits or PR titles/bodies — describe
   the change on its own terms.
 - Prefer environment variables and documented config over anything hardcoded.
+- **Write credential-in-URL fixtures with angle-bracket placeholders** —
+  `https://<user>:<pass>@host`, never the bare `user:pass@` form. The redaction
+  code and its tests need URLs that still carry userinfo before the `@`, and
+  the secret scanner's URI detector reads a bare one as a real leaked
+  credential (`.github/workflows/secret-scanning.yml`'s diff gate now runs that
+  detector, so a bare fixture added in a PR fails CI — including one added to a
+  comment or a doc like this file). Keep the real `http`/`https` scheme:
+  `failure_log._URL_RE` only matches `https?://`, so a made-up scheme would
+  document behavior the scrubber does not have.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,11 +125,9 @@ ruff format --check .     # format check (run `ruff format .` to fix)
 ```
 
 CI (`.github/workflows/ci.yml`) runs all three on Python 3.10 and 3.14 for every
-PR. Get them green locally before pushing. The workflow carries no path filter
-on `pull_request` — the `test (py3.10)` / `test (py3.14)` contexts are required
-by branch protection, so they have to report on every PR — and it decides
-internally whether to run the suite, no-opping when a PR changes only Markdown.
-Do not add a `paths` / `paths-ignore` filter to that trigger.
+PR; get them green locally first. Never add a `paths`/`paths-ignore` filter to its
+`pull_request` trigger — the required `test (py3.10)`/`test (py3.14)` contexts must
+report on every PR, and the workflow already no-ops on Markdown-only changes.
 
 ## Tests
 
@@ -191,18 +189,11 @@ This repository is **private but destined to go public.** Treat everything you
 write as if it were already public:
 
 - **No secrets** — API keys, tokens, or credentials in code, commits, tests,
-  fixtures, or PR text.
+  fixtures, or PR text. Credential-in-URL fixtures use `https://<user>:<pass>@host`:
+  a bare `user:pass@` fails the secret-scanning diff gate, and a fake scheme
+  documents behavior the scrubber lacks (`failure_log._URL_RE` needs `https?://`).
 - **No internal hostnames, IPs, or internal-only URLs** in code, comments, or
   commit messages.
 - **No internal-tracker references** in commits or PR titles/bodies — describe
   the change on its own terms.
 - Prefer environment variables and documented config over anything hardcoded.
-- **Write credential-in-URL fixtures with angle-bracket placeholders** —
-  `https://<user>:<pass>@host`, never the bare `user:pass@` form. The redaction
-  code and its tests need URLs that still carry userinfo before the `@`, and
-  the secret scanner's URI detector reads a bare one as a real leaked
-  credential (`.github/workflows/secret-scanning.yml`'s diff gate now runs that
-  detector, so a bare fixture added in a PR fails CI — including one added to a
-  comment or a doc like this file). Keep the real `http`/`https` scheme:
-  `failure_log._URL_RE` only matches `https?://`, so a made-up scheme would
-  document behavior the scrubber does not have.

--- a/src/comfy_local_mcp/failure_log.py
+++ b/src/comfy_local_mcp/failure_log.py
@@ -125,7 +125,7 @@ def _scrub_url(url: str) -> str:
 
 # A URL ANYWHERE in a recorded string — deliberately not anchored to the start.
 # argv is not all bare URLs: `_render_param_args` emits combined-flag tokens
-# (`--image_url=https://user:pass@host/x?token=…`, `--param=k={"https://…"}`)
+# (`--image_url=https://<user>:<pass>@host/x?token=…`, `--param=k={"https://…"}`)
 # whose URL sits mid-token, so a start-anchored test would wave the credential
 # straight through into `args`. Anchoring on the literal scheme still lets the
 # engine skip ahead to a candidate rather than re-scan from every offset, and
@@ -170,7 +170,7 @@ def _scrubbed_stream_tail(stream: str | bytes | None, limit: int) -> str:
     Scrubbing has to happen BEFORE the final clip to ``limit``, not after: the
     tail keeps the END of a capture, so a URL straddling the cut would arrive
     here already shorn of its ``https://`` and slip past :data:`_URL_RE`
-    entirely — leaving the ``user:pass@host`` remainder in the file. So bound
+    entirely — leaving the ``<user>:<pass>@host`` remainder in the file. So bound
     generously first (``_stream_tail`` slices raw bytes before decoding, so the
     wider window is still cheap on a multi-MB capture), scrub the whole window,
     and only then clip: any half-URL at the window's head is now beyond
@@ -320,7 +320,7 @@ def _log_failure(
             "exit_code": exit_code,
             "error_code": error_code,
             # Scrub first, THEN cap. Capping first would cut a
-            # `https://user:pass@host` URL straddling the boundary, and
+            # `https://<user>:<pass>@host` URL straddling the boundary, and
             # `_redact_url` only masks userinfo when it still finds the `@` in
             # the netloc — so the surviving `user:pass` half would be written
             # unredacted. `_URL_RE` is a linear single-pass scan, so running it

--- a/src/comfy_local_mcp/failure_log.py
+++ b/src/comfy_local_mcp/failure_log.py
@@ -133,6 +133,12 @@ def _scrub_url(url: str) -> str:
 # multi-KB message.
 _URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
 
+# The first whitespace-delimited token of a clipped stream window — the one
+# place a URL can appear with its `https://` already sliced off, so the one
+# place `_URL_RE` above is structurally unable to help. See
+# `_scrubbed_stream_tail`.
+_LEADING_TOKEN_RE = re.compile(r"\S*")
+
 
 def _scrub_text(text: str) -> str:
     """Apply :func:`_scrub_url` to every URL embedded anywhere in ``text``.
@@ -173,8 +179,16 @@ def _scrubbed_stream_tail(stream: str | bytes | None, limit: int) -> str:
     entirely — leaving the ``<user>:<pass>@host`` remainder in the file. So bound
     generously first (``_stream_tail`` slices raw bytes before decoding, so the
     wider window is still cheap on a multi-MB capture), scrub the whole window,
-    and only then clip: any half-URL at the window's head is now beyond
-    ``limit`` and is dropped rather than written.
+    and only then clip.
+
+    The generous bound is NOT on its own enough, which is why the head fragment
+    is masked explicitly below rather than left for the re-clip to push out of
+    range: scrubbing SHRINKS the window — ``_scrub_url`` deletes whole query
+    strings and userinfo — so a URL-dense capture can come out of it already at
+    or under ``limit``, take the early return, and be written with its
+    scheme-shorn head still attached. The re-clip is safe by contrast:
+    everything it can cut has been scrubbed already, so a URL it bisects has no
+    userinfo or query left to leak.
     """
     if limit <= 0:
         # Mirror `_stream_tail`'s own non-positive guard: `[-0:]` is the WHOLE
@@ -183,6 +197,18 @@ def _scrubbed_stream_tail(stream: str | bytes | None, limit: int) -> str:
         return "<empty>"
     window = _stream_tail(stream, limit * 2)
     scrubbed = _scrub_message(window)
+    if scrubbed.startswith("..."):
+        # `_stream_tail` prefixes that marker onto a window it CLIPPED, and a
+        # clipped window can begin part-way through a URL — past the `https://`
+        # that `_URL_RE` anchors on, which is precisely why the scrub above
+        # cannot see a credential sitting in that leading remainder.
+        # `_scrub_url` handles a scheme-less string (it reads offset 0 as the
+        # netloc's start), so mask the head token as if it were a whole URL.
+        # A capture whose real first line happens to start with `...` is masked
+        # the same way; over-redacting one debug-log token is the right side to
+        # err on.
+        head = _LEADING_TOKEN_RE.match(scrubbed, 3).group(0)
+        scrubbed = "..." + _scrub_url(head) + scrubbed[3 + len(head) :]
     if len(scrubbed) <= limit:
         return scrubbed
     # Re-clipping loses the marker `_stream_tail` may have added, so re-add it:

--- a/src/comfy_local_mcp/textutil.py
+++ b/src/comfy_local_mcp/textutil.py
@@ -77,7 +77,7 @@ def _redact_url(url: str) -> str:
 
     :class:`ComfyCliError` messages echo the offending config value and may reach
     the MCP client or logs, so a credential embedded in ``COMFYUI_URL`` (e.g.
-    ``http://user:token@host``) must not be surfaced raw. Only the netloc
+    ``http://<user>:<token>@host``) must not be surfaced raw. Only the netloc
     (scheme-separator up to the first path/query/fragment delimiter) is inspected
     so a stray ``@`` in a path can't confuse the masking.
     """

--- a/tests/test_failure_log.py
+++ b/tests/test_failure_log.py
@@ -378,7 +378,7 @@ def test_scrub_arg_masks_userinfo_and_strips_query(log_path, fake_comfy):
     ``comfy <args> failed …`` — i.e. it echoes the RAW argv, so scrubbing only
     the ``args`` list would leave the credential in the very next key.
     """
-    url = "https://user:tok@host/x?token=abc#frag"
+    url = "https://<user>:<tok>@host/x?token=abc#frag"
     fake_comfy(stdout=_ERROR_ENVELOPE)
 
     with pytest.raises(server.ComfyCliError):
@@ -396,7 +396,7 @@ def test_scrub_arg_masks_userinfo_and_strips_query(log_path, fake_comfy):
 
 def test_scrub_message_masks_urls_but_keeps_prose():
     """Only URL-shaped substrings are rewritten; the surrounding prose survives."""
-    text = "comfy model download --url https://u:p@h/m.safetensors?token=s failed"
+    text = "comfy model download --url https://<u>:<p>@h/m.safetensors?token=s failed"
     assert failure_log._scrub_message(text) == (
         "comfy model download --url https://***@h/m.safetensors failed"
     )
@@ -411,7 +411,7 @@ def test_scrub_message_masks_urls_but_keeps_prose():
         # would defeat the log.
         ("run", "run"),
         ("/Users/me/wf.json", "/Users/me/wf.json"),
-        ("user:pass@notaurl", "user:pass@notaurl"),
+        ("<user>:<pass>@notaurl", "<user>:<pass>@notaurl"),
         # Query stripped even with no credential in it (mirrors comfy-cli's own
         # scrubber: a CivitAI URL carries its token as `?token=…`).
         ("https://h/m.safetensors?token=abc", "https://h/m.safetensors"),
@@ -419,8 +419,8 @@ def test_scrub_message_masks_urls_but_keeps_prose():
         # A fragment BEFORE a query still cuts at the first delimiter.
         ("https://h/p#f?q=1", "https://h/p"),
         # Userinfo masked with no query present, and the scheme is case-blind.
-        ("https://u:p@h/path", "https://***@h/path"),
-        ("HTTPS://u:p@h/path", "HTTPS://***@h/path"),
+        ("https://<u>:<p>@h/path", "https://***@h/path"),
+        ("HTTPS://<u>:<p>@h/path", "HTTPS://***@h/path"),
         # A bare host URL is untouched.
         ("https://h/path", "https://h/path"),
     ],
@@ -435,12 +435,12 @@ def test_scrub_arg_cases(arg, expected):
         # `_render_param_args` emits combined-flag tokens, so the URL is not at
         # the token's start — a start-anchored test would log the credential.
         (
-            "--image_url=https://user:tok@host/x?token=abc",
+            "--image_url=https://<user>:<tok>@host/x?token=abc",
             "--image_url=https://***@host/x",
         ),
         # …and `run_template` wraps the value in JSON, offsetting it further.
         (
-            '--param=src={"https://u:p@h/i.png"}',
+            '--param=src={"https://<u>:<p>@h/i.png"}',
             '--param=src={"https://***@h/i.png"}',
         ),
     ],
@@ -453,24 +453,27 @@ def test_scrub_arg_finds_a_url_anywhere_in_the_token(arg, expected):
 def test_message_is_scrubbed_before_it_is_capped(log_path):
     """A URL straddling the message cap is masked, not cut into an unmasked half.
 
-    Capping first would slice ``https://user:pass@host`` before its ``@``, and
-    :func:`_redact_url` only masks userinfo it can still find in the netloc — so
-    the surviving ``user:pass`` would land in the file verbatim.
+    Capping first would slice ``https://<user>:<pass>@host`` before its ``@``,
+    and :func:`_redact_url` only masks userinfo it can still find in the netloc
+    — so the surviving ``<user>:<pass>`` would land in the file verbatim.
     """
     cap = failure_log._FAILURE_LOG_MESSAGE_CHARS
     # Place the URL so the cap falls on its `@` — the whole userinfo is inside
     # the kept prefix but the `@` that marks it as userinfo is not, which is
-    # precisely what defeats `_redact_url` when the cap runs first.
-    message = "x" * (cap - 16) + "https://user:tok@host/m.safetensors?token=abc"
+    # precisely what defeats `_redact_url` when the cap runs first. Both the
+    # 16 and the userinfo's width are that placement: `https://<u>:<pw>` is
+    # exactly 16 characters, and so is the `https://***@host` the masked URL
+    # gets clipped to below.
+    message = "x" * (cap - 16) + "https://<u>:<pw>@host/m.safetensors?token=abc"
 
     failure_log._log_failure("error_envelope", ("run",), message=message)
 
     (entry,) = _entries(log_path)
-    assert "user:tok" not in entry["message"]
+    assert "<u>:<pw>" not in entry["message"]
     assert "token=abc" not in entry["message"]
     assert len(entry["message"]) == cap
     # The cap now lands inside the *masked* URL, so what it clips is `***@…`
-    # rather than the raw `user:tok@…` the old cap-then-scrub order would leave.
+    # rather than the raw `<u>:<pw>@…` the old cap-then-scrub order would leave.
     assert entry["message"].endswith("https://***@host")
 
 
@@ -479,14 +482,14 @@ def test_stream_tails_are_scrubbed_like_the_message(log_path):
     failure_log._log_failure(
         "no_json",
         ("model", "download"),
-        stdout="fetching https://user:tok@host/m.safetensors?token=abc",
-        stderr="failed: https://u:p@h/x?sig=deadbeef",
+        stdout="fetching https://<user>:<tok>@host/m.safetensors?token=abc",
+        stderr="failed: https://<u>:<p>@h/x?sig=deadbeef",
     )
 
     (entry,) = _entries(log_path)
     assert entry["stdout_tail"] == "fetching https://***@host/m.safetensors"
     assert entry["stderr_tail"] == "failed: https://***@h/x"
-    assert "user:tok" not in log_path.read_text()
+    assert "tok" not in log_path.read_text()
     assert "deadbeef" not in log_path.read_text()
 
 
@@ -497,18 +500,18 @@ def test_stream_tail_scrubs_a_url_straddling_the_tail_cut(log_path):
     URL already shorn of its ``https://`` and skip it entirely.
     """
     limit = failure_log._FAILURE_LOG_TAIL_CHARS
-    url = "https://user:tok@host/x"
+    url = "https://<user>:<tok>@host/x"
     # Sized so the clip falls immediately after the URL's `https://` — the exact
     # case where a scrub-after-clip pass sees no scheme, matches nothing, and
-    # writes the whole `user:tok@host/x` remainder to disk.
+    # writes the whole `<user>:<tok>@host/x` remainder to disk.
     stderr = "A" * 100 + url + "B" * (limit + 108 - 100 - len(url))
     assert len(textutil._stream_tail(stderr, limit)) == limit + 3  # it IS clipped
 
     failure_log._log_failure("no_json", ("run",), stderr=stderr)
 
     (entry,) = _entries(log_path)
-    assert "user:tok" not in entry["stderr_tail"]
-    assert "tok@host" not in entry["stderr_tail"]
+    assert "<user>:<tok>" not in entry["stderr_tail"]
+    assert "<tok>@host" not in entry["stderr_tail"]
     # Still bounded, and still marked as truncated.
     assert entry["stderr_tail"].startswith("...")
     assert len(entry["stderr_tail"]) == limit + 3

--- a/tests/test_failure_log.py
+++ b/tests/test_failure_log.py
@@ -517,6 +517,37 @@ def test_stream_tail_scrubs_a_url_straddling_the_tail_cut(log_path):
     assert len(entry["stderr_tail"]) == limit + 3
 
 
+def test_stream_tail_scrubs_the_head_fragment_of_a_url_dense_capture(log_path):
+    """The straddling-URL guard holds even when scrubbing shrinks the window.
+
+    The double-width window is bounded generously so a half-URL at its head
+    falls outside the final clip — but scrubbing DELETES query strings and
+    userinfo, so a URL-dense capture can shrink to under ``limit`` and take
+    `_scrubbed_stream_tail`'s early return with that head still attached. The
+    head fragment has no ``https://`` left for ``_URL_RE`` to anchor on, so
+    nothing else in the pipeline can catch it.
+    """
+    limit = failure_log._FAILURE_LOG_TAIL_CHARS
+    head = "user:tok@host/x "
+    # Each unit scrubs 119 chars down to 12, so a window packed with them lands
+    # far under `limit` — that shrinkage is what reaches the early return.
+    unit = "https://h/a?token=" + "A" * 100 + " "
+    filler = unit * ((limit * 2 - len(head)) // len(unit))
+    # Exactly `limit * 2` after the scheme, so the window's cut lands right
+    # after `https://` and `head` arrives scheme-shorn. No trailing whitespace:
+    # `_tail` strips before slicing, which would otherwise shift the cut.
+    tail_bytes = head + filler + "B" * (limit * 2 - len(head) - len(filler))
+    stderr = "Z" * 10_000 + "https://" + tail_bytes
+
+    failure_log._log_failure("no_json", ("run",), stderr=stderr)
+
+    (entry,) = _entries(log_path)
+    assert len(entry["stderr_tail"]) <= limit  # it DID take the early return
+    assert "user:tok" not in log_path.read_text()
+    # Masked rather than dropped: the host still says which fetch was in flight.
+    assert entry["stderr_tail"].startswith("...***@host/x ")
+
+
 # --- best-effort + rotation --------------------------------------------------
 
 

--- a/tests/test_remote_host.py
+++ b/tests/test_remote_host.py
@@ -135,8 +135,14 @@ def test_target_url_unbalanced_ipv6_raises_comfy_error(monkeypatch):
 
 
 def test_target_url_redacts_userinfo_in_error(monkeypatch):
-    """A credential embedded in COMFYUI_URL is not echoed raw in the error message."""
-    monkeypatch.setenv("COMFYUI_URL", "https://user:sekret@gpu.example:8188")
+    """A credential embedded in COMFYUI_URL is not echoed raw in the error message.
+
+    The userinfo is written with angle-bracket placeholders (see AGENTS.md) so a
+    secret scanner does not read the fixture itself as a leaked credential; the
+    masking under test is scheme- and content-blind, so the assertions below are
+    the same ones a bare ``user:sekret`` fixture would make.
+    """
+    monkeypatch.setenv("COMFYUI_URL", "https://<user>:<sekret>@gpu.example:8188")
     with pytest.raises(server.ComfyCliError) as excinfo:
         server._comfy_target()
     assert "sekret" not in str(excinfo.value)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -3873,7 +3873,7 @@ def test_download_model_legacy_timeout_message_redacts_the_signed_url(
     """The argv echoed in a timeout must not carry the URL's credential.
 
     A CivitAI / HuggingFace model URL keeps its token in a `?token=…` query (or in
-    `user:pass@` userinfo), and this message lands in the tool response the MCP
+    `<user>:<pass>@` userinfo), and this message lands in the tool response the MCP
     client renders and in the host's logs — the same exposure that makes
     `_synthesize_plain_result` omit raw args altogether.
     """
@@ -3882,12 +3882,12 @@ def test_download_model_legacy_timeout_message_redacts_the_signed_url(
 
     with pytest.raises(server.ComfyCliError) as excinfo:
         _download_model(
-            "https://user:pw@hf.co/big.safetensors?token=SECRETTOKEN", wait=False
+            "https://<user>:<pw>@hf.co/big.safetensors?token=SECRETTOKEN", wait=False
         )
 
     message = str(excinfo.value)
     assert "SECRETTOKEN" not in message
-    assert "user:pw" not in message
+    assert "<user>:<pw>" not in message
     # Masked, not dropped: which command wedged is still legible.
     assert "model download --url https://***@hf.co/big.safetensors" in message
 


### PR DESCRIPTION
## ELI-5

Our secret scanner has two passes. Pass 1 only reports secrets it can phone home and confirm are real. Pass 2 reports everything, even unconfirmed — except it had the "credential inside a URL" detector switched off. That left one gap with nobody watching it: a real secret embedded in a URL for a host CI can't reach (an internal hostname, an offline endpoint). Pass 1 can't confirm it, and pass 2 wasn't looking.

The detector was off for a mundane reason: our own test placeholder for "a URL with a password in it" looked exactly like a real leaked credential, so the scanner screamed about it 24 times. This PR renames the placeholder to a form the scanner doesn't mistake for a secret (`https://<user>:<pass>@host`), then switches the detector back on for the PR gate. The weekly full-history scan keeps it off, because old commits still contain the old placeholder and nothing can edit those.

## Summary

Closes the one documented residual in `secret-scanning.yml`: an **unverifiable URI credential** was reported by neither pass on either job. Pass 1 (`--only-verified`) drops it because verification never succeeds; pass 2 dropped it because `--exclude-detectors=URI` turned the detector off. This rewrites the redaction fixtures so the URI detector no longer fires on them, and removes the exclusion from the **diff gate's** pass 2 only.

## Changes

- **Fixtures** — every credential-in-URL placeholder in the working tree now uses angle-bracket userinfo (`https://<user>:<pass>@host`) instead of the bare `user:pass@` form the URI detector reads as a real leaked credential. Touches `failure_log.py`, `textutil.py`, `test_failure_log.py`, `test_remote_host.py`, `test_wrapper.py`.
- **`secret-scanning.yml`** — the `scan` (diff gate) job's pass 2 drops `--exclude-detectors=URI`; the `full-history` job keeps it. Both comment blocks are rewritten to state why the two now differ, plus the header comment that advertised the exclusion.
- **`AGENTS.md`** — the fixture convention is written down under "Destined-public hygiene", so the next person adding a redaction test doesn't reintroduce the bare form and get a red gate with no explanation.

## Motivation

Six of eight panel reviewers on #143 flagged the URI exclusion as the widest remaining blind spot, and the repo's own destined-public rule specifically targets internal hostnames and URLs — which is exactly the unverifiable case. `--exclude-paths` could not fix it: two of the 24 historical hits live in commit message bodies, which no path or glob filter reaches, and excluding `server.py`/`textutil.py` would blind the scanner to the two largest source modules. Changing the fixture is what makes the detector safe to re-enable.

## Testing

- [x] Existing tests pass (`pytest`) — 1375 passed, 4 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — empirical TruffleHog runs, below

Everything below is `ghcr.io/trufflesecurity/trufflehog:3.95.8`, the digest this workflow pins.

**1. Working tree is clean under an unverified, all-detectors scan** (`git archive HEAD` into a scratch dir, so only tracked files are scanned):

```
filesystem <tree> --no-update --json   ->  0 findings   (was 6 URI findings on main)
```

**2. This PR passes its own strengthened gate** — the diff-gate pass 2 as CI will run it, against this branch:

```
git file:///repo --since-commit <main> --branch <head> --fail --no-update
  -> chunks 23, verified 0, unverified 0, exit 0
```

That also settles the removed-lines question: the diff still *deletes* bare fixtures, and the scan does not fire on removed content.

**3. The gate actually catches what it is supposed to** (negative control). On a throwaway commit adding `https://svcacct:<a real-looking password>@internal-registry.example/v1` — an unverifiable internal-hostname credential, i.e. the exact case this PR exists for:

```
new config (no exclusions)      -> Detector Type: URI, unverified_secrets 1, exit 183  (gate FAILS)
old config (--exclude-detectors=URI) -> exit 0                                          (gate was blind)
```

**4. `full-history` still passes clean** on this branch, both passes:

```
git file:///repo --branch <head> --fail --no-update --only-verified          -> exit 0
git file:///repo --branch <head> --fail --no-update --exclude-detectors=URI  -> exit 0
```

**5. The redaction assertions are still load-bearing, not just still-passing.** Mutation check: stubbing `failure_log._scrub_text` to a no-op fails 12 tests in `test_failure_log.py`, including all three whose assertion text this PR touches. The masked outputs asserted (`https://***@host/x`, `https://***@gpu.example:8188`, `https://***@hf.co/big.safetensors`) are byte-identical to before — `_redact_url` is scheme- and content-blind, so the placeholder fixture masks to exactly what the old one did.

## Additional Notes

**Judgment call — placeholder form.** The ticket suggested a non-routable scheme (`x-test://user:pass@host`). I used angle-bracket userinfo with the real `http`/`https` scheme instead, and verified it does not match the detector. Reason: `failure_log._URL_RE` is `https?://\S+`, so a made-up scheme would document — and in the parametrized `_scrub_arg` cases, *assert* — behavior the scrubber does not have. Both dodge the detector; only one keeps the fixtures true to the code under test.

**Judgment call — scope beyond the detector's current matches.** The ticket named six files from the historical breakdown. I converted every credential-in-URL fixture in the working tree, not only the ones firing today, because the detector's matching is not a clean function of the fixture: `https://user:tok@host` in `test_failure_log.py` did **not** appear in a scan of that file alone but **did** appear once the surrounding matches were removed (results dedupe within a chunk). Fixing only "what fires today" would therefore have left a fixture that starts failing the gate the moment someone edits an unrelated line near it. `server.py` needed no change — its three historical hits are already gone from the working tree.

**One assertion was tightened, not just renamed.** `test_stream_tail_scrubs_a_url_straddling_the_tail_cut` asserted `"tok@host" not in stderr_tail`. Under the new fixture the raw text is `<tok>@host`, so that spelling had silently become a check that can never fail; it is now `"<tok>@host"`. Two others (`"tok" not in …`) were left as the original bare substring, which is strictly tighter than the placeholder spelling.

**Known consequence, and it is the intent.** A URL carrying bare `user:pass@` userinfo added in any future PR — in code, in a test, or in a comment — now fails the diff gate. Note this widens only the URI surface: pass 2 already reported unverified findings from every other detector. Writing this PR tripped it twice on my own new prose, which is why the two comment blocks and the AGENTS.md bullet describe the bare form rather than quoting it.

**Not closed, by design.** An unverifiable URI credential already sitting in history stays invisible to the weekly rescan, because that job cannot enable the detector until history is rewritten. The residual is now bounded to what landed before this gate existed; every new one is caught before it can become history. The `full-history` pass-2 comment says so explicitly rather than leaving it implied.
