### PR TITLE
docs(readme): add a trademark notice for the Comfy Org marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Add the server to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` in a proje
 - [Smoke test](#smoke-test)
 - [Contributing](#contributing)
 - [License](#license)
+- [Trademarks](#trademarks)
 
 ## Prerequisites
 
@@ -775,3 +776,16 @@ GPL-3.0 [`comfy-cli`](https://github.com/Comfy-Org/comfy-cli) by shelling out to
 the `comfy` binary as a separate process — no GPL code is imported or linked.
 `comfy-cli` remains GPL-3.0-licensed and is distributed separately; how its
 copyleft applies depends on how the programs interact.
+
+## Trademarks
+
+"Comfy," "ComfyUI," and the Comfy Org name and logos — including the mark in
+[`assets/logo.svg`](assets/logo.svg) — are trademarks of Comfy Org. Apache-2.0
+is a copyright and patent license; per [section 6 of the license](LICENSE) it
+grants **no** rights to use those names or logos. Forks and derivative works are
+welcome under the license, but must not be named or branded in a way that
+suggests they are official Comfy Org software or carry Comfy Org's endorsement.
+
+Accurate, descriptive references — tutorials, reviews, integrations — are
+welcome. See the [brand guidelines](https://www.comfy.org/brand) for the full
+rules and how to request permission beyond them.


### PR DESCRIPTION
## ELI-5

The code in this repo is Apache-2.0, which lets anyone copy, change, and redistribute it. What that license deliberately does *not* hand over is the branding: the Comfy/ComfyUI names and the logo the README displays. This adds a short "Trademarks" section to the README saying so, so a forker knows they can take the code but shouldn't ship it wearing Comfy Org's name and logo.

## Summary

Adds a `## Trademarks` section to the README (after `## License`) plus its table-of-contents entry. Documentation only — no code, no behavior change.

Apache-2.0 is a copyright and patent license, and section 6 of the bundled `LICENSE` explicitly withholds trademark permission. This repo nevertheless ships `assets/logo.svg` and uses the Comfy/ComfyUI names throughout the README, and before this change nothing outside the license boilerplate told a reader where the code grant ends and the marks begin.

## Changes

- `README.md`: new `## Trademarks` section stating that "Comfy," "ComfyUI," and the Comfy Org name and logos (including `assets/logo.svg`) are Comfy Org trademarks, that Apache-2.0 section 6 grants no rights to use them, that forks and derivative works must not be branded as official or endorsed, and that accurate descriptive references (tutorials, reviews, integrations) are welcome — with a pointer to the published brand guidelines at https://www.comfy.org/brand for the full rules and permission requests.
- `README.md`: `- [Trademarks](#trademarks)` added to the table of contents.

## Motivation

Part of the OSS-release checklist for this repo: an Apache-2.0 project that ships logo assets should say plainly that the marks are not part of the grant.

## Testing

- [x] Existing tests pass (`pytest`) — 1376 passed, 4 skipped
- [x] Lint passes (`ruff check .`) — All checks passed
- [x] Format check passes (`ruff format --check .`) — 38 files already formatted
- [x] Tested manually — verified every fact and link the new section asserts: `LICENSE` really is Apache-2.0 and its section 6 reads "This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor"; `assets/logo.svg` exists on `main`; `https://www.comfy.org/brand` returns HTTP 200; and a repo-wide grep for "trademark" on `main` confirms `LICENSE` was the only mention, i.e. nothing elsewhere in the repo grants or contradicts this.

## Additional Notes

**Judgment calls**

- *"Consistent with conventions used elsewhere in Comfy Org's OSS repos"* — worth flagging that no such README convention currently exists to copy. A code search across the org and a grep of every local Comfy clone found no other repo carrying a README trademark section, so the wording here is derived from the two places Comfy Org has actually published this position: the brand guidelines page (`Comfy and ComfyUI are trademarks of Comfy Org…`) and section 8 of the Comfy Desktop EULA (`"Comfy," "ComfyUI," … and the Comfy logo are trademarks of Comfy Org. Nothing in this EULA grants you a license to use those marks.`). If we want a single canonical paragraph reused across repos, this one is a reasonable template — but that standardization is a separate call, not made here.
- **No registration claim.** The text says "are trademarks of," with no ® and no registration-status assertion — matching the published language rather than going beyond it.
- **Scope kept to the README**, as the ticket asks. A companion line in `NOTICE` is defensible and might be a sensible follow-up, but `NOTICE` has specific Apache attribution semantics and changing it wasn't asked for.
- **CI**: this is a Markdown-only change, so `ci.yml`'s "Detect non-docs changes" step reports the required `test (py3.10)` / `test (py3.14)` contexts as a green no-op by design. The suite was run locally anyway (above).

**Negative-claim falsification** — the self-review trigger (a diff whose user-facing outcome denies a capability) does not fire here: there is no code path, no throw/deny branch, and no test flipped to assert a dead-end. The one negative statement, "Apache-2.0 grants no trademark rights," is not a product-capability denial but a restatement of the license this repo already ships, and it was verified directly against `LICENSE` section 6 and against a repo-wide grep confirming no other file grants those rights.
