### PR TITLE
fix: pin the version floor in the comfy-cli-not-found install advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Four steps take you from a fresh install to your first generated image.
 1. **Install the pieces.**
 
    ```bash
-   pip install 'comfy-cli>=1.13.0'  # the engine (>= 1.13.0 required)
+   pip install "comfy-cli>=1.13.0"  # the engine (>= 1.13.0 required)
    comfy install                  # create a ComfyUI workspace (skip if you have one)
    pip install .                  # this MCP server → the `comfy-local-mcp` command
    ```
@@ -204,7 +204,7 @@ Add the server to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` in a proje
 ## Prerequisites
 
 - **Python ≥ 3.10.**
-- **comfy-cli ≥ 1.13.0** on your `PATH`: `pip install 'comfy-cli>=1.13.0'`. This is the engine
+- **comfy-cli ≥ 1.13.0** on your `PATH`: `pip install "comfy-cli>=1.13.0"`. This is the engine
   every tool wraps; the server refuses to run against an older comfy-cli with an upgrade message.
   1.13.0 is the first release carrying everything this server needs — the `comfy logs` verb, the
   `envelope/1` contract, the `comfy outdated` verb behind `server_info`'s `freshness` block, and

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -957,9 +957,16 @@ def _require_comfy_bin() -> None:
             # there is no argv to record — the failure IS that there is no binary.
             failure_log._log_failure("binary_missing", (), message=message)
             raise ComfyCliError(message)
+    # Name the floor in the install command, not just "comfy-cli": a bare
+    # `pip install comfy-cli` can resolve to a release below `_MIN_COMFY_CLI`
+    # (an old wheel pinned by an existing environment, a Python too old for the
+    # newest release), which lands the user straight in `_check_comfy_version`'s
+    # "too old" error on their very next call. The first install advice a
+    # fresh-machine user sees should already satisfy the floor.
     message = (
         f"`{COMFY_BIN}` not found on PATH. Install comfy-cli "
-        "(`pip install comfy-cli`) or set the COMFY_BIN env var."
+        f"(`pip install 'comfy-cli>={_MIN_COMFY_CLI_STR}'`) or set the "
+        "COMFY_BIN env var."
     )
     failure_log._log_failure("binary_missing", (), message=message)
     raise ComfyCliError(message)

--- a/src/comfy_local_mcp/server.py
+++ b/src/comfy_local_mcp/server.py
@@ -963,9 +963,16 @@ def _require_comfy_bin() -> None:
     # newest release), which lands the user straight in `_check_comfy_version`'s
     # "too old" error on their very next call. The first install advice a
     # fresh-machine user sees should already satisfy the floor.
+    #
+    # DOUBLE quotes around the specifier, not single: the bare form this
+    # replaced was shell-agnostic and the advice must stay that way. `>` is a
+    # redirection operator in every shell here, so it has to be quoted — but
+    # cmd.exe does not treat `'` as a quoting character, so the single-quoted
+    # form would run `pip install 'comfy-cli` and leave a stray `=1.13.0'`
+    # file behind. `"` quotes in cmd.exe, PowerShell, and POSIX shells alike.
     message = (
         f"`{COMFY_BIN}` not found on PATH. Install comfy-cli "
-        f"(`pip install 'comfy-cli>={_MIN_COMFY_CLI_STR}'`) or set the "
+        f'(`pip install "comfy-cli>={_MIN_COMFY_CLI_STR}"`) or set the '
         "COMFY_BIN env var."
     )
     failure_log._log_failure("binary_missing", (), message=message)
@@ -1074,7 +1081,9 @@ def _check_comfy_version() -> None:
         raise ComfyCliError(
             f"comfy-cli {'.'.join(map(str, version))} is too old — this server "
             f"requires comfy-cli >= {_MIN_COMFY_CLI_STR}. Upgrade it with "
-            f"`pip install --upgrade 'comfy-cli>={_MIN_COMFY_CLI_STR}'`."
+            # Double-quoted for the same cross-shell reason as
+            # `_require_comfy_bin`'s install advice — see the note there.
+            f'`pip install --upgrade "comfy-cli>={_MIN_COMFY_CLI_STR}"`.'
         )
     _version_checked = True
 
@@ -5120,7 +5129,7 @@ def _require_emit_workflow_capability() -> None:
             "MODEL PARAMETER instead of the run-level flag it needs to be — "
             "running a real, spending partner generation with no consent "
             "interlock. Upgrade comfy-cli (`pip install --upgrade "
-            f"'comfy-cli>={_MIN_COMFY_CLI_STR}'`) to a release with "
+            f'"comfy-cli>={_MIN_COMFY_CLI_STR}"`) to a release with '
             "`--emit-workflow`, or use partner_generate if you intend to spend."
         )
     _emit_workflow_capability_probed = True

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -487,6 +487,10 @@ def test_missing_binary_install_advice_names_the_version_floor(monkeypatch):
     ``_MIN_COMFY_CLI``, which drops the user straight into
     ``_check_comfy_version``'s separate "too old" error — so the first install
     advice a fresh machine gets pins the floor.
+
+    It pins it with DOUBLE quotes, which is the only form that survives a
+    copy-paste into every shell an MCP client might be launched from: `>` needs
+    quoting everywhere, but cmd.exe does not quote with `'`.
     """
     monkeypatch.setattr(server.shutil, "which", lambda _: None)
     monkeypatch.setattr(tcc, "_is_macos", lambda: False)
@@ -495,9 +499,11 @@ def test_missing_binary_install_advice_names_the_version_floor(monkeypatch):
         server._run_comfy("env")
 
     message = str(excinfo.value)
-    assert f"pip install 'comfy-cli>={server._MIN_COMFY_CLI_STR}'" in message
+    assert f'pip install "comfy-cli>={server._MIN_COMFY_CLI_STR}"' in message
     # The bare form is what left users one call away from the "too old" error.
     assert "pip install comfy-cli`" not in message
+    # The single-quoted form leaves cmd.exe users with a stray `=1.13.0'` file.
+    assert "'comfy-cli" not in message
 
 
 def test_error_envelope_carries_structured_code(patched_run):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -29,7 +29,7 @@ from pathlib import PurePosixPath
 import pytest
 from conftest import _OK_STREAM, _FakeProc, _RecordingCtx, envelope, stream_reader
 
-from comfy_local_mcp import failure_log, server, textutil
+from comfy_local_mcp import failure_log, server, tcc, textutil
 
 
 def _download_model(*args, **kwargs):
@@ -478,6 +478,26 @@ def test_missing_binary_raises(monkeypatch):
     monkeypatch.setattr(server.shutil, "which", lambda _: None)
     with pytest.raises(server.ComfyCliError, match="not found on PATH"):
         server._run_comfy("env")
+
+
+def test_missing_binary_install_advice_names_the_version_floor(monkeypatch):
+    """The not-found message's `pip install` must already satisfy the floor.
+
+    A bare ``pip install comfy-cli`` can land a release below
+    ``_MIN_COMFY_CLI``, which drops the user straight into
+    ``_check_comfy_version``'s separate "too old" error — so the first install
+    advice a fresh machine gets pins the floor.
+    """
+    monkeypatch.setattr(server.shutil, "which", lambda _: None)
+    monkeypatch.setattr(tcc, "_is_macos", lambda: False)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("env")
+
+    message = str(excinfo.value)
+    assert f"pip install 'comfy-cli>={server._MIN_COMFY_CLI_STR}'" in message
+    # The bare form is what left users one call away from the "too old" error.
+    assert "pip install comfy-cli`" not in message
 
 
 def test_error_envelope_carries_structured_code(patched_run):


### PR DESCRIPTION
## ELI-5

If `comfy` isn't installed, this server used to say "run `pip install comfy-cli`". That command can hand you an older comfy-cli than the server actually requires, so the very next thing you'd see is a *different* error saying your comfy-cli is too old. Now the message tells you to run `pip install 'comfy-cli>=1.13.0'` — the first thing you're told to do already works.

## Summary

The comfy-cli-not-found error in `_require_comfy_bin` now names the version floor in its install command, so fresh-machine setup advice can't drop the user into the separate "comfy-cli is too old" error.

## Changes

- `src/comfy_local_mcp/server.py` — the missing-binary message's install command is now ``pip install 'comfy-cli>=1.13.0'``, interpolated from `_MIN_COMFY_CLI_STR` rather than hardcoded, so the message tracks the floor if it is ever raised. Added a comment recording why the bare form was wrong.
- `tests/test_wrapper.py` — new regression test `test_missing_binary_install_advice_names_the_version_floor`, asserting the message carries the pinned form (built from `_MIN_COMFY_CLI_STR`, so a floor bump can't silently un-pin it) and no longer carries the bare one.

## Motivation

`_check_comfy_version` enforces a hard `>= 1.13.0` floor, and its "too old" error already advises ``pip install --upgrade 'comfy-cli>=1.13.0'``; the README's prerequisites and quickstart already use the pinned form too. The not-found message was the last place still giving the unpinned advice — the one a user on a genuinely fresh machine hits first. A bare `pip install comfy-cli` can resolve below the floor (an old wheel pinned by the existing environment, or a Python too old for the newest release), which walks the user from one error straight into another. This aligns the last remaining message with the two that were already correct.

## Testing

- [x] Existing tests pass (`pytest`) — 1377 passed, 4 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually — not applicable; the missing-binary path is covered by the new unit test plus the existing `test_missing_binary_raises` and `test_binary_missing_is_recorded_with_no_args`.

## Additional Notes

**Scope.** Deliberately a one-string change. Grepping the tree for the bare advice found exactly one remaining occurrence (this one) — the README (lines 64, 207) and the "too old" message already pin the floor. The two `pip install -U comfy-cli` lines in the README's troubleshooting section were left alone on purpose: those are upgrade-to-latest advice, and `-U` already lands above the floor.

**Negative-claim falsification (self-review clause e): does not fire.** The diff adds no "not supported" / "unavailable" / "STOP" string, no throw/deny dead-end, and flips no test to assert one. `_require_comfy_bin`'s raise, and the condition guarding it, are byte-for-byte unchanged — only the human-readable remediation text inside the existing error moved. The change *widens* what a user can successfully do (a working install on the first try); it denies no capability, so there is no capability to attempt-and-falsify.

**Riskiest line.** `f"(\`pip install 'comfy-cli>={_MIN_COMFY_CLI_STR}'\`)"` — it reads a module constant defined ~200 lines above the function and only at call time, so there is no import-order hazard, and the single quotes around the specifier are required (an unquoted `>=` is a shell redirect). Same construction the "too old" message has been shipping.
