### PR TITLE
docs(security): record the GitHub-native protections now enabled on this repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,13 @@ ComfyUI; it **skips** cleanly when ComfyUI or the `comfy` binary is absent.
 2. Make your change, with tests, and get the three checks above green.
 3. Open a PR and fill in [the template](.github/PULL_REQUEST_TEMPLATE.md).
 
+Two more things run against your work without you asking for them: a
+[TruffleHog scan](.github/workflows/secret-scanning.yml) of the pushed range,
+and GitHub push protection, which rejects a push carrying a recognized provider
+credential to this repository outright. If a push is rejected that way, rotate
+the credential and rewrite it out of your commits rather than bypassing the block —
+see [`SECURITY.md`](SECURITY.md#automated-security-tooling).
+
 ## Reporting bugs and requesting features
 
 Use the [issue templates](.github/ISSUE_TEMPLATE/) — a bug report or a feature

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,6 +77,16 @@ This server is a thin wrapper that shells out to the local [`comfy-cli`](https:/
 - Social engineering or phishing
 - Reports from automated scanners without a demonstrated exploit
 
+## Automated security tooling
+
+GitHub's own safety nets are enabled on this repository, alongside the workflows in [`.github/workflows/`](.github/workflows/). What each one actually covers — so a reporter can tell what is already watched, and a contributor knows what will block a push:
+
+- **Private vulnerability reporting** — the Security Advisories route in [How to report](#how-to-report) above. GitHub offers this on public repositories, so it is the preferred channel for a public release of this repository; the email route works either way.
+- **Secret scanning, with push protection** — GitHub matches known provider credential patterns across this repository, and push protection **rejects a push that introduces one** rather than reporting it afterwards. This is a narrower net than the [TruffleHog workflow](.github/workflows/secret-scanning.yml), not a replacement for it: TruffleHog runs many more detectors (verified *and* unverified, including private keys and providers GitHub has no pattern for) but only after the push, on a diff gate plus a weekly full-history rescan. Push protection covers fewer patterns and stops the push itself. Neither subsumes the other, which is why both are on.
+- **Dependabot alerts and security updates** — advisories against the `pip` and `github-actions` dependencies declared in [`.github/dependabot.yml`](.github/dependabot.yml), with fix PRs opened automatically. Alerts are independent of the version-update schedule in that file: a new advisory surfaces when it is published, not on the weekly/monthly cadence.
+
+If a push of yours is rejected by push protection, treat the credential as burned — **rotate it**, then rewrite it out of your commits. Do not take the bypass option: bypassing on a public repository publishes the secret, and the rotation is needed regardless.
+
 ## Supported Versions
 
 Security fixes are applied to the **latest release** on the `main` branch. We do not maintain patch branches for older versions.


### PR DESCRIPTION
## ELI-5

Before this repo goes public we want GitHub's own alarms switched on. Two of the three were flipped on the repo itself (they are settings, not code) — this PR is the part that belongs in the repo: it writes down which alarms are on, what each one actually catches, and what a contributor should do when one of them blocks their push.

## Summary

Turns on the GitHub-native safety nets ahead of the public flip and documents the resulting posture.

The settings work was done directly against the repository (settings have no diff):

| Feature | Before | After | How |
| :-- | :-- | :-- | :-- |
| Secret scanning | `disabled` | **`enabled`** | `PATCH /repos/Comfy-Org/comfy-local-mcp` |
| Secret scanning push protection | `disabled` | **`enabled`** | `PATCH /repos/Comfy-Org/comfy-local-mcp` |
| Dependabot alerts | already on | unchanged | `GET /repos/.../vulnerability-alerts` → `204` |
| Dependabot security updates | already on | unchanged | `security_and_analysis.dependabot_security_updates: enabled` |
| Private vulnerability reporting | off | **still off — blocked, see below** | not available on a private repository |

Readback after the change (`gh api repos/Comfy-Org/comfy-local-mcp --jq .security_and_analysis`): `secret_scanning: enabled`, `secret_scanning_push_protection: enabled`, `dependabot_security_updates: enabled`.

Turning secret scanning on triggered a full-history scan: **0 alerts** (`GET /repos/.../secret-scanning/alerts` → empty). Open Dependabot alerts: **0**. So nothing is currently outstanding to remediate before the public flip.

## Changes

- `SECURITY.md` — new "Automated security tooling" section: what private vulnerability reporting, secret scanning + push protection, and Dependabot alerts each cover, why push protection does **not** replace the TruffleHog workflow (fewer detectors, but it blocks the push instead of reporting after it), and what to do when a push is rejected (rotate the credential; do not bypass).
- `CONTRIBUTING.md` — a short note under "Opening a pull request" so a contributor whose push is rejected knows what happened and what the correct response is.

## Motivation

From the "Checklist for releasing local-mcp" doc, section "Repo settings — blockers before flipping public": the standard GitHub-native safety nets should be on before the repo is externally visible. The setting flips are the substance; this PR is the repo-side record so the posture is discoverable by contributors and reporters rather than living only in a settings page.

## Not done — private vulnerability reporting (needs the public flip)

**PVR could not be enabled, and this is not fixable from here: GitHub offers it on public repositories only.** Falsified empirically rather than assumed, via every path this token can reach:

- `PUT /repos/Comfy-Org/comfy-local-mcp/private-vulnerability-reporting` → `404 Not Found`
- `GET /repos/Comfy-Org/comfy-local-mcp/private-vulnerability-reporting` → `404 Not Found`
- Same `GET` on **public** org repos with the **same token**: `Comfy-Org/comfy-cli` → `200 {"enabled":false}`, `Comfy-Org/ComfyUI_frontend` → `200`. So the endpoint is reachable and the token is sufficient — the 404 is about this repo being private, not about scope or permissions.
- `GET /orgs/Comfy-Org/private-vulnerability-reporting` → `404` (no org-level route available here either).

**Action required at the public flip:** enable private vulnerability reporting immediately after making the repo public (Settings → Advanced Security → Private vulnerability reporting, or `gh api -X PUT repos/Comfy-Org/comfy-local-mcp/private-vulnerability-reporting`). Until then the Security Advisories link at the top of `SECURITY.md` will not accept an external report and the email route is the working one. The `SECURITY.md` wording added here is deliberately visibility-agnostic so it stays accurate before *and* after that flip.

## Judgment calls

- **Wrote the docs rather than only flipping settings.** The ticket's substance is a settings change with no diff. Rather than ship nothing reviewable, the reviewable artifact is the posture record — which also matters for an OSS repo where a contributor meeting push protection for the first time needs to be told to rotate rather than bypass.
- **Stayed in the ticket's scope on the adjacent toggles.** `secret_scanning_validity_checks`, `secret_scanning_non_provider_patterns`, and `code_security` (code scanning / CodeQL) are all still `disabled`. Validity checks in particular are a cheap follow-up worth considering (they tell you whether a leaked token is still live), but none of the three were asked for and each changes the alert volume, so they are left as a separate decision.
- **Left the TruffleHog workflow alone.** Native secret scanning overlaps it but does not subsume it — TruffleHog runs many more detectors, verified and unverified, including private keys and providers GitHub has no pattern for. Removing it would be a coverage regression, so both stay and the docs explain the split.

## Testing

- [x] Existing tests pass (`pytest`) — 1376 passed, 4 skipped
- [x] Lint passes (`ruff check .`) — All checks passed
- [x] Format check passes (`ruff format --check .`) — 38 files already formatted
- [x] Tested manually — settings verified by API readback after each write (see the table above); secret-scanning and Dependabot alert counts queried post-enable

Docs-only diff, so the suite is unaffected; it was run to confirm the branch is clean against current `main`.

## Additional Notes

Push protection is live on this repository as of this PR, so a push containing a recognized provider credential will now be rejected outright. That is the intended behavior; the response is to rotate the credential, not to use the bypass.
