### PR TITLE
docs(readme): add Comfy Cloud MCP installation and correct the local/cloud scope statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,15 @@
 <p>
   <a href="#quickstart"><strong>Quickstart</strong></a> ·
   <a href="#configure-your-ai-client">Configure your client</a> ·
+  <a href="#comfy-cloud-mcp">Comfy Cloud MCP</a> ·
   <a href="#tools">Tools</a> ·
   <a href="#contributing">Contributing</a>
 </p>
 
 </div>
 
-> Looking for the cloud-hosted version? See the [Comfy Cloud MCP docs](https://docs.comfy.org/agent-tools/mcp).
+> Looking for the cloud-hosted version? [Comfy Cloud MCP](#comfy-cloud-mcp) is set up below — install
+> it instead of this server, or alongside it.
 
 **What it does:**
 
@@ -46,9 +48,19 @@ the ComfyUI on **your** machine (`127.0.0.1:8188`).
 (Flux / Ideogram / Kling / …) entirely on partner infrastructure — no local ComfyUI in the
 execution path — and [partner-API nodes](#partner-api-nodes) let a locally-executed workflow call
 those same hosted models, while [`COMFYUI_URL`](#driving-a-remote-comfyui) points the run/job tools
-at a ComfyUI on another machine you control. What this server is **not** is a Comfy Cloud client:
-it shares no code with the Comfy Cloud MCP and implements none of its cloud-native feature set. If
-your workflows live in Comfy Cloud, use that MCP — alongside this one if you like.
+at a ComfyUI on another machine you control.
+
+**This server vs. [Comfy Cloud MCP](#comfy-cloud-mcp).** Two different servers, and running both is
+normal. This one is **stdio**: your client launches it as a subprocess on **your own machine**, and
+it drives the ComfyUI installed there (or one on another machine you control). Comfy Cloud MCP is a
+**remote HTTP** server at `https://cloud.comfy.org/mcp` that your client connects to over the
+network, and it executes workflows on **Comfy Cloud GPUs** — no local GPU, no ComfyUI install. Both
+authenticate: this one signs in to Comfy through comfy-cli ([`auth_login`](#partner-api-nodes) or
+`COMFY_API_KEY`), the cloud one through OAuth in your browser or a Comfy Cloud API key. Both can
+spend credits on **partner** models, so partner generation is not the dividing line — what this
+server has no path to is Comfy Cloud itself: no cloud-hosted execution, no cloud queue, no
+cross-session cloud batches. Every tool here shells out to `comfy --where local`. Pick by where you
+want the work to run, or [install the cloud server too](#comfy-cloud-mcp).
 
 > **Status:** beta. 49 tools; core loop validated end-to-end against a live local ComfyUI
 > (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on
@@ -182,10 +194,110 @@ Add the server to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` in a proje
 }
 ```
 
+## Comfy Cloud MCP
+
+Everything above sets up **this** server, which runs on your machine. Comfy also runs a **hosted**
+MCP server — **Comfy Cloud MCP** — and it is a good fit when the machine can't carry local
+diffusion, or when you'd rather not install ComfyUI at all. It lives at:
+
+```
+https://cloud.comfy.org/mcp
+```
+
+Your client connects to that URL over **remote HTTP** (no subprocess, nothing to `pip install`) and
+workflows execute on **Comfy Cloud GPUs**. You need a [Comfy Cloud](https://cloud.comfy.org)
+account — sign up first if you don't have one, since the sign-in below uses it.
+
+**Two ways to authenticate.** **OAuth** is the default: your client opens a browser, you pick a
+workspace, and tokens refresh themselves. For clients that don't speak MCP OAuth (Cursor today) and
+for headless/CI use, create a **Comfy Cloud API key** at
+[platform.comfy.org/profile/api-keys](https://platform.comfy.org/profile/api-keys) — it starts with
+`comfyui-` — and pass it as an `X-API-Key` header. Prefer your client's env interpolation
+(`${env:COMFY_API_KEY}`) over pasting a key into a file you might commit.
+
+Note that this is a **separate** credential path from the `COMFY_API_KEY` this server's own examples
+show: that one is read by comfy-cli on **this** machine for [partner-API
+nodes](#partner-api-nodes). The same key works for both, but each server is configured on its own.
+
+### Claude Code (cloud)
+
+Install the `comfy-cloud` plugin — it registers the MCP connection and adds `/comfy-cloud:*` slash
+commands in one step:
+
+```
+/plugin marketplace add Comfy-Org/comfy-skills
+/plugin install comfy-cloud@comfy-skills
+```
+
+Then run `/mcp`, select **comfy-cloud** → **Authenticate**, and finish the sign-in in your browser.
+
+Prefer just the connection, without the plugin? Add the server directly (`-s user` makes it
+available in every project):
+
+```bash
+claude mcp add --transport http comfy-cloud https://cloud.comfy.org/mcp
+```
+
+and authenticate the same way, via `/mcp`.
+
+### Claude Desktop (cloud)
+
+Claude Desktop adds it as a **custom connector** through its UI:
+
+1. Sidebar → **Customize** → **Connectors**.
+2. Click **+** in the Connectors header → **Add custom connector**.
+3. **Name** it (e.g. `Comfy Cloud MCP`), set **Remote MCP server URL** to
+   `https://cloud.comfy.org/mcp`, and click **Add**.
+4. A browser window opens: choose your workspace and click **Continue** to authorize.
+
+### Cursor (cloud)
+
+Cursor connects to remote MCP servers over HTTP but does **not** support MCP OAuth today, so use an
+API key. Add this to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project), with
+`COMFY_API_KEY` set in your shell or system environment:
+
+```json
+{
+  "mcpServers": {
+    "comfy-cloud": {
+      "url": "https://cloud.comfy.org/mcp",
+      "headers": {
+        "X-API-Key": "${env:COMFY_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### Other clients (cloud)
+
+Any client with a **remote HTTP** MCP transport can connect to the same URL. Most use a JSON config
+with a `url` field (Windsurf uses `serverUrl` instead):
+
+```json
+{
+  "mcpServers": {
+    "comfy-cloud": {
+      "url": "https://cloud.comfy.org/mcp"
+    }
+  }
+}
+```
+
+Sign in through the browser if the client supports MCP OAuth; otherwise add the `X-API-Key` header
+shown above. Restart the client and you should see the cloud tools (`search_templates`,
+`submit_workflow`, `get_output`, …) registered under the **comfy-cloud** server.
+
+**Codex** and **OpenClaw** have first-class setup steps — including `codex mcp add comfy-cloud --url
+https://cloud.comfy.org/mcp` and `openclaw mcp set` / `openclaw mcp login` — in the [Comfy Cloud MCP
+docs](https://docs.comfy.org/agent-tools/mcp), which is also where the screenshot walkthroughs, the
+full cloud tool list, and the slash-command/prompt tables live.
+
 ## Table of contents
 
 - [Quickstart](#quickstart)
 - [Configure your AI client](#configure-your-ai-client)
+- [Comfy Cloud MCP](#comfy-cloud-mcp)
 - [Prerequisites](#prerequisites)
 - [When to use this server](#when-to-use-this-server)
 - [Using with local LLMs (VRAM coordination)](#using-with-local-llms-vram-coordination)
@@ -279,7 +391,7 @@ Local diffusion is only a good default on a machine that can actually carry it, 
 |---|---|
 | Discrete GPU, **≥ 24 GB** VRAM | Local generation is a good default. |
 | Discrete GPU, **8 GB to under 24 GB** VRAM | Images are fine (prefer current, smaller models); video will be slow or infeasible. |
-| **< 8 GB** VRAM, or the user confirming there is no GPU | Don't run local diffusion. Use partner nodes (plain web calls, fine on any machine) or the Comfy Cloud MCP if your client has it connected. |
+| **< 8 GB** VRAM, or the user confirming there is no GPU | Don't run local diffusion. Use partner nodes (plain web calls, fine on any machine) or the [Comfy Cloud MCP](#comfy-cloud-mcp) if your client has it connected. |
 | **Apple Silicon**, **≥ 32 GB** unified memory | Images are OK. Video on the Apple GPU is not recommended — time estimates are unreliable and thermals suffer. |
 | **Apple Silicon**, under 32 GB unified memory | Same as the no-GPU row above — go partner/cloud rather than local. |
 


### PR DESCRIPTION
## ELI-5

The README only told you how to install the server that runs on your own computer, and then said flat-out that this thing "is not a Comfy Cloud client." That reads like a dead end for anyone who wants the hosted option. This PR adds real instructions for the hosted **Comfy Cloud MCP** — the URL, how to sign in, and the click-by-click for each client — and replaces the contradicting paragraph with an honest side-by-side of what each server actually is.

## What changed

- **New `## Comfy Cloud MCP` section**, right after the local client setup: the hosted server at `https://cloud.comfy.org/mcp`, the OAuth sign-in flow, the API-key alternative (`X-API-Key`, keys from platform.comfy.org, `comfyui-` prefix) for clients that don't speak MCP OAuth and for headless/CI, plus per-client steps for **Claude Code** (plugin route + plain `claude mcp add --transport http`), **Claude Desktop** (custom connector), **Cursor** (API key — Cursor has no MCP OAuth today), and **Other clients** (remote-HTTP JSON config; Windsurf's `serverUrl`). Content mirrors the [docs page](https://docs.comfy.org/agent-tools/mcp).
- **Deleted the "not a Comfy Cloud client" paragraph** and replaced it with the accurate scope statement: this server is **stdio** on your own machine; the cloud MCP is a **remote HTTP** server; both authenticate; both spend credits on partner models — so partner generation is not the dividing line. What this one has no path to is Comfy Cloud itself (cloud-hosted execution, cloud queue, cross-session cloud batches).
- **Replaced the one-line docs pointer** at the top with a link to the new in-repo section, and added the section to the header nav, the table of contents, and the `< 8 GB VRAM` routing-table row.

Docs only — no source, no tests, no tool-surface change.

## Verification

- `ruff check .` — clean; `ruff format --check .` — 38 files already formatted.
- `pytest -q` — **1377 passed, 4 skipped**.
- Anchor check over the whole README: 0 broken `#…` links, 0 duplicate headings (the cloud per-client headings are suffixed `(cloud)` so they don't collide with the local `### Claude Code` / `### Cursor` anchors).

## Negative-claim falsification

The new text keeps one narrow denial — this server has no path to Comfy Cloud execution — so it was checked against the whole tool surface rather than asserted:

- All three spawn sites hardcode the target: `cmd = [COMFY_BIN, "--json", "--where", "local", *args]` (`server.py:1357`, `:2468`, and the `--json-stream` twin at `:2604`). `_run_comfy` is the only route to the CLI (AGENTS.md architecture rule), so **every** one of the 49 tools is pinned to `--where local`.
- Enumerating every verb those calls pass, the only `comfy cloud …` verbs reached are `cloud whoami` (`auth_status`) and `cloud login` (`auth_login`) — credentials, never execution. `partner_generate` is `comfy generate`, i.e. a partner API, not a Comfy Cloud workflow run.
- Caveat, stated rather than papered over: the `comfy` binary is not installed on this machine, so the evidence is exhaustive-static (every call site) rather than a live invocation.

Note this diff is a redirect, not a dead end: it *removes* the blanket "not a cloud client" denial and hands the reader working install steps for the server that does have those capabilities.

## Judgment calls

- **Codex and OpenClaw are pointed at the docs rather than reproduced.** Their setup in the docs page is screenshot-driven UI flow; duplicating it here would rot fastest and is the least likely path for someone arriving at this repo. The one-line CLI form for each (`codex mcp add …`, `openclaw mcp set` / `login`) is quoted so the section isn't a bare "go read the docs."
- **`CONTRIBUTING.md` and the `server.py` module docstring still say this repo shares no code with the cloud MCP.** Those are contributor-facing *architecture* rules (the "no code from the cloud MCP" guardrail in `AGENTS.md`), which remain true and are not the user-facing "this is not a cloud client" framing the change targets. Left alone deliberately.
- **No tracker reference in the title/body**, per this repo's destined-public hygiene rule; the branch name carries the link.
