### PR TITLE
docs: resolve the COMFYUI_URL / COMFY_LOCAL_URL collision and strip "local" branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 <h1>Comfy MCP</h1>
 
-**Drive your local [ComfyUI](https://github.com/comfyanonymous/ComfyUI) from Claude Code, Claude Desktop, Cursor, or any MCP-speaking AI agent — a local [MCP](https://modelcontextprotocol.io) server built on [`comfy-cli`](https://github.com/Comfy-Org/comfy-cli).**
+**Drive your own [ComfyUI](https://github.com/comfyanonymous/ComfyUI) from Claude Code, Claude Desktop, Cursor, or any MCP-speaking AI agent — an [MCP](https://modelcontextprotocol.io) server built on [`comfy-cli`](https://github.com/Comfy-Org/comfy-cli).**
 
 <p>
-  <a href="https://github.com/comfyanonymous/ComfyUI"><img src="https://img.shields.io/badge/ComfyUI-local-blue?style=for-the-badge" alt="ComfyUI local"></a>
+  <a href="https://github.com/comfyanonymous/ComfyUI"><img src="https://img.shields.io/badge/ComfyUI-self--hosted-blue?style=for-the-badge" alt="ComfyUI self-hosted"></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-Compatible-green?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIiPjxwYXRoIGQ9Ik0xMiAyTDIgN2wxMCA1IDEwLTUtMTAtNXoiLz48cGF0aCBkPSJNMiAxN2wxMCA1IDEwLTUiLz48cGF0aCBkPSJNMiAxMmwxMCA1IDEwLTUiLz48L3N2Zz4=" alt="MCP"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/Python-%E2%89%A5%203.10-blue?style=for-the-badge&logo=python&logoColor=white" alt="Python"></a>
 </p>
@@ -168,6 +168,13 @@ the rename is **not** something `pip install .` finishes on its own, because `co
 All three clients speak the same MCP stdio contract: run the `comfy-mcp` command as a
 server. Pick your client.
 
+> The **server key** (`comfy-mcp` in every snippet below) is just the label your client files
+> these tools under — it is yours to choose, and the `"command"` (`comfy-mcp`) is the only part
+> that has to match the installed console script. Earlier versions of this README used
+> `comfy-local`, so **if your config already has a `comfy-local` entry, edit it rather than
+> pasting a second one** — two keys pointing at the same command register the server twice and
+> your client shows every tool twice. Keeping the old key is equally fine; nothing reads it.
+
 > The `COMFY_BIN` env entry is shown in every example. Drop it if `comfy` is already on the
 > environment your client launches the server with; keep it (pointing at the absolute path) if
 > it isn't. `COMFY_API_KEY` is also shown, commented as optional — keep it only if you use
@@ -186,7 +193,7 @@ One command registers the server:
 ```bash
 # COMFY_API_KEY is optional — add it only if you use partner-API nodes
 # (see the Partner-API nodes section).
-claude mcp add comfy-local \
+claude mcp add comfy-mcp \
   -e COMFY_BIN=/path/to/venv/bin/comfy \
   -e COMFY_API_KEY=<your-comfy-api-key> \
   -- comfy-mcp
@@ -197,7 +204,7 @@ Or, to check it into a project, add a `.mcp.json` at the repo root:
 ```json
 {
   "mcpServers": {
-    "comfy-local": {
+    "comfy-mcp": {
       "command": "comfy-mcp",
       "env": {
         "COMFY_BIN": "/path/to/venv/bin/comfy",
@@ -217,7 +224,7 @@ restart Claude Desktop:
 ```json
 {
   "mcpServers": {
-    "comfy-local": {
+    "comfy-mcp": {
       "command": "comfy-mcp",
       "env": {
         "COMFY_BIN": "/path/to/venv/bin/comfy",
@@ -235,7 +242,7 @@ Add the server to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` in a proje
 ```json
 {
   "mcpServers": {
-    "comfy-local": {
+    "comfy-mcp": {
       "command": "comfy-mcp",
       "env": {
         "COMFY_BIN": "/path/to/venv/bin/comfy",
@@ -359,6 +366,7 @@ full cloud tool list, and the slash-command/prompt tables live.
 - [Templates your install can't run](#templates-your-install-cant-run)
 - [Driving a remote ComfyUI](#driving-a-remote-comfyui)
 - [Targeting a non-default ComfyUI address](#targeting-a-non-default-comfyui-address)
+- [Which address variable do I want?](#which-address-variable-do-i-want)
 - [Tools](#tools)
 - [Troubleshooting](#troubleshooting)
 - [Failure log (opt-in)](#failure-log-opt-in)
@@ -414,17 +422,19 @@ full cloud tool list, and the slash-command/prompt tables live.
   client registration `env` block. See **[Partner-API nodes](#partner-api-nodes)** below for the
   full precedence chain; every example in
   [Configure your AI client](#configure-your-ai-client) shows where it goes.
-- **`COMFYUI_URL` / `COMFYUI_HOST` / `COMFYUI_PORT` (optional — drive a *remote* ComfyUI).** By
-  default every tool targets the local `127.0.0.1:8188`. Set `COMFYUI_URL`
-  (e.g. `http://gpu-box:8188`) — or the `COMFYUI_HOST` (+ optional `COMFYUI_PORT`, default `8188`)
-  pair — to point the **run / job** tools at a ComfyUI running elsewhere, e.g. a GPU box reachable
-  over a private network (Tailscale). See **[Driving a remote ComfyUI](#driving-a-remote-comfyui)**
-  for what is and isn't remoted. Unset ⇒ local behavior is unchanged.
-- **`COMFY_LOCAL_URL` (optional — a local ComfyUI on a non-default port).** For a ComfyUI on
-  *this* machine that isn't on `127.0.0.1:8188` (e.g. `:8189` because Docker Desktop's ComfyUI
-  holds `:8188`). Read by comfy-cli, not by this server — it rides the environment passthrough,
-  so setting it in the client `env` block re-points every tool. See
-  **[Targeting a non-default ComfyUI address](#targeting-a-non-default-comfyui-address)**.
+- **`COMFYUI_URL` / `COMFYUI_HOST` / `COMFYUI_PORT` (optional — drive a ComfyUI on *another
+  machine*).** Read by **this server**. By default every tool targets `127.0.0.1:8188`. Set
+  `COMFYUI_URL` (e.g. `http://gpu-box:8188`) — or the `COMFYUI_HOST` (+ optional `COMFYUI_PORT`,
+  default `8188`) pair — to point the **run / job** tools at a ComfyUI running elsewhere, e.g. a
+  GPU box reachable over a private network (Tailscale). See **[Driving a remote
+  ComfyUI](#driving-a-remote-comfyui)** for what is and isn't remoted. Unset ⇒ nothing changes.
+- **`COMFY_LOCAL_URL` (optional — a ComfyUI on *this machine*, on a non-default port).** Read by
+  **comfy-cli**, never by this server — it rides the environment passthrough, so setting it in the
+  client `env` block re-points every tool. For a ComfyUI on this machine that isn't on
+  `127.0.0.1:8188` (e.g. `:8189` because Docker Desktop's ComfyUI holds `:8188`). See
+  **[Targeting a non-default ComfyUI address](#targeting-a-non-default-comfyui-address)**, and
+  **[Which address variable do I want?](#which-address-variable-do-i-want)** for the difference
+  between the two.
 - **`COMFY_T2I_TEMPLATE` / `COMFY_T2I_PROMPT_SLOT` / `COMFY_T2I_CHECKPOINT_SLOT` (optional — retarget
   `generate_image`).** `generate_image(prompt)` runs the gallery's `default` template (ComfyUI's own
   basic SD1.5 text-to-image graph), filling its positive-prompt slot `6.text` and, when you pass
@@ -645,7 +655,9 @@ By default the server drives ComfyUI on the local `127.0.0.1:8188`. Point it at 
   A port without a host (setting only `COMFYUI_PORT`) is rejected — set the host too.
 
 Set it in the client registration `env` block (same place as `COMFY_BIN`). With nothing set,
-behavior is unchanged (local `127.0.0.1:8188`).
+behavior is unchanged (`127.0.0.1:8188` on this machine). If what you actually have is a ComfyUI on
+*this* machine on a different port, you want `COMFY_LOCAL_URL` instead — see [Which address variable
+do I want?](#which-address-variable-do-i-want).
 
 When configured, the server forwards `--host` / `--port` to comfy-cli for exactly the verbs that
 accept them — `comfy run` and `comfy jobs …` — so the **run and job tools** target the remote:
@@ -685,7 +697,7 @@ alongside `COMFY_BIN` in the client registration:
 ```json
 {
   "mcpServers": {
-    "comfy-local": {
+    "comfy-mcp": {
       "command": "comfy-mcp",
       "env": {
         "COMFY_BIN": "/path/to/venv/bin/comfy",
@@ -731,12 +743,34 @@ effect, rather than the version alone.
 **Precedence** (comfy-cli resolves this, first match wins): an explicit `--host`/`--port` flag →
 `COMFY_LOCAL_URL` → a comfy-cli-launched background server → `127.0.0.1:8188`.
 
-> **Use this *or* `COMFYUI_URL`, not both.** [`COMFYUI_URL`/`COMFYUI_HOST`](#driving-a-remote-comfyui)
-> makes this server forward explicit `--host`/`--port` flags for `comfy run` / `comfy jobs`, and an
-> explicit flag **outranks** `COMFY_LOCAL_URL` — so with both set the run/job tools would follow
-> `COMFYUI_URL` while every other verb followed `COMFY_LOCAL_URL`. For a non-default address on
-> *this* machine prefer `COMFY_LOCAL_URL` alone: it also covers the verbs that accept no
-> `--host`/`--port` (`comfy env`, templates, models, download), which `COMFYUI_URL` cannot reach.
+## Which address variable do I want?
+
+Two variables point ComfyUI work at an address, their names are similar, and they are **not**
+alternative spellings of each other — they belong to **different programs** and are read at
+different layers. Pick by which one you need; the table is the whole answer.
+
+| | `COMFYUI_URL` (+ `COMFYUI_HOST` / `COMFYUI_PORT`) | `COMFY_LOCAL_URL` |
+| --- | --- | --- |
+| **Read by** | **this MCP server** (`_comfy_target`) | **comfy-cli** (`comfy_cli/local_address.py`); this server never reads it |
+| **Means** | "a ComfyUI on **another machine** I control" | "the ComfyUI on **this machine** is not on `127.0.0.1:8188`" |
+| **How it acts** | this server forwards `--host` / `--port` to the verbs that accept them | comfy-cli resolves its own target from the environment it inherits |
+| **What it moves** | the **run / job** tools only — see [what is and isn't remoted](#driving-a-remote-comfyui) | **every** verb, including the ones that take no `--host` / `--port` (`comfy env`, templates, models, download) |
+| **Reported as** | a `comfy_target` block on `server_info` | the resolved `server` URL on `server_info` — **no** `comfy_target` block |
+| **Use it for** | a GPU box over Tailscale / a private network | a port clash, a second instance, a container publishing a different port |
+
+**Set one, not both.** They resolve independently, so together they *split* your tools rather than
+conflicting loudly: comfy-cli ranks an explicit `--host` / `--port` flag above `COMFY_LOCAL_URL`, so
+the run/job tools would follow `COMFYUI_URL` while every other verb followed `COMFY_LOCAL_URL` — two
+different ComfyUIs, no error. For a non-default address on **this** machine prefer `COMFY_LOCAL_URL`
+alone, since it also reaches the verbs `COMFYUI_URL` cannot.
+
+**Neither name is changing, and neither is deprecated.** They look like a rename waiting to happen —
+they are not, because only one of them is ours. `COMFY_LOCAL_URL` is comfy-cli's own published
+variable: renaming it here would document a name nothing reads, and its "local" is a factual
+address-scope word (comfy-cli's *local* target, as opposed to its cloud one), not this project's
+branding. `COMFYUI_URL` is this server's, and already carries no "local" to strip. So there is no
+old spelling to accept and no deprecation period to sit through — if you have either variable in an
+MCP client config today, it keeps working unchanged.
 
 ## Tools
 
@@ -762,7 +796,7 @@ handle is `prompt_id`.
 | `watch_job(prompt_id, timeout_seconds=600.0)` | `comfy jobs watch <prompt_id>` (streamed) | Tail an async-submitted job's live execution, streaming progress notifications; bounded, returns a `{"timed_out": True, …}` payload on expiry. Streaming counterpart to `wait_for_job`. |
 | `get_execution_error(prompt_id)` | `comfy jobs status <prompt_id>` | Compact failure verdict for a failed run — the failing node, `exception_type`/`exception_message`, and a bounded traceback tail — so an agent can self-repair; returns `error: None` on a healthy prompt. |
 | `cancel_job(prompt_id)` | `comfy jobs cancel <prompt_id>` | Cancel a queued or running job. |
-| `get_queue()` | `comfy jobs ls` | List known **local** jobs with status (pending/running/completed); cloud-tracked rows are filtered out. |
+| `get_queue()` | `comfy jobs ls` | List known jobs with status (pending/running/completed); Comfy Cloud-tracked rows are filtered out, since this server never drives them. Follows a configured remote, like the other job tools. |
 | `fetch_outputs(prompt_id, out_dir, url_only=False, inline_images=False)` | `comfy download <prompt_id> --where local -o <out_dir> [--url-only]` | Write a finished local job's outputs into `out_dir`; `url_only=True` emits the output URLs without copying bytes; `inline_images=True` also returns the copied images as inline MCP image content so the agent can see them without a second read. |
 
 ### Resource management

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -88,8 +88,11 @@ This server drives a ComfyUI the user runs themselves through comfy-cli — by
 default the one on this machine (`127.0.0.1:8188`), never Comfy Cloud. Canonical
 flows:
 
-- Call `server_info` FIRST to confirm a local ComfyUI is running before anything
-  else.
+- Call `server_info` FIRST, before anything else. Its `comfy env` fields
+  (running / url / workspace) always describe the ComfyUI on THIS machine —
+  `comfy env` takes no `--host` — so with `COMFYUI_URL` set they confirm the
+  local install, not the remote: the `comfy_target` block names that remote,
+  and the first run/job call is what confirms it is reachable.
 - Long generations: submit non-blocking with `run_workflow(wait=False)` to get a
   `prompt_id`, poll `wait_for_job` (a short bounded wait — chain several) or
   `job_status` until it finishes, then collect files with `fetch_outputs`.
@@ -6091,7 +6094,11 @@ def get_queue() -> Any:
     ComfyUI the user runs themselves. Passing a cloud job's ``prompt_id`` to
     ``job_status`` / ``cancel_job`` would route to this server's own target
     regardless, so listing those ids here would only invite calls that cannot
-    work.
+    work. The filter is deliberately conservative: it drops rows POSITIVELY
+    marked ``"cloud"`` out of the ``{"jobs": [...]}`` shape comfy-cli returns
+    today and passes any other payload shape through untouched rather than
+    reshaping it — so read a row's ``where`` rather than assuming the listing
+    has already been cleaned.
     """
     return _drop_cloud_jobs(_run_comfy("jobs", "ls", timeout=60.0))
 

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -84,7 +84,9 @@ from . import failure_log, tcc, textutil
 # Rides every client handshake — teach an agent the canonical flows up front so
 # it does not have to rediscover them tool-by-tool. Keep this short.
 INSTRUCTIONS = """\
-This server drives a LOCAL ComfyUI through comfy-cli. Canonical flows:
+This server drives a ComfyUI the user runs themselves through comfy-cli — by
+default the one on this machine (`127.0.0.1:8188`), never Comfy Cloud. Canonical
+flows:
 
 - Call `server_info` FIRST to confirm a local ComfyUI is running before anything
   else.
@@ -3716,7 +3718,11 @@ async def run_workflow(
     confirm_spend: bool = False,
     ctx: Context | None = None,
 ) -> Any:
-    """Run a ComfyUI workflow JSON on the LOCAL ComfyUI.
+    """Run a ComfyUI workflow JSON on the ComfyUI this server targets.
+
+    That is the ComfyUI on this machine unless ``COMFYUI_URL`` /
+    ``COMFYUI_HOST`` points the run/job tools at another one you control (see
+    :func:`_comfy_target`) — this is one of the tools that follows it.
 
     Accepts an API-format or UI-export workflow file — call it as
     ``run_workflow(workflow_path=...)``. Wraps ``comfy run --workflow <path>``.
@@ -3739,8 +3745,8 @@ async def run_workflow(
     CAUTION — a workflow whose nodes request a huge TOTAL allocation (e.g. an
     ``EmptyImage`` / ``EmptyLatentImage`` with a very large width x height x
     ``batch_size``) can pass ALL validation — every input is within its declared
-    range, and no layer estimates memory — and then crash the whole local
-    ComfyUI process mid-run when the OS kills it on the allocation. When that
+    range, and no layer estimates memory — and then crash the whole ComfyUI
+    process mid-run when the OS kills it on the allocation. When that
     happens there is no node-level error to fetch: this tool surfaces a
     connection-loss / timeout error, and subsequent ``job_status`` /
     ``get_execution_error`` calls report ``server_not_running`` (both query the
@@ -5915,7 +5921,7 @@ def _is_terminal(status: Any) -> bool:
 
 @mcp.tool()
 def wait_for_job(prompt_id: str, timeout_seconds: float = 25.0) -> Any:
-    """Wait (bounded) for a submitted LOCAL job to reach a terminal status.
+    """Wait (bounded) for a submitted job to reach a terminal status.
 
     Polls ``comfy jobs status <prompt_id>`` with a short sleep between polls
     until the job finishes (completed / error / cancelled) or
@@ -5998,7 +6004,7 @@ async def watch_job(
     timeout_seconds: float = 600.0,
     ctx: Context | None = None,
 ) -> Any:
-    """Tail a submitted LOCAL job's live execution, streaming progress.
+    """Tail a submitted job's live execution, streaming progress.
 
     Wraps ``comfy jobs watch <prompt_id>``, which follows a job's execution
     events (per-node execution + sampler step counts) and ends on the terminal
@@ -6028,7 +6034,7 @@ async def watch_job(
 
 @mcp.tool()
 def cancel_job(prompt_id: str) -> Any:
-    """Cancel a queued or running LOCAL job.
+    """Cancel a queued or running job.
 
     Wraps ``comfy jobs cancel <prompt_id>``. Use this to stop a job you
     submitted via ``run_workflow(wait=False)`` before it finishes; cancelling an
@@ -6073,18 +6079,19 @@ def _drop_cloud_jobs(data: Any) -> Any:
 
 @mcp.tool()
 def get_queue() -> Any:
-    """List known LOCAL jobs with their status (pending / running / completed).
+    """List known jobs with their status (pending / running / completed).
 
     Wraps ``comfy jobs ls``. comfy-cli merges its on-disk job state with the
     running ComfyUI server's queue, so this returns both jobs still in the queue
     and recently completed ones — call it to find a ``prompt_id`` to inspect with
     ``job_status`` or cancel with ``cancel_job``.
 
-    LOCAL ONLY: jobs comfy-cli tracks in its state store from a CLOUD run are
-    filtered out of the listing, because this server drives the user's local
-    ComfyUI and nothing else. Passing a cloud job's ``prompt_id`` to
-    ``job_status`` / ``cancel_job`` would route locally regardless, so listing
-    those ids here would only invite calls that cannot work.
+    NO COMFY CLOUD JOBS: jobs comfy-cli tracks in its state store from a CLOUD
+    run are filtered out of the listing, because this server only ever drives a
+    ComfyUI the user runs themselves. Passing a cloud job's ``prompt_id`` to
+    ``job_status`` / ``cancel_job`` would route to this server's own target
+    regardless, so listing those ids here would only invite calls that cannot
+    work.
     """
     return _drop_cloud_jobs(_run_comfy("jobs", "ls", timeout=60.0))
 

--- a/tests/test_address_env_docs.py
+++ b/tests/test_address_env_docs.py
@@ -1,0 +1,103 @@
+"""Guards on the documented split between the two address environment variables.
+
+``COMFYUI_URL`` and ``COMFY_LOCAL_URL`` read like two spellings of one knob and
+are not: only the first is **ours**. ``_comfy_target`` reads ``COMFYUI_URL`` /
+``COMFYUI_HOST`` / ``COMFYUI_PORT`` and forwards ``--host`` / ``--port``;
+``COMFY_LOCAL_URL`` is comfy-cli's own variable, resolved inside comfy-cli off
+the environment ``_comfy_env`` forwards, and this server never reads it at all.
+
+That asymmetry is the reason neither name is being renamed, and it lives only in
+README prose — no functional test would notice the section going stale, and a
+future "strip the word local" pass would happily rename a variable this repo does
+not own. These assertions are that tripwire: they key on the SPLIT (who reads
+what) rather than on wording, so the section can be rewritten freely.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from comfy_mcp import server
+
+_SECTION = "## Which address variable do I want?"
+
+
+@pytest.fixture(scope="module")
+def readme() -> str:
+    return (pathlib.Path(__file__).resolve().parent.parent / "README.md").read_text(
+        encoding="utf-8"
+    )
+
+
+@pytest.fixture(scope="module")
+def section(readme: str) -> str:
+    """The comparison section alone. A deleted section fails here first."""
+    assert _SECTION in readme, f"the address-variable section is gone: {_SECTION!r}"
+    return readme.split(_SECTION, 1)[1].split("\n## ", 1)[0]
+
+
+def test_server_reads_the_comfyui_vars_and_not_comfy_local_url():
+    """The ownership claim the README makes, asserted against the source itself.
+
+    If a future change made this server read ``COMFY_LOCAL_URL`` directly, the
+    documented "comfy-cli's, not ours" split would become a lie — and the whole
+    argument for leaving the name alone would go with it.
+    """
+    source = pathlib.Path(server.__file__).read_text(encoding="utf-8")
+    for ours in ("COMFYUI_URL", "COMFYUI_HOST", "COMFYUI_PORT"):
+        assert f'os.environ.get("{ours}"' in source, f"{ours} is no longer read"
+    assert 'os.environ.get("COMFY_LOCAL_URL"' not in source, (
+        "this server now reads COMFY_LOCAL_URL directly — it is comfy-cli's "
+        "variable, and the README's ownership split (and the decision not to "
+        "rename it) assumes the passthrough, not a direct read"
+    )
+
+
+def test_section_names_the_owner_of_each_variable(section: str):
+    """A reader has to be able to tell which program reads which variable."""
+    assert "COMFYUI_URL" in section and "COMFY_LOCAL_URL" in section
+    assert "comfy-cli" in section, "the section no longer names COMFY_LOCAL_URL's owner"
+    assert "never reads it" in section, "the 'not read by this server' claim is gone"
+
+
+def test_section_states_that_neither_variable_is_deprecated(section: str):
+    """Users have these in MCP client configs; the doc must say they still work.
+
+    The ticket that produced this section asked for backwards compatibility with
+    a deprecation notice. The resolution was that nothing gets renamed, so the
+    compatibility statement IS the deliverable — drop it and a reader is left
+    assuming a rename is pending.
+    """
+    assert "deprecated" in section
+    assert "keeps working unchanged" in section
+
+
+def test_section_warns_against_setting_both(section: str):
+    """Set together they split the tool surface across two ComfyUIs, silently."""
+    assert "not both" in section
+
+
+def test_target_aware_tools_do_not_claim_to_be_local_only():
+    """The run/job tools FOLLOW ``COMFYUI_URL``; their summaries must not deny it.
+
+    ``_TARGET_AWARE_SUBCOMMANDS`` is ``{"run", "jobs"}``, so exactly these tools
+    are diverted to a configured remote. Their one-line summaries used to open
+    with "LOCAL", which is the one place the local/remote distinction is
+    load-bearing and was simply wrong. The tools that genuinely stay on this
+    machine (lifecycle, ``fetch_outputs``, discovery, …) keep saying so, and are
+    deliberately not covered here.
+    """
+    for tool in (
+        server.run_workflow,
+        server.job_status,
+        server.wait_for_job,
+        server.watch_job,
+        server.cancel_job,
+        server.get_queue,
+    ):
+        summary = (tool.__doc__ or "").strip().splitlines()[0]
+        assert "LOCAL" not in summary, (
+            f"{tool.__name__} is target-aware but its summary claims LOCAL: {summary!r}"
+        )

--- a/tests/test_address_env_docs.py
+++ b/tests/test_address_env_docs.py
@@ -16,12 +16,40 @@ what) rather than on wording, so the section can be rewritten freely.
 from __future__ import annotations
 
 import pathlib
+import re
 
 import pytest
 
 from comfy_mcp import server
 
 _SECTION = "## Which address variable do I want?"
+# Anchored at both ends so the slice cannot start at a DEMOTED (`### …`) copy of
+# the heading and cannot swallow the next H2's prose.
+_SECTION_START = f"\n{_SECTION}\n"
+_SECTION_END = "\n## "
+
+# The package's own sources — every module `server` reaches, since a read of
+# comfy-cli's variable would breach the ownership split from any of them.
+_PACKAGE_SOURCES = sorted(pathlib.Path(server.__file__).resolve().parent.glob("*.py"))
+
+
+def _reads_env(source: str, name: str) -> bool:
+    """Does ``source`` READ the environment variable ``name``?
+
+    Matches the read SPELLINGS rather than one literal call, so
+    ``os.getenv(...)``, subscripting, and either quote style all count — the
+    bare name alone would not work, because these variables are named all over
+    this package's prose. An indirect read through a constant would still slip
+    past; that is the known floor of a source-level tripwire.
+    """
+    return (
+        re.search(
+            rf"""(?:environ\.get|getenv)\(\s*["']{name}["']"""
+            rf"""|environ\[\s*["']{name}["']\s*\]""",
+            source,
+        )
+        is not None
+    )
 
 
 @pytest.fixture(scope="module")
@@ -34,8 +62,13 @@ def readme() -> str:
 @pytest.fixture(scope="module")
 def section(readme: str) -> str:
     """The comparison section alone. A deleted section fails here first."""
-    assert _SECTION in readme, f"the address-variable section is gone: {_SECTION!r}"
-    return readme.split(_SECTION, 1)[1].split("\n## ", 1)[0]
+    assert _SECTION_START in readme, (
+        f"the address-variable section is gone (or is no longer an H2): {_SECTION!r}"
+    )
+    body = readme.split(_SECTION_START, 1)[1]
+    # Should this ever become the last H2, the slice runs to EOF — still the
+    # section, just with nothing after it to cut at.
+    return body.split(_SECTION_END, 1)[0]
 
 
 def test_server_reads_the_comfyui_vars_and_not_comfy_local_url():
@@ -45,14 +78,18 @@ def test_server_reads_the_comfyui_vars_and_not_comfy_local_url():
     documented "comfy-cli's, not ours" split would become a lie — and the whole
     argument for leaving the name alone would go with it.
     """
-    source = pathlib.Path(server.__file__).read_text(encoding="utf-8")
+    sources = {path.name: path.read_text(encoding="utf-8") for path in _PACKAGE_SOURCES}
+    assert "server.py" in sources, "the package layout moved out from under this test"
+
     for ours in ("COMFYUI_URL", "COMFYUI_HOST", "COMFYUI_PORT"):
-        assert f'os.environ.get("{ours}"' in source, f"{ours} is no longer read"
-    assert 'os.environ.get("COMFY_LOCAL_URL"' not in source, (
-        "this server now reads COMFY_LOCAL_URL directly — it is comfy-cli's "
-        "variable, and the README's ownership split (and the decision not to "
-        "rename it) assumes the passthrough, not a direct read"
-    )
+        assert _reads_env(sources["server.py"], ours), f"{ours} is no longer read"
+
+    for name, source in sources.items():
+        assert not _reads_env(source, "COMFY_LOCAL_URL"), (
+            f"{name} now reads COMFY_LOCAL_URL directly — it is comfy-cli's "
+            "variable, and the README's ownership split (and the decision not to "
+            "rename it) assumes the passthrough, not a direct read"
+        )
 
 
 def test_section_names_the_owner_of_each_variable(section: str):
@@ -97,7 +134,11 @@ def test_target_aware_tools_do_not_claim_to_be_local_only():
         server.cancel_job,
         server.get_queue,
     ):
-        summary = (tool.__doc__ or "").strip().splitlines()[0]
+        lines = (tool.__doc__ or "").strip().splitlines()
+        # Report a missing docstring as itself: under `python -OO` (or if one is
+        # deleted) indexing [0] would raise IndexError instead.
+        assert lines, f"{tool.__name__} has no docstring for this guard to read"
+        summary = lines[0]
         assert "LOCAL" not in summary, (
             f"{tool.__name__} is target-aware but its summary claims LOCAL: {summary!r}"
         )


### PR DESCRIPTION
## ELI-5

Two environment variables have almost the same name and mean different things: `COMFYUI_URL` ("my ComfyUI is on another machine") and `COMFY_LOCAL_URL` ("my ComfyUI is on this machine but not on port 8188"). The obvious fix — rename one — turns out to be off the table, because **only one of them is ours**. `COMFY_LOCAL_URL` belongs to comfy-cli; this server never reads it, it just rides the environment passthrough. Renaming it here would document a name nothing reads. So nothing is renamed, nothing is deprecated, and this PR instead writes down which program reads which variable, in a table, with a test so it cannot rot. Separately it strips the word "local" from the places where it was the project's old branding — the tagline, the badge, the example server key — and leaves it everywhere it draws a real distinction.

## Summary

Resolves the `COMFY_LOCAL_URL` / `COMFYUI_URL` collision (decision: **no rename**, stated and tested), then does the "strip local" sweep scoped to branding rather than to the factual local-vs-remote and local-vs-cloud distinctions. Also corrects six tool summaries that asserted "LOCAL" while being the exact tools a remote target diverts.

## The env-var decision — and why the ticket's two options were both wrong

The ticket offered "pick a new name for one of them, or rename both." Neither is available, and the reason is ownership, not taste:

| | `COMFYUI_URL` / `COMFYUI_HOST` / `COMFYUI_PORT` | `COMFY_LOCAL_URL` |
|---|---|---|
| Read by | **this server** — `_comfy_target()`, `server.py` | **comfy-cli** — `ENV_LOCAL_URL = "COMFY_LOCAL_URL"` in `comfy_cli/local_address.py` |
| This server reads it? | yes | **no — verified, it appears in no `os.environ` call** |
| Contains "local"? | no | yes, and it is comfy-cli's *local* target as opposed to its cloud one |

**Evidence (both claims are negative claims, so I went and checked rather than asserting):**

- Every environment read in this server, enumerated: `git grep -n "os\.environ" src/comfy_mcp/ ` → `COLUMNS`, `COMFYUI_HOST`, `COMFYUI_PORT`, `COMFYUI_URL`, `COMFY_API_KEY`, `COMFY_BIN`, `COMFY_CLI_MIN_VERSION`, `COMFY_T2I_CHECKPOINT_SLOT`, `COMFY_T2I_PROMPT_SLOT`, `COMFY_T2I_TEMPLATE`, `_FAILURE_LOG_ENV`. `COMFY_LOCAL_URL` is **not among them** — it appears only in prose (docstrings, comments, README).
- Upstream ownership, against `Comfy-Org/comfy-cli` `origin/main`: `comfy_cli/local_address.py:32` is `ENV_LOCAL_URL = "COMFY_LOCAL_URL"`, with the resolver, precedence chain and tests around it. It is comfy-cli's published interface.

So: **`COMFY_LOCAL_URL` is not ours to rename**, and **`COMFYUI_URL` already carries no "local" to strip** and renaming it would break every user's MCP client config for zero gain against the ticket's goal. Since nothing is renamed, there is no old spelling to accept and no deprecation period — the backwards-compatibility requirement in the ticket's scope is satisfied *completely* rather than via a shim. That is stated explicitly in the new README section so a reader does not sit waiting for a rename that is not coming.

## Changes

- **`README.md` — new `## Which address variable do I want?` section** replacing the old "use this *or* `COMFYUI_URL`, not both" blockquote: an ownership/behavior comparison table, the set-one-not-both warning (they split your tool surface across two ComfyUIs *silently* — no error), and the explicit "neither name is changing, neither is deprecated" statement. Cross-linked from the Prerequisites env block, from "Driving a remote ComfyUI", and added to the table of contents.
- **`README.md` — branding sweep.** Tagline drops two "local"s (`Drive your own ComfyUI … an MCP server`); the `ComfyUI | local` badge becomes `ComfyUI | self-hosted`; the `comfy-local` **server key** in all five client-config snippets becomes `comfy-mcp`, which is also the name the server already advertises over the wire (`MCPServer("comfy-mcp", …)`) — that key and the advertised name had been disagreeing since the rename.
- **`src/comfy_mcp/server.py` — correctness fix in six tool summaries.** `_TARGET_AWARE_SUBCOMMANDS` is `{"run", "jobs"}`, applied on all three spawn paths (`_run_comfy_raw`, `_run_comfy_async`, `_run_comfy_streaming`), so `run_workflow`, `job_status`, `wait_for_job`, `watch_job`, `cancel_job` and `get_queue` are precisely the tools `COMFYUI_URL` diverts to another machine — and five of them opened with "LOCAL". They now say what they do; `run_workflow` gains a sentence naming the override. `get_queue`'s "LOCAL ONLY" paragraph becomes "NO COMFY CLOUD JOBS", which is what it actually meant, and its inaccurate "would route locally regardless" becomes "would route to this server's own target regardless".
- **`src/comfy_mcp/server.py` — handshake opener.** "This server drives a LOCAL ComfyUI" → "a ComfyUI the user runs themselves … by default the one on this machine (`127.0.0.1:8188`), never Comfy Cloud." Same guarantee, accurate about the remote case.
- **`tests/test_address_env_docs.py` (new, 6 tests).** Pins the ownership split against the *source* (this server reads the three `COMFYUI_*` vars and does **not** read `COMFY_LOCAL_URL`), pins the README section's load-bearing claims, and pins that no target-aware tool's summary claims LOCAL again.

## What was deliberately NOT changed

The ticket says to keep "local" where it is a factual distinction. I applied that rule and it turns out to cover most of the file, so I want the line I drew to be reviewable rather than implied:

- **Every "Not remoted" surface keeps its "local".** The lifecycle tools, `fetch_outputs`, `system_stats` / `free_memory`, discovery/validation, `run_template`, `generate_image`, `search_models` — these genuinely stay on this machine when `COMFYUI_URL` points the run/job tools elsewhere, and stripping "local" would delete exactly the distinction the ticket says to preserve. (`run_template` is worth naming: it shells `run-template`, and the match is exact on `args[0]`, so it is *not* target-aware and its "local" is correct.)
- **The routing block and the closing guarantee in `INSTRUCTIONS` are untouched.** "Everything targets the LOCAL server only — there is no cloud access here" is guarded by `test_instructions_retain_the_local_only_closing_guarantee`, whose docstring explains it is what stops "point them at Comfy Cloud" from reading as "this server can run it there". That LOCAL means "not Comfy Cloud" and is exactly true.
- **`SECURITY.md` and the threat model** — untouched, per the ticket.
- **`AGENTS.md`** — untouched. It is contributor docs, not user-facing branding, and it is covered by the `agents-md-integrity` workflow; its "local-only, single-process" phrasing is about not importing multi-tenant cloud patterns. Easy follow-up if you want it swept.
- **The `Upgrading from comfy-local-mcp` section** keeps every `comfy-local-mcp` — it is history, and `test_readme_migration_note_names_the_live_env_var_and_log_dir` depends on it.

## Judgment calls, flagged

- **The ticket's headline number ("local" appears ~96 times in the README) is not what this PR moves.** I removed roughly a dozen and then *audited the remainder rather than assuming*: I dumped every remaining bare-`local` occurrence with surrounding context and classified each. They are the factual distinction — cloud contrast, the routing thresholds, the not-remoted list, filesystem paths, the failure log's on-disk locality. If you want a more aggressive reading of "branding", say so and I will take another pass; I did not want to strip meaning to hit a count.
- **Renaming the example server key `comfy-local` → `comfy-mcp` is user-visible in a soft way.** The key is arbitrary and client-local, so nobody's setup breaks — but a returning user who *pastes* the new snippet next to their existing `comfy-local` entry registers the server twice and sees every tool twice. The note above the snippets now says to edit the existing entry rather than paste a second one, and that keeping the old key is fine.
- **Badge wording.** `ComfyUI | local` → `ComfyUI | self-hosted`. A badge is branding, so it was in scope, but "self-hosted" is my word choice, not the ticket's. Rendering verified against shields.io (the `--` is the literal-hyphen escape).

## Testing

- [x] `pytest` — **1383 passed, 4 skipped** (the 4 skips are the live-ComfyUI e2e markers, skipped as designed). 6 of those are the new tests.
- [x] `ruff check .` passes.
- [x] `ruff format --check .` passes.
- [x] Verified the new docstring test is **not vacuous** — printed the six `__doc__` first lines through the `@mcp.tool()` decorator to confirm it reads real summaries rather than passing on `None`.
- [x] Verified the ownership claim empirically against both codebases (see the Evidence block above), not from the existing prose.
- [x] Verified `_with_target` is applied on all three spawn paths, so the "these six are target-aware" premise behind the docstring fix holds for the streaming tool (`watch_job`) too.

## Negative-claim falsification

This diff adds no deny/dead-end path, no "not supported" / "unavailable" string, and refuses no capability — every tool, argument and error path is unchanged. It does make two **negative claims in prose**, so both were falsified by going and looking rather than by reasoning: *"this server never reads `COMFY_LOCAL_URL`"* (checked by enumerating every `os.environ` read in the package — the full list is in the Evidence block) and *"`COMFY_LOCAL_URL` is comfy-cli's"* (checked against `comfy-cli` `origin/main`, `comfy_cli/local_address.py:32`). The one new test that asserts an absence asserts *that architecture* — the passthrough — and would correctly fail the day this server starts reading the variable directly, which is the day the no-rename argument stops holding.

## Follow-ups a human owns

Neither is expressible as a commit here:

- The two tracker tickets that documented the `COMFY_LOCAL_URL` passthrough and the earlier README rework describe the collision as unresolved. They now have an answer (no rename, ownership documented) and want updating. No tracker access from here.
- `AGENTS.md`'s "local" phrasing, if you want it in scope.
