### PR TITLE
feat: add node_dependencies tool wrapping `comfy node deps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ server has no path to is Comfy Cloud itself: no cloud-hosted execution, no cloud
 cross-session cloud batches. Every tool here shells out to `comfy --where local`. Pick by where you
 want the work to run, or [install the cloud server too](#comfy-cloud-mcp).
 
-> **Status:** beta. 49 tools; core loop validated end-to-end against a live local ComfyUI
+> **Status:** beta. 50 tools; core loop validated end-to-end against a live local ComfyUI
 > (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on
 > Python 3.10 and 3.14.
 
@@ -774,7 +774,7 @@ MCP client config today, it keeps working unchanged.
 
 ## Tools
 
-49 tools, grouped below by what they do. Every tool runs `comfy` with the global
+50 tools, grouped below by what they do. Every tool runs `comfy` with the global
 `--json --where local` flags, unwraps comfy-cli's `envelope/1`, and returns its `data`.
 
 **Argument naming** is uniform, so an agent never has to guess it (the server's handshake
@@ -842,6 +842,7 @@ handle is `prompt_id`.
 | `nodes_path(from_type, to_type, max_depth=6, max_paths=10)` | `comfy nodes path <FROM> <TO> --max-depth N --max-paths N` | Node chains routing a value between two connection types (e.g. `MODEL` → `IMAGE`). Reads the **live install**. |
 | `nodes_types()` | `comfy nodes types` | All connection types (`MODEL`, `IMAGE`, …) ranked by connectivity. Reads the **live install**. |
 | `nodes_categories()` | `comfy nodes categories` | The node category tree. Reads the **live install**. |
+| `node_dependencies(pack="", registry_id="")` | `comfy node deps [<pack>] [--registry <id>]` | A custom node **pack**'s declared Python requirements (its `requirements.txt` / `pyproject.toml`) against the versions actually installed in the workspace venv — each requirement carrying a `satisfied` / `mismatch` / `missing` / `unparseable` / `unknown` status, plus per-pack counts. This is what tells you whether a pack's imports are failing because a dependency is absent, or whether installing one pack would conflict with another. `pack` empty reports every installed pack; `registry_id` pre-checks a **not-yet-installed** registry pack against the same venv before you install it (its latest published version — the registry exposes no per-version endpoint). The two are additive, so naming the same id both ways yields an installed row and a registry row to compare. Read-only: nothing is installed or changed. Pack-level filesystem + venv introspection, so it is deliberately separate from `get_node` / `search_nodes`, which introspect node **classes** over the live `object_info`. Needs a comfy-cli newer than v1.13.0; on an older one it returns `{"error": …, "unsupported": true}` rather than a raw usage dump. |
 | `search_models(query="", folder="")` | `comfy models search` / `models list-folder <folder>` / `models list-folders` | List/search model files on disk. **Local:** filenames only, no cloud enrichment. |
 | `list_partner_models(style="", partner="", query="", limit=100, offset=0)` | `comfy generate list [--style S] [--partner P] [--query Q]` | The catalog of hosted **partner** models `partner_generate` can run — the only place that list exists (nothing in `discover` / `search_nodes` / `search_templates` carries the partner aliases). One record per model: `alias` (what you pass as `model`), `id`, `partner`, `category` (the model's style, and the axis `style` filters on — `text-to-image`, `image-edit`, `image-to-image`, `text-to-video`, `image-to-video`, `video-extend`, `controlnet`, `inpaint`, `outpaint`, `upscale`, `background`, `lipsync`, `vectorize` as this is written; comfy-cli owns that set, so read it off an unfiltered call), `mode` (`sync`/`async`, the partner's protocol — `partner_generate` waits either way) and the model's full, untruncated `summary`. Filters are forwarded to comfy-cli: `style` is exact and **case-sensitive**, `partner` exact and case-insensitive, `query` a substring over `id` + `summary`. `limit` (default 100, capped at 200) / `offset` page the result (`{total, shown, offset, filters, models}`) so a growing catalog can't trip the client's tool-output cap; 52 models as this is written, so the default returns all of them — check `shown` against `total` rather than assuming that stays true. |
 | `partner_model_schema(model)` | `comfy generate schema <model>` | One partner model's callable parameters — what to put in `partner_generate`'s `params`. Returns `{model, id, partner, category, summary, mode, polling, content_type, params, example}`, where each `params` record carries `name`, `type` (`string`/`integer`/`number`/`boolean`/`enum`/`object`/`array`/`binary` — `binary` is a local file path comfy-cli uploads or inlines for you), `required`, `default`, `enum` and the spec's own `description`. Reads the spec only: no partner call, no key, no spend. |
@@ -866,6 +867,10 @@ Node introspection (`search_nodes` / `get_node` / `list_nodes` / `nodes_upstream
 read the **user's live install** (custom nodes included), not a static catalog — that's the
 local differentiator from the cloud MCP's equivalents. The graph-wiring verbs (`upstream` /
 `downstream` / `path`) are what an agent authoring a workflow uses to find compatible nodes.
+`node_dependencies` reads that same live install from the other side — the **packs** on disk and
+the venv they installed into, rather than the node classes ComfyUI loaded from them — which is how
+an agent tells "this pack's nodes are missing from `object_info`" apart from "this pack's Python
+dependencies never installed".
 
 ## Troubleshooting
 

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -8736,6 +8736,90 @@ def nodes_categories() -> Any:
 
 
 @mcp.tool()
+def node_dependencies(pack: str = "", registry_id: str = "") -> Any:
+    """Report a custom node pack's Python dependency requirements vs the versions
+    installed in the workspace venv (read-only).
+
+    Wraps ``comfy node deps``. With ``pack`` empty, reports every installed pack.
+    ``pack`` names an INSTALLED pack (as shown by ``list_nodes``'s pack filter);
+    ``registry_id`` names a NOT-yet-installed registry pack to pre-check before
+    install (latest published version only). Each requirement carries a status —
+    satisfied / mismatch / missing / unparseable / unknown — computed against the
+    live venv, which is what an agent needs to assess dependency-conflict risk or
+    diagnose a pack's missing imports. Reporting only: nothing is installed or
+    changed.
+
+    Deliberately NOT part of ``get_node`` / ``search_nodes``: those introspect
+    node CLASSES over the running ComfyUI's live ``object_info``, while this reads
+    the workspace filesystem and its venv (``pip list``) — folding it in would put
+    a pip-list subprocess behind every schema lookup.
+
+    The two arguments are additive rather than exclusive, and each yields its own
+    row, so ``pack`` and ``registry_id`` may name the same id to compare an
+    installed pack against what the registry publishes. Rows are keyed by
+    (``pack``, ``registry``), not by ``pack`` alone.
+
+    Freshness: LIVE for the installed half — the pack's declared requirements are
+    re-read off disk and diffed against the venv on every call. The
+    ``registry_id`` half reflects the registry's LATEST published version, which
+    is not necessarily what an install would resolve to.
+    """
+    args = ["node", "deps"]
+    # `pack` is a bare positional and `registry_id` is `--registry`'s value, so
+    # the same guarded pattern `get_node` / `list_nodes` use applies to both: a
+    # dash-leading positional is read as an option (argument injection), a
+    # dash-leading option value is a caller mistake worth naming, and a NUL would
+    # otherwise escape as `subprocess`' bare ValueError instead of a
+    # `ComfyCliError`. Empty values are omitted entirely — a bare `node deps`
+    # reports every installed pack.
+    if pack:
+        _reject_option_like(
+            "pack", pack, expected="an installed pack name (e.g. 'comfyui-impact-pack')"
+        )
+        _reject_nul("pack", pack)
+        args.append(pack)
+    if registry_id:
+        _reject_option_like(
+            "registry_id",
+            registry_id,
+            expected="a registry node id (e.g. 'comfyui-impact-pack')",
+        )
+        _reject_nul("registry_id", registry_id)
+        args += ["--registry", registry_id]
+    try:
+        # 60s, the tier the other node tools use — not `_freshness_report`'s 15s:
+        # the verb runs `pip list` in the workspace venv, and `--registry` adds a
+        # registry lookup on top.
+        return _run_comfy(*args, timeout=60.0)
+    except ComfyCliError as exc:
+        # `comfy node deps` ships in comfy-cli releases AFTER 1.13.0, which is
+        # also this server's floor (`_MIN_COMFY_CLI`) — so every comfy-cli that
+        # currently satisfies the version guard still lacks the verb, making this
+        # the COMMON path today rather than an edge one. Verified against the
+        # released 1.13.0: `comfy --json --where local node deps` exits 2 with no
+        # envelope and Click's `No such command 'deps'.` on stderr, inside a rich
+        # panel — i.e. a missing SUBcommand of `node` produces exactly the message
+        # shape `_is_missing_verb_error` already matches for a missing TOP-LEVEL
+        # verb, so no widening of the matcher was needed. Same shape and same
+        # strictness as `_freshness_report` / `_download_verb_unsupported` /
+        # `list_workflow_notes`: the no-envelope + Click-usage-exit pair is
+        # required, so a real failure from a verb comfy-cli DID dispatch (no
+        # workspace, an unknown pack name, an unreachable registry) keeps the raw
+        # raise instead of being waved through as a capability gap.
+        if not _is_missing_verb_error(exc, "deps"):
+            raise
+        return {
+            "error": (
+                "node_dependencies unavailable: the installed comfy-cli does not "
+                "support 'comfy node deps' (the verb ships in releases after "
+                f"{_MIN_COMFY_CLI_STR}). Nothing else is affected. Update "
+                "comfy-cli to use this tool."
+            ),
+            "unsupported": True,
+        }
+
+
+@mcp.tool()
 def search_models(query: str = "", folder: str = "") -> Any:
     """Search / list model files available to the LOCAL ComfyUI install.
 

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -8735,6 +8735,60 @@ def nodes_categories() -> Any:
     return _run_comfy("nodes", "categories", timeout=60.0)
 
 
+# Ceiling on `node_dependencies`' two id-shaped arguments, set the way
+# :data:`_MAX_DOWNLOAD_ID_LEN` is. A pack id is a registry slug — tens of
+# characters — and an oversized one is not a lookup that misses but a value that
+# never reaches comfy-cli at all: past the platform's `ARG_MAX`, `execve` fails
+# with an `OSError` no caller here converts to a `ComfyCliError`. Checked FIRST,
+# ahead of `_reject_option_like`, so the error reports a size rather than echoing
+# a megabyte-long "pack name" back through the tool response and the failure log.
+_MAX_NODE_PACK_ID_LEN = 128
+
+
+# The missing-verb/-option matchers are deliberately strict because their
+# degrade asserts NOTHING IS BROKEN (see `_is_missing_verb_error`), and their
+# `no_envelope` condition exists to keep a RELAYED "no such command" out. This
+# closes the one door that condition cannot: text the CALLER put on the command
+# line. `node deps` is the only degrade site whose argv carries caller-controlled
+# values — `outdated` / `notes` / `download-status` take none — and Click echoes
+# an offending value verbatim in its usage error (`Invalid value for '[PACK]':
+# …`), which lands on the same exit 2 with no envelope the matchers read. So a
+# caller passing `pack="no such command 'deps'"` could otherwise forge the
+# parser's own message about `deps` and convert a genuine usage failure into
+# "your comfy-cli is just too old". Local to this call site rather than folded
+# into the matchers, which have no way to know what their caller passed.
+def _phrase_is_only_the_caller_s(
+    exc: ComfyCliError, pattern: str, *values: str
+) -> bool:
+    """Does *pattern* match only text the CALLER supplied, not comfy-cli's own?
+
+    Removes every non-empty entry of *values* from the normalized message and
+    re-runs *pattern*. No match afterwards means the sole occurrence came from an
+    echoed argument, and the degrade must not fire.
+
+    A value that is itself a substring of comfy-cli's genuine message deletes
+    that occurrence too, so a caller who passes the parser's exact wording gets
+    the raw passthrough instead of the degrade. That is the same one-directional
+    trade :func:`_is_missing_verb_error` documents — noisy but honest beats a
+    false "nothing is broken" — and here it is also the only self-inflicted way
+    to reach it.
+
+    Matching is on the echo being VERBATIM (modulo the normalization both sides
+    get), which is what Click's ``repr`` of an offending value gives for the
+    shapes that can carry the phrase at all — the value needs a quote, and
+    ``repr`` answers a single-quoted value with double quotes rather than
+    backslashes. A value carrying BOTH quote styles would come back re-escaped
+    and survive this subtraction. That residual is left as-is: the caller would
+    be deceiving only itself, since the degrade it forges is returned to the
+    same caller that crafted the argument.
+    """
+    normalized = _normalize_cli_text(str(exc))
+    for value in values:
+        if value:
+            normalized = normalized.replace(_normalize_cli_text(value), " ")
+    return re.search(pattern, normalized, re.IGNORECASE) is None
+
+
 @mcp.tool()
 def node_dependencies(pack: str = "", registry_id: str = "") -> Any:
     """Report a custom node pack's Python dependency requirements vs the versions
@@ -8759,6 +8813,17 @@ def node_dependencies(pack: str = "", registry_id: str = "") -> Any:
     installed pack against what the registry publishes. Rows are keyed by
     (``pack``, ``registry``), not by ``pack`` alone.
 
+    Pass ``pack`` when you are diagnosing ONE pack: the bare call carries every
+    installed pack's every requirement row, so on a workspace with dozens of
+    packs it is a much larger payload than you need to answer "why do this
+    pack's nodes not load".
+
+    May return ``{"error": ..., "unsupported": True}`` INSTEAD of the payload,
+    on a comfy-cli that predates the verb — which today is every released one,
+    so a caller must check for that key before indexing ``["packs"]``. A missing
+    ``--registry`` reports the same shape, naming that half only. Any other
+    failure raises, as everywhere else.
+
     Freshness: LIVE for the installed half — the pack's declared requirements are
     re-read off disk and diffed against the venv on every call. The
     ``registry_id`` half reflects the registry's LATEST published version, which
@@ -8772,6 +8837,13 @@ def node_dependencies(pack: str = "", registry_id: str = "") -> Any:
     # otherwise escape as `subprocess`' bare ValueError instead of a
     # `ComfyCliError`. Empty values are omitted entirely — a bare `node deps`
     # reports every installed pack.
+    for label, value in (("pack", pack), ("registry_id", registry_id)):
+        if value and len(value) > _MAX_NODE_PACK_ID_LEN:
+            # Report the length, not the value — see `_MAX_NODE_PACK_ID_LEN`.
+            raise ComfyCliError(
+                f"invalid {label}: {len(value)} characters exceeds the "
+                f"{_MAX_NODE_PACK_ID_LEN}-character maximum."
+            )
     if pack:
         _reject_option_like(
             "pack", pack, expected="an installed pack name (e.g. 'comfyui-impact-pack')"
@@ -8805,18 +8877,68 @@ def node_dependencies(pack: str = "", registry_id: str = "") -> Any:
         # `list_workflow_notes`: the no-envelope + Click-usage-exit pair is
         # required, so a real failure from a verb comfy-cli DID dispatch (no
         # workspace, an unknown pack name, an unreachable registry) keeps the raw
-        # raise instead of being waved through as a capability gap.
-        if not _is_missing_verb_error(exc, "deps"):
-            raise
-        return {
-            "error": (
-                "node_dependencies unavailable: the installed comfy-cli does not "
-                "support 'comfy node deps' (the verb ships in releases after "
-                f"{_MIN_COMFY_CLI_STR}). Nothing else is affected. Update "
-                "comfy-cli to use this tool."
-            ),
-            "unsupported": True,
-        }
+        # raise instead of being waved through as a capability gap. On top of
+        # that pair, `_phrase_is_only_the_caller_s` discounts a phrase Click
+        # merely echoed back out of `pack` / `registry_id` — the one route to a
+        # false `unsupported` those two conditions leave open here, and the
+        # reason this call site needs a check the other degrade sites do not.
+        caller_values = (pack, registry_id)
+        if _is_missing_verb_error(exc, "deps") and not _phrase_is_only_the_caller_s(
+            exc,
+            _MISSING_VERB_RE_TEMPLATE.format(verb=re.escape("deps")),
+            *caller_values,
+        ):
+            return {
+                "error": (
+                    "node_dependencies unavailable: the installed comfy-cli does "
+                    "not support 'comfy node deps' (the verb ships in releases "
+                    # "1.13.0" is written out rather than interpolated from
+                    # `_MIN_COMFY_CLI_STR`: that constant is this server's version
+                    # FLOOR, and raising the floor to a release that HAS the verb
+                    # would turn this sentence into a contradiction. The release
+                    # the verb landed in is a fact about comfy-cli, so it is
+                    # spelled out — the same way `_download_verb_unsupported`
+                    # spells out its own.
+                    "after 1.13.0). Nothing else is affected. Update comfy-cli "
+                    "to use this tool."
+                ),
+                "unsupported": True,
+            }
+        # The OPTION-shaped half of the same version gap, the way `download_model`
+        # covers `--background` alongside the `model download-status` verb: a
+        # comfy-cli with `node deps` but without `--registry` raises Click's
+        # `No such option: --registry` — exit 2, no envelope, and no match for
+        # the verb pattern above — which would otherwise fall through as the raw
+        # usage dump this degrade exists to replace. Forward cover rather than a
+        # gap that exists today: on comfy-cli main the option and the verb are
+        # one commit (`comfy_cli/command/node_deps.py`), and neither is in any
+        # release yet — which is precisely the window in which the option could
+        # still be renamed before it ships. `download_model` carries the same
+        # both-halves cover over a verb group its own docstring calls
+        # all-or-nothing. Gated on `registry_id` because with it empty the flag
+        # is never on the command line, so any such phrase can only have been
+        # echoed from somewhere else.
+        if (
+            registry_id
+            and _is_missing_option_error(exc, "--registry")
+            and not _phrase_is_only_the_caller_s(
+                exc,
+                _MISSING_OPTION_RE_TEMPLATE.format(option=re.escape("--registry")),
+                *caller_values,
+            )
+        ):
+            return {
+                "error": (
+                    "node_dependencies registry_id unavailable: the installed "
+                    "comfy-cli's 'comfy node deps' does not support '--registry' "
+                    "(it ships with the verb, in releases after 1.13.0). The "
+                    "installed-pack half still works — call again with "
+                    "registry_id empty — or update comfy-cli to pre-check a pack "
+                    "before installing it."
+                ),
+                "unsupported": True,
+            }
+        raise
 
 
 @mcp.tool()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -410,6 +410,111 @@ def test_node_dependencies_different_verb_is_not_unsupported(patched_run):
         server.node_dependencies()
 
 
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"pack": "no such command 'deps'"},
+        {"registry_id": "no such command 'deps'"},
+    ],
+    ids=lambda kw: next(iter(kw)),
+)
+def test_node_dependencies_echoed_phrase_is_not_unsupported(patched_run, kwargs):
+    """A caller cannot forge the version gap through its own argument.
+
+    Click echoes an offending value verbatim in a usage error, on the same exit 2
+    with no envelope `_is_missing_verb_error` reads — the one route to a false
+    `unsupported` its two conditions cannot close. A real failure must stay a
+    real failure rather than becoming "your comfy-cli is just too old".
+    """
+    value = next(iter(kwargs.values()))
+    patched_run(
+        "",
+        returncode=2,
+        stderr=(
+            "Usage: comfy node deps [OPTIONS] [PACK]\n"
+            f"Error: Invalid value for '[PACK]': {value!r} is not an installed pack."
+        ),
+    )
+
+    with pytest.raises(server.ComfyCliError):
+        server.node_dependencies(**kwargs)
+
+
+def test_node_dependencies_degrades_with_a_pack_argument(patched_run):
+    """The echoed-input check must not cost the genuine degrade.
+
+    Discounting the caller's own text is subtraction, not a veto: an ordinary
+    `pack` shares no wording with Click's message, so the parser's own phrase
+    survives and the version gap still reports as one.
+    """
+    patched_run(
+        "",
+        returncode=2,
+        stderr=("Usage: comfy node [OPTIONS] COMMAND\nError: No such command 'deps'."),
+    )
+
+    assert server.node_dependencies(pack="comfyui-impact-pack")["unsupported"] is True
+
+
+def test_node_dependencies_degrades_without_the_registry_option(patched_run):
+    """The OPTION half of the version gap, the way `download_model` covers it.
+
+    A comfy-cli that HAS `node deps` but not `--registry` never matches the verb
+    pattern, so without this it falls through as the raw usage dump the degrade
+    exists to replace.
+    """
+    patched_run(
+        "",
+        returncode=2,
+        stderr=(
+            "Usage: comfy node deps [OPTIONS] [PACK]\n"
+            "Try 'comfy node deps --help' for help.\n"
+            "Error: No such option: --registry"
+        ),
+    )
+
+    result = server.node_dependencies(registry_id="comfyui-impact-pack")
+
+    assert result["unsupported"] is True
+    assert "--registry" in result["error"]
+    # Points at the half that still works rather than dead-ending.
+    assert "registry_id empty" in result["error"]
+    assert "No such option" not in result["error"]
+
+
+def test_node_dependencies_registry_option_gap_needs_the_argument(patched_run):
+    """With `registry_id` empty the flag is never on the command line.
+
+    So a "no such option: --registry" can only have been relayed from elsewhere,
+    and degrading on it would assert this call is fine when it is not.
+    """
+    patched_run(
+        "",
+        returncode=2,
+        stderr="Error: No such option: --registry",
+    )
+
+    with pytest.raises(server.ComfyCliError):
+        server.node_dependencies(pack="comfyui-impact-pack")
+
+
+@pytest.mark.parametrize("label", ["pack", "registry_id"])
+def test_node_dependencies_rejects_an_oversized_id(patched_run, label):
+    """An id past `ARG_MAX` fails `execve`, not the lookup — refuse it first.
+
+    And the error must report the SIZE: `_reject_option_like` would otherwise
+    echo a megabyte-long value back through the response and the failure log.
+    """
+    calls = patched_run(envelope(data={"packs": []}))
+    oversized = "-" + "x" * server._MAX_NODE_PACK_ID_LEN
+
+    with pytest.raises(server.ComfyCliError, match="exceeds the") as excinfo:
+        server.node_dependencies(**{label: oversized})
+
+    assert oversized not in str(excinfo.value)
+    assert calls == []
+
+
 def test_search_models_query_uses_search(patched_run):
     # BE-2952: comfy-cli 1.12's `models search` takes the query as `--text`,
     # not a positional — a positional exits 2 ("returned no JSON (exit 2)").

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -198,6 +198,218 @@ def test_nodes_categories_argv(patched_run):
     assert calls[0]["cmd"][4:] == ["nodes", "categories"]
 
 
+def test_node_dependencies_bare_argv(patched_run):
+    """No arguments -> a bare `node deps`, which reports every installed pack."""
+    data = {"workspace": "/ws", "python": "/ws/.venv/bin/python", "packs": []}
+    calls = patched_run(envelope(data=data))
+    assert server.node_dependencies() == data
+    # `node` (pack-level), NOT the `nodes` class-introspection family
+    assert calls[0]["cmd"][4:] == ["node", "deps"]
+    assert calls[0]["timeout"] == 60.0
+
+
+def test_node_dependencies_pack_is_a_positional(patched_run):
+    calls = patched_run(envelope(data={"packs": []}))
+    server.node_dependencies(pack="comfyui-impact-pack")
+    assert calls[0]["cmd"][4:] == ["node", "deps", "comfyui-impact-pack"]
+
+
+def test_node_dependencies_registry_id_uses_the_flag(patched_run):
+    calls = patched_run(envelope(data={"packs": []}))
+    server.node_dependencies(registry_id="comfyui-impact-pack")
+    assert calls[0]["cmd"][4:] == ["node", "deps", "--registry", "comfyui-impact-pack"]
+
+
+def test_node_dependencies_both_are_additive(patched_run):
+    """The two are not exclusive — comfy-cli emits a row for each.
+
+    Naming the same id both ways is the deliberate "installed vs published"
+    comparison, so the positional must stay ahead of the option rather than
+    either one replacing the other.
+    """
+    calls = patched_run(envelope(data={"packs": []}))
+    server.node_dependencies(pack="was-suite", registry_id="was-suite")
+    assert calls[0]["cmd"][4:] == [
+        "node",
+        "deps",
+        "was-suite",
+        "--registry",
+        "was-suite",
+    ]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"pack": "--help"}, {"pack": "-p"}, {"registry_id": "--registry"}],
+    ids=["pack-long", "pack-short", "registry_id"],
+)
+def test_node_dependencies_rejects_leading_dash(patched_run, kwargs):
+    """Both values are refused before the spawn, `get_node`/`list_nodes`-style."""
+    calls = patched_run(envelope(data={"packs": []}))
+    with pytest.raises(server.ComfyCliError, match="leading '-'"):
+        server.node_dependencies(**kwargs)
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"pack": "was\0suite"}, {"registry_id": "was\0suite"}],
+    ids=lambda kw: next(iter(kw)),
+)
+def test_node_dependencies_rejects_embedded_nul(patched_run, kwargs):
+    """A NUL surfaces as ComfyCliError, not subprocess's bare ValueError."""
+    calls = patched_run(envelope(data={"packs": []}))
+    with pytest.raises(server.ComfyCliError, match="embedded NUL"):
+        server.node_dependencies(**kwargs)
+    assert calls == []
+
+
+def test_node_dependencies_returns_the_envelope_payload(patched_run):
+    """Thin passthrough: comfy-cli's `data` is returned verbatim, unreshaped."""
+    data = {
+        "workspace": "/ws",
+        "python": "/ws/.venv/bin/python",
+        "compiled_lock": {"present": False, "path": None},
+        "packs": [
+            {
+                "pack": "demo-pack",
+                "path": "custom_nodes/demo-pack",
+                "status": "installed",
+                "requirement_files": ["requirements.txt"],
+                "requirements": [
+                    {
+                        "raw": "numpy==1.26.4",
+                        "name": "numpy",
+                        "specifier": "==1.26.4",
+                        "installed": None,
+                        "status": "missing",
+                        "source": "requirements.txt",
+                    }
+                ],
+                "summary": {
+                    "satisfied": 0,
+                    "mismatch": 0,
+                    "missing": 1,
+                    "unparseable": 0,
+                    "unknown": 0,
+                },
+            }
+        ],
+        "warnings": [],
+    }
+    patched_run(envelope(data=data))
+    assert server.node_dependencies() == data
+
+
+def test_node_dependencies_degrades_without_the_verb(patched_run):
+    """A comfy-cli predating `comfy node deps` reads as a version gap, not a break.
+
+    The verb ships in releases AFTER the `_MIN_COMFY_CLI` floor, so an install
+    that satisfies the version guard can still lack it — the common path today.
+    Verified against the released 1.13.0: a missing SUBcommand of `node` exits 2
+    with no envelope and Click's `No such command 'deps'.` on stderr, exactly the
+    shape `_is_missing_verb_error` already matches for a top-level verb.
+    """
+    patched_run(
+        "",
+        returncode=2,
+        stderr="Usage: comfy node [OPTIONS] COMMAND\nNo such command 'deps'.",
+    )
+
+    result = server.node_dependencies()
+
+    assert result["unsupported"] is True
+    assert "node_dependencies unavailable" in result["error"]
+    assert "comfy node deps" in result["error"]
+    # None of the raw wrapper/CLI text leaks through.
+    assert "No such command" not in result["error"]
+    assert "Usage: comfy" not in result["error"]
+    assert "returned no JSON" not in result["error"]
+
+
+def test_node_dependencies_degrades_through_a_rich_panel(patched_run):
+    """Typer wraps the same error in a bordered, width-wrapped rich panel.
+
+    `_normalize_cli_text` folds the box glyphs and the wrap away, so the degrade
+    must not depend on the terminal width the child happened to render at. This
+    is the stderr the real 1.13.0 emits, box characters and all.
+    """
+    patched_run(
+        "",
+        returncode=2,
+        stderr=(
+            "Usage: comfy node [OPTIONS] COMMAND [ARGS]...\n"
+            "Try 'comfy node --help' for help.\n"
+            "╭─ Error ─────────────────────╮\n"
+            "│ No such command\n"
+            "│ 'deps'.                     │\n"
+            "╰─────────────────────────────╯\n"
+        ),
+    )
+
+    assert server.node_dependencies()["unsupported"] is True
+
+
+def test_node_dependencies_keeps_a_real_error_raw(patched_run):
+    """A verb comfy-cli DID dispatch must never be waved through as a gap.
+
+    No workspace is the case that matters: comfy-cli answers with an
+    `not_in_workspace` envelope, and the agent has to see it to know the fix is
+    `comfy install`, not a comfy-cli upgrade.
+    """
+    patched_run(
+        envelope(
+            ok=False,
+            error={
+                "code": "not_in_workspace",
+                "message": "ComfyUI workspace not found.",
+            },
+        )
+    )
+
+    with pytest.raises(server.ComfyCliError, match="not_in_workspace"):
+        server.node_dependencies()
+
+
+def test_node_dependencies_relayed_phrase_is_not_unsupported(patched_run):
+    """A failure that merely QUOTES the phrase, inside an envelope, stays raw.
+
+    `_is_missing_verb_error` requires the no-envelope + usage-exit pair exactly
+    so a nested error relaying "No such command 'deps'" from somewhere else — a
+    pack's own build hook, a pip/git call comfy-cli shelled out to — cannot be
+    mistaken for the verb itself being absent.
+    """
+    patched_run(
+        envelope(
+            ok=False,
+            error={
+                "code": "pack_scan_failed",
+                "message": "a pack hook failed: No such command 'deps'.",
+            },
+        ),
+        returncode=2,
+    )
+
+    with pytest.raises(server.ComfyCliError, match="pack_scan_failed"):
+        server.node_dependencies()
+
+
+def test_node_dependencies_different_verb_is_not_unsupported(patched_run):
+    """A "no such command" naming a DIFFERENT verb is not this tool's gap.
+
+    A CLI new enough to have `node deps` can still reject something the verb
+    shells out to; degrading on that would assert nothing is broken.
+    """
+    patched_run(
+        "",
+        returncode=2,
+        stderr="Error: No such command 'deps-in-workflow'.",
+    )
+
+    with pytest.raises(server.ComfyCliError):
+        server.node_dependencies()
+
+
 def test_search_models_query_uses_search(patched_run):
     # BE-2952: comfy-cli 1.12's `models search` takes the query as `--text`,
     # not a positional — a positional exits 2 ("returned no JSON (exit 2)").


### PR DESCRIPTION
## ELI-5

Custom node packs bring their own Python dependencies. When one of them doesn't install cleanly, the pack's nodes just silently don't show up — and the only way to find out why was to go read `requirements.txt` by hand and compare it against `pip list`. comfy-cli grew a verb that does that comparison for you; this PR exposes it as an MCP tool, so an agent with no shell access can ask "what does this pack need, what's actually installed, and do they disagree?"

## Summary

Adds one new tool, `node_dependencies(pack="", registry_id="")`, a thin passthrough to `comfy node deps`. It reports each custom node pack's declared Python requirements (`requirements.txt` and/or `pyproject.toml`) against the versions installed in the workspace venv, with a per-requirement `satisfied` / `mismatch` / `missing` / `unparseable` / `unknown` status and per-pack counts. Read-only: nothing is installed or changed.

- `pack` empty → every installed pack.
- `pack` → one installed pack (the same names `list_nodes`' `pack` filter uses).
- `registry_id` → a **not-yet-installed** registry pack, diffed against the same venv so conflict risk can be checked *before* installing. Latest published version only — the registry exposes no per-version dependency endpoint.
- The two are additive, not exclusive: naming the same id both ways yields an installed row and a registry row, which is the "what I have vs what they publish" comparison.

Deliberately a NEW tool rather than a field on `get_node` / `search_nodes`. Those introspect node **classes** over the running ComfyUI's live `object_info`; this is **pack**-level filesystem + venv introspection, and folding it in would put a `pip list` subprocess behind every schema lookup.

## Changes

- `src/comfy_mcp/server.py`: the `node_dependencies` tool, placed with the other node tools. Builds argv `["node", "deps"]` and appends the positional `pack` and/or `--registry <registry_id>` only when non-empty; both values go through `_reject_option_like` + `_reject_nul` exactly like `get_node` / `list_nodes` (a dash-leading positional is read as an option; a NUL would otherwise escape as `subprocess`' bare `ValueError`). Calls `_run_comfy(*args, timeout=60.0)` — the node tools' tier, not `_freshness_report`'s 15s, because the verb runs `pip list` in the venv and `--registry` adds a lookup on top.
- Missing-verb degrade: the verb ships in a comfy-cli release *after* 1.13.0, which is also this server's floor (`_MIN_COMFY_CLI`), so every comfy-cli that satisfies the version guard today still lacks it — the common path, not an edge one. That case returns `{"error": "node_dependencies unavailable: …", "unsupported": true}` instead of relaying Click's raw usage dump, using the same shape and the same strictness as `_freshness_report` / `_download_verb_unsupported` / `list_workflow_notes`.
- `tests/test_discovery.py`: 15 tests — argv for the three shapes (bare / `pack` / `registry_id`) plus the additive both-at-once shape, leading-dash and NUL rejection for both params (asserting no child was spawned), envelope passthrough, the degrade (plain and inside a rich panel), and three narrowness cases that must NOT degrade.
- `README.md`: tool-table row, the node-introspection paragraph, and the 49 → 50 tool count in both places it appears.

## Motivation

Closes the dependency-diagnosis gap: an agent could see that a pack's nodes were missing from `object_info` but had no way to see *why*, and no way to pre-check a pack's requirements against the venv before installing it.

## Testing

- [x] Existing tests pass (`pytest`) — 1398 passed, 4 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — see below

Manual verification ran the tool end-to-end against two real comfy-cli installs in throwaway venvs (a scratch ComfyUI workspace with one fixture pack):

- **comfy-cli 1.13.0 (latest release, verb absent):** `comfy --json --where local node deps` exits **2** with **no envelope** and Click's `No such command 'deps'.` on stderr, rendered inside a wrapped rich panel. Calling `node_dependencies()` against that binary returns the `unsupported: true` payload — no raw usage text leaks through.
- **comfy-cli at `main` (verb present):** `node_dependencies(pack="demo-pack")` returned the real report (`requests>=2.0` → `satisfied` 2.34.2, `numpy==1.26.4` → `missing`, `-r other.txt` → `unparseable`, with matching `summary` counts), and `node_dependencies(registry_id="comfyui-impact-pack")` returned a `registry` row with that pack's published dependencies diffed against the venv.
- **Real-error passthrough:** against the same `main` binary with no workspace, the tool raises `not_in_workspace` verbatim rather than degrading — the error was dispatched by a verb comfy-cli recognized, so it must stay raw.

### Negative-claim falsification

This diff adds an "unavailable" / capability-denying path, so the denial was falsified empirically rather than only unit-tested:

- The denied capability **genuinely does not exist** on any released comfy-cli — `comfy node deps` landed on comfy-cli `main` after v1.13.0 was cut (no tag contains it), and the 1.13.0 probe above is the direct evidence.
- The denial is **scoped to exactly that case** and the redirect it names ("update comfy-cli") is proven to work — the `main` probe above is that proof.
- **No other path in this server offers the capability.** Swept every registered tool's description for a dependency/venv/pip surface: `server_info`, `run_workflow`, `launch_comfyui`, `update_comfyui`, `switch_comfyui_version` all mention requirements only incidentally (environment info, or *installing* them); none report per-pack declared requirements against installed versions. There is nothing to redirect an agent to on an old comfy-cli, so the message says "upgrade" rather than dead-ending.

## Additional Notes

Judgment calls, all flagged rather than silent:

- **`unknown` added to the documented status set.** The spec listed satisfied / mismatch / missing / unparseable; comfy-cli's own schema and the live payload also emit `unknown` (the pip probe failed, or an installed dist records a non-PEP-440 version). Omitting it would have been inaccurate documentation of the tool's own output.
- **The missing-verb matcher needed no change.** The spec flagged this as the one place this might differ from the top-level `outdated` precedent — a missing *sub*command of `node`. Verified against the real 1.13.0: Click emits the identical `No such command '<verb>'.` for a nested group, with the same exit 2 / no-envelope pair, so `_is_missing_verb_error(exc, "deps")` matches unchanged. The short, generic verb name is covered by the existing lookahead — `install-deps` and `deps-in-workflow` do not match, and there is a test for the latter.
- **The error message uses this repo's established phrasing** ("the verb ships in releases after 1.13.0. Nothing else is affected.") to match `list_workflow_notes` / `_download_verb_unsupported`, rather than a one-off sentence.
- **Not wired: `--refresh`, and the repeatable forms of both arguments.** comfy-cli's `deps` accepts multiple pack names and repeatable `--registry`, plus `--refresh` to bypass the 1h registry cache. The spec scoped this tool to one of each and no cache control; adding them later is additive and non-breaking.
