### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfy-mcp"
-version = "0.4.0"
+version = "0.5.0"
 description = "MCP server for ComfyUI — a thin wrapper over comfy-cli."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/comfy_mcp/__init__.py
+++ b/src/comfy_mcp/__init__.py
@@ -1,3 +1,3 @@
 """comfy-mcp: a thin MCP wrapper over comfy-cli."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"


### PR DESCRIPTION
## ELI-5

The version number in `pyproject.toml` is the only thing standing between `main` and a tagged `v0.5.0` release. This bumps it (and the matching `__version__`), so the tag can be cut.

## Why 0.5.0

42 commits since `v0.4.0`. Three of them would each carry a minor bump on their own:

- **The package is renamed** `comfy-local-mcp` to `comfy-mcp` (#152). Distribution, import package, and console script all move, so an existing install needs `pip uninstall comfy-local-mcp` and a `"command"` change in every client config. README has the migration table.
- **Relicensed** from Apache-2.0 to `AGPL-3.0-or-later OR LicenseRef-Comfy-Commercial` (#135).
- **Ported to MCP Python SDK 2.x** (#111), floor now `mcp>=2,<3`. 2.0 deleted `mcp.server.fastmcp` outright, and elicitation (the spend-confirmation interlock) moved with it.

Also breaking for callers: `fetch_template` returns `{path, local_check}` rather than a bare path string (#104), `discover` defaults to `--schemas-only` (#112), and the comfy-cli floor rises to `>= 1.13.0` (#106).

Six new tools landed in this window: `node_dependencies` (#155), `list_partner_models` + `partner_model_schema` (#118), `list_workflow_notes` (#117), `system_stats` + `free_memory` (#116), `emit_partner_workflow` (#113), and `switch_comfyui_version` (#126).

**Staying pre-1.0** rather than calling this 1.0.0: SemVer allows breaking changes in a 0.x minor, and the tool surface is still moving.

## Verification

- `pytest -q -m "not e2e"`: 1405 passed, 1 skipped, 3 deselected.
- `ruff check .`: all checks passed.
- `ruff format --check .`: 39 files already formatted.
- No other file in the tree carries a `0.4.0` string (`grep` over `.py`/`.toml`/`.md`/`.cfg`).

The 3 deselected are `tests/e2e/`, which need a real ComfyUI. They fail on my machine only because the local install lacks the `v1-5-pruned-emaonly-fp16.safetensors` checkpoint the smoke test expects, which is an install-content mismatch and not a code issue.

## Note, not part of this PR

README badges and docs now point at `github.com/Comfy-Org/comfy-mcp`, but this repo is still named `comfy-local-mcp`, so those links 404 today. Renaming the repo fixes them and GitHub redirects the old URL. Flagging rather than doing it here.

Created by Claude Code