### PR TITLE
feat: self-attribute comfy-cli calls so partner usage is traceable to this MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ full cloud tool list, and the slash-command/prompt tables live.
   `server_info`. Nothing here starts ComfyUI implicitly.
 
 <details>
-<summary><strong>Optional environment variables</strong> (<code>COMFY_BIN</code>, <code>COMFY_API_KEY</code>, <code>COMFYUI_URL</code>, <code>COMFY_LOCAL_URL</code>, <code>COMFY_T2I_TEMPLATE</code>)</summary>
+<summary><strong>Optional environment variables</strong> (<code>COMFY_BIN</code>, <code>COMFY_API_KEY</code>, <code>COMFYUI_URL</code>, <code>COMFY_LOCAL_URL</code>, <code>COMFY_T2I_TEMPLATE</code>; plus <code>COMFY_USER_AGENT</code>, which the server sets itself)</summary>
 
 <br>
 
@@ -435,6 +435,14 @@ full cloud tool list, and the slash-command/prompt tables live.
   **[Targeting a non-default ComfyUI address](#targeting-a-non-default-comfyui-address)**, and
   **[Which address variable do I want?](#which-address-variable-do-i-want)** for the difference
   between the two.
+- **`COMFY_USER_AGENT` (set by the server — not yours to configure).** Every comfy-cli call this
+  server makes is labelled `comfy-mcp`, which is how comfy-cli tells work that came from this MCP
+  apart from a human typing the same command — most usefully on the partner-API calls that spend
+  credits. A value you set is **overridden**, on purpose: it would otherwise file this server's
+  calls under someone else's name. The label is a caller identity, not content — nothing about
+  your prompts, workflows, or outputs travels with it, and comfy-cli's own telemetry stays subject
+  to comfy-cli's consent settings (`comfy tracking disable`, or the `DO_NOT_TRACK` /
+  `COMFY_NO_TELEMETRY` environment variables, both of which this server passes straight through).
 - **`COMFY_T2I_TEMPLATE` / `COMFY_T2I_PROMPT_SLOT` / `COMFY_T2I_CHECKPOINT_SLOT` (optional — retarget
   `generate_image`).** `generate_image(prompt)` runs the gallery's `default` template (ComfyUI's own
   basic SD1.5 text-to-image graph), filling its positive-prompt slot `6.text` and, when you pass

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -741,6 +741,29 @@ _MIN_COMFY_CLI_STR = "1.13.0"
 _version_checked = False
 
 
+# How this server identifies itself to comfy-cli, via comfy-cli's documented
+# self-attribution hook (`comfy_cli/caller.py`: `COMFY_USER_AGENT` is the
+# highest-priority signal in `detect_caller`, ahead of `AI_AGENT` / `CLAUDECODE`
+# / the non-TTY fallback). It exists so partner-node usage that ORIGINATES here
+# is attributable rather than folded into the generic CLI bucket: every partner
+# call this server makes is a `comfy generate` / `comfy run` shelled out from
+# `_run_comfy`, so without a caller label the engine's telemetry and the
+# `Comfy-Usage-Source` attribution it sends upstream cannot tell an MCP-driven
+# partner call apart from a human typing the same command.
+#
+# The value is the distribution name (`pyproject.toml` `name`), bare and
+# unversioned: it is consumed as an identifier to match on, so a version suffix
+# would only defeat an exact-match lookup. Keep the two in sync.
+#
+# Setting it changes nothing about how comfy-cli BEHAVES for us. `detect_caller`
+# already classified this server as agentic through the non-TTY path (`kind`
+# "pipe"), and `agentic` — not `kind` — is what drives comfy-cli's output-mode
+# resolution; the only place `kind` itself is read is the bare-`comfy` welcome
+# screen, which this server never reaches because `_run_comfy` always passes a
+# subcommand. So this is an attribution label, not a behavior switch.
+_MCP_USER_AGENT = "comfy-mcp"
+
+
 def _comfy_env() -> dict[str, str]:
     """Child-process environment for every comfy-cli spawn.
 
@@ -755,6 +778,15 @@ def _comfy_env() -> dict[str, str]:
     - ``COMFY_WHERE=local`` — belt-and-suspenders pin so we never touch cloud.
     - ``COMFY_NO_WATCH=1`` — suppress comfy-cli's file watcher for agentic
       callers like this MCP; a harmless no-op on versions that lack the flag.
+    - ``COMFY_USER_AGENT=comfy-mcp`` — self-attribution, so usage that
+      originates here (partner-node calls above all: ``partner_generate`` ->
+      ``comfy generate``, and ``run_workflow`` over a graph carrying partner-API
+      nodes -> ``comfy run``) is attributable to this server rather than folded
+      into the generic CLI bucket. See :data:`_MCP_USER_AGENT`. It is INJECTED,
+      not defaulted — an inherited value (a stale one in the user's shell, or the
+      client's own label) would silently mis-attribute calls this server made,
+      which is the one thing the label exists to answer. A caller wanting to
+      record *which host drove the MCP* wants a second field, not this one.
     - ``PYTHONUTF8=1`` / ``PYTHONIOENCODING=utf-8`` — force UTF-8 on the child's
       console. Without them a default Windows (cp1252) console raises
       ``UnicodeEncodeError`` printing the UTF-8 catalog output and wedges, so the
@@ -809,6 +841,7 @@ def _comfy_env() -> dict[str, str]:
         **os.environ,
         "COMFY_WHERE": "local",
         "COMFY_NO_WATCH": "1",
+        "COMFY_USER_AGENT": _MCP_USER_AGENT,
         "PYTHONUTF8": "1",
         "PYTHONIOENCODING": "utf-8",
         "GIT_TERMINAL_PROMPT": "0",

--- a/tests/test_partner_generate.py
+++ b/tests/test_partner_generate.py
@@ -95,6 +95,22 @@ def test_partner_generate_argv_is_a_local_json_passthrough(patched_plain_run):
     assert calls[0]["env"]["COMFY_WHERE"] == "local"  # belt-and-suspenders pin
 
 
+def test_partner_generate_is_attributed_to_this_server(patched_plain_run):
+    """The paid partner call carries this server's caller label.
+
+    `comfy generate` is the spend path, so it is the one whose origin the
+    engine's usage attribution most needs to record: without the label an
+    MCP-driven partner generation is indistinguishable from a human running the
+    same command. `_comfy_env` sets it for every spawn; this pins it on the
+    partner one specifically, since that is the reason it is set at all.
+    """
+    calls = patched_plain_run(0, stdout="Saved image to /tmp/out.png")
+
+    _generate("flux-pro", params={"prompt": "a red fox"})
+
+    assert calls[0]["env"]["COMFY_USER_AGENT"] == "comfy-mcp"
+
+
 def test_partner_generate_marshals_param_types(patched_plain_run):
     """Params render in the spellings comfy-cli's schema parser accepts."""
     calls = patched_plain_run(0, stdout="done")

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -18,6 +18,8 @@ import asyncio
 import enum
 import json
 import os
+import pathlib
+import re
 import shutil
 import signal
 import subprocess
@@ -137,6 +139,51 @@ def test_run_comfy_sets_no_watch_env(patched_run):
     server._run_comfy("jobs", "status", "abc")
 
     assert calls[0]["env"]["COMFY_NO_WATCH"] == "1"
+
+
+def test_run_comfy_self_attributes_via_user_agent_env(patched_run):
+    """Every spawn labels itself `comfy-mcp` through comfy-cli's caller hook.
+
+    The attribution the engine needs to tell usage that originated in THIS
+    server apart from a human running the same subcommand — partner-node calls
+    above all, since those are the ones that cost money.
+    """
+    calls = patched_run(envelope(data={"x": 1}))
+
+    server._run_comfy("jobs", "status", "abc")
+
+    assert calls[0]["env"]["COMFY_USER_AGENT"] == "comfy-mcp"
+
+
+def test_comfy_env_user_agent_wins_over_an_inherited_value(monkeypatch):
+    """An inherited `COMFY_USER_AGENT` is overwritten, not deferred to.
+
+    `_comfy_env` forwards `os.environ` wholesale, so a value in the user's shell
+    or the MCP client's `env` block reaches the child — and comfy-cli reads
+    `COMFY_USER_AGENT` ahead of every other caller signal. Deferring to it would
+    file calls this server made under someone else's label, which is exactly the
+    question the label exists to answer.
+    """
+    monkeypatch.setenv("COMFY_USER_AGENT", "some-other-harness")
+
+    assert server._comfy_env()["COMFY_USER_AGENT"] == "comfy-mcp"
+
+
+def test_mcp_user_agent_matches_the_distribution_name():
+    """The label is the distribution name, bare — it is matched on exactly.
+
+    A tripwire for the rename half of the sync note on `_MCP_USER_AGENT`: the
+    value is consumed downstream as an identifier, so a package rename that left
+    this behind would silently strand every attributed call under a name nothing
+    matches (and a version suffix would defeat the match outright).
+    """
+    pyproject = (
+        pathlib.Path(__file__).resolve().parent.parent / "pyproject.toml"
+    ).read_text(encoding="utf-8")
+    name = re.search(r'(?m)^name\s*=\s*"([^"]+)"', pyproject)
+
+    assert name is not None, "pyproject.toml has no [project] name"
+    assert server._MCP_USER_AGENT == name.group(1)
 
 
 def test_run_comfy_forces_utf8_env(patched_run):
@@ -4167,6 +4214,21 @@ def test_run_workflow_stream_sets_no_watch_env(patched_stream):
 
     assert procs[0].env["COMFY_WHERE"] == "local"
     assert procs[0].env["COMFY_NO_WATCH"] == "1"
+
+
+def test_run_workflow_stream_self_attributes_via_user_agent_env(patched_stream):
+    """The streaming spawn carries the caller label too.
+
+    `run_workflow` is the second partner-node path — a graph with partner-API
+    nodes bills them wherever it runs — and `wait=True` takes the streaming
+    spawn, a different site from `_run_comfy`. Both read `_comfy_env`; this is
+    the guard that keeps them from drifting apart on the attribution.
+    """
+    procs = patched_stream(_OK_STREAM)
+
+    asyncio.run(server.run_workflow("wf.json", wait=True))
+
+    assert procs[0].env["COMFY_USER_AGENT"] == "comfy-mcp"
 
 
 def test_run_workflow_stream_forces_utf8_env(patched_stream):


### PR DESCRIPTION
## ELI-5

When you ask an agent to run a paid partner model, this server does it by running the `comfy` command — the same command a person would type by hand. So when someone later asks "how much of our partner usage comes from the MCP?", nobody can tell: the two look identical from the outside. This PR has the server write its name on every call it makes (`comfy-mcp`), so the calls it originated can be counted separately from the ones a human ran.

## Summary

Set `COMFY_USER_AGENT=comfy-mcp` on every comfy-cli spawn, using comfy-cli's own documented self-attribution hook. This is the origin-side half of attributing partner-node usage that comes from this MCP — see **Scope** below for the two downstream pieces that are NOT in this repo and that this PR cannot deliver.

## Changes

- `_comfy_env()` injects `COMFY_USER_AGENT=comfy-mcp`, alongside the existing `COMFY_WHERE` / `COMFY_NO_WATCH` pins. All four comfy-cli spawn sites (`_run_comfy`, `_run_comfy_streaming`, `_run_comfy_async`, `auth_login`'s `_start_login`) go through `_comfy_env`, so this covers every call the server makes.
- `_MCP_USER_AGENT` constant carrying the reasoning: why the value is the bare distribution name, and why setting it is an attribution label rather than a behavior switch.
- Tests: the plain spawn, the streaming spawn (a separate site that must not drift from `_run_comfy`), and the paid `partner_generate` path specifically; plus that an inherited value loses to ours, and that the label stays equal to the `pyproject.toml` distribution name.
- README: a bullet in the optional-environment-variables block stating that the server sets this, that a value you set is overridden, that the label is a caller identity and carries no prompt/workflow/output content, and that comfy-cli's telemetry remains subject to comfy-cli's own consent settings (`comfy tracking disable`, `DO_NOT_TRACK`, `COMFY_NO_TELEMETRY` — all of which this server passes straight through, unchanged).

## Motivation

Every partner-node call this server makes is a `comfy generate` (`partner_generate`) or a `comfy run` over a graph carrying partner-API nodes (`run_workflow`), shelled out from `_run_comfy`. comfy-cli attributes all of that as CLI traffic, so a partner generation an agent drove through this MCP is indistinguishable from a human running the same command, and MCP-originated partner usage can't be counted on its own.

`COMFY_USER_AGENT` is comfy-cli's existing hook for exactly this: `comfy_cli/caller.py`'s `detect_caller` reads it as the highest-priority signal, ahead of `AI_AGENT` / `CLAUDECODE` / the non-TTY fallback, and its docstring calls it the place "custom agent frameworks self-attribute." Using it means this repo mints no new cross-repo contract — the label rides a hook that already exists.

## Scope — what this PR does NOT do, and why

**This change alone does not make MCP-originated partner calls show up as their own bucket in metrics.** It supplies the signal at the origin; two downstream changes are needed to consume it, and neither is in this repo:

1. **comfy-cli** — the usage-source value sent upstream is a hardcoded literal in three places (`comfy_cli/comfy_client.py`, `comfy_cli/command/run/execution.py`, `comfy_cli/command/generate/client.py`: `Comfy-Usage-Source: comfy-cli`, and `extra_data.comfy_usage_source = "comfy-cli"` on the local `/prompt` submit). Caller detection currently drives only output mode, not attribution. comfy-cli needs to derive the value from `detect_caller()` instead of hardcoding it.
2. **The API side** — the usage source is normalized against a closed allowlist before it is stamped onto partner-node analytics events; a value not on that list is folded into `other`. There is no entry for this server today, so `comfy-mcp` would land in `other` until one is added.

Both are outside this repo, and this repo's architecture rule (`AGENTS.md`) is explicit that a feature which can't be expressed as a `comfy` subcommand is a comfy-cli change rather than a workaround here — I checked for an in-repo path and there isn't one: comfy-cli exposes no flag to inject `extra_data` or override the usage source, and this server has no HTTP client to stamp a header with. So the origin label is genuinely the whole of this repo's half. Ordering doesn't matter — landing this first is harmless, since an unconsumed env var is inert.

## Judgment calls

- **Injected, not defaulted.** An inherited `COMFY_USER_AGENT` (a stale one in the user's shell, or the client's own label) is overridden. Deferring to it would file calls this server made under someone else's name, which is the one question the label exists to answer. This matches how every other key in that block behaves. It does cost the ability to see *which agent host* drove the MCP — that wants a second field, not this one.
- **Bare `comfy-mcp`, no version suffix.** The value is consumed as an identifier matched exactly (see allowlist above), so a version suffix would defeat the match. A test pins it to the `pyproject.toml` distribution name so a future rename can't silently strand it.
- **No behavior change, verified against comfy-cli's source.** `detect_caller` already classified this server as agentic through the non-TTY path (`kind` "pipe"); `agentic`, not `kind`, is what `Renderer.resolve` keys on, and the only reader of `kind` itself is the bare-`comfy` welcome screen in `cmdline.py`, which this server never reaches — every spawn passes a subcommand *and* an explicit `--json` / `--json-stream`, which outranks caller detection in mode resolution regardless.
- **Privacy, stated in the README rather than assumed.** The label is a caller identity and carries no content. comfy-cli's telemetry is consent-gated on comfy-cli's side and honors `DO_NOT_TRACK` / `COMFY_NO_TELEMETRY`; `_comfy_env` forwards `os.environ` wholesale and injects none of those, so every existing opt-out keeps working untouched.

## Testing

- [x] Existing tests pass (`pytest`) — 1410 passed, 4 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually — not applicable: the tests mock comfy-cli (repo convention), and the end-to-end effect is not observable until the two downstream changes above land.

The four new assertions were falsified against the change: removing the `_comfy_env` injection turns all four red, so they test the behavior rather than restating it.

## Additional Notes

Additive only — no existing check, default, or precedence is flipped, broadened, or removed, and no capability is denied.
