### PR TITLE
fix: forward the configured remote host to run-template (generate_image, run_template)

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,9 @@ The recipe, in order:
    - **llama.cpp (`llama-server`)** — in [router mode](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md) (started with no `-m`, or with `--models-dir`) `POST /models/unload` with `{"model": "<name>"}` unloads one model; `GET /models` lists what is currently loaded. Independently of router mode, `--sleep-idle-seconds N` makes the server unload the model and its KV cache after N idle seconds and reload it automatically on the next request — which handles both step 2 and step 5 with no orchestration at all. Only a classic single-model server started without either (`llama-server -m model.gguf`) has nothing to call: there, stopping and restarting the process is the reclaim.
 3. **Free ComfyUI's own models too** with `free_memory()`. ComfyUI applies it when its queue worker next iterates — immediate if idle, after the current job if busy — and it never interrupts a running job. Re-read `system_stats()` to confirm the VRAM actually came back before committing to a big run.
 4. **Run the job** — `run_workflow(...)` / `run_template(...)` / `generate_image(...)` — then collect with `fetch_outputs(...)`.
+   (This whole recipe is about **this machine's** VRAM: `system_stats` and `free_memory` are never
+   remoted, so with a `COMFYUI_URL` configured steps 1–3 measure and free the wrong box while step 4
+   submits to the remote. See [Driving a remote ComfyUI](#driving-a-remote-comfyui).)
 5. **The client reloads its LLM** afterwards, again through its own runtime. Ollama, LM Studio and a sleep-idle `llama-server` all reload on demand, so for those "reload" is just the next request; a single-model `llama-server` stopped in step 2 has to be started again.
 
 **Why steps 2 and 5 cannot live in this MCP server.** This server is a **stdio subprocess of your MCP client** — it holds no handle on whatever LLM runtime that client is using, is not told which one it is, and has no business reaching into a process it does not own. Reaching one anyway would also breach the [thin-wrapper rule](AGENTS.md): every tool here is a `comfy` passthrough, and there is no `comfy` subcommand for "unload someone else's model". The deeper reason is step 5: the *model* that was unloaded cannot ask for itself back, so something still running has to sequence unload → run → reload. Where the LLM's own runtime can do that (Ollama's on-demand load, LM Studio's JIT, `llama-server --sleep-idle-seconds`) it should — that is the least-coordination option and it needs nothing from this server. Otherwise the client, or the orchestrator driving it, is the only participant present throughout. Either way the split is structural rather than a missing feature: this server owns reading and freeing **ComfyUI's** memory, and the client owns its **own** model's lifecycle.
@@ -675,12 +678,19 @@ machines.
   `switch_comfyui_version`, `get_logs`) — these manage a **local** ComfyUI process/install and stay
   local-only; they cannot start/stop, update, version-switch, or read logs from a remote box. Start
   and update ComfyUI on the remote host yourself.
-- **Output download** (`fetch_outputs` → `comfy download`) and `search_templates` / `search_models`
-  / `download_model` / `partner_generate` — this server forwards **no** `--host`/`--port` to these
-  verbs (they accept none at all), so they run against comfy-cli's local default. Against a remote
-  target, prefer `run_workflow(wait=True)` / `job_status` (which return the remote job's `/view`
-  output URLs) to retrieve results — and note that a model must be installed on the machine that
-  actually runs the job, which `download_model` cannot do for you.
+- **Catalog / partner verbs** — `search_templates` / `search_models` / `download_model` /
+  `partner_generate` — this server forwards **no** `--host`/`--port` to these verbs (they accept
+  none at all), so they run against comfy-cli's local default. In particular a model must be
+  installed on the machine that actually runs the job, which `download_model` cannot do for you:
+  put it on the remote host yourself.
+- **Output download** (`fetch_outputs` → `comfy download`) takes no `--host`/`--port` either, but it
+  still retrieves a **remote** job's files, because it never asks a server which job that is: the
+  same comfy-cli run that submitted the job wrote a state file **on this machine** keyed by
+  `prompt_id`, and for a non-loopback target that file records each output as an absolute
+  `http://<remote>:<port>/view?…` URL, which `comfy download` then streams from the remote. It falls
+  back to querying the local default server only when no such state file exists (an id this machine
+  never submitted). `run_workflow(wait=True)` / `job_status` return those same URLs if you would
+  rather hand them off than copy bytes.
 - **Discovery / validation** (`search_nodes`, `get_node`, `validate_workflow`, and the
   `local_check` block on `fetch_template` / `get_template`) — their comfy-cli verbs *do* accept
   `--host`/`--port`, but this version forwards only to the submit/poll tools, so they still
@@ -805,7 +815,7 @@ handle is `prompt_id`.
 | `get_execution_error(prompt_id)` | `comfy jobs status <prompt_id>` | Compact failure verdict for a failed run — the failing node, `exception_type`/`exception_message`, and a bounded traceback tail — so an agent can self-repair; returns `error: None` on a healthy prompt. |
 | `cancel_job(prompt_id)` | `comfy jobs cancel <prompt_id>` | Cancel a queued or running job. |
 | `get_queue()` | `comfy jobs ls` | List known jobs with status (pending/running/completed); Comfy Cloud-tracked rows are filtered out, since this server never drives them. Follows a configured remote, like the other job tools. |
-| `fetch_outputs(prompt_id, out_dir, url_only=False, inline_images=False)` | `comfy download <prompt_id> --where local -o <out_dir> [--url-only]` | Write a finished local job's outputs into `out_dir`; `url_only=True` emits the output URLs without copying bytes; `inline_images=True` also returns the copied images as inline MCP image content so the agent can see them without a second read. |
+| `fetch_outputs(prompt_id, out_dir, url_only=False, inline_images=False)` | `comfy download <prompt_id> --where local -o <out_dir> [--url-only]` | Write a finished job's outputs into `out_dir` — including a job that ran on a configured remote, which comfy-cli resolves from the local `prompt_id` state file rather than from a server (see [Driving a remote ComfyUI](#driving-a-remote-comfyui)); `url_only=True` emits the output URLs without copying bytes; `inline_images=True` also returns the copied images as inline MCP image content so the agent can see them without a second read. |
 
 ### Resource management
 

--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ full cloud tool list, and the slash-command/prompt tables live.
 - **`COMFYUI_URL` / `COMFYUI_HOST` / `COMFYUI_PORT` (optional — drive a ComfyUI on *another
   machine*).** Read by **this server**. By default every tool targets `127.0.0.1:8188`. Set
   `COMFYUI_URL` (e.g. `http://gpu-box:8188`) — or the `COMFYUI_HOST` (+ optional `COMFYUI_PORT`,
-  default `8188`) pair — to point the **run / job** tools at a ComfyUI running elsewhere, e.g. a
+  default `8188`) pair — to point the **submit / job** tools at a ComfyUI running elsewhere, e.g. a
   GPU box reachable over a private network (Tailscale). See **[Driving a remote
   ComfyUI](#driving-a-remote-comfyui)** for what is and isn't remoted. Unset ⇒ nothing changes.
 - **`COMFY_LOCAL_URL` (optional — a ComfyUI on *this machine*, on a non-default port).** Read by
@@ -462,7 +462,7 @@ The discrete-GPU rows are written for NVIDIA but apply to an AMD or Intel card o
 
 The instructions walk these as an ordered procedure, because several of the checks only make sense in sequence:
 
-1. **Is the work even local?** `hardware` describes the machine *this server* runs on, and that is where most tools execute. A `comfy_target` block ([Driving a remote ComfyUI](#driving-a-remote-comfyui)) diverts only `run_workflow` and the queue/`jobs` tools — `generate_image`, `run_template` and the rest stay local, so the thresholds still govern them. It counts as another machine only when its `host` is neither loopback (anything in `127.0.0.0/8`, `localhost`, IPv6 `::1`) nor this host's own address, and a malformed config produces an error-shaped `{error, note}` block that resolves no remote at all. Nothing the server returns carries the local hostname or interface addresses, so a `host` the agent can't place is a question for you rather than a guess — a hostname or LAN IP can be this same machine, and a loopback host can be a tunnel to a remote GPU. `COMFY_LOCAL_URL` is a second signal worth checking: it repoints comfy-cli without producing a `comfy_target` block.
+1. **Is the work even local?** `hardware` describes the machine *this server* runs on, and that is where most tools execute. A `comfy_target` block ([Driving a remote ComfyUI](#driving-a-remote-comfyui)) diverts every tool that submits a job — `run_workflow`, `generate_image`, `run_template` — along with the queue/`jobs` tools, while discovery, templates, downloads, outputs and the lifecycle tools stay here; so against a genuine remote the thresholds below describe the wrong machine. It counts as another machine only when its `host` is neither loopback (anything in `127.0.0.0/8`, `localhost`, IPv6 `::1`) nor this host's own address, and a malformed config produces an error-shaped `{error, note}` block that resolves no remote at all. Nothing the server returns carries the local hostname or interface addresses, so a `host` the agent can't place is a question for you rather than a guess — a hostname or LAN IP can be this same machine, and a loopback host can be a tunnel to a remote GPU. `COMFY_LOCAL_URL` is a second signal worth checking: it repoints comfy-cli without producing a `comfy_target` block.
 2. **Get a memory figure.** The sizes are bytes (`ram_bytes`, `gpu.vram_bytes`) and the divisor gives GiB, while drivers report under the advertised size — a consumer 24 GB card reads 23.99, an ECC/reserving datacenter card (A10, L4) about 22.3 — so a *small* shortfall, within ~10% of a nominal size, reads as that nominal capacity. A gap wider than that is not driver overhead and is taken at face value instead: on a MIG/vGPU partition the model string names the whole card while `vram_bytes` is the slice you actually get, and rounding a 6 GB A100 slice up into the ≥ 24 GB band would OOM the run. On Apple Silicon `gpu.vram_bytes` is `null` (with `gpu.unified_memory` true) and the figure is `ram_bytes` — an Apple-only substitution.
 3. **If the figure is missing, ask.** A `null` **or zero** `vram_bytes` on any **non-Apple** GPU (a discrete card comfy-cli can't size, but also a non-Apple unified part like a Jetson/Grace board or a Strix Halo APU), a missing `gpu` object, or a missing/zero `ram_bytes` on the Apple path all mean **unknown**, not "no GPU" — the agent asks rather than stranding a machine that has one. The "no GPU" verdict is reserved for a *confirmed* absence, and the only thing that confirms one is your own answer: no `hardware` payload encodes it, because a null or missing `gpu` is unknown by this same step. Nothing in this repo probes hardware, and the instructions tell the agent not to shell out either: a probe runs on a path this server can neither bound nor audit.
 4. **Route on the figure**, then **redirect rather than dead-end** when the answer is "not on this machine". A figure that came from your answer rather than the payload routes on whichever row fits the machine — the unified-memory row on an Apple Silicon Mac, the VRAM rows otherwise, which is what covers the non-Apple unified-memory boards that have no row of their own.
@@ -494,7 +494,7 @@ A note on scope: `free_memory()` asks ComfyUI to release *its* models. It does n
 
 **Read that signal against the lag, not instantly.** The free applies on the queue worker's next iteration, so on a *busy* server an immediate re-read legitimately shows no change while the VRAM is still ComfyUI's — the request simply has not been serviced yet. Before concluding the memory belongs to another process, either wait for the current job to finish (`get_queue()` shows whether one is running) or re-poll `system_stats()` a few times over a few seconds. Only a number that stays flat on an *idle* server means the holder is someone else.
 
-A second caveat: `system_stats()` and `free_memory()` are **not** redirected by `COMFYUI_URL` / `COMFYUI_HOST` — they always describe and act on whichever ComfyUI comfy-cli itself targets, because `comfy system-stats` and `comfy free` take no `--host` / `--port`. With a remote ComfyUI configured, `run_workflow` submits *there* while these two read and free the *local* install, so this recipe applies to a local-ComfyUI setup. Don't gate a remote run on it.
+A second caveat: `system_stats()` and `free_memory()` are **not** redirected by `COMFYUI_URL` / `COMFYUI_HOST` — they always describe and act on whichever ComfyUI comfy-cli itself targets, because `comfy system-stats` and `comfy free` take no `--host` / `--port`. With a remote ComfyUI configured, `run_workflow` / `generate_image` / `run_template` submit *there* while these two read and free the *local* install, so this recipe applies to a local-ComfyUI setup. Don't gate a remote run on it.
 
 ## Partner-API nodes
 
@@ -532,7 +532,7 @@ they bill through the workflow, below this server. `run_workflow` therefore carr
 That gate covers the partner-API nodes comfy-cli recognizes, which is not the same as every node
 that can bill something: an arbitrary custom node can still call a paid service of its own, with
 nothing to gate it. **Check what a workflow contains before running one you did not build.**
-`generate_image` needs no gate because it runs a free local template — though note it is
+`generate_image` needs no gate because it runs a free OSS template — though note it is
 [retargetable via `COMFY_T2I_TEMPLATE`](#prerequisites), and pointed at an `API`-tagged template it
 would spend with no prompt.
 
@@ -660,9 +660,14 @@ behavior is unchanged (`127.0.0.1:8188` on this machine). If what you actually h
 do I want?](#which-address-variable-do-i-want).
 
 When configured, the server forwards `--host` / `--port` to comfy-cli for exactly the verbs that
-accept them — `comfy run` and `comfy jobs …` — so the **run and job tools** target the remote:
-`run_workflow`, `job_status`, `wait_for_job`, `watch_job`, `cancel_job`, `get_queue`. `server_info`
-reports the configured target under a `comfy_target` block.
+accept them — `comfy run`, `comfy run-template` and `comfy jobs …` — so every tool that **submits a
+job or reads one back** targets the remote: `run_workflow`, `generate_image`, `run_template`,
+`job_status`, `wait_for_job`, `watch_job`, `cancel_job`, `get_queue`. `server_info` reports the
+configured target under a `comfy_target` block.
+
+That set is deliberately closed under submit-then-poll: a `prompt_id` only means something to the
+server that issued it, so a tool that submits and a tool that polls must never resolve to different
+machines.
 
 **Not remoted (this repo is a thin wrapper and never opens its own socket):**
 
@@ -671,14 +676,17 @@ reports the configured target under a `comfy_target` block.
   local-only; they cannot start/stop, update, version-switch, or read logs from a remote box. Start
   and update ComfyUI on the remote host yourself.
 - **Output download** (`fetch_outputs` → `comfy download`) and `search_templates` / `search_models`
-  / `generate_image` / `run_template` / `partner_generate` — this server forwards **no**
-  `--host`/`--port` to these verbs (most of them accept none at all), so they run
-  against comfy-cli's local default. Against a remote target, prefer `run_workflow(wait=True)` /
-  `job_status` (which return the remote job's `/view` output URLs) to retrieve results.
-- **Discovery / validation** (`search_nodes`, `get_node`, `validate_workflow`) — their comfy-cli
-  verbs *do* accept `--host`/`--port`, but this version forwards only to the run/job tools (the
-  ticket's scope), so they still target local. Remoting them is a planned follow-up; until then,
-  author/validate against a local ComfyUI matching the remote's node set.
+  / `download_model` / `partner_generate` — this server forwards **no** `--host`/`--port` to these
+  verbs (they accept none at all), so they run against comfy-cli's local default. Against a remote
+  target, prefer `run_workflow(wait=True)` / `job_status` (which return the remote job's `/view`
+  output URLs) to retrieve results — and note that a model must be installed on the machine that
+  actually runs the job, which `download_model` cannot do for you.
+- **Discovery / validation** (`search_nodes`, `get_node`, `validate_workflow`, and the
+  `local_check` block on `fetch_template` / `get_template`) — their comfy-cli verbs *do* accept
+  `--host`/`--port`, but this version forwards only to the submit/poll tools, so they still
+  describe the **local** install. Remoting them is a planned follow-up; until then a workflow or
+  template can pass a local check and still fail on a remote whose node set differs, so
+  author/validate against a local ComfyUI matching the remote's.
 - The remote ComfyUI must be reachable and **unauthenticated** on that network (the private network
   is the boundary); the server does not authenticate to it. `server_info` does not live-probe the
   remote — reachability surfaces on the first run/job call.
@@ -754,13 +762,13 @@ different layers. Pick by which one you need; the table is the whole answer.
 | **Read by** | **this MCP server** (`_comfy_target`) | **comfy-cli** (`comfy_cli/local_address.py`); this server never reads it |
 | **Means** | "a ComfyUI on **another machine** I control" | "the ComfyUI on **this machine** is not on `127.0.0.1:8188`" |
 | **How it acts** | this server forwards `--host` / `--port` to the verbs that accept them | comfy-cli resolves its own target from the environment it inherits |
-| **What it moves** | the **run / job** tools only — see [what is and isn't remoted](#driving-a-remote-comfyui) | **every** verb, including the ones that take no `--host` / `--port` (`comfy env`, templates, models, download) |
+| **What it moves** | the **submit / job** tools only (`run_workflow`, `generate_image`, `run_template`, and the `jobs` family) — see [what is and isn't remoted](#driving-a-remote-comfyui) | **every** verb, including the ones that take no `--host` / `--port` (`comfy env`, templates, models, download) |
 | **Reported as** | a `comfy_target` block on `server_info` | the resolved `server` URL on `server_info` — **no** `comfy_target` block |
 | **Use it for** | a GPU box over Tailscale / a private network | a port clash, a second instance, a container publishing a different port |
 
 **Set one, not both.** They resolve independently, so together they *split* your tools rather than
 conflicting loudly: comfy-cli ranks an explicit `--host` / `--port` flag above `COMFY_LOCAL_URL`, so
-the run/job tools would follow `COMFYUI_URL` while every other verb followed `COMFY_LOCAL_URL` — two
+the submit/job tools would follow `COMFYUI_URL` while every other verb followed `COMFY_LOCAL_URL` — two
 different ComfyUIs, no error. For a non-default address on **this** machine prefer `COMFY_LOCAL_URL`
 alone, since it also reaches the verbs `COMFYUI_URL` cannot.
 
@@ -787,10 +795,10 @@ handle is `prompt_id`.
 | Tool | Wraps | What it does |
 |---|---|---|
 | `run_workflow(workflow_path, wait=True, timeout_seconds=110.0, confirm_spend=False)` | `comfy run --workflow <path> [--wait] [--allow-spend]` | Run a workflow JSON; `wait=False` submits async and returns a `prompt_id`. Most workflows are free local graphs, but one embedding partner (paid) nodes spends credits: `confirm_spend=True` unlocks that, and on an elicitation-capable client asks **you** per call, same posture as `run_template`. On a comfy-cli whose `comfy run` carries the gate the default fails closed (`spend_consent_required`, naming the `partner_nodes`); no release has it yet, so today a paid graph still spends either way. See [Workflows that spend](#workflows-that-spend--run_workflow). |
-| `generate_image(prompt, checkpoint=None, wait=True, timeout_seconds=600.0)` | `comfy run-template default --param=6.text=<prompt> [--param=ckpt_name=<ckpt>]` | Text prompt → image in one call, with no hand-assembled workflow needed: it runs ComfyUI's own default SD1.5 text-to-image gallery template through the same verb (and the same local run path) as `run_template`. Free and fully local — nothing here spends credits. Retarget it with [`COMFY_T2I_TEMPLATE` and its slot-key companions](#prerequisites). Same envelope shape as `run_workflow` (`prompt_id` + outputs); the fast on-ramp. |
+| `generate_image(prompt, checkpoint=None, wait=True, timeout_seconds=600.0)` | `comfy run-template default --param=6.text=<prompt> [--param=ckpt_name=<ckpt>]` | Text prompt → image in one call, with no hand-assembled workflow needed: it runs ComfyUI's own default SD1.5 text-to-image gallery template through the same verb (and the same run path) as `run_template`. Free — nothing here spends credits. Runs on whichever ComfyUI the server targets, so it follows `COMFYUI_URL`/`COMFYUI_HOST` like `run_workflow` does ([Driving a remote ComfyUI](#driving-a-remote-comfyui)); the checkpoint has to be installed on *that* machine. Retarget the template with [`COMFY_T2I_TEMPLATE` and its slot-key companions](#prerequisites). Same envelope shape as `run_workflow` (`prompt_id` + outputs); the fast on-ramp. |
 | `partner_generate(model, params=None, confirm_spend=False, out_path=None, timeout_seconds=600.0)` | `comfy generate <model> [--param=value…] [--download=<path>] [--timeout=<s>] [--yes]` | Run a hosted **partner** model (Flux / Ideogram / DALL·E / Recraft / …). **Spends Comfy credits** on every call, where the local `run_workflow` / `generate_image` paths spend only when the graph itself carries partner nodes. Every call confirms the spend with you first — see [Spending credits](#spending-credits-on-partner-models) below. Runs **entirely on the partner's infrastructure** — your local ComfyUI is never in the execution path; use `emit_partner_workflow` below for the path where it is. `params` are the model's own schema-driven inputs, forwarded verbatim — `list_partner_models()` gives you the `model` aliases and `partner_model_schema(model)` the parameter list, so neither needs a terminal. `out_path` becomes comfy-cli's `--download` and is a save-path *template*: a plain path names the file, `{request_id}` / `{index}` / `{ext}` are substituted per output, and a trailing slash means "a default filename in this directory". `timeout_seconds` becomes comfy-cli's own `--timeout` so the engine — not a parent kill — owns the deadline on a job the partner may already have charged for. The result carries comfy-cli's printed text as `message` and, when it named the files it wrote, the resolved paths as `saved_paths` — so a caller reads the destination as data instead of scraping prose that rich may have wrapped mid-filename. |
 | `emit_partner_workflow(model, out_path, params=None)` | `comfy generate <model> [--param=value…] --emit-workflow=<path>` | Write a runnable workflow JSON that drives the partner model's **API node** instead of calling the proxy, so **your own ComfyUI executes the partner model** (the other way there is an existing `API`-tagged gallery template via `search_templates` / `run_template`; this is the path from a model *alias*). Chain it: `emit_partner_workflow` → `run_workflow` → `fetch_outputs` (the three stay separate so the graph can be inspected, edited with `set_workflow_slot`, re-run, or embedded in a bigger pipeline). Calls no partner API, needs no API key, and **spends nothing**, so unlike `partner_generate` it has no `confirm_spend` argument and raises no confirmation prompt — *running* the emitted graph is what bills the partner node, so that `run_workflow` step is the one that needs `confirm_spend=True`. **Coverage is narrow:** comfy-cli maps only `flux-2`, `flux-pro`, `kling-i2v`, `nano-banana` and `seedance` to a node class, a small subset of `list_partner_models()`; every other model reaches its partner through the proxy only, so send those to `partner_generate`. An unsupported model raises with comfy-cli's own `emit_workflow_failed` message, which names the supported set for the comfy-cli you actually have installed. Returns comfy-cli's envelope data — `{"out", "model", "nodes"}`. |
-| `run_template(name, params=None, confirm_spend=False, wait=True, timeout_seconds=600.0, ctx=None)` | `comfy run-template <name> [--param=KEY=VALUE…] [--timeout=<s>] [--allow-spend] [--async]` | One-command template run — fetch the gallery template, fill its parameterized slots, and run it on local ComfyUI (the one-shot alternative to `fetch_template` → `run_workflow`). `params` are `{slot: value}` (slot address `6.text` or name `prompt`), JSON-encoded so types round-trip. Most templates are free OSS graphs; one embedding partner (paid) nodes spends credits and fails closed unless `confirm_spend=True` unlocks it — and on an elicitation-capable client that asks **you** per call before anything runs (same posture as `partner_generate`; a default, free run is never prompted, and `comfy generate consent always` does not apply to this verb). No capability probe is needed here (unlike `partner_generate`): this verb's gate ships inside the verb itself, so a comfy-cli that has `run-template` has the gate. `wait=True` (the default) streams the run's live progress as MCP progress notifications, the same way `run_workflow` / `watch_job` do, so a long template run is not a silent block; `wait=False` submits `--async` and returns a `prompt_id`. comfy-cli's `--timeout` for this verb is *per-event*, not a whole-run deadline, so `timeout_seconds` is forwarded only to tighten it below the engine's 120s default — prefer `wait=False` over a large `timeout_seconds` for long runs. |
+| `run_template(name, params=None, confirm_spend=False, wait=True, timeout_seconds=600.0, ctx=None)` | `comfy run-template <name> [--param=KEY=VALUE…] [--timeout=<s>] [--allow-spend] [--async]` | One-command template run — fetch the gallery template, fill its parameterized slots, and run it on whichever ComfyUI the server targets, so it follows `COMFYUI_URL`/`COMFYUI_HOST` like `run_workflow` does ([Driving a remote ComfyUI](#driving-a-remote-comfyui)) (the one-shot alternative to `fetch_template` → `run_workflow`). `params` are `{slot: value}` (slot address `6.text` or name `prompt`), JSON-encoded so types round-trip. Most templates are free OSS graphs; one embedding partner (paid) nodes spends credits and fails closed unless `confirm_spend=True` unlocks it — and on an elicitation-capable client that asks **you** per call before anything runs (same posture as `partner_generate`; a default, free run is never prompted, and `comfy generate consent always` does not apply to this verb). No capability probe is needed here (unlike `partner_generate`): this verb's gate ships inside the verb itself, so a comfy-cli that has `run-template` has the gate. `wait=True` (the default) streams the run's live progress as MCP progress notifications, the same way `run_workflow` / `watch_job` do, so a long template run is not a silent block; `wait=False` submits `--async` and returns a `prompt_id`. comfy-cli's `--timeout` for this verb is *per-event*, not a whole-run deadline, so `timeout_seconds` is forwarded only to tighten it below the engine's 120s default — prefer `wait=False` over a large `timeout_seconds` for long runs. |
 | `job_status(prompt_id)` | `comfy jobs status <prompt_id>` | Poll a submitted job's status + outputs. |
 | `wait_for_job(prompt_id, timeout_seconds=25.0)` | `comfy jobs status <prompt_id>` (polled) | Bounded wait until a job reaches a terminal status; returns a `{"timed_out": True, …}` payload on expiry. Chain several. |
 | `watch_job(prompt_id, timeout_seconds=600.0)` | `comfy jobs watch <prompt_id>` (streamed) | Tail an async-submitted job's live execution, streaming progress notifications; bounded, returns a `{"timed_out": True, …}` payload on expiry. Streaming counterpart to `wait_for_job`. |

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -170,8 +170,9 @@ flows:
   lands only when the current job ends, so an immediate re-read can still show
   the old number. Both tools describe/act on whichever ComfyUI comfy-cli itself
   targets and are NOT redirected by `COMFYUI_URL`/`COMFYUI_HOST` — so when those
-  are set, they report and free the LOCAL install while `run_workflow` submits to
-  the remote one. Do not sequence them against a remote run.
+  are set, they report and free the LOCAL install while `run_workflow`,
+  `generate_image` and `run_template` all submit to the remote one. Do not
+  sequence them against a remote run.
 - Before running a workflow whose nodes call partner APIs (Seedream / Veo /
   Kling / Gemini / …), call `auth_status` to check Comfy Cloud credentials.
   Treat credentials as GOOD if `signed_in` is true OR
@@ -251,12 +252,14 @@ and work through these steps IN ORDER — a later step never overrides an
 earlier one:
 - STEP 1, is the work even local? `hardware` describes the machine THIS server
   runs on, and that is where MOST tools execute. A `comfy_target` block
-  carrying a `host` diverts only `run_workflow` and the queue/`jobs` tools;
-  `generate_image`, `run_template` and everything else still run HERE, so the
-  thresholds below keep governing them. Count the target as another machine
-  only when its `host` is neither a loopback address (anything in
-  `127.0.0.0/8`, `localhost`, or IPv6 `::1`) nor this host's own name or
-  address; an ERROR-shaped `comfy_target` (`{"error": …, "note": …}` from a
+  carrying a `host` diverts every tool that SUBMITS a job — `run_workflow`,
+  `generate_image`, `run_template` — along with the queue/`jobs` tools, while
+  discovery, templates, downloads, outputs and the lifecycle tools still run
+  HERE. So against a genuine remote the thresholds below describe the wrong
+  machine: they govern generation only while the target is this one. Count the
+  target as another machine only when its `host` is neither a loopback address
+  (anything in `127.0.0.0/8`, `localhost`, or IPv6 `::1`) nor this host's own
+  name or address; an ERROR-shaped `comfy_target` (`{"error": …, "note": …}` from a
   malformed config) resolves no remote at all. Nothing this server returns
   carries the local hostname or interface addresses, so if the `host` is a name
   or LAN IP you cannot place, ASK the user which machine it is rather than
@@ -346,19 +349,41 @@ COMFY_BIN = os.environ.get("COMFY_BIN", "comfy")
 DEFAULT_COMFYUI_PORT = 8188
 
 # The comfy-cli verbs this server forwards ``--host`` / ``--port`` to: ``comfy
-# run`` and every ``comfy jobs`` subcommand — the "run/queue" tools this ticket
-# scopes, and the pair comfy-cli's ``comfy_cli/host_port.py`` contractually
-# guarantees accept the options. Deliberately NOT forwarded (v1 scope):
+# run``, ``comfy run-template``, and every ``comfy jobs`` subcommand — every verb
+# that SUBMITS a job or reads one back, which is the set that has to agree on
+# which server it is talking to. ``run`` / ``jobs`` are the pair comfy-cli's
+# ``comfy_cli/host_port.py`` documents; ``run-template`` declares the same two
+# options and resolves them through that module's own ``resolve_host_port``
+# (``comfy_cli/command/templates.py``), it is just missing from that docstring's
+# list.
+#
+# ``run-template`` is here because SUBMIT and POLL must land on the SAME server.
+# It backs both ``run_template`` and ``generate_image``, and while it was absent
+# the submit-then-poll flow did not merely run on the wrong box, it could not
+# complete at all: the run executed locally, ``wait_for_job`` (a ``jobs`` verb,
+# forwarded) polled the configured remote, and the local ``prompt_id`` came back
+# ``prompt_not_found`` from a queue it was never submitted to. Adding a verb here
+# is only safe when comfy-cli actually accepts the flags on it — otherwise the
+# forward turns every call into "No such option". There is no such window for
+# this one: ``run-template`` shipped WITH both options, in the same comfy-cli
+# release (1.13.0) that introduced the verb — which is also the floor
+# ``_check_comfy_version`` enforces (``_MIN_COMFY_CLI``). A comfy-cli old enough
+# to reject ``--host`` here has no ``run-template`` at all, so it fails on the
+# verb before the flags are ever parsed.
+#
+# Deliberately NOT forwarded:
 #   * ``env`` / ``download`` / ``upload`` / ``templates`` / ``models`` /
 #     ``generate`` / the lifecycle verbs take NO ``--host`` / ``--port`` at all,
 #     so forwarding would error "No such option" — they stay local-only (a real
 #     comfy-cli limitation; e.g. ``download`` can't fetch a remote job's files).
 #   * ``nodes`` / ``validate`` DO accept ``--host`` / ``--port`` in current
-#     comfy-cli, but remoting live discovery/validation is out of this pass's
-#     "run/queue" scope; forwarding them is a clean follow-up.
+#     comfy-cli, but remoting live discovery/validation is out of scope here;
+#     forwarding them is a clean follow-up. Their local answers are advisory —
+#     ``run_workflow`` and ``run_template`` already submit to a remote whose node
+#     set a local check cannot see.
 # Forwarding is a no-op for the local default regardless, so unconfigured
 # behavior is unchanged for every tool.
-_TARGET_AWARE_SUBCOMMANDS = frozenset({"run", "jobs"})
+_TARGET_AWARE_SUBCOMMANDS = frozenset({"run", "run-template", "jobs"})
 
 # The envelope schema major version this server speaks. comfy-cli tags every
 # result with a ``schema`` like ``envelope/1``; the whole contract (result
@@ -1299,9 +1324,9 @@ def _comfy_target() -> tuple[str, int, str] | None:
 def _with_target(args: tuple[str, ...]) -> tuple[str, ...]:
     """Append ``--host`` / ``--port`` to a target-aware subcommand, if configured.
 
-    The flags are injected into the SUBCOMMAND args (after the ``run`` / ``jobs``
-    verb), never into the global ``--json`` / ``--where`` prefix, since
-    ``--host`` / ``--port`` are ``comfy run`` / ``comfy jobs`` subcommand options.
+    The flags are injected into the SUBCOMMAND args (after the ``run`` /
+    ``run-template`` / ``jobs`` verb), never into the global ``--json`` /
+    ``--where`` prefix, since ``--host`` / ``--port`` are subcommand options.
     A no-op for the local default (``_comfy_target`` is None) and for any
     subcommand that doesn't accept the flags (see :data:`_TARGET_AWARE_SUBCOMMANDS`),
     so unconfigured behavior is byte-identical to today.
@@ -3970,12 +3995,18 @@ async def generate_image(
     timeout_seconds: float = 600.0,
     ctx: Context | None = None,
 ) -> Any:
-    """Generate an image from a text prompt on the LOCAL ComfyUI — the fast on-ramp.
+    """Generate an image from a text prompt — the fast on-ramp.
+
+    Runs on the ComfyUI this server targets: the one on this machine unless
+    ``COMFYUI_URL`` / ``COMFYUI_HOST`` points the run/job tools at another one
+    you control (see :func:`_comfy_target`) — this is one of the tools that
+    follows it, so the ``prompt_id`` it returns belongs to that same server and
+    ``job_status`` / ``wait_for_job`` / ``watch_job`` read it back there.
 
     A single call that turns a text prompt into an image, so an agent does not
     have to hand-assemble a workflow graph. It runs ComfyUI's default SD1.5
     text-to-image gallery template through ``comfy run-template <name>
-    --param=KEY=VALUE`` — the same verb (and the same local run path) as
+    --param=KEY=VALUE`` — the same verb (and the same run path) as
     ``run_template``, with the prompt filled into the template's positive
     CLIPTextEncode slot. Returns the same envelope shape as ``run_workflow``
     (``prompt_id`` + outputs).
@@ -3987,11 +4018,13 @@ async def generate_image(
     graph; the two must name DIFFERENT slots (one key for both is refused rather
     than silently dropping the prompt). Pass ``checkpoint`` to swap the
     template's checkpoint model (it must
-    already be installed locally — see ``search_models`` / ``download_model``);
-    omit it to use the template's own default. The default template is a free,
-    fully local OSS graph: nothing here spends Comfy credits, so no spend
-    consent is passed and none is needed. (For hosted PARTNER models, which do
-    spend, use ``partner_generate``.)
+    already be installed on the machine that RUNS the job — ``search_models`` /
+    ``download_model`` inspect and write to THIS machine's install, so with a
+    remote configured you have to put the checkpoint on that machine yourself);
+    omit it to use the template's own default. The default template is a free
+    OSS graph that runs on your own ComfyUI: nothing here spends Comfy credits,
+    so no spend consent is passed and none is needed. (For hosted PARTNER
+    models, which do spend, use ``partner_generate``.)
 
     With ``wait=True`` (default) this waits until the generation finishes and
     streams live progress as MCP progress notifications (per-node execution +
@@ -4006,8 +4039,9 @@ async def generate_image(
     template, editing its graph, or running a hand-authored workflow — use the
     ``search_templates`` -> ``fetch_template`` -> ``run_workflow`` chain instead.
 
-    Everything targets the LOCAL server (``--where local`` is injected by
-    ``_run_comfy``), so there is no cloud reachability here.
+    This never reaches Comfy Cloud (``--where local`` is injected by
+    ``_run_comfy``); a configured ``COMFYUI_URL`` is a ComfyUI YOU run
+    elsewhere, not a hosted one.
     """
     template, prompt_slot, checkpoint_slot = _t2i_config()
     if not template:
@@ -5601,11 +5635,17 @@ async def run_template(
     timeout_seconds: float = 600.0,
     ctx: Context | None = None,
 ) -> Any:
-    """Run a gallery template on the LOCAL ComfyUI — fetch, fill params, execute.
+    """Run a gallery template — fetch, fill params, execute.
+
+    Runs on the ComfyUI this server targets: the one on this machine unless
+    ``COMFYUI_URL`` / ``COMFYUI_HOST`` points the run/job tools at another one
+    you control (see :func:`_comfy_target`) — this is one of the tools that
+    follows it, so the ``prompt_id`` it returns belongs to that same server and
+    ``job_status`` / ``wait_for_job`` / ``watch_job`` read it back there.
 
     Thin passthrough to ``comfy run-template <name> [--param=KEY=VALUE]…`` (the
     engine fetches the template graph, fills its parameterized slots, and runs it
-    through the same local run path as ``run_workflow``). Named ``run_template``
+    through the same run path as ``run_workflow``). Named ``run_template``
     for contract parity with the cloud MCP's ``run_template(name, params)``; this
     is the one-command alternative to the manual ``search_templates`` →
     ``fetch_template`` → ``run_workflow`` chain.
@@ -5672,9 +5712,12 @@ async def run_template(
     immediately with a ``prompt_id`` to poll via ``job_status`` /
     ``wait_for_job`` / ``watch_job`` — use that for long (e.g. video) runs that
     may exceed your MCP client's tool timeout. OSS templates need their referenced
-    models installed locally; a missing model surfaces the run path's per-node
-    error (see ``search_models`` / ``download_model``). Everything targets the
-    LOCAL server (``--where local`` is injected by ``_run_comfy``).
+    models installed on the machine that runs the job; a missing model surfaces
+    the run path's per-node error (see ``search_models`` / ``download_model``,
+    which inspect and write to THIS machine's install even when the run itself
+    goes to a configured remote). This never reaches Comfy Cloud (``--where
+    local`` is injected by ``_run_comfy``); a configured ``COMFYUI_URL`` is a
+    ComfyUI YOU run elsewhere, not a hosted one.
     """
     if not name:
         raise ComfyCliError(

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -146,7 +146,9 @@ flows:
   `partner_nodes`); no release has it yet, so treat a paid graph as able to
   spend either way and ASK before running one.
   For the quickest path from text to an image, `generate_image(prompt)` runs the
-  default local text-to-image template through that same verb — free, no API key.
+  default OSS text-to-image template through that same verb — free, no API key.
+  It submits to the same ComfyUI `run_workflow` does: this machine, or the
+  remote a `comfy_target` names.
 - Templates that use the frontend's "subgraph" feature (UUID-typed nodes plus a
   `definitions.subgraphs` block in the workflow JSON) are FULLY supported:
   `run_workflow` and `run_template` expand them client-side via comfy-cli, and
@@ -200,8 +202,9 @@ flows:
   `confirm_switch=True`, which you may set ONLY when the user has agreed.
   `update_comfyui` is the different, forward-only "get me current" verb.
 - Hosted PARTNER models (Flux / Ideogram / DALL·E / …) run via `partner_generate`,
-  which SPENDS the user's Comfy credits. A local `generate_image` is always free,
-  and so is a `run_workflow` of an ordinary graph — but a workflow that embeds
+  which SPENDS the user's Comfy credits. `generate_image` is always free — it
+  runs an OSS graph on the user's own ComfyUI, whichever machine that is — and
+  so is a `run_workflow` of an ordinary graph; but a workflow that embeds
   partner-API nodes bills them wherever it runs, so `run_workflow` carries the
   same `confirm_spend` gate (below). Discover them here, never in a terminal:
   `list_partner_models()` is the alias catalog (filter it with `style="text-to-image"` /
@@ -254,8 +257,10 @@ earlier one:
   runs on, and that is where MOST tools execute. A `comfy_target` block
   carrying a `host` diverts every tool that SUBMITS a job — `run_workflow`,
   `generate_image`, `run_template` — along with the queue/`jobs` tools, while
-  discovery, templates, downloads, outputs and the lifecycle tools still run
-  HERE. So against a genuine remote the thresholds below describe the wrong
+  discovery, templates, model downloads and the lifecycle tools still describe
+  and act on THIS machine. (`fetch_outputs` is neither: it forwards no host but
+  still collects a remote job's files, from the local state file the submit
+  wrote.) So against a genuine remote the thresholds below describe the wrong
   machine: they govern generation only while the target is this one. Count the
   target as another machine only when its `host` is neither a loopback address
   (anything in `127.0.0.0/8`, `localhost`, or IPv6 `::1`) nor this host's own
@@ -369,13 +374,23 @@ DEFAULT_COMFYUI_PORT = 8188
 # release (1.13.0) that introduced the verb — which is also the floor
 # ``_check_comfy_version`` enforces (``_MIN_COMFY_CLI``). A comfy-cli old enough
 # to reject ``--host`` here has no ``run-template`` at all, so it fails on the
-# verb before the flags are ever parsed.
+# verb before the flags are ever parsed. That argument is about RELEASED
+# comfy-cli, and the floor guard deliberately fails OPEN, so a fork or source
+# build carrying ``run-template`` with its options stripped would still get a
+# Click usage error rather than a graceful degrade. No probe is added for it
+# because the exposure is not this verb's: ``run`` and ``jobs`` have been
+# forwarded unprobed all along and would fail the same way. Probing (the
+# ``_comfy_run_takes_allow_spend`` shape) is the fix if that ever stops being
+# hypothetical — for ALL THREE verbs, not just this one.
 #
 # Deliberately NOT forwarded:
 #   * ``env`` / ``download`` / ``upload`` / ``templates`` / ``models`` /
 #     ``generate`` / the lifecycle verbs take NO ``--host`` / ``--port`` at all,
-#     so forwarding would error "No such option" — they stay local-only (a real
-#     comfy-cli limitation; e.g. ``download`` can't fetch a remote job's files).
+#     so forwarding would error "No such option" — they stay local-only. That is
+#     not always a functional limit: ``download`` still collects a REMOTE job's
+#     files, because it resolves the ``prompt_id`` from the state file this
+#     machine wrote at submit (which records absolute ``/view`` URLs on the
+#     remote) instead of asking a server — see ``fetch_outputs``.
 #   * ``nodes`` / ``validate`` DO accept ``--host`` / ``--port`` in current
 #     comfy-cli, but remoting live discovery/validation is out of scope here;
 #     forwarding them is a clean follow-up. Their local answers are advisory —
@@ -3196,12 +3211,12 @@ def server_info() -> Any:
 
     Remote target: when a remote ComfyUI is configured (``COMFYUI_URL`` or
     ``COMFYUI_HOST`` — see :func:`_comfy_target`), a ``comfy_target`` block is
-    attached reporting the ``host`` / ``port`` the run/queue tools drive, so an
+    attached reporting the ``host`` / ``port`` the submit/poll tools drive, so an
     agent knows they are NOT targeting localhost. NOTE: the ``comfy env`` fields
     (running / url / workspace / python) always describe the LOCAL comfy-cli
     install — ``comfy env`` takes no ``--host`` — and this server never opens an
     HTTP socket (AGENTS.md), so it does not live-probe the remote here;
-    reachability is confirmed by the first run/queue call, which targets the
+    reachability is confirmed by the first submit/poll call, which targets the
     same host.
     """
     envelope, stdout, args, returncode, stderr = _run_comfy_raw("env", timeout=60.0)
@@ -3227,8 +3242,9 @@ def server_info() -> Any:
         report["comfy_target"] = {
             "error": str(exc),
             "note": (
-                "COMFYUI_URL/COMFYUI_HOST is set but malformed; the run/queue "
-                "tools will raise this same error until it is fixed."
+                "COMFYUI_URL/COMFYUI_HOST is set but malformed; the submit/poll "
+                "tools (run_workflow, generate_image, run_template and the "
+                "jobs/queue tools) will raise this same error until it is fixed."
             ),
         }
     else:
@@ -3239,8 +3255,14 @@ def server_info() -> Any:
                 "port": port,
                 "source": source,
                 "note": (
-                    "run/queue tools target this remote ComfyUI via --host/--port; "
-                    "the env fields above describe the LOCAL comfy-cli install."
+                    "the submit/poll tools target this remote ComfyUI via "
+                    "--host/--port — run_workflow, generate_image, run_template "
+                    "and the jobs/queue tools; the lifecycle, discovery and "
+                    "catalog tools forward no host and describe THIS machine, "
+                    "and so do the env fields above, which are the LOCAL "
+                    "comfy-cli install. (fetch_outputs forwards no host either "
+                    "but still collects a remote job's files, from the local "
+                    "state file the submit wrote.)"
                 ),
             }
     return report
@@ -5342,8 +5364,9 @@ class TemplateSpendApproval(BaseModel):
         description=(
             "Yes lets the run proceed even if the template contains "
             "partner-API (paid) nodes, spending credits from the Comfy account "
-            "this machine is signed into. No cancels it and spends nothing; a "
-            "template with no paid nodes runs free either way."
+            "the machine that RUNS it is signed into — this one, or the remote "
+            "a COMFYUI_URL/COMFYUI_HOST names. No cancels it and spends "
+            "nothing; a template with no paid nodes runs free either way."
         ),
     )
 
@@ -5365,8 +5388,9 @@ class WorkflowSpendApproval(BaseModel):
         description=(
             "Yes lets the run proceed even if the workflow contains "
             "partner-API (paid) nodes, spending credits from the Comfy account "
-            "this machine is signed into. No cancels it and spends nothing; a "
-            "workflow with no paid nodes runs free either way."
+            "the machine that RUNS it is signed into — this one, or the remote "
+            "a COMFYUI_URL/COMFYUI_HOST names. No cancels it and spends "
+            "nothing; a workflow with no paid nodes runs free either way."
         ),
     )
 
@@ -5436,9 +5460,10 @@ async def _resolve_template_spend_consent(
         schema=TemplateSpendApproval,
         prompt=(
             f"Run the gallery template `{_display_model(name)}` with credit "
-            "spending ALLOWED? Most templates are free graphs that run on this "
-            "machine, but one containing partner-API nodes SPENDS Comfy credits "
-            "from the account this machine is signed into."
+            "spending ALLOWED? Most templates are free graphs that run on your "
+            "own ComfyUI, but one containing partner-API nodes SPENDS Comfy "
+            "credits from the account the machine RUNNING it is signed into — "
+            "this one, or the remote a COMFYUI_URL/COMFYUI_HOST names."
         ),
         declined=(
             f"spend not confirmed: the user declined to let the template "
@@ -5511,9 +5536,10 @@ async def _resolve_workflow_spend_consent(
         schema=WorkflowSpendApproval,
         prompt=(
             f"Run the workflow `{path_display}` with credit spending ALLOWED? "
-            "Most workflows run for free on this machine, but one containing "
-            "partner-API nodes SPENDS Comfy credits from the account this "
-            "machine is signed into."
+            "Most workflows run for free on your own ComfyUI, but one "
+            "containing partner-API nodes SPENDS Comfy credits from the account "
+            "the machine RUNNING it is signed into — this one, or the remote a "
+            "COMFYUI_URL/COMFYUI_HOST names."
         ),
         declined=(
             f"spend not confirmed: the user declined to let the workflow "
@@ -5660,8 +5686,10 @@ async def run_template(
     engine expands ``definitions.subgraphs`` for you.
 
     SPEND CONSENT — most gallery templates are free OSS graphs that run entirely
-    on the user's own machine. SOME embed partner-API (paid) nodes, and running
-    one spends the user's Comfy credits. comfy-cli gates that path and this
+    on the user's own ComfyUI (this machine, or a configured remote). SOME embed
+    partner-API (paid) nodes, and running one spends the Comfy credits of the
+    account the machine RUNNING the job is signed into, which with a remote
+    configured is not necessarily this one. comfy-cli gates that path and this
     wrapper only passes consent through (see
     :func:`_resolve_template_spend_consent`):
 
@@ -6399,7 +6427,7 @@ def fetch_outputs(
     url_only: bool = False,
     inline_images: bool = False,
 ) -> Any:
-    """Download a completed LOCAL job's output files into ``out_dir``.
+    """Download a completed job's output files into ``out_dir``.
 
     Thin passthrough to ``comfy download <prompt_id> --where local -o <out_dir>``:
     comfy-cli resolves the job's outputs and writes them into ``out_dir``, so
@@ -6407,6 +6435,17 @@ def fetch_outputs(
     supplied by :func:`_run_comfy` as a global flag.) Pass ``url_only=True`` to
     add ``--url-only`` — comfy-cli then emits the output URLs without downloading,
     handy for handing URLs to other tools instead of copying bytes.
+
+    That ``local`` means "not Comfy Cloud", NOT "not a remote ComfyUI". This verb
+    takes no ``--host`` / ``--port`` and none is forwarded (see
+    :data:`_TARGET_AWARE_SUBCOMMANDS`), yet it still collects a job that ran on a
+    configured remote — because it never asks a server which job that is. The
+    comfy-cli run that SUBMITTED the job wrote a state file on THIS machine keyed
+    by ``prompt_id``, and against a non-loopback target that file records each
+    output as an absolute ``http://<remote>:<port>/view?…`` URL, which comfy-cli
+    streams from the remote. Only a ``prompt_id`` this machine never submitted
+    has no such state file, and that falls back to the local default server as a
+    ``download_job_not_found`` — never a silently wrong file.
 
     Pass ``inline_images=True`` to ALSO return the copied images as inline MCP
     image content (base64) so the calling agent can see the result without a

--- a/tests/test_address_env_docs.py
+++ b/tests/test_address_env_docs.py
@@ -119,15 +119,23 @@ def test_section_warns_against_setting_both(section: str):
 def test_target_aware_tools_do_not_claim_to_be_local_only():
     """The run/job tools FOLLOW ``COMFYUI_URL``; their summaries must not deny it.
 
-    ``_TARGET_AWARE_SUBCOMMANDS`` is ``{"run", "jobs"}``, so exactly these tools
-    are diverted to a configured remote. Their one-line summaries used to open
-    with "LOCAL", which is the one place the local/remote distinction is
-    load-bearing and was simply wrong. The tools that genuinely stay on this
-    machine (lifecycle, ``fetch_outputs``, discovery, …) keep saying so, and are
-    deliberately not covered here.
+    ``_TARGET_AWARE_SUBCOMMANDS`` is ``{"run", "run-template", "jobs"}``, so
+    exactly these tools are diverted to a configured remote. Their one-line
+    summaries used to open with "LOCAL", which is the one place the local/remote
+    distinction is load-bearing and was simply wrong. The tools that genuinely
+    stay on this machine (lifecycle, ``fetch_outputs``, discovery, …) keep saying
+    so, and are deliberately not covered here.
+
+    ``generate_image`` and ``run_template`` are the ``run-template`` pair: they
+    were the tools whose summaries said LOCAL *while* their submissions really
+    did stay local, and both halves moved together — forwarding the flags without
+    correcting the summary would leave the one sentence a caller reads before
+    deciding which machine a job lands on saying the opposite of what happens.
     """
     for tool in (
         server.run_workflow,
+        server.generate_image,
+        server.run_template,
         server.job_status,
         server.wait_for_job,
         server.watch_job,

--- a/tests/test_remote_host.py
+++ b/tests/test_remote_host.py
@@ -3,15 +3,19 @@
 The run/queue tools normally target the implicit local 127.0.0.1:8188. Setting
 ``COMFYUI_URL`` — or the ``COMFYUI_HOST`` / ``COMFYUI_PORT`` pair — points them
 at a ComfyUI running elsewhere by forwarding ``--host`` / ``--port`` to the
-comfy-cli verbs that accept them (``comfy run`` and every ``comfy jobs``
-subcommand). These lock in:
+comfy-cli verbs that accept them (``comfy run``, ``comfy run-template``, and
+every ``comfy jobs`` subcommand). These lock in:
 
 1. ``_comfy_target`` env parsing (URL, host/port, defaults, malformed values).
 2. ``--host`` / ``--port`` forwarded into the SUBCOMMAND (not the global prefix)
-   for ``run`` / ``jobs``, and NOT for verbs that don't accept them (``env`` /
-   ``download`` / ``upload`` / …).
+   for ``run`` / ``run-template`` / ``jobs``, and NOT for verbs that don't accept
+   them (``env`` / ``download`` / ``upload`` / …).
 3. Byte-identical local behavior when nothing is configured.
 4. ``server_info`` surfacing the configured ``comfy_target``.
+5. Submit and poll agreeing on ONE server: a ``generate_image`` / ``run_template``
+   submission and the ``wait_for_job`` that follows it must carry the same
+   ``--host`` / ``--port``, or the ``prompt_id`` from one is meaningless to the
+   other.
 """
 
 from __future__ import annotations
@@ -221,6 +225,80 @@ def test_jobs_forwards_host_port_into_subcommand(patched_run, monkeypatch):
     ]
 
 
+def test_run_template_forwards_host_port_into_subcommand(patched_run, monkeypatch):
+    """`comfy run-template` accepts --host/--port, so a submit follows the remote.
+
+    Driven through the raw wrapper rather than a tool so this asserts the
+    allowlist entry itself; the two tool-level tests below cover the argv the
+    tools actually build.
+    """
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
+    calls = patched_run(envelope(data={"prompt_id": "p1"}))
+
+    server._run_comfy("run-template", "default", "--async")
+
+    cmd = calls[0]["cmd"]
+    assert cmd[1:4] == ["--json", "--where", "local"]  # global prefix unchanged
+    assert cmd[4:] == [
+        "run-template",
+        "default",
+        "--async",
+        "--host",
+        "gpu.example",
+        "--port",
+        "9001",
+    ]
+
+
+def test_generate_image_submit_forwards_host_port(patched_run, monkeypatch):
+    """`generate_image(wait=False)` submits to the remote, not to this machine.
+
+    The whole ticket in one assertion: this is the easiest text-to-image
+    on-ramp, it goes through `run-template`, and while that verb was off the
+    allowlist the run happened HERE while `wait_for_job` polled THERE.
+    """
+    monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
+    monkeypatch.setenv("COMFYUI_PORT", "9001")
+    calls = patched_run(envelope(data={"prompt_id": "p1"}))
+
+    result = asyncio.run(server.generate_image("a red fox in snow", wait=False))
+
+    assert result == {"prompt_id": "p1"}
+    assert calls[0]["cmd"][4:] == [
+        "run-template",
+        "default",
+        '--param=6.text="a red fox in snow"',
+        "--timeout=60",
+        "--async",
+        "--host",
+        "gpu.example",
+        "--port",
+        "9001",
+    ]
+
+
+def test_run_template_tool_submit_forwards_host_port(patched_run, monkeypatch):
+    """`run_template(wait=False)` submits to the remote too — same verb, same fix."""
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
+    calls = patched_run(envelope(data={"prompt_id": "p1"}))
+
+    asyncio.run(
+        server.run_template("image_flux2", params={"prompt": "a cat"}, wait=False)
+    )
+
+    assert calls[0]["cmd"][4:] == [
+        "run-template",
+        "image_flux2",
+        '--param=prompt="a cat"',
+        "--timeout=60",
+        "--async",
+        "--host",
+        "gpu.example",
+        "--port",
+        "9001",
+    ]
+
+
 def test_env_is_not_forwarded_host_port(patched_run, monkeypatch):
     """`comfy env` takes no --host/--port; forwarding would error 'No such option'."""
     monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
@@ -250,6 +328,47 @@ def test_local_default_is_byte_identical(patched_run):
     server._run_comfy("run", "--workflow", "wf.json")
 
     assert calls[0]["cmd"][4:] == ["run", "--workflow", "wf.json"]  # no --host/--port
+
+
+def test_run_template_local_default_is_byte_identical(patched_run):
+    """Adding `run-template` to the allowlist changes NOTHING with no remote set.
+
+    The mirror of the assertion above for the newly-forwarded verb: forwarding is
+    conditional on a resolved target, so an unconfigured install must produce the
+    same argv it produced before this verb was ever allowlisted.
+    """
+    calls = patched_run(envelope(data={"prompt_id": "p1"}))
+
+    asyncio.run(server.generate_image("a cat", wait=False))
+
+    assert calls[0]["cmd"][4:] == [
+        "run-template",
+        "default",
+        '--param=6.text="a cat"',
+        "--timeout=60",
+        "--async",
+    ]
+
+
+def test_run_template_malformed_config_fails_like_run_does(patched_run, monkeypatch):
+    """A malformed COMFYUI_URL breaks `run-template` no worse than it breaks `run`.
+
+    `_with_target` checks the VERB before it resolves the target, so a bad config
+    can only ever reach a verb that would have used it. For a target-aware verb
+    that means a named `ComfyCliError` and NO spawn — the same failure `run` has
+    always had, not a silent fall back to running on this machine, which is the
+    outcome the ticket is about. (Local-only verbs are unaffected; that is
+    `test_local_only_verb_survives_malformed_config` above.)
+    """
+    monkeypatch.setenv("COMFYUI_URL", "https://gpu.example")  # scheme rejected
+    calls = patched_run(envelope(data={"prompt_id": "p1"}))
+
+    with pytest.raises(server.ComfyCliError, match="scheme"):
+        server._run_comfy("run", "--workflow", "wf.json")
+    with pytest.raises(server.ComfyCliError, match="scheme"):
+        asyncio.run(server.generate_image("a cat", wait=False))
+
+    assert calls == []  # neither verb ever spawned comfy-cli
 
 
 # --- forwarding into the streaming (--json-stream) path --------------------
@@ -294,6 +413,88 @@ def test_watch_job_stream_forwards_host_port(patched_stream, monkeypatch):
         "--port",
         "9001",
     ]
+
+
+def test_generate_image_stream_forwards_host_port(patched_stream, monkeypatch):
+    """`generate_image(wait=True)` streams from the remote, with the flags forwarded."""
+    monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
+    monkeypatch.setenv("COMFYUI_PORT", "9001")
+    procs = patched_stream(_OK_STREAM)
+
+    result = asyncio.run(server.generate_image("a cat"))
+
+    assert result == {"outputs": ["/x.png"]}
+    cmd = procs[0].cmd
+    assert cmd[1:4] == ["--json-stream", "--where", "local"]  # global prefix unchanged
+    assert cmd[4:] == [
+        "run-template",
+        "default",
+        '--param=6.text="a cat"',
+        "--timeout=120",
+        "--host",
+        "gpu.example",
+        "--port",
+        "9001",
+    ]
+
+
+def test_run_template_stream_forwards_host_port(patched_stream, monkeypatch):
+    """`run_template(wait=True)` streams from the remote as well."""
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
+    procs = patched_stream(_OK_STREAM)
+
+    asyncio.run(server.run_template("image_flux2"))
+
+    assert procs[0].cmd[4:] == [
+        "run-template",
+        "image_flux2",
+        "--timeout=120",
+        "--host",
+        "gpu.example",
+        "--port",
+        "9001",
+    ]
+
+
+# --- submit and poll must agree on ONE server ------------------------------
+
+
+def _target_flags(cmd: list[str]) -> list[str]:
+    """The `--host`/`--port` pair a spawned argv carries, or `[]` for none."""
+    if "--host" not in cmd:
+        return []
+    start = cmd.index("--host")
+    return cmd[start : start + 4]
+
+
+@pytest.mark.parametrize("submit_argv", ["generate_image", "run_template"])
+def test_submit_then_wait_for_job_hit_the_same_server(
+    patched_run, monkeypatch, submit_argv
+):
+    """The end-to-end break: submit and poll must land on the SAME ComfyUI.
+
+    This is the reported failure, not merely "the run happened on the wrong
+    machine". `wait_for_job` goes through the `jobs` verb, which was already
+    forwarded, while the submit went through `run-template`, which was not — so a
+    client got a `prompt_id` from a LOCAL run and then asked the REMOTE queue
+    about it, where it had never been submitted, and got `prompt_not_found`. The
+    invariant that has to hold is agreement, so assert the two argvs carry the
+    SAME target rather than re-asserting one tool's flags.
+    """
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
+    calls = patched_run(envelope(data={"prompt_id": "p1", "status": "completed"}))
+
+    if submit_argv == "generate_image":
+        submitted = asyncio.run(server.generate_image("a cat", wait=False))
+    else:
+        submitted = asyncio.run(server.run_template("image_flux2", wait=False))
+    polled = server.wait_for_job(submitted["prompt_id"])
+
+    assert polled["status"] == "completed"  # no `prompt_not_found`
+    assert calls[0]["cmd"][4] == "run-template"
+    assert calls[1]["cmd"][4:7] == ["jobs", "status", "p1"]
+    assert _target_flags(calls[0]["cmd"]) == ["--host", "gpu.example", "--port", "9001"]
+    assert _target_flags(calls[0]["cmd"]) == _target_flags(calls[1]["cmd"])
 
 
 # --- server_info surfaces the configured target ----------------------------

--- a/tests/test_remote_host.py
+++ b/tests/test_remote_host.py
@@ -321,6 +321,49 @@ def test_download_and_upload_not_forwarded(patched_run, monkeypatch):
     assert calls[1]["cmd"][4:] == ["upload", "a.png"]
 
 
+def test_fetch_outputs_docs_do_not_deny_remote_retrieval():
+    """Not-forwarded must not be documented as not-working, for this one verb.
+
+    ``download`` takes no ``--host`` / ``--port`` (asserted above) and the
+    obvious reading — that ``fetch_outputs`` therefore cannot collect a job that
+    ran on the configured remote — is wrong, which is why this is a tripwire
+    rather than a comment. comfy-cli's ``download`` resolves the ``prompt_id``
+    from the state file the SUBMITTING run wrote on THIS machine, and for a
+    non-loopback target that file records each output as an absolute
+    ``http://<remote>:<port>/view?…`` URL it then streams from the remote (the
+    on-disk shortcut in ``run.execution.format_image_path`` is gated on a
+    loopback host, so it cannot fire for a remote job). Only an id this machine
+    never submitted has no such file.
+
+    Two review passes read the non-forwarding as a broken chain and asked for
+    the denial to be written into the docstrings; documenting it would have
+    talked users out of a path that works. Keyed on the load-bearing MECHANISM
+    (the state file) plus the absence of a denial, so the prose can be rewritten
+    without churn.
+    """
+    doc = server.fetch_outputs.__doc__ or ""
+    assert "state file" in doc, (
+        "fetch_outputs no longer explains WHY it reaches a remote job's outputs "
+        "— the state file is the whole mechanism"
+    )
+    assert "_TARGET_AWARE_SUBCOMMANDS" in doc, (
+        "the docstring no longer ties its behavior to the forwarding allowlist"
+    )
+    # The denial this guards against, in the spellings a rewrite would reach for.
+    lowered = " ".join(doc.split()).lower()
+    for denial in (
+        "cannot collect",
+        "can't collect",
+        "cannot fetch a remote",
+        "can't fetch a remote",
+        "unreachable for these jobs",
+    ):
+        assert denial not in lowered, (
+            f"fetch_outputs' docstring now denies remote retrieval ({denial!r}); "
+            "comfy-cli resolves the prompt_id from the local state file, so it works"
+        )
+
+
 def test_local_default_is_byte_identical(patched_run):
     """With nothing configured the argv is exactly today's — no --host appended."""
     calls = patched_run(envelope())

--- a/tests/test_routing_instructions.py
+++ b/tests/test_routing_instructions.py
@@ -134,12 +134,10 @@ def test_routing_defers_to_comfy_target_instead_of_local_hardware(routing):
     (surfaced as ``comfy_target``). Routing off local hardware would then reject
     a capable remote GPU, or pile work onto a weaker one.
 
-    The exemption has to be NARROW, though: only ``run`` and ``jobs`` are
-    target-aware (``_TARGET_AWARE_SUBCOMMANDS``), so ``generate_image`` and
-    friends still run locally and the thresholds still govern them; a loopback
-    host is this same machine; and a malformed config yields an error-shaped
-    block that resolves no remote at all. Treating any ``comfy_target`` as
-    "runs elsewhere" would switch routing off on all three.
+    The exemption still has to be NARROW, though: a loopback host is this same
+    machine, and a malformed config yields an error-shaped block that resolves no
+    remote at all. Treating any ``comfy_target`` as "runs elsewhere" would switch
+    routing off on both.
 
     Loopback is stated as a RANGE, not a pair of literals: ``_comfy_target``
     accepts a bracketed IPv6 host (``COMFYUI_URL=http://[::1]:8188``, see
@@ -149,10 +147,31 @@ def test_routing_defers_to_comfy_target_instead_of_local_hardware(routing):
     producing the block at all.
     """
     assert "comfy_target" in routing
-    assert "generate_image" in routing  # named as still-local
     assert "ERROR-shaped" in routing
     assert "127.0.0.0/8" in routing and "::1" in routing
     assert "COMFY_LOCAL_URL" in routing
+
+
+def test_routing_names_every_submitting_tool_as_diverted(routing):
+    """All three job-SUBMITTING tools follow ``comfy_target`` — the block must say so.
+
+    ``_TARGET_AWARE_SUBCOMMANDS`` covers ``run``, ``run-template`` and ``jobs``,
+    so ``run_workflow``, ``generate_image`` and ``run_template`` all submit to a
+    configured remote. The block used to name the last two as *still local*,
+    which is the failure this guards against in both directions: an agent that
+    believes ``generate_image`` runs here will apply this machine's VRAM
+    thresholds to a job that lands elsewhere, and — worse — will read a
+    ``prompt_not_found`` from ``wait_for_job`` as a broken queue rather than as
+    the two calls having been pointed at different servers.
+
+    Scoped to the diversion SENTENCE, not the whole block: every one of these
+    names appears elsewhere in the routing prose, so a whole-block ``in`` check
+    would keep passing after the sentence had been rewritten to exclude them.
+    """
+    assert "diverts" in routing, "the routing block no longer states a diversion"
+    sentence = routing.split("diverts", 1)[1].split(". ", 1)[0]
+    for tool in ("run_workflow", "generate_image", "run_template"):
+        assert tool in sentence, f"{tool} is target-aware but not named as diverted"
 
 
 def test_routing_asks_when_it_cannot_place_the_target_host(routing):


### PR DESCRIPTION
## ELI-5

You can tell this server "my ComfyUI lives on the GPU box over there" by setting `COMFYUI_URL`. It was only telling *some* of the tools. `generate_image` and `run_template` kept running on your own laptop, then `wait_for_job` went and asked the GPU box about the job — which had never heard of it. So you got a job id back that looked fine and then a confusing "prompt_not_found" from the wrong machine. This tells those two tools about the remote as well, so submitting and polling now always talk to the same ComfyUI.

## What changed

`comfy run-template` accepts `--host` / `--port`, but it was missing from this server's forwarding allowlist (`_TARGET_AWARE_SUBCOMMANDS`, previously `{"run", "jobs"}`). Both `generate_image` and `run_template` go through that verb; `wait_for_job` goes through `jobs`, which *was* allowlisted. With a remote configured that asymmetry broke the flow end to end rather than merely running it on the wrong machine — submission landed locally, polling targeted the remote, and the local `prompt_id` came back `prompt_not_found` from a queue it was never submitted to. That error points a reader at the remote's queue/history rather than at the missing allowlist entry, which is what made it expensive to diagnose.

- `src/comfy_mcp/server.py` — add `"run-template"` to `_TARGET_AWARE_SUBCOMMANDS`. That is the whole functional change; `_with_target` already appends the flags **after** the subcommand verb (never into the global `--json --where local` prefix) and is already applied in all three spawn paths (`_run_comfy_raw`, `_run_comfy_async`, `_run_comfy_streaming`), which is why no call site needed touching.
- Docs that described these two tools as local-only, corrected in the same change: the `INSTRUCTIONS` routing block (STEP 1 named `generate_image` / `run_template` as *still local*), the `generate_image` and `run_template` docstrings (both summaries opened with "LOCAL"), and the README's remote-ComfyUI section, routing bullet, address-variable table and tool table.
- `tests/test_remote_host.py` — forwarding for both tools on both the plain (`wait=False`) and streaming (`wait=True`) paths, the raw-wrapper allowlist assertion, byte-identical local default, malformed-config behavior, and the submit-then-poll regression case.

## Why it is safe

The riskiest line is the allowlist entry itself: forwarding a flag to a verb that does not accept it turns every call into `No such option`. There is no such window here. `comfy run-template` declares `--host` / `--port` (`comfy_cli/command/templates.py`) and resolves them through the same `comfy_cli/host_port.py` `resolve_host_port` that `comfy run`'s local branch uses — explicit `--port` wins over a port parsed out of `--host`, and a bare IPv6 host is re-bracketed, identical semantics to `run`. And it shipped **with** both options in the same comfy-cli release (1.13.0) that introduced the verb, which is also the floor `_check_comfy_version` enforces (`_MIN_COMFY_CLI`), so a comfy-cli old enough to reject `--host` has no `run-template` at all and fails on the verb first. Verified against comfy-cli `main` and the `v1.13.0` tag rather than from the ticket's assertion.

`comfy_cli/host_port.py`'s own module docstring still says only "`comfy run` and every `comfy jobs` subcommand" accept the pair — that docstring is stale on the comfy-cli side (`templates.py` imports and calls into it), not a signal that the verb lacks the options. Worth a one-line follow-up there; it does not affect this change.

## Acceptance criteria

- [x] `"run-template"` added to `_TARGET_AWARE_SUBCOMMANDS`; flags appended after the verb, never into the global prefix — asserted directly (`cmd[1:4] == ["--json", "--where", "local"]`).
- [x] `generate_image` and `run_template` submit to the host from `COMFYUI_URL` / `COMFYUI_HOST` + `COMFYUI_PORT`.
- [x] With no remote configured the argv is byte-identical — a new mirror of the existing assertion, plus the whole pre-existing `test_generate.py` / `test_run_template.py` exact-argv suite, which is unchanged and still green.
- [x] A malformed `COMFYUI_URL` breaks these tools no more than it breaks `run` — `_with_target` checks the verb before resolving the target, so local-only verbs are untouched; covered by a test that runs both verbs and asserts neither spawned comfy-cli.
- [x] New tests for both tools, plain and streaming paths.
- [x] Regression case for the reported repro: parametrized over both tools, asserting the submit argv and the following `wait_for_job` argv carry the **same** `--host`/`--port` (agreement is the invariant, so it is asserted as agreement rather than as one tool's flags).

## Judgment calls

- **A malformed `COMFYUI_URL` now fails these two tools loudly instead of silently running locally.** That is a real behavior change and it is the intended one — it is exactly how `run_workflow` has always behaved, and the error names the offending variable. Silently falling back to this machine is the failure mode being fixed.
- **Docs were in scope, not drive-by.** Two existing guard tests encoded the old allowlist as documented behavior (`test_target_aware_tools_do_not_claim_to_be_local_only` and the routing-block guard asserting `generate_image` is named as still-local), so shipping the forward without correcting the prose would have left the server's own handshake instructions telling an agent the opposite of what happens. Both guards were updated to assert the new invariant rather than deleted, and the routing one now scopes its check to the diversion sentence.
- **The local template pre-check stays local** (`_local_template_check`), per the ticket's out-of-scope note — matching how `run_workflow` / `validate_workflow` already behave. Divergent node sets can still pass a local check and fail on the remote; the README's "not remoted" list now says so explicitly instead of leaving it implied.
- **No capability is denied by this change** — it grants one, so there is no dead-end path to falsify. The only new failure is the malformed-config one above, which is a config error with a named fix, not a "this is not supported" wall.

## Verification

`pytest -q` → 1415 passed, 4 skipped (the 4 are the opt-in e2e smoke tests). `ruff check .` and `ruff format --check .` clean. Run on Python 3.14; CI covers 3.10 as well.
