### PR TITLE
WIP: feat: extend COMFYUI_URL target-awareness to validate, nodes and workflow authoring (BE-5664)

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ The discrete-GPU rows are written for NVIDIA but apply to an AMD or Intel card o
 
 The instructions walk these as an ordered procedure, because several of the checks only make sense in sequence:
 
-1. **Is the work even local?** `hardware` describes the machine *this server* runs on, and that is where most tools execute. A `comfy_target` block ([Driving a remote ComfyUI](#driving-a-remote-comfyui)) diverts every tool that submits a job — `run_workflow`, `generate_image`, `run_template` — along with the queue/`jobs` tools, while discovery, templates, downloads, outputs and the lifecycle tools stay here; so against a genuine remote the thresholds below describe the wrong machine. It counts as another machine only when its `host` is neither loopback (anything in `127.0.0.0/8`, `localhost`, IPv6 `::1`) nor this host's own address, and a malformed config produces an error-shaped `{error, note}` block that resolves no remote at all. Nothing the server returns carries the local hostname or interface addresses, so a `host` the agent can't place is a question for you rather than a guess — a hostname or LAN IP can be this same machine, and a loopback host can be a tunnel to a remote GPU. `COMFY_LOCAL_URL` is a second signal worth checking: it repoints comfy-cli without producing a `comfy_target` block.
+1. **Is the work even local?** `hardware` describes the machine *this server* runs on, and that is where most tools execute. A `comfy_target` block ([Driving a remote ComfyUI](#driving-a-remote-comfyui)) diverts every tool that submits a job — `run_workflow`, `generate_image`, `run_template` — along with the queue/`jobs` tools and every tool that reads a live node catalog (`validate_workflow`, the `search_nodes` / `nodes_*` family, `list_workflow_slots` / `set_workflow_slot` / `vary_workflow`), while templates, model downloads, outputs, `system_stats`/`free_memory` and the lifecycle tools stay here; so against a genuine remote the thresholds below describe the wrong machine. It counts as another machine only when its `host` is neither loopback (anything in `127.0.0.0/8`, `localhost`, IPv6 `::1`) nor this host's own address, and a malformed config produces an error-shaped `{error, note}` block that resolves no remote at all. Nothing the server returns carries the local hostname or interface addresses, so a `host` the agent can't place is a question for you rather than a guess — a hostname or LAN IP can be this same machine, and a loopback host can be a tunnel to a remote GPU. `COMFY_LOCAL_URL` is a second signal worth checking: it repoints comfy-cli without producing a `comfy_target` block.
 2. **Get a memory figure.** The sizes are bytes (`ram_bytes`, `gpu.vram_bytes`) and the divisor gives GiB, while drivers report under the advertised size — a consumer 24 GB card reads 23.99, an ECC/reserving datacenter card (A10, L4) about 22.3 — so a *small* shortfall, within ~10% of a nominal size, reads as that nominal capacity. A gap wider than that is not driver overhead and is taken at face value instead: on a MIG/vGPU partition the model string names the whole card while `vram_bytes` is the slice you actually get, and rounding a 6 GB A100 slice up into the ≥ 24 GB band would OOM the run. On Apple Silicon `gpu.vram_bytes` is `null` (with `gpu.unified_memory` true) and the figure is `ram_bytes` — an Apple-only substitution.
 3. **If the figure is missing, ask.** A `null` **or zero** `vram_bytes` on any **non-Apple** GPU (a discrete card comfy-cli can't size, but also a non-Apple unified part like a Jetson/Grace board or a Strix Halo APU), a missing `gpu` object, or a missing/zero `ram_bytes` on the Apple path all mean **unknown**, not "no GPU" — the agent asks rather than stranding a machine that has one. The "no GPU" verdict is reserved for a *confirmed* absence, and the only thing that confirms one is your own answer: no `hardware` payload encodes it, because a null or missing `gpu` is unknown by this same step. Nothing in this repo probes hardware, and the instructions tell the agent not to shell out either: a probe runs on a path this server can neither bound nor audit.
 4. **Route on the figure**, then **redirect rather than dead-end** when the answer is "not on this machine". A figure that came from your answer rather than the payload routes on whichever row fits the machine — the unified-memory row on an Apple Silicon Mac, the VRAM rows otherwise, which is what covers the non-Apple unified-memory boards that have no row of their own.
@@ -676,15 +676,31 @@ behavior is unchanged (`127.0.0.1:8188` on this machine). If what you actually h
 *this* machine on a different port, you want `COMFY_LOCAL_URL` instead — see [Which address variable
 do I want?](#which-address-variable-do-i-want).
 
-When configured, the server forwards `--host` / `--port` to comfy-cli for exactly the verbs that
-accept them — `comfy run`, `comfy run-template` and `comfy jobs …` — so every tool that **submits a
-job or reads one back** targets the remote: `run_workflow`, `generate_image`, `run_template`,
-`job_status`, `wait_for_job`, `watch_job`, `cancel_job`, `get_queue`. `server_info` reports the
-configured target under a `comfy_target` block.
+When configured, the server forwards `--host` / `--port` to comfy-cli for exactly the calls that
+accept them, which is every tool that **submits a job or reads one back** —
 
-That set is deliberately closed under submit-then-poll: a `prompt_id` only means something to the
-server that issued it, so a tool that submits and a tool that polls must never resolve to different
-machines.
+- `comfy run`, `comfy run-template`, `comfy jobs …` → `run_workflow`, `generate_image`,
+  `run_template`, `job_status`, `wait_for_job`, `watch_job`, `cancel_job`, `get_queue`.
+
+— and every tool that **reads a live node catalog**, so discovery, validation and workflow authoring
+all describe the machine the job will actually run on:
+
+- `comfy validate` → `validate_workflow`, and the `local_check` block on `fetch_template` /
+  `get_template`.
+- `comfy nodes …` → `search_nodes`, `get_node`, `list_nodes`, `nodes_upstream`, `nodes_downstream`,
+  `nodes_path`, `nodes_types`, `nodes_categories`.
+- `comfy workflow slots` / `set-slot` / `vary` → `list_workflow_slots`, `set_workflow_slot`,
+  `vary_workflow`. (`list_workflow_notes` is **not** in this group — `comfy workflow notes` is an
+  offline read of the file on disk and takes no `--host` / `--port` at all.)
+
+`server_info` reports the configured target under a `comfy_target` block.
+
+The first set is deliberately closed under submit-then-poll: a `prompt_id` only means something to
+the server that issued it, so a tool that submits and a tool that polls must never resolve to
+different machines. The second set answers the matching question for authoring: a workflow that
+passes a node check *here* can still fail *there*, so the check is asked of the same install the run
+will land on. Both sets read comfy-cli's live `object_info`, so the answers still reflect whatever
+that install actually has, staleness included.
 
 **Not remoted (this repo is a thin wrapper and never opens its own socket):**
 
@@ -692,9 +708,12 @@ machines.
   `switch_comfyui_version`, `get_logs`) — these manage a **local** ComfyUI process/install and stay
   local-only; they cannot start/stop, update, version-switch, or read logs from a remote box. Start
   and update ComfyUI on the remote host yourself.
-- **Catalog / partner verbs** — `search_templates` / `search_models` / `download_model` /
-  `partner_generate` — this server forwards **no** `--host`/`--port` to these verbs (they accept
-  none at all), so they run against comfy-cli's local default. A model must be installed on the
+- **Model catalog / partner verbs** — `search_models` / `download_model` / `partner_generate` —
+  this server forwards **no** `--host`/`--port` to these verbs (they accept
+  none at all, only `--where local|cloud`; giving them a target is comfy-cli work, not this repo's),
+  so they run against comfy-cli's local default. `search_models` therefore answers about *this*
+  machine's models even with a remote configured — unlike the node tools next to it, which do
+  follow the target. A model must be installed on the
   machine that actually runs the job, and `download_model` cannot do that for you — so rather than
   writing the checkpoint to the wrong disk and letting the run fail later on a missing model, it
   **refuses** while `COMFYUI_URL`/`COMFYUI_HOST` is set, naming the remote it would have missed.
@@ -712,12 +731,15 @@ machines.
   back to querying the local default server only when no such state file exists (an id this machine
   never submitted). `run_workflow(wait=True)` / `job_status` return those same URLs if you would
   rather hand them off than copy bytes.
-- **Discovery / validation** (`search_nodes`, `get_node`, `validate_workflow`, and the
-  `local_check` block on `fetch_template` / `get_template`) — their comfy-cli verbs *do* accept
-  `--host`/`--port`, but this version forwards only to the submit/poll tools, so they still
-  describe the **local** install. Remoting them is a planned follow-up; until then a workflow or
-  template can pass a local check and still fail on a remote whose node set differs, so
-  author/validate against a local ComfyUI matching the remote's.
+- **Template gallery** (`search_templates`, `fetch_template`, `get_template`) — `comfy templates`
+  takes no `--host`/`--port`, and needs none: the gallery is comfy-cli's own cached index of
+  `Comfy-Org/workflow_templates`, not something either ComfyUI serves. The template JSON is written
+  **here**, which is where `run_workflow` reads it from; only the `local_check` verdict attached to
+  it is remoted (it goes through `comfy validate`, above).
+- **Workflow notes** (`list_workflow_notes`) — `comfy workflow notes` reads the file on disk and
+  never contacts a server, so there is nothing to point elsewhere. Its sibling
+  `list_workflow_slots` *is* remoted, which is why the forwarding allowlist is keyed on
+  (verb, subcommand) rather than on the verb alone.
 - The remote ComfyUI must be reachable and **unauthenticated** on that network (the private network
   is the boundary); the server does not authenticate to it. `server_info` does not live-probe the
   remote — reachability surfaces on the first run/job call.
@@ -793,7 +815,7 @@ different layers. Pick by which one you need; the table is the whole answer.
 | **Read by** | **this MCP server** (`_comfy_target`) | **comfy-cli** (`comfy_cli/local_address.py`); this server never reads it |
 | **Means** | "a ComfyUI on **another machine** I control" | "the ComfyUI on **this machine** is not on `127.0.0.1:8188`" |
 | **How it acts** | this server forwards `--host` / `--port` to the verbs that accept them | comfy-cli resolves its own target from the environment it inherits |
-| **What it moves** | the **submit / job** tools only (`run_workflow`, `generate_image`, `run_template`, and the `jobs` family) — see [what is and isn't remoted](#driving-a-remote-comfyui) | **every** verb, including the ones that take no `--host` / `--port` (`comfy env`, templates, models, download) |
+| **What it moves** | the **submit / job** tools (`run_workflow`, `generate_image`, `run_template`, the `jobs` family) **and the live-catalog tools** (`validate_workflow`, the `search_nodes` / `nodes_*` discovery family, `list_workflow_slots` / `set_workflow_slot` / `vary_workflow`) — but nothing whose comfy-cli verb takes no `--host` / `--port`, see [what is and isn't remoted](#driving-a-remote-comfyui) | **every** verb, including the ones that take no `--host` / `--port` (`comfy env`, templates, models, download) |
 | **Reported as** | a `comfy_target` block on `server_info` | the resolved `server` URL on `server_info` — **no** `comfy_target` block |
 | **Use it for** | a GPU box over Tailscale / a private network | a port clash, a second instance, a container publishing a different port |
 
@@ -858,6 +880,8 @@ handle is `prompt_id`.
 
 ### Workflow building
 
+Everything here except `list_workflow_notes` resolves against a live `object_info`, so it follows `COMFYUI_URL`/`COMFYUI_HOST` and answers for the ComfyUI the run will land on ([Driving a remote ComfyUI](#driving-a-remote-comfyui)). `list_workflow_notes` is an offline read of the file on disk and takes no target.
+
 | Tool | Wraps | What it does |
 |---|---|---|
 | `validate_workflow(workflow_path)` | `comfy validate --workflow <path>` | Pre-flight a workflow against the live `object_info` before a slow run; surfaces the structured error code on failure. |
@@ -873,7 +897,7 @@ handle is `prompt_id`.
 | `search_templates(query="", limit=25, offset=0, tag="", type="", model="", provider="", exclude_api=False)` | `comfy templates ls [--tag/--type/--model/--provider …]` | Find a built-in workflow template: free-text `query` (client-side over name/title/description/tags/models), paged via `limit`/`offset`, narrowed by the `tag`/`type`/`model`/`provider` gallery filters or `exclude_api=True`. Returns `{total, shown, offset, rows:[{name,title,description,output_type}]}`. |
 | `get_template(name, check_local=True)` | `comfy templates show <name>` (+ `comfy validate`) | Show one template's details/schema before fetching it, plus a `local_check` block cross-checking its graph against the live `object_info` of your install — see [Templates your install can't run](#templates-your-install-cant-run). `check_local=False` skips the check (metadata only, one call). |
 | `fetch_template(name, out_path, check_local=True)` | `comfy templates fetch <name> --out <path>` (+ `comfy validate`) | Write a template's runnable workflow JSON to `out_path`; returns `{path, local_check}` — `path` is the absolute path for `run_workflow`, `local_check` is the same cross-check run on the file just written. The file is written either way. |
-| `search_nodes(query)` | `comfy nodes search <query>` | Find node classes in the **live local** `object_info` (includes installed custom nodes). |
+| `search_nodes(query)` | `comfy nodes search <query>` | Find node classes in the **live** `object_info` (includes installed custom nodes). The whole `nodes` family follows `COMFYUI_URL`/`COMFYUI_HOST`, so it describes the ComfyUI a run would land on ([Driving a remote ComfyUI](#driving-a-remote-comfyui)); the template rows below do not — the gallery is comfy-cli's own cache — but their `local_check` does. |
 | `get_node(name)` | `comfy nodes show <ClassName>` | Full input/output schema for one node class — what you need to author/repair a graph. |
 | `list_nodes(produces="", accepts="", category="", pack="", label="")` | `comfy nodes ls [--produces/--accepts/--category/--pack/--label …]` | List node classes, filtered by output/input type, category, pack, or label; bare call lists all. Reads the **live install**. |
 | `nodes_upstream(name, limit=None)` | `comfy nodes upstream <name> [--limit N]` | Nodes whose outputs can feed `<name>`'s inputs ("what wires INTO this?"). Reads the **live install**. |

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -118,7 +118,8 @@ flows:
   hosted-API key), `fetch_template` to save its workflow JSON, then — only once
   the check below has CLEARED — `run_workflow` on `result["path"]`.
   `fetch_template` and `get_template` return a `local_check` block comparing the
-  template against the live node catalog of the installed ComfyUI. The gallery
+  template against the live node catalog of the ComfyUI it would run on — this
+  machine, or the remote a `comfy_target` names. The gallery
   catalog is CACHED by comfy-cli and maintained independently of the install (it
   is not read from it at all), so a template can need a node or model option this
   install does not have yet — clearing `local_check` is MANDATORY, not advisory,
@@ -265,9 +266,14 @@ earlier one:
 - STEP 1, is the work even local? `hardware` describes the machine THIS server
   runs on, and that is where MOST tools execute. A `comfy_target` block
   carrying a `host` diverts every tool that SUBMITS a job — `run_workflow`,
-  `generate_image`, `run_template` — along with the queue/`jobs` tools, while
-  discovery, templates, model downloads and the lifecycle tools still describe
-  and act on THIS machine. (`fetch_outputs` is neither: it forwards no host but
+  `generate_image`, `run_template` — along with the queue/`jobs` tools and every
+  tool that reads a live node catalog (`search_nodes`, `get_node`, `list_nodes`,
+  the `nodes_*` family, `validate_workflow`, the `local_check` block, and
+  `list_workflow_slots` / `set_workflow_slot` / `vary_workflow`), so discovery
+  and validation answer for the machine the job will land on; templates, model
+  downloads, `system_stats` / `free_memory`, the offline `list_workflow_notes`
+  and the lifecycle tools still describe and act on THIS machine.
+  (`fetch_outputs` is neither: it forwards no host but
   still collects a remote job's files, from the local state file the submit
   wrote.) So against a genuine remote the thresholds below describe the wrong
   machine: they govern generation only while the target is this one. Count the
@@ -359,7 +365,7 @@ COMFY_BIN = os.environ.get("COMFY_BIN", "comfy")
 # pair. When UNSET the tools behave byte-identically to the local-only default
 # (no ``--host`` forwarded); when set, ``_with_target`` forwards ``--host`` /
 # ``--port`` to the comfy-cli verbs that accept them (see ``_comfy_target`` /
-# ``_with_target`` and ``_TARGET_AWARE_SUBCOMMANDS`` below).
+# ``_with_target`` and ``_TARGET_AWARE`` below).
 DEFAULT_COMFYUI_PORT = 8188
 
 # Escape hatch for the one tool that REFUSES to run against a configured remote:
@@ -383,52 +389,100 @@ DEFAULT_COMFYUI_PORT = 8188
 REMOTE_SHARED_MODELS_ENV = "COMFY_MCP_REMOTE_SHARED_MODELS"
 _REMOTE_SHARED_MODELS_TRUE = frozenset({"1", "true", "yes", "on"})
 
-# The comfy-cli verbs this server forwards ``--host`` / ``--port`` to: ``comfy
-# run``, ``comfy run-template``, and every ``comfy jobs`` subcommand — every verb
-# that SUBMITS a job or reads one back, which is the set that has to agree on
-# which server it is talking to. ``run`` / ``jobs`` are the pair comfy-cli's
-# ``comfy_cli/host_port.py`` documents; ``run-template`` declares the same two
-# options and resolves them through that module's own ``resolve_host_port``
-# (``comfy_cli/command/templates.py``), it is just missing from that docstring's
-# list.
+# Which comfy-cli calls this server forwards ``--host`` / ``--port`` to, keyed by
+# VERB and — where the verb is not uniform — by subcommand:
 #
-# ``run-template`` is here because SUBMIT and POLL must land on the SAME server.
-# It backs both ``run_template`` and ``generate_image``, and while it was absent
-# the submit-then-poll flow did not merely run on the wrong box, it could not
-# complete at all: the run executed locally, ``wait_for_job`` (a ``jobs`` verb,
-# forwarded) polled the configured remote, and the local ``prompt_id`` came back
-# ``prompt_not_found`` from a queue it was never submitted to. Adding a verb here
-# is only safe when comfy-cli actually accepts the flags on it — otherwise the
-# forward turns every call into "No such option". There is no such window for
-# this one: ``run-template`` shipped WITH both options, in the same comfy-cli
-# release (1.13.0) that introduced the verb — which is also the floor
-# ``_check_comfy_version`` enforces (``_MIN_COMFY_CLI``). A comfy-cli old enough
-# to reject ``--host`` here has no ``run-template`` at all, so it fails on the
-# verb before the flags are ever parsed. That argument is about RELEASED
-# comfy-cli, and the floor guard deliberately fails OPEN, so a fork or source
-# build carrying ``run-template`` with its options stripped would still get a
-# Click usage error rather than a graceful degrade. No probe is added for it
-# because the exposure is not this verb's: ``run`` and ``jobs`` have been
+#   * value ``None``  → every subcommand of that verb (and its bare form).
+#   * a ``frozenset`` → only those subcommands; anything else passes through
+#     untouched, exactly as an unlisted verb does.
+#
+# The granularity is not decoration: ``comfy workflow`` is a MIXED group. Its
+# graph-shaped subcommands resolve ``object_info`` from a server and declare both
+# options, while ``workflow notes`` is an offline read of the file on disk and
+# declares NEITHER (``comfy_cli/command/workflow.py``) — so a verb-level
+# allowlist would hand ``notes`` an option typer has never heard of and turn a
+# working local call into a usage error. Any new mixed group belongs here as a
+# frozenset for the same reason; only a group that is uniform gets ``None``.
+#
+# ⚠️ BLOCKED UPSTREAM — the ``validate`` / ``nodes`` / ``workflow`` entries below
+# are NOT SAFE TO SHIP against today's comfy-cli. Declaring ``--host`` is only
+# half of accepting one: everything that resolves ``object_info`` goes through
+# ``comfy_cli.cql.engine._load_from_target``, which REFUSES a non-loopback host
+# in ``--where local`` mode ("Refusing to fetch object_info from non-loopback
+# host … (potential SSRF). Use --where cloud for remote targets") at BOTH the
+# v1.13.0 floor and ``main``. So forwarding a real remote to them turns calls
+# that work today into a hard ``cql_no_graph`` error. ``run`` / ``jobs`` /
+# ``run-template`` are unaffected — they reach the server through
+# ``host_port.resolve_host_port``, not through that loader. Lifting the guard for
+# an EXPLICIT ``--host`` (the way ``run`` already trusts one) is a comfy-cli
+# change; until it lands, this table must keep only the three run/job verbs.
+#
+# What is forwarded, and why each is safe (verified against comfy-cli v1.13.0 —
+# the floor ``_check_comfy_version`` enforces — and against its ``main``):
+#
+#   * ``run`` / ``jobs`` — the submit-and-poll pair comfy-cli's
+#     ``comfy_cli/host_port.py`` documents. A ``prompt_id`` only means something
+#     to the server that issued it, so these two must never disagree.
+#   * ``run-template`` — declares the same two options and resolves them through
+#     that module's own ``resolve_host_port`` (``comfy_cli/command/templates.py``),
+#     it is just missing from that docstring's list. It is here because SUBMIT and
+#     POLL must land on the SAME server: it backs both ``run_template`` and
+#     ``generate_image``, and while it was absent the flow did not merely run on
+#     the wrong box, it could not complete at all — the run executed locally,
+#     ``wait_for_job`` (a ``jobs`` verb, forwarded) polled the configured remote,
+#     and the local ``prompt_id`` came back ``prompt_not_found`` from a queue it
+#     was never submitted to.
+#   * ``validate`` — ``comfy validate`` reads the live ``object_info`` it checks a
+#     graph against from a server, and takes ``--host`` / ``--port`` to say which
+#     (``comfy_cli/cmdline.py``). Without them the verdict described THIS machine
+#     while ``run_workflow`` / ``run_template`` submitted elsewhere, so a workflow
+#     could pass the check here and fail there on a node the remote lacks — the
+#     advisory was answering about the wrong install.
+#   * ``nodes`` — every subcommand this server calls (``ls`` / ``show`` /
+#     ``search`` / ``upstream`` / ``downstream`` / ``path`` / ``types`` /
+#     ``categories``) is host-annotated in ``comfy_cli/command/nodes.py``; they all
+#     read the same live ``object_info``, so they answer about whichever install
+#     the graph will actually run on. (``nodes refresh`` takes no host, but this
+#     server does not wrap it — if it ever does, ``nodes`` becomes a frozenset.)
+#   * ``workflow slots`` / ``set-slot`` / ``vary`` — these resolve a workflow's
+#     slots against ``object_info`` too, so the slots they report and write are
+#     the ones the target install actually exposes.
+#
+# Adding a verb here is only safe when comfy-cli actually accepts the flags on it
+# — otherwise the forward turns every call into "No such option". Every entry
+# above is present at the enforced floor (v1.13.0), with one deliberate
+# exception: ``run-template`` shipped WITH both options in that same release, so
+# a comfy-cli old enough to reject ``--host`` here has no ``run-template`` at all
+# and fails on the verb before the flags are ever parsed. That argument is about
+# RELEASED comfy-cli, and the floor guard deliberately fails OPEN, so a fork or
+# source build carrying one of these verbs with its options stripped would still
+# get a Click usage error rather than a graceful degrade. No probe is added for
+# it because the exposure is not any one verb's: ``run`` and ``jobs`` have been
 # forwarded unprobed all along and would fail the same way. Probing (the
 # ``_comfy_run_takes_allow_spend`` shape) is the fix if that ever stops being
-# hypothetical — for ALL THREE verbs, not just this one.
+# hypothetical — for the whole table, not for one entry.
 #
 # Deliberately NOT forwarded:
-#   * ``env`` / ``download`` / ``upload`` / ``templates`` / ``models`` /
-#     ``generate`` / the lifecycle verbs take NO ``--host`` / ``--port`` at all,
-#     so forwarding would error "No such option" — they stay local-only. That is
-#     not always a functional limit: ``download`` still collects a REMOTE job's
-#     files, because it resolves the ``prompt_id`` from the state file this
-#     machine wrote at submit (which records absolute ``/view`` URLs on the
-#     remote) instead of asking a server — see ``fetch_outputs``.
-#   * ``nodes`` / ``validate`` DO accept ``--host`` / ``--port`` in current
-#     comfy-cli, but remoting live discovery/validation is out of scope here;
-#     forwarding them is a clean follow-up. Their local answers are advisory —
-#     ``run_workflow`` and ``run_template`` already submit to a remote whose node
-#     set a local check cannot see.
+#   * ``env`` / ``download`` / ``upload`` / ``templates`` / ``models`` / ``model``
+#     / ``generate`` / ``system-stats`` / ``free`` / ``which`` / the lifecycle
+#     verbs take NO ``--host`` / ``--port`` at all (only ``--where``), so
+#     forwarding would error "No such option" — they stay local-only. Giving them
+#     a target is comfy-cli work, not this repo's. That is not always a functional
+#     limit: ``download`` still collects a REMOTE job's files, because it resolves
+#     the ``prompt_id`` from the state file this machine wrote at submit (which
+#     records absolute ``/view`` URLs on the remote) instead of asking a server —
+#     see ``fetch_outputs``.
+#   * ``workflow notes`` — see the mixed-group note above.
 # Forwarding is a no-op for the local default regardless, so unconfigured
 # behavior is unchanged for every tool.
-_TARGET_AWARE_SUBCOMMANDS = frozenset({"run", "run-template", "jobs"})
+_TARGET_AWARE: dict[str, frozenset[str] | None] = {
+    "run": None,
+    "jobs": None,
+    "run-template": None,
+    "validate": None,
+    "nodes": None,
+    "workflow": frozenset({"slots", "set-slot", "vary"}),
+}
 
 # The envelope schema major version this server speaks. comfy-cli tags every
 # result with a ``schema`` like ``envelope/1``; the whole contract (result
@@ -1400,21 +1454,31 @@ def _comfy_target() -> tuple[str, int, str] | None:
 
 
 def _with_target(args: tuple[str, ...]) -> tuple[str, ...]:
-    """Append ``--host`` / ``--port`` to a target-aware subcommand, if configured.
+    """Append ``--host`` / ``--port`` to a target-aware call, if configured.
 
     The flags are injected into the SUBCOMMAND args (after the ``run`` /
-    ``run-template`` / ``jobs`` verb), never into the global ``--json`` /
-    ``--where`` prefix, since ``--host`` / ``--port`` are subcommand options.
-    A no-op for the local default (``_comfy_target`` is None) and for any
-    subcommand that doesn't accept the flags (see :data:`_TARGET_AWARE_SUBCOMMANDS`),
-    so unconfigured behavior is byte-identical to today.
+    ``nodes show`` / … verb), never into the global ``--json`` / ``--where``
+    prefix, since ``--host`` / ``--port`` are subcommand options. A no-op for the
+    local default (``_comfy_target`` is None) and for any call that doesn't
+    accept the flags (see :data:`_TARGET_AWARE`), so unconfigured behavior is
+    byte-identical to today.
+
+    The lookup is (verb, subcommand), not verb alone, because ``comfy workflow``
+    is a mixed group — see :data:`_TARGET_AWARE`.
     """
-    # Check the verb FIRST, then resolve the target. A malformed
-    # COMFYUI_URL/PORT must not brick local-only verbs (server_info's `env`,
-    # download, the stop/logs lifecycle) that never touch the remote — they'd
-    # otherwise raise ComfyCliError here despite ignoring the target entirely,
-    # breaking the "local behavior unchanged" contract (BE-3869 review).
-    if not args or args[0] not in _TARGET_AWARE_SUBCOMMANDS:
+    # Decide from the ARGV alone first, and only then resolve the target. A
+    # malformed COMFYUI_URL/PORT must not brick calls that never touch the remote
+    # (server_info's `env`, download, `workflow notes`, the stop/logs lifecycle)
+    # — they'd otherwise raise ComfyCliError here despite ignoring the target
+    # entirely, breaking the "local behavior unchanged" contract (BE-3869
+    # review). `test_remote_host.py` pins both halves of that ordering.
+    if not args or args[0] not in _TARGET_AWARE:
+        return args
+    subcommands = _TARGET_AWARE[args[0]]
+    if subcommands is not None and (len(args) < 2 or args[1] not in subcommands):
+        # A subcommand of a mixed group that takes no target (or a bare verb, or
+        # one comfy-cli grew since this table was written): pass through exactly
+        # as an unlisted verb does, rather than guessing it accepts the flags.
         return args
     target = _comfy_target()
     if target is None:
@@ -1439,7 +1503,7 @@ def _remote_shared_models_optin() -> bool:
 def _reject_remote_model_download() -> None:
     """Refuse a model download while a REMOTE ComfyUI target is configured.
 
-    ``comfy model download`` is not in :data:`_TARGET_AWARE_SUBCOMMANDS` and has
+    ``comfy model download`` is not in :data:`_TARGET_AWARE` and has
     no ``--host`` / ``--port`` to be added to it: comfy-cli resolves the
     destination from ``get_workspace()``, i.e. the models directory of the
     machine running THIS server. So with ``COMFYUI_URL`` / ``COMFYUI_HOST``
@@ -6563,7 +6627,7 @@ def fetch_outputs(
 
     That ``local`` means "not Comfy Cloud", NOT "not a remote ComfyUI". This verb
     takes no ``--host`` / ``--port`` and none is forwarded (see
-    :data:`_TARGET_AWARE_SUBCOMMANDS`), yet it still collects a job that ran on a
+    :data:`_TARGET_AWARE`), yet it still collects a job that ran on a
     configured remote — because it never asks a server which job that is. The
     comfy-cli run that SUBMITTED the job wrote a state file on THIS machine keyed
     by ``prompt_id``, and against a non-loopback target that file records each
@@ -8420,17 +8484,22 @@ def _unchecked(summary: str, reason: str) -> dict:
 
 
 def _local_template_check(workflow_path: str) -> dict:
-    """Cross-check a fetched template against the LOCAL install's ``object_info``.
+    """Cross-check a fetched template against the target install's ``object_info``.
 
     The gallery is served fresh from ``Comfy-Org/workflow_templates`` while the
     user's ComfyUI is whatever they installed, so a template can legitimately
     reference a node class — or an input option inside one, e.g. a partner
-    model key added in a later release — that this install does not expose yet.
+    model key added in a later release — that the install does not expose yet.
     Discovery then succeeds and the RUN fails, which is a bad place to find out.
     This runs ``comfy validate --workflow <path>`` (the same engine
     ``validate_workflow`` exposes: class_types, input shapes, enum values, edge
     wiring, all read from the running server's live ``object_info``) and turns
     its report into a block the agent can relay.
+
+    "Local" in the name is historical: ``validate`` is target-aware
+    (:data:`_TARGET_AWARE`), so with ``COMFYUI_URL`` / ``COMFYUI_HOST`` set the
+    comparison is made against the REMOTE the run will land on rather than this
+    machine — which is what makes the verdict worth relaying at all.
 
     Advisory only, and deliberately fail-OPEN: the template is already written
     and every caller still gets its path, a negative verdict is comfy-cli's own
@@ -8452,7 +8521,10 @@ def _local_template_check(workflow_path: str) -> dict:
                 "(the live node catalog was unreachable — the server may not be "
                 "running). The template was still written. Start ComfyUI with "
                 "`launch_comfyui`, then re-check with "
-                "`validate_workflow(workflow_path=...)`. "
+                "`validate_workflow(workflow_path=...)`. If a remote target is "
+                "configured (`server_info` reports it as `comfy_target`), the "
+                "check was aimed THERE — start or reach that machine instead; "
+                "`launch_comfyui` only starts the local one. "
                 f"Details: {str(exc)[:_MAX_ERROR_FIELD_CHARS]}",
                 "check_unavailable",
             )
@@ -8724,16 +8796,21 @@ def fetch_template(name: str, out_path: str, check_local: bool = True) -> dict:
 
 @mcp.tool()
 def search_nodes(query: str) -> Any:
-    """Search node classes in the LOCAL ComfyUI's live ``object_info``.
+    """Search node classes in the targeted ComfyUI's live ``object_info``.
 
-    Wraps ``comfy nodes search <query>``. Because the catalog is read from the
-    user's running install, results include their INSTALLED custom nodes — not a
+    Wraps ``comfy nodes search <query>``. Because the catalog is read from a
+    running install, results include its INSTALLED custom nodes — not a
     static/bundled catalog. Use this to find the class name of a node (e.g.
     "KSampler", "load image") before authoring or repairing a workflow graph;
     pass the returned name to ``get_node`` for its full schema.
 
-    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
-    call; reflects exactly what THIS install has (including its staleness: an
+    Target: follows ``COMFYUI_URL`` / ``COMFYUI_HOST`` (see :func:`_comfy_target`)
+    — with one set, ``--host`` / ``--port`` are forwarded and the catalog comes
+    from that REMOTE ComfyUI, the same machine ``run_workflow`` / ``run_template``
+    submit to. Unconfigured, it reads this machine's.
+
+    Freshness: LIVE — read from the targeted ComfyUI's ``object_info`` on every
+    call; reflects exactly what THAT install has (including its staleness: an
     outdated install lists outdated nodes).
     """
     # Bare positional: a leading-dash query is read as an option, not a search
@@ -8747,16 +8824,21 @@ def search_nodes(query: str) -> Any:
 
 @mcp.tool()
 def get_node(name: str) -> Any:
-    """Return one node class's full input/output schema from the live local catalog.
+    """Return one node class's full input/output schema from the live catalog.
 
     Wraps ``comfy nodes show <ClassName>``. ``name`` is the node's class name
     (as returned by ``search_nodes``). The schema — required/optional inputs,
     their types and defaults, and outputs — is what an agent needs to author or
-    repair a workflow graph. Reflects the user's live install, so it resolves
-    custom-node classes too (not just built-ins).
+    repair a workflow graph. Reflects a live install, so it resolves custom-node
+    classes too (not just built-ins).
 
-    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
-    call; reflects exactly what THIS install has (including its staleness: an
+    Target: follows ``COMFYUI_URL`` / ``COMFYUI_HOST`` (see :func:`_comfy_target`)
+    — with one set, ``--host`` / ``--port`` are forwarded and the schema comes
+    from that REMOTE ComfyUI, the same machine ``run_workflow`` / ``run_template``
+    submit to. Unconfigured, it reads this machine's.
+
+    Freshness: LIVE — read from the targeted ComfyUI's ``object_info`` on every
+    call; reflects exactly what THAT install has (including its staleness: an
     outdated install lists outdated nodes).
     """
     # Bare positional: a leading-dash name is read as an option rather than the
@@ -8774,7 +8856,7 @@ def list_nodes(
     pack: str = "",
     label: str = "",
 ) -> Any:
-    """List node classes from the live local ``object_info``, with optional filters.
+    """List node classes from the live ``object_info``, with optional filters.
 
     Wraps ``comfy nodes ls``. Each argument, when non-empty, adds the matching
     filter flag (empty ones are omitted, so a bare call lists everything):
@@ -8794,11 +8876,16 @@ def list_nodes(
       comfy-cli annotates (a purely local custom node carries none). This is not
       a display-name search; use ``search_nodes`` for that.
 
-    Reads the user's live install, so results include installed custom nodes —
-    the broad "what nodes can do X?" companion to ``search_nodes``' name search.
+    Reads a live install, so results include its installed custom nodes — the
+    broad "what nodes can do X?" companion to ``search_nodes``' name search.
 
-    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
-    call; reflects exactly what THIS install has (including its staleness: an
+    Target: follows ``COMFYUI_URL`` / ``COMFYUI_HOST`` (see :func:`_comfy_target`)
+    — with one set, ``--host`` / ``--port`` are forwarded and the catalog comes
+    from that REMOTE ComfyUI, the same machine ``run_workflow`` / ``run_template``
+    submit to. Unconfigured, it reads this machine's.
+
+    Freshness: LIVE — read from the targeted ComfyUI's ``object_info`` on every
+    call; reflects exactly what THAT install has (including its staleness: an
     outdated install lists outdated nodes).
     """
     args = ["nodes", "ls"]
@@ -8828,11 +8915,16 @@ def nodes_upstream(name: str, limit: int | None = None) -> Any:
 
     Wraps ``comfy nodes upstream <name> [--limit N]``. Answers "what can I wire
     INTO this node?" — the candidates that produce the types ``name`` accepts,
-    computed against the live local ``object_info`` (custom nodes included). Pass
+    computed against the live ``object_info`` (custom nodes included). Pass
     ``limit`` to cap the number of results; omit it for the full set.
 
-    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
-    call; reflects exactly what THIS install has (including its staleness: an
+    Target: follows ``COMFYUI_URL`` / ``COMFYUI_HOST`` (see :func:`_comfy_target`)
+    — with one set, ``--host`` / ``--port`` are forwarded and the graph comes from
+    that REMOTE ComfyUI, the same machine ``run_workflow`` / ``run_template``
+    submit to. Unconfigured, it reads this machine's.
+
+    Freshness: LIVE — read from the targeted ComfyUI's ``object_info`` on every
+    call; reflects exactly what THAT install has (including its staleness: an
     outdated install lists outdated nodes).
     """
     # Bare positional, and it sits beside this command's own `--limit`: a
@@ -8851,12 +8943,16 @@ def nodes_downstream(name: str, limit: int | None = None) -> Any:
 
     Wraps ``comfy nodes downstream <name> [--limit N]``. Answers "what can I wire
     this node INTO?" — the candidates whose inputs accept the types ``name``
-    produces, computed against the live local ``object_info`` (custom nodes
-    included). Pass ``limit`` to cap the number of results; omit it for the full
-    set.
+    produces, computed against the live ``object_info`` (custom nodes included).
+    Pass ``limit`` to cap the number of results; omit it for the full set.
 
-    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
-    call; reflects exactly what THIS install has (including its staleness: an
+    Target: follows ``COMFYUI_URL`` / ``COMFYUI_HOST`` (see :func:`_comfy_target`)
+    — with one set, ``--host`` / ``--port`` are forwarded and the graph comes from
+    that REMOTE ComfyUI, the same machine ``run_workflow`` / ``run_template``
+    submit to. Unconfigured, it reads this machine's.
+
+    Freshness: LIVE — read from the targeted ComfyUI's ``object_info`` on every
+    call; reflects exactly what THAT install has (including its staleness: an
     outdated install lists outdated nodes).
     """
     # Bare positional, and it sits beside this command's own `--limit`: a
@@ -8878,11 +8974,16 @@ def nodes_path(
     Wraps ``comfy nodes path <FROM> <TO> --max-depth N --max-paths N``. Given two
     connection types (e.g. ``MODEL`` → ``IMAGE``), returns sequences of nodes
     whose wiring carries a value from ``from_type`` to ``to_type`` over the live
-    local ``object_info`` graph. ``max_depth`` bounds the chain length and
+    ``object_info`` graph. ``max_depth`` bounds the chain length and
     ``max_paths`` caps how many routes are returned.
 
-    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
-    call; reflects exactly what THIS install has (including its staleness: an
+    Target: follows ``COMFYUI_URL`` / ``COMFYUI_HOST`` (see :func:`_comfy_target`)
+    — with one set, ``--host`` / ``--port`` are forwarded and the graph comes from
+    that REMOTE ComfyUI, the same machine ``run_workflow`` / ``run_template``
+    submit to. Unconfigured, it reads this machine's.
+
+    Freshness: LIVE — read from the targeted ComfyUI's ``object_info`` on every
+    call; reflects exactly what THAT install has (including its staleness: an
     outdated install lists outdated nodes).
     """
     # Two bare positionals ahead of `--max-depth` / `--max-paths`: a leading-dash
@@ -8912,15 +9013,20 @@ def nodes_path(
 
 @mcp.tool()
 def nodes_types() -> Any:
-    """List every connection type in the live local graph, ranked by connectivity.
+    """List every connection type in the live graph, ranked by connectivity.
 
     Wraps ``comfy nodes types``. Returns the set of edge types (``MODEL``,
-    ``IMAGE``, ``LATENT``, ``CONDITIONING``, …) present across the user's
-    installed nodes, ordered by how connective each is — the vocabulary you wire
+    ``IMAGE``, ``LATENT``, ``CONDITIONING``, …) present across the targeted
+    install's nodes, ordered by how connective each is — the vocabulary you wire
     with. Reflects custom nodes, so install-specific types show up too.
 
-    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
-    call; reflects exactly what THIS install has (including its staleness: an
+    Target: follows ``COMFYUI_URL`` / ``COMFYUI_HOST`` (see :func:`_comfy_target`)
+    — with one set, ``--host`` / ``--port`` are forwarded and the types come from
+    that REMOTE ComfyUI, the same machine ``run_workflow`` / ``run_template``
+    submit to. Unconfigured, it reads this machine's.
+
+    Freshness: LIVE — read from the targeted ComfyUI's ``object_info`` on every
+    call; reflects exactly what THAT install has (including its staleness: an
     outdated install lists outdated nodes).
     """
     return _run_comfy("nodes", "types", timeout=60.0)
@@ -8928,15 +9034,20 @@ def nodes_types() -> Any:
 
 @mcp.tool()
 def nodes_categories() -> Any:
-    """Return the node category tree from the live local ``object_info``.
+    """Return the node category tree from the live ``object_info``.
 
     Wraps ``comfy nodes categories``. Gives the menu-category hierarchy the
-    user's installed nodes fall under — a map for browsing what is available by
+    targeted install's nodes fall under — a map for browsing what is available by
     area (loaders, sampling, image, …) rather than by name. Reflects the live
     install, so custom-node categories appear too.
 
-    Freshness: LIVE — read from the running ComfyUI's ``object_info`` on every
-    call; reflects exactly what THIS install has (including its staleness: an
+    Target: follows ``COMFYUI_URL`` / ``COMFYUI_HOST`` (see :func:`_comfy_target`)
+    — with one set, ``--host`` / ``--port`` are forwarded and the tree comes from
+    that REMOTE ComfyUI, the same machine ``run_workflow`` / ``run_template``
+    submit to. Unconfigured, it reads this machine's.
+
+    Freshness: LIVE — read from the targeted ComfyUI's ``object_info`` on every
+    call; reflects exactly what THAT install has (including its staleness: an
     outdated install lists outdated nodes).
     """
     return _run_comfy("nodes", "categories", timeout=60.0)
@@ -10065,7 +10176,7 @@ def upload_file(paths: list[str], overwrite: bool = False) -> Any:
 
 @mcp.tool()
 def validate_workflow(workflow_path: str) -> Any:
-    """Pre-flight a workflow against the live local ComfyUI before running it.
+    """Pre-flight a workflow against the live ComfyUI before running it.
 
     Wraps ``comfy validate --workflow <path>``; call it as
     ``validate_workflow(workflow_path=...)``. Checks the workflow's
@@ -10075,6 +10186,13 @@ def validate_workflow(workflow_path: str) -> Any:
     raises :class:`ComfyCliError` carrying comfy-cli's structured error code
     (e.g. ``workflow_unknown_nodes``) and message, so a missing-node or
     missing-model problem stays actionable instead of failing deep inside a run.
+
+    Target: follows ``COMFYUI_URL`` / ``COMFYUI_HOST`` (see :func:`_comfy_target`)
+    — with one set, ``--host`` / ``--port`` are forwarded and the workflow is
+    checked against that REMOTE ComfyUI's catalog, i.e. the same install
+    ``run_workflow`` / ``run_template`` will actually run it on. That is the point
+    of forwarding here: a check answered by this machine could pass while the run
+    failed there on a node the remote lacks.
 
     Known blind spots (upstream comfy-cli, fixes in progress): a passing result
     does NOT currently guarantee the server will accept the workflow.
@@ -10140,6 +10258,14 @@ def list_workflow_slots(workflow_path: str) -> Any:
     Slots are tweakable PARAMETERS only. Note/MarkdownNote documentation text is
     not a slot — use ``list_workflow_notes`` to read what the template's author
     wrote (trigger words, model links, usage instructions).
+
+    Target: comfy-cli resolves a workflow's slots against a live ``object_info``,
+    so this follows ``COMFYUI_URL`` / ``COMFYUI_HOST`` (see
+    :func:`_comfy_target`) — with one set, ``--host`` / ``--port`` are forwarded
+    and the slots reported are the ones the REMOTE install exposes, i.e. the
+    machine ``run_workflow`` / ``run_template`` submit to. ``list_workflow_notes``
+    is the exception in this group: it is an offline file read that takes no
+    target at all.
     """
     # Bare positional, same as `set_workflow_slot` — a leading-dash path is read
     # as a flag rather than the path comfy-cli is meant to read.
@@ -10430,6 +10556,12 @@ def set_workflow_slot(
         ]
         modified = set_workflow_slot(path, overrides)
         # write `modified` to disk (or call with stdout=False), then run_workflow
+
+    Target: comfy-cli resolves the addresses against a live ``object_info``, so
+    this follows ``COMFYUI_URL`` / ``COMFYUI_HOST`` (see :func:`_comfy_target`) —
+    with one set, ``--host`` / ``--port`` are forwarded and the edit is resolved
+    against the REMOTE install the run will land on. The file it reads and writes
+    is always the local ``workflow_path``; only the slot resolution is remoted.
     """
     # `workflow_path` and each override are splatted in as bare positionals, so
     # a leading-dash entry is read by comfy-cli as a flag — e.g. `"--stdout"`
@@ -10692,6 +10824,12 @@ def vary_workflow(
     stdout; set ``out_dir`` to instead write ``<stem>_<N>.json`` files there (and
     forward ``--out-dir``). Run each variant with ``run_workflow`` to sweep a
     parameter grid.
+
+    Target: comfy-cli resolves the addresses against a live ``object_info``, so
+    this follows ``COMFYUI_URL`` / ``COMFYUI_HOST`` (see :func:`_comfy_target`) —
+    with one set, ``--host`` / ``--port`` are forwarded and the variants are
+    resolved against the REMOTE install the runs will land on. The files are
+    still read and written here; only the slot resolution is remoted.
     """
     # Bare positional, same as `set_workflow_slot` — a leading-dash path is read
     # as a flag rather than the path. `slots` and `out_dir` ride behind `--slot`

--- a/tests/test_address_env_docs.py
+++ b/tests/test_address_env_docs.py
@@ -117,20 +117,26 @@ def test_section_warns_against_setting_both(section: str):
 
 
 def test_target_aware_tools_do_not_claim_to_be_local_only():
-    """The run/job tools FOLLOW ``COMFYUI_URL``; their summaries must not deny it.
+    """Every target-aware tool FOLLOWS ``COMFYUI_URL``; no summary may deny it.
 
-    ``_TARGET_AWARE_SUBCOMMANDS`` is ``{"run", "run-template", "jobs"}``, so
-    exactly these tools are diverted to a configured remote. Their one-line
-    summaries used to open with "LOCAL", which is the one place the local/remote
-    distinction is load-bearing and was simply wrong. The tools that genuinely
-    stay on this machine (lifecycle, ``fetch_outputs``, discovery, …) keep saying
-    so, and are deliberately not covered here.
+    ``_TARGET_AWARE`` covers ``run`` / ``run-template`` / ``jobs`` (submit and
+    poll) plus ``validate`` / ``nodes`` / ``workflow slots``-``set-slot``-``vary``
+    (everything that reads a live node catalog), so exactly these tools are
+    diverted to a configured remote. Their one-line summaries used to open with
+    "LOCAL", which is the one place the local/remote distinction is load-bearing
+    and was simply wrong. The tools that genuinely stay on this machine
+    (lifecycle, ``fetch_outputs``, ``system_stats`` / ``free_memory``,
+    ``download_model``, the offline ``list_workflow_notes``, …) keep saying so,
+    and are deliberately not covered here.
 
     ``generate_image`` and ``run_template`` are the ``run-template`` pair: they
     were the tools whose summaries said LOCAL *while* their submissions really
     did stay local, and both halves moved together — forwarding the flags without
     correcting the summary would leave the one sentence a caller reads before
     deciding which machine a job lands on saying the opposite of what happens.
+    The discovery/validation block below is the same pairing one step later: a
+    summary that still says the answer describes the LOCAL install is the single
+    sentence an agent reads before trusting a node lookup or a pre-flight verdict.
     """
     for tool in (
         server.run_workflow,
@@ -141,6 +147,18 @@ def test_target_aware_tools_do_not_claim_to_be_local_only():
         server.watch_job,
         server.cancel_job,
         server.get_queue,
+        server.validate_workflow,
+        server.search_nodes,
+        server.get_node,
+        server.list_nodes,
+        server.nodes_upstream,
+        server.nodes_downstream,
+        server.nodes_path,
+        server.nodes_types,
+        server.nodes_categories,
+        server.list_workflow_slots,
+        server.set_workflow_slot,
+        server.vary_workflow,
     ):
         lines = (tool.__doc__ or "").strip().splitlines()
         # Report a missing docstring as itself: under `python -OO` (or if one is

--- a/tests/test_remote_host.py
+++ b/tests/test_remote_host.py
@@ -1,21 +1,28 @@
 """Tests for driving a configurable (remote/tailnet) ComfyUI host.
 
-The run/queue tools normally target the implicit local 127.0.0.1:8188. Setting
+The tools normally target the implicit local 127.0.0.1:8188. Setting
 ``COMFYUI_URL`` — or the ``COMFYUI_HOST`` / ``COMFYUI_PORT`` pair — points them
 at a ComfyUI running elsewhere by forwarding ``--host`` / ``--port`` to the
-comfy-cli verbs that accept them (``comfy run``, ``comfy run-template``, and
-every ``comfy jobs`` subcommand). These lock in:
+comfy-cli calls that accept them (``comfy run``, ``comfy run-template``, every
+``comfy jobs`` and ``comfy nodes`` subcommand, ``comfy validate``, and
+``comfy workflow slots`` / ``set-slot`` / ``vary``). These lock in:
 
 1. ``_comfy_target`` env parsing (URL, host/port, defaults, malformed values).
 2. ``--host`` / ``--port`` forwarded into the SUBCOMMAND (not the global prefix)
-   for ``run`` / ``run-template`` / ``jobs``, and NOT for verbs that don't accept
-   them (``env`` / ``download`` / ``upload`` / …).
+   for every entry in ``_TARGET_AWARE``, and NOT for calls that don't accept
+   them (``env`` / ``download`` / ``upload`` / ``workflow notes`` / …).
 3. Byte-identical local behavior when nothing is configured.
 4. ``server_info`` surfacing the configured ``comfy_target``.
 5. Submit and poll agreeing on ONE server: a ``generate_image`` / ``run_template``
    submission and the ``wait_for_job`` that follows it must carry the same
    ``--host`` / ``--port``, or the ``prompt_id`` from one is meaningless to the
    other.
+
+``_TARGET_AWARE`` is a (verb, subcommand) table rather than a verb allowlist
+because ``comfy workflow`` is a MIXED group — ``slots`` / ``set-slot`` / ``vary``
+resolve a live ``object_info`` and take the flags, ``notes`` is an offline file
+read and takes neither — so the negative assertion for ``workflow notes`` is the
+one that keeps the granularity from quietly collapsing back to a verb check.
 """
 
 from __future__ import annotations
@@ -299,6 +306,198 @@ def test_run_template_tool_submit_forwards_host_port(patched_run, monkeypatch):
     ]
 
 
+# --- discovery / validation / workflow authoring follow the target too --------
+#
+# These verbs do not submit a job, so nothing here can produce the
+# `prompt_not_found` the run-template gap did. What they produce is a confident
+# WRONG ANSWER: `validate_workflow` clearing a graph against this machine's node
+# set while `run_workflow` submits to a remote whose set differs, or
+# `list_workflow_slots` reporting slots the target install does not expose. The
+# fix is the same one — ask the machine the job will actually run on.
+
+_TARGET_FLAGS = ["--host", "gpu.example", "--port", "9001"]
+
+# (id, call, the leading argv tokens that call must build). The tail is asserted
+# separately as `_TARGET_FLAGS`, so a change to how the MIDDLE of an argv renders
+# (slot encoding, a new default flag) does not drag these assertions with it.
+_TARGET_AWARE_TOOL_CALLS = [
+    (
+        "validate_workflow",
+        lambda: server.validate_workflow("wf.json"),
+        ["validate", "--workflow", "wf.json"],
+    ),
+    (
+        "search_nodes",
+        lambda: server.search_nodes("KSampler"),
+        ["nodes", "search", "KSampler"],
+    ),
+    ("get_node", lambda: server.get_node("KSampler"), ["nodes", "show", "KSampler"]),
+    (
+        "list_nodes",
+        lambda: server.list_nodes(produces="IMAGE"),
+        ["nodes", "ls", "--produces", "IMAGE"],
+    ),
+    (
+        "nodes_upstream",
+        lambda: server.nodes_upstream("KSampler"),
+        ["nodes", "upstream", "KSampler"],
+    ),
+    (
+        "nodes_downstream",
+        lambda: server.nodes_downstream("KSampler"),
+        ["nodes", "downstream", "KSampler"],
+    ),
+    (
+        "nodes_path",
+        lambda: server.nodes_path("MODEL", "IMAGE"),
+        ["nodes", "path", "MODEL", "IMAGE"],
+    ),
+    ("nodes_types", lambda: server.nodes_types(), ["nodes", "types"]),
+    ("nodes_categories", lambda: server.nodes_categories(), ["nodes", "categories"]),
+    (
+        "list_workflow_slots",
+        lambda: server.list_workflow_slots("wf.json"),
+        ["workflow", "slots", "wf.json"],
+    ),
+    (
+        "set_workflow_slot",
+        lambda: server.set_workflow_slot(
+            "wf.json", [{"address": "6.text", "value": "a cat"}]
+        ),
+        ["workflow", "set-slot", "wf.json"],
+    ),
+    (
+        "vary_workflow",
+        lambda: server.vary_workflow(
+            "wf.json", [{"address": "3.seed", "values": [1, 2]}]
+        ),
+        ["workflow", "vary", "wf.json"],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("call", "head"),
+    [(call, head) for _id, call, head in _TARGET_AWARE_TOOL_CALLS],
+    ids=[tool_id for tool_id, _call, _head in _TARGET_AWARE_TOOL_CALLS],
+)
+def test_target_aware_tool_forwards_host_port(patched_run, monkeypatch, call, head):
+    """Each newly remoted tool appends the flags AFTER its subcommand args."""
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
+    calls = patched_run(envelope(data={"ok": True}))
+
+    call()
+
+    cmd = calls[0]["cmd"]
+    assert cmd[1:4] == ["--json", "--where", "local"]  # global prefix unchanged
+    assert cmd[4 : 4 + len(head)] == head
+    assert cmd[-4:] == _TARGET_FLAGS
+
+
+@pytest.mark.parametrize(
+    ("call", "head"),
+    [(call, head) for _id, call, head in _TARGET_AWARE_TOOL_CALLS],
+    ids=[tool_id for tool_id, _call, _head in _TARGET_AWARE_TOOL_CALLS],
+)
+def test_target_aware_tool_local_default_is_byte_identical(patched_run, call, head):
+    """...and with nothing configured each one builds exactly today's argv."""
+    calls = patched_run(envelope(data={"ok": True}))
+
+    call()
+
+    cmd = calls[0]["cmd"]
+    assert cmd[4 : 4 + len(head)] == head
+    assert "--host" not in cmd and "--port" not in cmd
+
+
+def test_workflow_notes_is_not_forwarded(patched_run, monkeypatch):
+    """`comfy workflow` is a MIXED group: `notes` declares no --host/--port.
+
+    This is the whole reason the allowlist is keyed on (verb, subcommand). Under
+    the old verb-level check, remoting `workflow slots` would have handed `notes`
+    an option typer has never heard of, turning a working offline read into a
+    Click usage error the envelope parser cannot even interpret.
+    """
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
+    calls = patched_run(envelope(data={"workflow": "wf.json", "count": 0, "notes": []}))
+
+    server.list_workflow_notes("wf.json")
+
+    assert calls[0]["cmd"][4:] == ["workflow", "notes", "wf.json"]
+
+
+def test_workflow_notes_survives_malformed_config(patched_run, monkeypatch):
+    """The BE-3869 ordering contract, at (verb, subcommand) granularity.
+
+    `_with_target` decides from the ARGV alone before it resolves the target, so
+    a malformed `COMFYUI_URL` cannot brick a call that would never have used it —
+    and that now has to hold for a non-target subcommand of a target-aware VERB,
+    not just for a wholly unlisted verb.
+    """
+    monkeypatch.setenv("COMFYUI_URL", "https://gpu.example")  # scheme rejected
+    calls = patched_run(envelope(data={"workflow": "wf.json", "count": 0, "notes": []}))
+
+    server.list_workflow_notes("wf.json")
+
+    assert calls[0]["cmd"][4:] == ["workflow", "notes", "wf.json"]
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("workflow",),  # bare verb, no subcommand to check
+        ("workflow", "notes", "wf.json"),
+        ("workflow", "list"),  # a subcommand the table does not name
+    ],
+)
+def test_unlisted_workflow_subcommands_pass_through(patched_run, monkeypatch, args):
+    """Anything outside the frozenset passes through exactly as an unlisted verb.
+
+    Including a subcommand comfy-cli may grow later: the table names what is
+    KNOWN to accept the flags, and everything else is left alone rather than
+    guessed at.
+    """
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
+    calls = patched_run(envelope())
+
+    server._run_comfy(*args)
+
+    assert calls[0]["cmd"][4:] == list(args)
+
+
+def test_validate_forwards_host_port_into_subcommand(patched_run, monkeypatch):
+    """The allowlist entry itself, driven through the raw wrapper.
+
+    `validate` is also reached from `_local_template_check` (the `local_check`
+    block on `fetch_template` / `get_template`), which builds the same argv.
+    """
+    monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
+    monkeypatch.setenv("COMFYUI_PORT", "9001")
+    calls = patched_run(envelope(data={"valid": True}))
+
+    server._run_comfy("validate", "--workflow", "wf.json")
+
+    assert calls[0]["cmd"][4:] == ["validate", "--workflow", "wf.json", *_TARGET_FLAGS]
+
+
+def test_fetch_template_local_check_forwards_host_port(patched_run, monkeypatch):
+    """`local_check` compares against the install the run will land on.
+
+    The blind spot this closes: the check cleared a template against THIS
+    machine's node set while `run_workflow` submitted to the remote, so a
+    template could pass the mandatory gate and still fail there on a missing node.
+    """
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
+    calls = patched_run(envelope(data={"valid": True, "errors": [], "warnings": []}))
+
+    server.fetch_template("image_flux2", "/tmp/wf.json")
+
+    assert calls[0]["cmd"][4:6] == ["templates", "fetch"]
+    assert "--host" not in calls[0]["cmd"]  # `templates` takes no target
+    assert calls[1]["cmd"][4] == "validate"
+    assert calls[1]["cmd"][-4:] == _TARGET_FLAGS
+
+
 def test_env_is_not_forwarded_host_port(patched_run, monkeypatch):
     """`comfy env` takes no --host/--port; forwarding would error 'No such option'."""
     monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
@@ -346,7 +545,7 @@ def test_fetch_outputs_docs_do_not_deny_remote_retrieval():
         "fetch_outputs no longer explains WHY it reaches a remote job's outputs "
         "— the state file is the whole mechanism"
     )
-    assert "_TARGET_AWARE_SUBCOMMANDS" in doc, (
+    assert "_TARGET_AWARE" in doc, (
         "the docstring no longer ties its behavior to the forwarding allowlist"
     )
     # The denial this guards against, in the spellings a rewrite would reach for.

--- a/tests/test_routing_instructions.py
+++ b/tests/test_routing_instructions.py
@@ -155,8 +155,8 @@ def test_routing_defers_to_comfy_target_instead_of_local_hardware(routing):
 def test_routing_names_every_submitting_tool_as_diverted(routing):
     """All three job-SUBMITTING tools follow ``comfy_target`` — the block must say so.
 
-    ``_TARGET_AWARE_SUBCOMMANDS`` covers ``run``, ``run-template`` and ``jobs``,
-    so ``run_workflow``, ``generate_image`` and ``run_template`` all submit to a
+    ``_TARGET_AWARE`` covers ``run``, ``run-template`` and ``jobs``, so
+    ``run_workflow``, ``generate_image`` and ``run_template`` all submit to a
     configured remote. The block used to name the last two as *still local*,
     which is the failure this guards against in both directions: an agent that
     believes ``generate_image`` runs here will apply this machine's VRAM


### PR DESCRIPTION
> **⚠️ DO NOT MERGE — WIP.** The implementation is complete, tested and lint-clean, but it is blocked on a comfy-cli change: today's comfy-cli **refuses** a non-loopback `--host` on exactly the verbs this PR starts forwarding to. Merging as-is would turn working local discovery/validation calls into hard errors for anyone with `COMFYUI_URL` set. Details and evidence below.

## ELI-5

The server can already point "run this job" at a ComfyUI on another machine. But "what nodes does it have?" and "will this workflow run?" still asked *this* machine — so a workflow could pass the check here and fail over there. This teaches those questions to follow the same address.

The catch found while building it: comfy-cli accepts the `--host` flag on those commands but then blocks any address that isn't this machine, as an anti-SSRF measure. So the flag exists and does nothing useful yet. The code is written and proven; it needs one upstream change before it can be switched on.

## What changed

**Allowlist → (verb, subcommand) table.** `_TARGET_AWARE_SUBCOMMANDS` (a `frozenset` of verbs) becomes `_TARGET_AWARE`, a `dict[str, frozenset[str] | None]`: `None` means "every subcommand", a `frozenset` names the ones that take the flags. `_with_target` consults it and passes everything else through untouched.

That granularity is load-bearing, not decoration. `comfy workflow` is a **mixed group** — `slots` / `set-slot` / `vary` resolve a live `object_info` and declare both options, while `workflow notes` is an offline read of the file on disk and declares neither (`comfy_cli/command/workflow.py`, verified at `v1.13.0` and on `main`). A verb-level check would hand `notes` an option typer has never heard of and turn a working local call into a Click usage error.

**Newly forwarded:** `comfy validate`, every `comfy nodes` subcommand this server calls (`ls` / `show` / `search` / `upstream` / `downstream` / `path` / `types` / `categories`), and `comfy workflow slots` / `set-slot` / `vary`. In tool terms: `validate_workflow`, the `local_check` block on `fetch_template` / `get_template`, `search_nodes`, `get_node`, `list_nodes`, `nodes_upstream`, `nodes_downstream`, `nodes_path`, `nodes_types`, `nodes_categories`, `list_workflow_slots`, `set_workflow_slot`, `vary_workflow`.

**Ordering contract preserved.** `_with_target` still decides entirely from the argv before it calls `_comfy_target()`, so a malformed `COMFYUI_URL` cannot brick a call that would never have used the target — and that now has to hold for a non-target *subcommand of a target-aware verb*, which is its own test.

**Docs + tests.** README's remote section, the address-variable table, the routing block in the server instructions, and every affected tool docstring were updated together. Tests add per-tool forwarding assertions, per-tool byte-identical-when-unconfigured assertions, and negative assertions for `workflow notes` (both configured and malformed-config), for unlisted `workflow` subcommands, and the pre-existing `env` / `download` / `upload` negatives unchanged.

## The blocker — why this is not ready

The ticket's fact-check confirmed that `validate`, `nodes *` and `workflow slots|set-slot|vary` all declare `--host` / `--port` at v1.13.0. That is true, and it is only half the story. **Declaring the option is not the same as accepting a value.** All of those commands resolve `object_info` through `comfy_cli.cql.engine._load_from_target`, which carries an anti-SSRF guard:

```python
# Loopback guard for local targets
if not target.is_cloud:
    parsed_host = urllib.parse.urlsplit(url).hostname or ""
    if not is_loopback_host(parsed_host):
        raise LoadError(
            f"Refusing to fetch object_info from non-loopback host {parsed_host!r} "
            f"in local mode (potential SSRF). Use --where cloud for remote targets."
        )
```

Present at the **v1.13.0 tag** (this server's enforced floor) and on **comfy-cli `main`**. `nodes` and `workflow` reach it through `cql.loader.resilient_load_object_info`, which calls the same function; `validate` reaches it through `Graph.load`.

**Empirically checked, not just read** — driving the real function from comfy-cli `main`:

```
127.0.0.1 -> cannot reach http://127.0.0.1:8188/object_info: [Errno 61] Connection refused
localhost -> cannot reach http://localhost:8188/object_info: [Errno 61] Connection refused
gpu-box   -> Refusing to fetch object_info from non-loopback host 'gpu-box' in local mode (potential SSRF)…
10.0.0.5  -> Refusing to fetch object_info from non-loopback host '10.0.0.5' in local mode (potential SSRF)…
```

Loopback hosts pass the guard and reach the HTTP fetch (refused here only because no ComfyUI is running). A real remote — the ticket's own acceptance example, `COMFYUI_URL=http://gpu-box:8188` — is refused outright.

So against today's engine this change is a **regression, not a feature**: with a remote configured, `search_nodes` / `get_node` / `validate_workflow` / `list_workflow_slots` and friends would fail with `cql_no_graph` where they currently return a (local, and admittedly less useful) answer. `set_workflow_slot` is the worst case — the `fetch_template` → `set_workflow_slot` → `run_workflow` on-ramp would break entirely for remote users.

`run` / `jobs` / `run-template` are unaffected: they reach the server through `comfy_cli/host_port.py`'s `resolve_host_port`, never through the `cql` loader. That asymmetry is exactly why remoting worked for the submit/poll set and silently would not for this one.

**The fix belongs upstream** (and AGENTS.md agrees — "if a feature can't be expressed as a `comfy` subcommand, the fix is a comfy-cli change, not a workaround in this repo"): comfy-cli should honor an **explicitly supplied** `--host` for `object_info` in local mode, the way `comfy run` already trusts one, keeping the guard for the implicit/default path. Once that lands, this PR flips to ready with no code change — only a re-verification.

I deliberately did **not** work around it here. The candidates were all bad: gating forwarding on a loopback target would duplicate an engine policy in this repo (and silently diverge when the guard is lifted) while delivering nothing the ticket asked for; `--where cloud` means Comfy Cloud, not "my GPU box".

## Judgment calls

- **Constant renamed** `_TARGET_AWARE_SUBCOMMANDS` → `_TARGET_AWARE` (the ticket's suggested shape). It is no longer a set of subcommands, so the old name would mislead. Four docstring references and one test tripwire assertion moved with it.
- **`list_nodes` included.** The ticket's call-site list omits it, but item 2 names `nodes ls` among the host-annotated subcommands and `"nodes": None` covers it; leaving it out would have been an inconsistency, not a smaller scope.
- **`nodes` maps to `None`, not a frozenset.** All eight subcommands this server calls are host-annotated; `nodes refresh` is not, but this server never wraps it. Noted in the comment: if it ever does, `nodes` becomes a frozenset.
- **`check_unavailable` guidance widened.** With a remote configured, the `local_check` failure path used to tell the caller to run `launch_comfyui`, which starts the *local* server. It now says so.
- **Dedup check not done.** The ticket asks to search for an existing ticket from the same line of work first; this worker has no tracker access. Worth noting that the immediately preceding work in that line (`run-template` forwarding, and the `download_model` remote refusal) is already on `main`, so the run/job half of the ticket's plan item 1 was already satisfied before this branch.
- **Concurrent branch.** Another in-flight change touches nearby README rows (the `system_stats` / `free_memory` table entries). No overlap with the sections here, but a trivial conflict is possible if both land.

## Verification

```
1471 passed, 4 skipped
ruff check .          → All checks passed!
ruff format --check . → 39 files already formatted
```

Note that a green suite is *not* evidence this is shippable — every test here mocks comfy-cli, so they prove the argv this server builds, not that comfy-cli accepts it. That gap is precisely what the empirical check above closes, and what it found.
