### PR TITLE
test: check every consent fake against the real SDK signature

### DIFF
--- a/tests/test_sdk_conformance.py
+++ b/tests/test_sdk_conformance.py
@@ -22,7 +22,7 @@ backstop for exactly that: it walks the test package and fails when a
 module-level double defines one of these methods without being listed.
 """
 
-import importlib
+import ast
 import inspect
 import pathlib
 
@@ -35,6 +35,19 @@ import test_run_workflow_spend
 import test_switch_version
 from mcp.server.mcpserver import Context
 from mcp.server.session import ServerSession
+
+_TESTS_DIR = pathlib.Path(__file__).parent
+
+
+def _label(fake: type) -> str:
+    """``module.QualName`` for a registered fake, so a failure names the file.
+
+    DERIVED from the class rather than typed beside it: a hand-written label can
+    be paired with the wrong object, and then the registry reads right while the
+    signature test checks some other fake twice and the real one goes unverified
+    — exactly the drift this module exists to catch.
+    """
+    return f"{fake.__module__}.{fake.__qualname__}"
 
 
 def _params(func) -> list[tuple[str, bool]]:
@@ -52,15 +65,15 @@ def _params(func) -> list[tuple[str, bool]]:
     ]
 
 
-# Every fake standing in for the real `Context.elicit`, named by where it lives
-# so a failure says which module to fix. One per consent gate: the three spend
-# gates, the version switch, and the network-exposure gate on the launch pair.
+# Every fake standing in for the real `Context.elicit`. One per consent gate: the
+# three spend gates, the version switch, and the network-exposure gate on the
+# launch pair. Each entry is the class itself — `_label` says where it lives.
 _ELICIT_FAKES = [
-    ("test_network_exposure._FakeCtx", test_network_exposure._FakeCtx),
-    ("test_partner_generate._FakeCtx", test_partner_generate._FakeCtx),
-    ("test_run_template._FakeCtx", test_run_template._FakeCtx),
-    ("test_run_workflow_spend._FakeCtx", test_run_workflow_spend._FakeCtx),
-    ("test_switch_version._FakeCtx", test_switch_version._FakeCtx),
+    test_network_exposure._FakeCtx,
+    test_partner_generate._FakeCtx,
+    test_run_template._FakeCtx,
+    test_run_workflow_spend._FakeCtx,
+    test_switch_version._FakeCtx,
 ]
 
 # Only the doubles that stand in for a context which also carries progress: the
@@ -69,17 +82,17 @@ _ELICIT_FAKES = [
 # neither tool streams, so registering them here would assert a method their
 # production path never calls.
 _PROGRESS_FAKES = [
-    ("conftest._RecordingCtx", conftest._RecordingCtx),
-    ("test_run_template._FakeCtx", test_run_template._FakeCtx),
-    ("test_run_workflow_spend._FakeCtx", test_run_workflow_spend._FakeCtx),
+    conftest._RecordingCtx,
+    test_run_template._FakeCtx,
+    test_run_workflow_spend._FakeCtx,
 ]
 
 _SESSION_FAKES = [
-    ("test_network_exposure._FakeSession", test_network_exposure._FakeSession),
-    ("test_partner_generate._FakeSession", test_partner_generate._FakeSession),
-    ("test_run_template._FakeSession", test_run_template._FakeSession),
-    ("test_run_workflow_spend._FakeSession", test_run_workflow_spend._FakeSession),
-    ("test_switch_version._FakeSession", test_switch_version._FakeSession),
+    test_network_exposure._FakeSession,
+    test_partner_generate._FakeSession,
+    test_run_template._FakeSession,
+    test_run_workflow_spend._FakeSession,
+    test_switch_version._FakeSession,
 ]
 
 #: Which registry above owns each SDK method a double may stand in for. Drives
@@ -91,55 +104,85 @@ _REGISTRY_BY_METHOD = {
 }
 
 
-def _discover_fakes(method: str) -> set[str]:
-    """Labels of every module-level class in ``tests/`` that defines ``method``.
+def _defines(node: ast.ClassDef, method: str) -> bool:
+    """Does this class body bind ``method`` ITSELF, rather than inherit it?
 
-    Own-``__dict__`` only, so a subclass that merely inherits the method is not
-    double-counted, and same-module only, so an imported name is attributed
-    where it is defined rather than everywhere it is used. The one-off doubles
-    defined INSIDE a test function are deliberately out of reach: they are
-    narrow overrides of a registered fake, scoped to a single assertion.
+    Mirrors the old ``method in vars(cls)``: a subclass that merely inherits a
+    registered fake's method is not a second copy and needs no second entry.
+    An ASSIGNED binding (``elicit = _raiser``) counts too, for the same reason
+    ``vars()`` counted it — it is a stand-in the call sites reach all the same.
+    """
+    for stmt in node.body:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if stmt.name == method:
+                return True
+        elif isinstance(stmt, ast.Assign):
+            if any(isinstance(t, ast.Name) and t.id == method for t in stmt.targets):
+                return True
+        elif isinstance(stmt, ast.AnnAssign):
+            if isinstance(stmt.target, ast.Name) and stmt.target.id == method:
+                return True
+    return False
+
+
+def _discover_fakes(method: str) -> set[str]:
+    """Labels of every module-level class under ``tests/`` that defines ``method``.
+
+    Read from the SOURCE with :mod:`ast` rather than by importing each file. The
+    walk has to be recursive — ``tests/e2e/`` already exists, and a double added
+    there must not slip past — but a nested directory is only importable once
+    pytest has collected something in it, so an import-based walk would depend
+    on which files the run happened to select. Parsing sees every file the same
+    way whether the suite runs whole or one file at a time, and imports nothing
+    that pytest would not have imported anyway.
+
+    Module-level classes only, and named by the class rather than by whatever
+    binds it, so a module-level alias of a registered fake is not a second copy
+    demanding a redundant entry. The one-off doubles defined INSIDE a test
+    function stay out of scope: no registry could name them (another module
+    cannot import a function-local class), and they are explode-on-call
+    stand-ins whose own test asserts the failure they produce — so drift there
+    surfaces as that test failing, not as a silently green one.
     """
     found: set[str] = set()
-    for path in sorted(pathlib.Path(__file__).parent.glob("*.py")):
-        module = importlib.import_module(path.stem)
-        for attr, obj in vars(module).items():
-            own = inspect.isclass(obj) and obj.__module__ == module.__name__
-            if own and method in vars(obj):
-                found.add(f"{module.__name__}.{attr}")
+    for path in sorted(_TESTS_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and _defines(node, method):
+                # `path.stem` is how pytest imports these — `tests/` has no
+                # `__init__.py`, so each file's `__module__` is its bare stem.
+                found.add(f"{path.stem}.{node.name}")
     return found
 
 
-@pytest.mark.parametrize("label,fake", _ELICIT_FAKES, ids=[n for n, _ in _ELICIT_FAKES])
-def test_fake_elicit_matches_the_real_context_signature(label, fake):
+@pytest.mark.parametrize("fake", _ELICIT_FAKES, ids=_label)
+def test_fake_elicit_matches_the_real_context_signature(fake):
     """A renamed ``elicit`` keyword must fail HERE, not as a spend-path TypeError."""
-    assert _params(fake.elicit) == _params(Context.elicit), label
+    assert _params(fake.elicit) == _params(Context.elicit), _label(fake)
     assert inspect.iscoroutinefunction(fake.elicit) == inspect.iscoroutinefunction(
         Context.elicit
-    ), label
+    ), _label(fake)
 
 
-@pytest.mark.parametrize(
-    "label,fake", _PROGRESS_FAKES, ids=[n for n, _ in _PROGRESS_FAKES]
-)
-def test_fake_report_progress_matches_the_real_context_signature(label, fake):
+@pytest.mark.parametrize("fake", _PROGRESS_FAKES, ids=_label)
+def test_fake_report_progress_matches_the_real_context_signature(fake):
     """The production call only debug-logs on failure, so drift is silent there."""
-    assert _params(fake.report_progress) == _params(Context.report_progress), label
+    assert _params(fake.report_progress) == _params(Context.report_progress), _label(
+        fake
+    )
     assert inspect.iscoroutinefunction(
         fake.report_progress
-    ) == inspect.iscoroutinefunction(Context.report_progress), label
+    ) == inspect.iscoroutinefunction(Context.report_progress), _label(fake)
 
 
-@pytest.mark.parametrize(
-    "label,fake", _SESSION_FAKES, ids=[n for n, _ in _SESSION_FAKES]
-)
-def test_fake_check_client_capability_matches_the_real_session_signature(label, fake):
+@pytest.mark.parametrize("fake", _SESSION_FAKES, ids=_label)
+def test_fake_check_client_capability_matches_the_real_session_signature(fake):
     """The capability probe decides whether a human is asked before money moves."""
     real = ServerSession.check_client_capability
-    assert _params(fake.check_client_capability) == _params(real), label
+    assert _params(fake.check_client_capability) == _params(real), _label(fake)
     assert inspect.iscoroutinefunction(
         fake.check_client_capability
-    ) == inspect.iscoroutinefunction(real), label
+    ) == inspect.iscoroutinefunction(real), _label(fake)
 
 
 @pytest.mark.parametrize("method", sorted(_REGISTRY_BY_METHOD))
@@ -154,7 +197,10 @@ def test_every_module_level_fake_is_registered(method):
     no longer defines the method.
     """
     registry_name, registry = _REGISTRY_BY_METHOD[method]
-    assert _discover_fakes(method) == {label for label, _ in registry}, registry_name
+    labels = [_label(fake) for fake in registry]
+    # Checked before the set compare, which would otherwise absorb a duplicate.
+    assert len(labels) == len(set(labels)), registry_name
+    assert _discover_fakes(method) == set(labels), registry_name
 
 
 def test_the_spend_prompt_keywords_bind_to_the_real_elicit():

--- a/tests/test_sdk_conformance.py
+++ b/tests/test_sdk_conformance.py
@@ -12,14 +12,27 @@ notifications — while the fakes keep the suite green.
 These tests close that loop by asserting each fake against the REAL signature
 imported from the installed SDK. They are cheap, and they are the reason a
 future major bump fails loudly here instead of quietly in production.
+
+Each consent gate keeps its OWN copy of those fakes on purpose — the copies are
+documented as deliberate in the files that hold them, so that a change to one
+tool's prompt cannot silently retune another tool's tests. That decision stands;
+what it costs is that the registries below have to name every copy, because a
+copy nobody registered is a copy that can drift. :func:`_discover_fakes` is the
+backstop for exactly that: it walks the test package and fails when a
+module-level double defines one of these methods without being listed.
 """
 
+import importlib
 import inspect
+import pathlib
 
 import conftest
 import pytest
+import test_network_exposure
 import test_partner_generate
 import test_run_template
+import test_run_workflow_spend
+import test_switch_version
 from mcp.server.mcpserver import Context
 from mcp.server.session import ServerSession
 
@@ -40,21 +53,61 @@ def _params(func) -> list[tuple[str, bool]]:
 
 
 # Every fake standing in for the real `Context.elicit`, named by where it lives
-# so a failure says which module to fix.
+# so a failure says which module to fix. One per consent gate: the three spend
+# gates, the version switch, and the network-exposure gate on the launch pair.
 _ELICIT_FAKES = [
+    ("test_network_exposure._FakeCtx", test_network_exposure._FakeCtx),
     ("test_partner_generate._FakeCtx", test_partner_generate._FakeCtx),
     ("test_run_template._FakeCtx", test_run_template._FakeCtx),
+    ("test_run_workflow_spend._FakeCtx", test_run_workflow_spend._FakeCtx),
+    ("test_switch_version._FakeCtx", test_switch_version._FakeCtx),
 ]
 
+# Only the doubles that stand in for a context which also carries progress: the
+# two STREAMING run verbs hand the same object to the prompt and to the run. The
+# `switch_version` / `network_exposure` fakes have no `report_progress` because
+# neither tool streams, so registering them here would assert a method their
+# production path never calls.
 _PROGRESS_FAKES = [
     ("conftest._RecordingCtx", conftest._RecordingCtx),
     ("test_run_template._FakeCtx", test_run_template._FakeCtx),
+    ("test_run_workflow_spend._FakeCtx", test_run_workflow_spend._FakeCtx),
 ]
 
 _SESSION_FAKES = [
+    ("test_network_exposure._FakeSession", test_network_exposure._FakeSession),
     ("test_partner_generate._FakeSession", test_partner_generate._FakeSession),
     ("test_run_template._FakeSession", test_run_template._FakeSession),
+    ("test_run_workflow_spend._FakeSession", test_run_workflow_spend._FakeSession),
+    ("test_switch_version._FakeSession", test_switch_version._FakeSession),
 ]
+
+#: Which registry above owns each SDK method a double may stand in for. Drives
+#: the completeness check below, so adding a registry means adding an entry here.
+_REGISTRY_BY_METHOD = {
+    "elicit": ("_ELICIT_FAKES", _ELICIT_FAKES),
+    "report_progress": ("_PROGRESS_FAKES", _PROGRESS_FAKES),
+    "check_client_capability": ("_SESSION_FAKES", _SESSION_FAKES),
+}
+
+
+def _discover_fakes(method: str) -> set[str]:
+    """Labels of every module-level class in ``tests/`` that defines ``method``.
+
+    Own-``__dict__`` only, so a subclass that merely inherits the method is not
+    double-counted, and same-module only, so an imported name is attributed
+    where it is defined rather than everywhere it is used. The one-off doubles
+    defined INSIDE a test function are deliberately out of reach: they are
+    narrow overrides of a registered fake, scoped to a single assertion.
+    """
+    found: set[str] = set()
+    for path in sorted(pathlib.Path(__file__).parent.glob("*.py")):
+        module = importlib.import_module(path.stem)
+        for attr, obj in vars(module).items():
+            own = inspect.isclass(obj) and obj.__module__ == module.__name__
+            if own and method in vars(obj):
+                found.add(f"{module.__name__}.{attr}")
+    return found
 
 
 @pytest.mark.parametrize("label,fake", _ELICIT_FAKES, ids=[n for n, _ in _ELICIT_FAKES])
@@ -87,6 +140,21 @@ def test_fake_check_client_capability_matches_the_real_session_signature(label, 
     assert inspect.iscoroutinefunction(
         fake.check_client_capability
     ) == inspect.iscoroutinefunction(real), label
+
+
+@pytest.mark.parametrize("method", sorted(_REGISTRY_BY_METHOD))
+def test_every_module_level_fake_is_registered(method):
+    """A sixth copy of a consent fake must be CHECKED, not merely written.
+
+    The registries above are hand-written, and hand-written lists rot: three of
+    the five consent fakes went unlisted for as long as they existed, so they
+    could have drifted from the SDK while their own tests stayed green. This
+    asserts the lists name every module-level double, in both directions — an
+    unregistered fake fails here, and so does a registry entry for a class that
+    no longer defines the method.
+    """
+    registry_name, registry = _REGISTRY_BY_METHOD[method]
+    assert _discover_fakes(method) == {label for label, _ in registry}, registry_name
 
 
 def test_the_spend_prompt_keywords_bind_to_the_real_elicit():


### PR DESCRIPTION
## ELI-5

The consent tests never talk to a real MCP client — they use hand-written stand-ins ("fakes") for the SDK's `Context` and `ServerSession`. There is one copy per gate, five in total. A separate test file, `test_sdk_conformance.py`, exists to check those fakes still match the real SDK, so that if the SDK renames an argument we find out from a red test instead of from users seeing "could not confirm the credit spend" on every paid call. It was only checking two of the five. This registers the other three, and adds a check that catches the next unregistered copy automatically.

## Summary

`tests/test_sdk_conformance.py` asserted only 2 of the 5 hand-rolled `Context`/`ServerSession` doubles against the real SDK signature. The three unlisted copies — `run_workflow`'s spend gate, `switch_comfyui_version`, and the network-exposure gate on the `launch_comfyui`/`restart_comfyui` pair — could drift from `Context.elicit` / `ServerSession.check_client_capability` while their own consent tests stayed green. That is precisely the failure mode that module's docstring says it exists to prevent, on the paths where it costs the most: the production call sites pass by keyword inside broad `except` handlers, so a signature change lands as a `TypeError` that surfaces as a failed confirmation on every gated call.

## Changes

- `_ELICIT_FAKES` — added `test_run_workflow_spend._FakeCtx`, `test_switch_version._FakeCtx`, `test_network_exposure._FakeCtx` (now all five gates).
- `_SESSION_FAKES` — added those three modules' `_FakeSession` (now all five).
- `_PROGRESS_FAKES` — added `test_run_workflow_spend._FakeCtx` only. It has `report_progress` because `run_workflow` hands the same context to the prompt and to the streaming run; the `switch_version` and `network_exposure` fakes have none because neither tool streams, so listing them would assert a method their production path never calls.
- New `test_every_module_level_fake_is_registered` + `_discover_fakes` — walks the test package and fails when a module-level double defines `elicit` / `report_progress` / `check_client_capability` without being listed in the matching registry. The comparison runs in both directions, so a registry entry for a class that no longer defines the method fails too.

The per-file duplication is **kept**. Four of the five copies carry an explicit comment stating why they are copies (a change to one tool's prompt must not silently retune another tool's tests), and hoisting them into `conftest.py` would override that documented decision on the consent/money path. `conftest.py`'s "one fake rather than a copy per test file" line and `AGENTS.md`'s equivalent are both scoped to the **comfy-cli spawn** helpers, not to these; `AGENTS.md` explicitly allows a local stub "where the call genuinely differs".

## Motivation

Follow-up to #158 (closed as part of the groom sweep that filed it). Security-adjacent only in that these fakes are the contract the consent and spend gates are asserted against; the change itself is test-only and additive.

## Testing

- [x] Existing tests pass (`pytest`) — 1459 passed, 4 skipped (was 1449 + 4; the 10 new cases are 3 elicit + 1 progress + 3 session parametrizations plus the 3-way completeness check).
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Falsified the new guard rather than only asserting it green: removing `test_switch_version._FakeCtx` from `_ELICIT_FAKES` makes `test_every_module_level_fake_is_registered[elicit]` fail with `Extra items in the left set: 'test_switch_version._FakeCtx'`, then passes again once restored. The three newly-registered fakes pass the signature assertions as written, so they match the installed SDK today — the value is that they cannot silently stop matching.

## Additional Notes

**Judgment call — one thing beyond the three registrations.** The ticket's plan was the three additive list edits. I also added the completeness guard, because the registries are hand-written and the gap being fixed here is exactly "a copy nobody listed": without it, the sixth copy reintroduces this ticket. It is ~25 test-only lines and no existing test changed behavior. Say the word if you'd rather ship the three registrations alone and I'll drop it.

Two deliberate limits in `_discover_fakes`, both documented in its docstring: it looks at a class's own `__dict__` (so a subclass that merely inherits is not double-counted) and only at module-level classes. The one-off doubles defined *inside* a test function (`_BrokenCtx`, `_SilentCtx`, `_ExplodingSession`, …) are intentionally out of scope — they are narrow overrides of a registered fake, scoped to a single assertion, and sweeping them in would make the registries churn on every new scenario test. It also assumes the flat `tests/` layout (`glob("*.py")` + import by stem), which is what the existing top-level `import conftest` in this file already relies on.

**Negative-claim falsification:** not applicable — the trigger does not fire. This diff adds no "not supported"/"unavailable"/"STOP" string, no throw/deny dead-end, and flips no test to assert a dead-end. It denies no capability; it only widens which existing test doubles get checked against the SDK.
