### PR TITLE
refactor: extract the shared bounded-poll loop behind wait_for_job and _poll_download

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -6175,9 +6175,30 @@ def _poll_until_terminal(
     ``timeout_seconds`` must already be bounded by the caller (see
     :func:`_bounded_timeout`): left raw, ``inf`` keeps ``remaining`` positive
     forever and NaN makes every comparison False, either of which re-spawns
-    comfy-cli until the client gives up.
+    comfy-cli until the client gives up. Extracting the loop moved that clamp
+    away from the code it protects, so the precondition is CHECKED here rather
+    than merely documented — a third caller that forgets ``_bounded_timeout``
+    gets a raise, not an unbounded spawn loop. The ceiling itself stays the
+    caller's (each tool has its own), so this is only the finiteness half —
+    and only that half: a bound at or below zero is legal here and reaches the
+    one-poll minimum on purpose (``download_model`` spends what its submit left,
+    which can land at or under zero, and still wants a real status back).
     """
+    if not math.isfinite(timeout_seconds):
+        raise ComfyCliError(
+            f"invalid timeout_seconds: {timeout_seconds!r} — expected a finite "
+            "number of seconds (clamp with `_bounded_timeout` first)."
+        )
+    # `timed_out` and `status` are the loop's OWN keys: `download_model` reads
+    # `result.get("timed_out")` to tell an expiry from a real result, and the
+    # unpack below sits after the `timed_out` literal — so an extra carrying
+    # either key would win, silently turning a timeout into a payload that falls
+    # through to `_download_failed`. No caller passes one; reject rather than let
+    # dict-unpack order quietly decide the envelope's meaning.
     extra = timed_out_extra or {}
+    reserved = sorted(extra.keys() & {"timed_out", "status"})
+    if reserved:
+        raise ValueError(f"timed_out_extra may not carry reserved keys: {reserved}")
     deadline = time.monotonic() + timeout_seconds
     last: Any = None
     while True:

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -6198,7 +6198,10 @@ def _poll_until_terminal(
     extra = timed_out_extra or {}
     reserved = sorted(extra.keys() & {"timed_out", "status"})
     if reserved:
-        raise ValueError(f"timed_out_extra may not carry reserved keys: {reserved}")
+        raise ComfyCliError(
+            f"timed_out_extra may not carry reserved keys: {reserved} — they are "
+            "the poll loop's own."
+        )
     deadline = time.monotonic() + timeout_seconds
     last: Any = None
     while True:

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -71,6 +71,7 @@ import tempfile
 import threading
 import time
 import unicodedata
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, NamedTuple, TypeVar
 from urllib.parse import urlparse
@@ -494,18 +495,21 @@ _DOWNLOAD_SYNC_TIMEOUT = 1800.0
 # rather than one status poll.
 _MIN_LEGACY_DOWNLOAD_TIMEOUT = 1.0
 
-# Sleep between `model download-status` polls. Matches `wait_for_job`'s cadence:
-# a download's state file is rewritten at most once a second, so polling faster
-# buys nothing.
-_DOWNLOAD_POLL_INTERVAL = 2.0
+# Sleep between polls in the shared bounded-poll loop (`_poll_until_terminal`) —
+# `wait_for_job`'s `jobs status` polls and `_poll_download`'s
+# `model download-status` polls run on the same cadence: a job's queue state and
+# a download's state file are each rewritten at most once a second, so polling
+# faster buys nothing. One named constant rather than two identical 2.0s that
+# would only ever drift apart.
+_POLL_INTERVAL = 2.0
 
-# Per-poll subprocess budget for `wait_for_job`'s `comfy jobs status` calls, and
-# the smallest slice worth spawning one for. `wait_for_job` caps each poll to
-# whatever is left of the caller's own bound, so a wedged status call can't hold
-# a one-second wait open for the full budget; the floor keeps a sliver of
-# remaining time from spawning a poll that is guaranteed to hit its own deadline.
-# `_poll_download` polls `comfy model download-status` on the same terms and
-# shares these two rather than minting a second pair that would only ever drift.
+# Per-poll subprocess budget for the shared bounded-poll loop's calls
+# (`wait_for_job`'s `comfy jobs status`, `_poll_download`'s
+# `comfy model download-status`), and the smallest slice worth spawning one for.
+# Each poll is capped to whatever is left of the caller's own bound, so a wedged
+# status call can't hold a one-second wait open for the full budget; the floor
+# keeps a sliver of remaining time from spawning a poll that is guaranteed to hit
+# its own deadline.
 _JOB_STATUS_POLL_TIMEOUT = 60.0
 _MIN_JOB_STATUS_POLL_TIMEOUT = 1.0
 
@@ -6148,6 +6152,80 @@ def _is_terminal(status: Any) -> bool:
     return False
 
 
+def _poll_until_terminal(
+    *args: str,
+    timeout_seconds: float,
+    is_terminal: Callable[[Any], bool],
+    timed_out_extra: dict[str, Any] | None = None,
+) -> Any:
+    """Poll ``comfy <args>`` until ``is_terminal`` or ``timeout_seconds`` expires.
+
+    The one bounded-poll loop behind :func:`wait_for_job` (``jobs status``) and
+    :func:`_poll_download` (``model download-status``). Those two ran
+    statement-for-statement identical loops and differ only in argv, in the
+    terminal predicate, and in the extra keys their timed-out payload carries —
+    so the timing rules below hold identically for both, and cannot drift apart.
+
+    Returns the first payload ``is_terminal`` accepts, or ``{"timed_out": True,
+    **timed_out_extra, "status": <last payload>}`` on expiry (the extras go in
+    FRONT of ``status``, preserving the key order each caller already returned).
+    A terminal FAILURE payload is returned like any other terminal one; deciding
+    whether that is an error is the caller's job.
+
+    ``timeout_seconds`` must already be bounded by the caller (see
+    :func:`_bounded_timeout`): left raw, ``inf`` keeps ``remaining`` positive
+    forever and NaN makes every comparison False, either of which re-spawns
+    comfy-cli until the client gives up.
+    """
+    extra = timed_out_extra or {}
+    deadline = time.monotonic() + timeout_seconds
+    last: Any = None
+    while True:
+        # `last is not None` keeps the one-poll minimum: a bound small enough to
+        # expire before the first poll (`timeout_seconds=1e-9`) must still report
+        # a real status rather than the degenerate `{"status": None}`.
+        remaining = deadline - time.monotonic()
+        if remaining <= 0 and last is not None:
+            return {"timed_out": True, **extra, "status": last}
+        # Cap each poll's own subprocess budget to what is left of the caller's
+        # bound. With a fixed 60s per poll the overall wait was only bounded
+        # between polls, so a wedged poll could hold a `timeout_seconds=1` call
+        # open for a full minute. The floor keeps a sliver of remaining time from
+        # spawning a poll that is guaranteed to hit its own deadline (and raise)
+        # instead of returning `timed_out`; it overshoots the caller's bound by
+        # at most that floor, never by 60s.
+        try:
+            last = _run_comfy(
+                *args,
+                timeout=min(
+                    _JOB_STATUS_POLL_TIMEOUT,
+                    max(remaining, _MIN_JOB_STATUS_POLL_TIMEOUT),
+                ),
+            )
+        except ComfyCliError as exc:
+            # Capping the poll to the time left means its deadline now doubles as
+            # the CALLER's: a slow-but-healthy poll (cold start plus imports)
+            # near the bound is killed where the old fixed 60s budget would have
+            # let it finish. That is this call expiring, not comfy-cli failing,
+            # so honor the documented envelope — and keep the last real status
+            # instead of discarding it with the exception. Two timeouts still
+            # raise, because neither is the caller's bound expiring: one with
+            # time left on that bound (the poll burned the full
+            # `_JOB_STATUS_POLL_TIMEOUT` — comfy-cli is genuinely wedged, which
+            # raised before this cap existed too), and one with no status yet
+            # read, where `{"status": None}` would bury a real failure under a
+            # contentless envelope.
+            if not exc.timed_out or last is None or deadline - time.monotonic() > 0:
+                raise
+            return {"timed_out": True, **extra, "status": last}
+        if is_terminal(last):
+            return last
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return {"timed_out": True, **extra, "status": last}
+        time.sleep(min(_POLL_INTERVAL, remaining))
+
+
 @mcp.tool()
 def wait_for_job(prompt_id: str, timeout_seconds: float = 25.0) -> Any:
     """Wait (bounded) for a submitted job to reach a terminal status.
@@ -6172,59 +6250,17 @@ def wait_for_job(prompt_id: str, timeout_seconds: float = 25.0) -> Any:
     prompt_id = _guard_prompt_id(prompt_id)
     # "Bounded by design" only holds if the bound itself is bounded. Left raw,
     # `inf` keeps `remaining` positive forever and NaN makes every comparison
-    # False (so `remaining <= 0` never fires and `min(2.0, nan)` yields 2.0) —
-    # either way the poll loop re-spawns `comfy jobs status` until the client
-    # gives up. See `_bounded_timeout`.
+    # False (so `remaining <= 0` never fires and `min(_POLL_INTERVAL, nan)`
+    # yields `_POLL_INTERVAL`) — either way the poll loop re-spawns
+    # `comfy jobs status` until the client gives up. See `_bounded_timeout`.
     timeout_seconds = _bounded_timeout(timeout_seconds, _MAX_WATCH_TIMEOUT)
-    deadline = time.monotonic() + timeout_seconds
-    poll_interval = 2.0
-    last: Any = None
-    while True:
-        # `last is not None` keeps the one-poll minimum: a bound small enough to
-        # expire before the first poll (`timeout_seconds=1e-9`) must still report
-        # a real status rather than the degenerate `{"status": None}`.
-        remaining = deadline - time.monotonic()
-        if remaining <= 0 and last is not None:
-            return {"timed_out": True, "status": last}
-        # Cap each poll's own subprocess budget to what is left of the caller's
-        # bound. With a fixed 60s per poll the overall wait was only bounded
-        # between polls, so a wedged `comfy jobs status` could hold a
-        # `timeout_seconds=1` call open for a full minute. The floor keeps a
-        # sliver of remaining time from spawning a poll that is guaranteed to
-        # hit its own deadline (and raise) instead of returning `timed_out`; it
-        # overshoots the caller's bound by at most that floor, never by 60s.
-        try:
-            last = _run_comfy(
-                "jobs",
-                "status",
-                prompt_id,
-                timeout=min(
-                    _JOB_STATUS_POLL_TIMEOUT,
-                    max(remaining, _MIN_JOB_STATUS_POLL_TIMEOUT),
-                ),
-            )
-        except ComfyCliError as exc:
-            # Capping the poll to the time left means its deadline now doubles as
-            # the CALLER's: a slow-but-healthy `comfy jobs status` (cold start
-            # plus imports) near the bound is killed where the old fixed 60s
-            # budget would have let it finish. That is this call expiring, not
-            # comfy-cli failing, so honor the documented envelope — and keep the
-            # last real status instead of discarding it with the exception.
-            # Two timeouts still raise, because neither is the caller's bound
-            # expiring: one with time left on that bound (the poll burned the
-            # full `_JOB_STATUS_POLL_TIMEOUT` — comfy-cli is genuinely wedged,
-            # which raised before this cap existed too), and one with no status
-            # yet read, where `{"status": None}` would bury a real failure under
-            # a contentless envelope.
-            if not exc.timed_out or last is None or deadline - time.monotonic() > 0:
-                raise
-            return {"timed_out": True, "status": last}
-        if _is_terminal(last):
-            return last
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            return {"timed_out": True, "status": last}
-        time.sleep(min(poll_interval, remaining))
+    return _poll_until_terminal(
+        "jobs",
+        "status",
+        prompt_id,
+        timeout_seconds=timeout_seconds,
+        is_terminal=_is_terminal,
+    )
 
 
 @mcp.tool()
@@ -9520,10 +9556,10 @@ def _poll_download(download_id: str, timeout_seconds: float) -> Any:
 
     The blocking half of ``wait_for_download`` and of ``download_model``'s wait
     path, shared so the two can never disagree about what a bound expiring means.
-    Structurally identical to ``wait_for_job``'s loop, including its per-poll
-    subprocess-budget capping — see that tool for why each poll is capped to the
-    time left on the caller's bound, why the floor exists, and why a poll killed
-    at that cap yields the ``timed_out`` payload instead of an error.
+    Runs on ``_poll_until_terminal``, the same bounded-poll loop ``wait_for_job``
+    uses — see it for why each poll is capped to the time left on the caller's
+    bound, why the floor exists, and why a poll killed at that cap yields the
+    ``timed_out`` payload instead of an error.
 
     Returns the terminal status payload, or ``{"timed_out": True, "download_id":
     ..., "status": <last payload>}`` on expiry. A ``failed`` / ``cancelled``
@@ -9531,37 +9567,14 @@ def _poll_download(download_id: str, timeout_seconds: float) -> Any:
     turns that into a raise, matching ``wait_for_job``, which likewise hands back
     a failed job's status rather than raising on it.
     """
-    deadline = time.monotonic() + timeout_seconds
-    last: Any = None
-    while True:
-        # `last is not None` keeps the one-poll minimum: a bound small enough to
-        # expire before the first poll must still report a real status.
-        remaining = deadline - time.monotonic()
-        if remaining <= 0 and last is not None:
-            return {"timed_out": True, "download_id": download_id, "status": last}
-        try:
-            last = _run_comfy(
-                "model",
-                "download-status",
-                download_id,
-                timeout=min(
-                    _JOB_STATUS_POLL_TIMEOUT,
-                    max(remaining, _MIN_JOB_STATUS_POLL_TIMEOUT),
-                ),
-            )
-        except ComfyCliError as exc:
-            # This call's bound expiring, not comfy-cli failing — honor the
-            # documented envelope and keep the last real status. See
-            # `wait_for_job` for the two timeouts that still raise.
-            if not exc.timed_out or last is None or deadline - time.monotonic() > 0:
-                raise
-            return {"timed_out": True, "download_id": download_id, "status": last}
-        if _is_download_terminal(last):
-            return last
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            return {"timed_out": True, "download_id": download_id, "status": last}
-        time.sleep(min(_DOWNLOAD_POLL_INTERVAL, remaining))
+    return _poll_until_terminal(
+        "model",
+        "download-status",
+        download_id,
+        timeout_seconds=timeout_seconds,
+        is_terminal=_is_download_terminal,
+        timed_out_extra={"download_id": download_id},
+    )
 
 
 @mcp.tool()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -3122,6 +3122,70 @@ def test_the_shared_poll_puts_its_extra_keys_before_the_status(monkeypatch):
     }
 
 
+@pytest.mark.parametrize("key", ["timed_out", "status"])
+def test_the_shared_poll_rejects_an_extra_that_shadows_its_own_keys(monkeypatch, key):
+    """An extra key may not redefine the two keys every caller branches on.
+
+    The extras are unpacked AFTER the `timed_out` literal, so a colliding key
+    would win — `download_model` reads `result.get("timed_out")` to tell an
+    expiry from a real result, and a shadowed `True` would send a timeout down
+    the `_download_failed` path instead.
+    """
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: {"status": "running"})
+
+    with pytest.raises(ValueError, match=f"reserved keys: \\['{key}'\\]"):
+        server._poll_until_terminal(
+            "model",
+            "download-status",
+            "a1b2c3d4e5f6",
+            timeout_seconds=25.0,
+            is_terminal=server._is_download_terminal,
+            timed_out_extra={key: "shadowed"},
+        )
+
+
+@pytest.mark.parametrize("timeout_seconds", [float("inf"), float("nan")])
+def test_the_shared_poll_rejects_an_unbounded_timeout(monkeypatch, timeout_seconds):
+    """The bound the loop needs is enforced here, not just documented.
+
+    Extracting the loop moved `_bounded_timeout` away from the code it protects:
+    with `inf` every `remaining <= 0` stays False forever, and with NaN every
+    comparison is False and `min(_POLL_INTERVAL, nan)` yields 2.0 — either way a
+    caller that forgot to clamp re-spawns `comfy` on a worker thread until the
+    client gives up. Refuse before the first spawn instead.
+    """
+    spawned: list[tuple] = []
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: spawned.append(a))
+
+    with pytest.raises(server.ComfyCliError, match="invalid timeout_seconds"):
+        server._poll_until_terminal(
+            "jobs",
+            "status",
+            "pid",
+            timeout_seconds=timeout_seconds,
+            is_terminal=server._is_terminal,
+        )
+    assert spawned == []
+
+
+@pytest.mark.parametrize("timeout_seconds", [0.0, -1.0])
+def test_the_shared_poll_still_takes_an_expired_bound(monkeypatch, timeout_seconds):
+    """A bound at or below zero is legal and hits the one-poll minimum.
+
+    `download_model` spends what its submit left (`deadline - monotonic()`),
+    which legitimately lands at or under zero on a slow submit, and still wants
+    a real status payload rather than a contentless `{"status": None}`. The
+    finiteness guard above must not swallow that documented path.
+    """
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: {"status": "running"})
+
+    assert server._poll_download("a1b2c3d4e5f6", timeout_seconds) == {
+        "timed_out": True,
+        "download_id": "a1b2c3d4e5f6",
+        "status": {"status": "running"},
+    }
+
+
 def test_run_comfy_marks_a_subprocess_timeout(patched_run):
     """The `timed_out` flag is set only where the child was killed at our budget.
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -3053,6 +3053,75 @@ def test_wait_for_job_reraises_a_non_timeout_poll_failure(monkeypatch):
         server.wait_for_job("pid", timeout_seconds=1.0)
 
 
+def test_wait_for_job_sleeps_the_shared_poll_interval(monkeypatch):
+    """The gap between polls is the named cadence, not a second hardcoded 2.0.
+
+    `wait_for_job` used to keep its own `poll_interval = 2.0` local while
+    `_poll_download` read `_POLL_INTERVAL` — the same number spelled two ways,
+    which is exactly how a cadence change lands on one poller and not the other.
+    """
+    statuses = iter([{"status": "running"}, {"status": "completed"}])
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: next(statuses))
+
+    slept: list[float] = []
+    monkeypatch.setattr(server.time, "sleep", slept.append)
+
+    assert server.wait_for_job("pid", timeout_seconds=600.0) == {"status": "completed"}
+    assert slept == [server._POLL_INTERVAL]  # the sleep is capped by the remaining
+
+
+def test_the_two_bounded_polls_run_on_one_shared_loop(monkeypatch):
+    """`wait_for_job` and `_poll_download` both route through the shared loop.
+
+    The two ran statement-for-statement identical loops — the one-poll minimum,
+    the per-poll budget cap, the three-clause re-raise — and drifted apart in the
+    only place they were spelled twice. Re-inlining either one is what this
+    guards against; the loop's own behavior is covered by the tests around it.
+    """
+    calls: list[tuple[tuple, dict]] = []
+
+    def fake_poll(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {"status": "completed"}
+
+    monkeypatch.setattr(server, "_poll_until_terminal", fake_poll)
+
+    server.wait_for_job("pid", timeout_seconds=25.0)
+    server._poll_download("a1b2c3d4e5f6", 25.0)
+
+    assert calls[0][0] == ("jobs", "status", "pid")
+    assert calls[0][1]["is_terminal"] is server._is_terminal
+    assert "timed_out_extra" not in calls[0][1]  # jobs add no extra key
+    assert calls[1][0] == ("model", "download-status", "a1b2c3d4e5f6")
+    assert calls[1][1]["is_terminal"] is server._is_download_terminal
+    assert calls[1][1]["timed_out_extra"] == {"download_id": "a1b2c3d4e5f6"}
+
+
+def test_the_shared_poll_puts_its_extra_keys_before_the_status(monkeypatch):
+    """A timed-out payload keeps the key order each caller already returned."""
+    monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: {"status": "running"})
+    monkeypatch.setattr(server.time, "sleep", lambda _s: None)
+
+    # A clock that jumps 10s per read, so the 25s bound expires mid-poll.
+    clock = {"t": 0.0}
+
+    def fake_monotonic():
+        now = clock["t"]
+        clock["t"] += 10.0
+        return now
+
+    monkeypatch.setattr(server.time, "monotonic", fake_monotonic)
+
+    result = server._poll_download("a1b2c3d4e5f6", 25.0)
+
+    assert list(result) == ["timed_out", "download_id", "status"]
+    assert result == {
+        "timed_out": True,
+        "download_id": "a1b2c3d4e5f6",
+        "status": {"status": "running"},
+    }
+
+
 def test_run_comfy_marks_a_subprocess_timeout(patched_run):
     """The `timed_out` flag is set only where the child was killed at our budget.
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -3133,7 +3133,7 @@ def test_the_shared_poll_rejects_an_extra_that_shadows_its_own_keys(monkeypatch,
     """
     monkeypatch.setattr(server, "_run_comfy", lambda *a, **k: {"status": "running"})
 
-    with pytest.raises(ValueError, match=f"reserved keys: \\['{key}'\\]"):
+    with pytest.raises(server.ComfyCliError, match=f"reserved keys: \\['{key}'\\]"):
         server._poll_until_terminal(
             "model",
             "download-status",


### PR DESCRIPTION
## ELI-5

Two tools in this server wait for something to finish by asking comfy-cli over and over until it says "done" or the caller's time runs out: `wait_for_job` (waiting on a render) and `_poll_download` (waiting on a model download). They were doing that with two copies of the same loop, line for line. This PR keeps one copy and has both call it, so a future fix to the waiting rules lands on both instead of one.

## Summary

`wait_for_job` (`src/comfy_mcp/server.py`) and `_poll_download` ran statement-for-statement identical bounded-poll loops and differed only in argv, in the terminal predicate, and in the one extra `download_id` key their timed-out payload carries. `_poll_download`'s own docstring already said so. They had also drifted in *spelling*: the sleep cadence was a local `poll_interval = 2.0` on one side and the named `_DOWNLOAD_POLL_INTERVAL` (also `2.0`) on the other.

Both now call one helper, `_poll_until_terminal(*argv, timeout_seconds=, is_terminal=, timed_out_extra=)`, and the cadence is a single named `_POLL_INTERVAL`.

## Changes

- New `_poll_until_terminal(*args, timeout_seconds, is_terminal, timed_out_extra=None)` — the single bounded-poll loop, carrying the comments that explain the one-poll minimum, the per-poll subprocess-budget cap and its floor, and the three-clause re-raise.
- `wait_for_job` keeps its `_guard_prompt_id` + `_bounded_timeout` preamble and delegates the loop; its tool signature, docstring, and return shapes are untouched.
- `_poll_download` delegates likewise, passing `timed_out_extra={"download_id": download_id}`.
- `_DOWNLOAD_POLL_INTERVAL` → `_POLL_INTERVAL` (same `2.0`), now the one cadence both pollers read; `wait_for_job`'s hardcoded `2.0` is gone. The surrounding comments were re-pointed at the shared loop.
- Three tests in `tests/test_wrapper.py`: the cadence is the named constant, both tools route through the shared loop with the expected argv/predicate/extras, and a timed-out download payload still orders its keys `timed_out, download_id, status`.

## Motivation

Duplication with no behavioural difference, on a loop whose subtle parts (the three-clause re-raise, the two separate `remaining <= 0` returns) are exactly the kind that get fixed in one copy and not the other. The identical-but-differently-spelled poll interval was that drift already starting.

## Testing

- [x] Existing tests pass (`pytest` — 1463 passed, 3 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually — not applicable; the repo's tests mock comfy-cli and already cover both loops end to end (one-poll minimum, per-poll cap, deadline-timeout-as-`timed_out`, both re-raise branches, oversized/NaN bounds).

## Additional Notes

**Behaviour is unchanged, deliberately statement-for-statement.** The extracted loop makes the same `time.monotonic()` reads in the same order (the existing tests drive it with sequence-sensitive fake clocks and assert exact per-poll budgets, e.g. `seen == [4.0, 2.0]`), keeps the three-clause re-raise `if not exc.timed_out or last is None or deadline - time.monotonic() > 0` verbatim including clause order, and keeps both `remaining <= 0` returns separate. Timed-out extras are merged in FRONT of `status` (`{"timed_out": True, **extra, "status": last}`) so each caller's payload key order is byte-identical to before.

**Judgment call — the interval is a shared constant, not a parameter.** The plan asked for the helper to be parameterized on the interval *and* for the hardcoded `2.0` to be folded onto the named constant. Those pull opposite ways: once both callers read one `_POLL_INTERVAL`, an interval parameter would be a knob with exactly one possible value at every call site. I took the fold and skipped the parameter — adding it back is one keyword argument if a third poller ever needs a different cadence.

`_poll_until_terminal` is deliberately *not* a general-purpose retry helper: it is the loop those two callers already shared, with the same required-and-pre-bounded `timeout_seconds` contract (callers still own `_bounded_timeout`, which is why `wait_for_job` keeps its clamp and `_poll_download`'s callers keep theirs).

Scope check: no capability-denial or dead-end path is added or changed here — no tool gains a refusal, and no test was flipped to assert one; every path that worked before takes the same branches on the same inputs.

Swept for other copies of this loop before extracting: the only other `timed_out` producer is the streaming `watch_job`/`run_workflow` tail, which is an `asyncio.wait_for` on a live NDJSON stream rather than a poll loop, so it is correctly out of scope.
