### PR TITLE
refactor: extract _run_template_exec so the run-template dispatch lives in one place

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -4270,23 +4270,10 @@ async def generate_image(
     # `spend_consent_required` here would mean the constant above names a paid
     # template — fix the constant, not the consent plumbing.
     try:
-        if not wait:
-            # Fire-and-return: no stream to follow, so keep the plain --json
-            # path — off the event loop, in the same pool `run_template` uses.
-            args.append("--async")
-            return await _in_generate_pool(
-                _run_comfy, *args, timeout=budget + _RUN_TEMPLATE_TIMEOUT_GRACE
-            )
-        # Same grace as the submit path above (and as `run_template`): the child
-        # was handed `--timeout=min(budget, 120)`, so for a budget at or under
-        # comfy-cli's 120s cap the engine's deadline and the parent's kill land
-        # on the SAME instant. Without slack the parent can SIGKILL comfy-cli
-        # mid-write of its own structured timeout / `server_not_running` result,
-        # replacing an actionable error with a generic parent kill (and orphaning
-        # an already-enqueued run). The engine must be the side that gives up.
-        return await _run_comfy_streaming(
-            *args, ctx=ctx, timeout=budget + _RUN_TEMPLATE_TIMEOUT_GRACE
-        )
+        # Submit-vs-stream and the parent's grace over the engine deadline are
+        # `_run_template_exec`'s, shared with `run_template` — this tool runs the
+        # same verb, so it spends the budget the same way.
+        return await _run_template_exec(args, budget, wait=wait, ctx=ctx)
     except ComfyCliError as exc:
         hinted = _t2i_slot_hint(
             exc, template, prompt_slot, checkpoint_slot if checkpoint else None
@@ -5807,6 +5794,41 @@ def _run_template_argv(
     return args, budget
 
 
+async def _run_template_exec(
+    args: list[str], budget: float, *, wait: bool, ctx: Context | None
+) -> Any:
+    """Run a built ``run-template`` argv on the branch ``wait`` selects.
+
+    The dispatch half of :func:`_run_template_argv`, shared by
+    :func:`run_template` and :func:`generate_image` for the same reason: this is
+    where the budget that helper returned is actually SPENT, so the rule for
+    spending it belongs in one place rather than in two verbatim copies. ``args``
+    is that helper's argv plus whatever consent flag the caller resolved — the
+    caller owns consent, this owns the run.
+
+    ``wait=False`` is fire-and-return: submit ``--async`` and hand back a
+    ``prompt_id`` to poll. There is no stream to follow, so it keeps the plain
+    ``--json`` path, off the event loop in the dedicated generate pool.
+    ``wait=True`` streams: ``comfy run-template`` hands the filled graph to the
+    same comfy-cli run path ``comfy run`` uses, so under ``--json-stream`` it
+    emits the same per-node events, and a run that can block for an hour (long
+    video runs) must report progress rather than sit silent.
+
+    Both branches allow the parent :data:`_RUN_TEMPLATE_TIMEOUT_GRACE` beyond the
+    engine's budget. The child was handed ``--timeout=min(budget, 120)``, so for a
+    budget at or under comfy-cli's 120s cap the engine's deadline and the parent's
+    kill would otherwise land on the SAME instant. Without slack the parent can
+    SIGKILL comfy-cli mid-write of its own structured timeout /
+    ``server_not_running`` result, replacing an actionable error with a generic
+    parent kill (and orphaning an already-enqueued run). The engine must be the
+    side that gives up.
+    """
+    timeout = budget + _RUN_TEMPLATE_TIMEOUT_GRACE
+    if not wait:
+        return await _in_generate_pool(_run_comfy, *args, "--async", timeout=timeout)
+    return await _run_comfy_streaming(*args, ctx=ctx, timeout=timeout)
+
+
 @mcp.tool()
 async def run_template(
     name: str,
@@ -5925,31 +5947,10 @@ async def run_template(
     if await _resolve_template_spend_consent(name, confirm_spend, ctx):
         # comfy-cli's paid-node consent for run-template; a bare boolean flag.
         args.append("--allow-spend")
-    if not wait:
-        # Fire-and-return: submit and hand back a prompt_id to poll. No stream to
-        # follow, so keep the plain --json path — off the event loop, in the
-        # dedicated pool `generate_image`'s submit branch uses.
-        args.append("--async")
-        return await _in_generate_pool(
-            _run_comfy, *args, timeout=budget + _RUN_TEMPLATE_TIMEOUT_GRACE
-        )
-    # wait=True streams. `comfy run-template` hands the filled graph to the same
-    # comfy-cli run path `comfy run` uses, so under `--json-stream` it emits the
-    # same per-node events — which is what `generate_image` already rides for
-    # this very verb. A template run can block for up to an hour (its own
-    # docstring calls out long video runs), so it must report progress rather
-    # than sit silent.
-    #
-    # Same grace as the submit path above (and as `generate_image`): the child
-    # was handed `--timeout=min(budget, 120)`, so for a budget at or under
-    # comfy-cli's 120s cap the engine's deadline and the parent's kill land on
-    # the SAME instant. Without slack the parent can SIGKILL comfy-cli mid-write
-    # of its own structured timeout / `server_not_running` result, replacing an
-    # actionable error with a generic parent kill (and orphaning an
-    # already-enqueued run). The engine must be the side that gives up.
-    return await _run_comfy_streaming(
-        *args, ctx=ctx, timeout=budget + _RUN_TEMPLATE_TIMEOUT_GRACE
-    )
+    # Submit-vs-stream and the parent's grace over the engine deadline are
+    # `_run_template_exec`'s, shared with `generate_image` — which rides this very
+    # verb, so the two spend the budget identically.
+    return await _run_template_exec(args, budget, wait=wait, ctx=ctx)
 
 
 @mcp.tool()

--- a/tests/test_run_template.py
+++ b/tests/test_run_template.py
@@ -479,6 +479,30 @@ def test_run_template_wait_false_submits_async(patched_run, monkeypatch):
     )
 
 
+def test_run_template_wait_false_still_forwards_consent(patched_run):
+    """A submit carries BOTH the consent flag and `--async`.
+
+    The two are appended by different owners — consent by the tool (before it
+    knows which branch will run), `--async` by the shared dispatch — and this is
+    the one call that exercises them together, so it pins that neither owner
+    drops the other's flag.
+    """
+    calls = patched_run(envelope(data={"prompt_id": "p9"}))
+
+    _run_template(
+        "api_seedance", params={"prompt": "x"}, confirm_spend=True, wait=False
+    )
+
+    assert calls[0]["cmd"][4:] == [
+        "run-template",
+        "api_seedance",
+        '--param=prompt="x"',
+        "--timeout=60",
+        "--allow-spend",
+        "--async",
+    ]
+
+
 class _BlockingProc:
     """A child fake that emits ``first_lines`` and then never yields an envelope.
 


### PR DESCRIPTION
## ELI-5

`run_template` and `generate_image` are two doors into the same engine command (`comfy run-template`). They already shared one helper for *building* the command line, but each then kept its own copy of the code that actually *runs* it — same two branches, same timeout arithmetic, and the same seven-line comment explaining why the parent waits a little longer than the engine. Two copies of a rule is one copy too many: fix a subtlety in one and the other silently drifts. This moves that run step into a single shared helper next to the existing one, so the rule is written down once.

## Summary

Extracts `_run_template_exec(args, budget, *, wait, ctx)` beside `_run_template_argv`, holding the `--async` submit branch, the streaming branch, and the single `budget + _RUN_TEMPLATE_TIMEOUT_GRACE` expression — with the grace rationale stated once. Each tool now reads: build argv via `_run_template_argv`, dispatch via `_run_template_exec`. Pure refactor; no behavior change.

## Changes

- `_run_template_exec` added in `src/comfy_mcp/server.py`, directly after `_run_template_argv` (its build-half counterpart), carrying both dispatch branches and the one grace expression.
- `generate_image` and `run_template` each collapse their duplicated dispatch to one call. `generate_image` keeps its `try/except ComfyCliError` slot-hint wrapper around that call, so the hint still covers both branches exactly as before.
- `_RUN_TEMPLATE_TIMEOUT_GRACE` went from four references (two copies of the same two expressions) to one, plus its definition.
- Consent stays with the caller: `run_template` still resolves and appends `--allow-spend` before dispatching; `generate_image` still forwards nothing (its template is free).
- New test `test_run_template_wait_false_still_forwards_consent` — see Testing.

## Motivation

`_run_template_argv`'s own docstring says it exists "so the engine deadline rule lives in exactly one place", and then both callers repeated the dispatch that spends that budget verbatim, including the ~7-line paragraph justifying the grace ("the engine must be the side that gives up"; without slack the parent can SIGKILL comfy-cli mid-write of its own structured timeout / `server_not_running` result). Each copy cross-referenced the other, which is the shape of a rule that wants to be one function.

## Testing

- [x] Existing tests pass (`pytest`) — 1460 passed, 4 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually — not applicable; tests mock comfy-cli per AGENTS.md, and this change is behavior-preserving.

Both branches of both callers were already covered by exact-argv + exact-timeout assertions (`test_run_template.py`, `test_generate.py`), which is what makes this refactor verifiable rather than merely plausible. The one combination nothing exercised was a `wait=False` submit with `confirm_spend=True` — the single call where the caller's `--allow-spend` and the shared dispatch's `--async` land on the same command line, i.e. exactly the seam this change creates. That test is added, and it pins that neither owner drops the other's flag.

## Additional Notes

**One premise in the task description turned out to be stale, and I did not implement around it.** It warned that "the two callers differ in pool: `generate_image` goes through `_in_generate_pool`", and asked me to pass the runner in rather than branch on the tool name if that could not be expressed cleanly. On current `main` both callers' submit branches already went through `_in_generate_pool` (`server.py:4277` and `:5933` pre-diff, and `run_template`'s own comment named it "the dedicated pool `generate_image`'s submit branch uses"). So there is no pool difference to parameterize, and the helper takes no runner argument — adding one would have been an unused seam. Flagging it explicitly since it was called out as the thing to confirm.

Argv is byte-identical. The one non-cosmetic detail: the submit branch used to do `args.append("--async")` and then unpack, and now passes `--async` as a trailing positional after the unpack. Same position in the final command line (last, after any `--allow-spend`), and it no longer mutates the caller's list — neither caller reads `args` afterwards, so that is a side benefit rather than a behavior change. The new exact-argv test above pins the ordering.

`_RUN_TEMPLATE_TIMEOUT_GRACE` is still read as a module global at call time, so `test_run_template.py`'s `monkeypatch.setattr(server, "_RUN_TEMPLATE_TIMEOUT_GRACE", 0.0)` keeps working unchanged.

No `AGENTS.md` update needed: this changes neither the architecture rule, the toolchain, nor the tool set — every call still goes through `_run_comfy` / `_run_comfy_streaming`, and no tool's surface moved.
