### PR TITLE
refactor: extract the shared timeout report behind _timeout_failure

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -1547,8 +1547,8 @@ def _timeout_failure(
     cmd: list[str],
     args: tuple[str, ...],
     timeout: float | None,
-    stdout: str,
-    stderr: str,
+    stdout: str | bytes | None,
+    stderr: str | bytes | None,
 ) -> ComfyCliError:
     """Format + log a runner timeout, and RETURN the error for the caller to raise.
 
@@ -1560,6 +1560,16 @@ def _timeout_failure(
     starts there rather than inside a formatting helper, and the explicit
     ``from exc`` chaining to the originating ``TimeoutExpired`` /
     ``asyncio.TimeoutError`` stays where that exception is actually bound.
+
+    The stream parameters are typed as widely as what the callers can hand over,
+    not as narrowly as the common case: :func:`_run_comfy_async` always decodes to
+    ``str`` first, but :func:`_drain_timed_out` can return ``None`` (nothing
+    written) or ``bytes`` (POSIX attaches the undecoded partial read to
+    ``TimeoutExpired``), and :func:`_run_comfy_raw` passes that through verbatim.
+    Both consumers below — :func:`textutil._tail` and
+    :func:`failure_log._log_failure` — already declare that same union, so
+    narrowing it here would only mislead a later edit into string-only work that
+    blows up on exactly the POSIX timeout path.
 
     Not shared with :func:`_run_comfy_streaming`, whose timeout is deliberately a
     different report — it adds the progress snapshot and the poll-instead advice,

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -1539,6 +1539,46 @@ def _cmd_for_message(cmd: list[str]) -> str:
     return failure_log._scrub_text(" ".join(cmd))
 
 
+def _timeout_failure(
+    cmd: list[str],
+    args: tuple[str, ...],
+    timeout: float | None,
+    stdout: str,
+    stderr: str,
+) -> ComfyCliError:
+    """Format + log a runner timeout, and RETURN the error for the caller to raise.
+
+    Shared by :func:`_run_comfy_raw` and :func:`_run_comfy_async` so both report a
+    timeout identically — a caller (or a QA log reader) sees one timeout report
+    regardless of which runner produced it, and a wording change lands in both at
+    once. Returning rather than raising keeps the ``raise ... from exc`` at the
+    call site: each runner stays visibly the thing that fails, its traceback
+    starts there rather than inside a formatting helper, and the explicit
+    ``from exc`` chaining to the originating ``TimeoutExpired`` /
+    ``asyncio.TimeoutError`` stays where that exception is actually bound.
+
+    Not shared with :func:`_run_comfy_streaming`, whose timeout is deliberately a
+    different report — it adds the progress snapshot and the poll-instead advice,
+    logs ``streaming=True``, and raises without ``timed_out``.
+    """
+    message = (
+        f"comfy-cli timed out after {timeout}s: {_cmd_for_message(cmd)}. "
+        f"stderr tail: {textutil._tail(stderr) or '<empty>'}; "
+        f"stdout tail: {textutil._tail(stdout) or '<empty>'}"
+    )
+    # `exit_code=None`: the child was killed at the deadline, so it never
+    # reported one. The log keeps a longer slice of both streams than the
+    # message above does — see `failure_log._FAILURE_LOG_TAIL_CHARS`.
+    failure_log._log_failure(
+        "timeout",
+        args,
+        message=message,
+        stdout=stdout,
+        stderr=stderr,
+    )
+    return ComfyCliError(message, timed_out=True)
+
+
 def _run_comfy_raw(
     *args: str, timeout: float | None = None
 ) -> tuple[dict | None, str, tuple[str, ...], int, str]:
@@ -1605,22 +1645,7 @@ def _run_comfy_raw(
         # crashed, wedged comfy-cli (e.g. a traceback on stderr) is not
         # indistinguishable from a genuinely slow one. See BE-3343.
         stdout, stderr = _drain_timed_out(proc, exc)
-        message = (
-            f"comfy-cli timed out after {timeout}s: {_cmd_for_message(cmd)}. "
-            f"stderr tail: {textutil._tail(stderr) or '<empty>'}; "
-            f"stdout tail: {textutil._tail(stdout) or '<empty>'}"
-        )
-        # `exit_code=None`: the child was killed at the deadline, so it never
-        # reported one. The log keeps a longer slice of both streams than the
-        # message above does — see `failure_log._FAILURE_LOG_TAIL_CHARS`.
-        failure_log._log_failure(
-            "timeout",
-            args,
-            message=message,
-            stdout=stdout,
-            stderr=stderr,
-        )
-        raise ComfyCliError(message, timed_out=True) from exc
+        raise _timeout_failure(cmd, args, timeout, stdout, stderr) from exc
     except BaseException:
         # Mirrors `subprocess.run`'s own bare `except` (it kills the child and
         # lets `Popen.__exit__` clean up): anything else raised while draining
@@ -2724,25 +2749,9 @@ async def _run_comfy_async(
             await _drain_timed_out_async(proc, stdout_sink, stderr_sink)
             stdout = stdout_sink[0].decode("utf-8", "replace")
             stderr = stderr_sink[0].decode("utf-8", "replace")
-            # Same message shape as `_run_comfy_raw`'s timeout, so a caller (or a
-            # QA log reader) sees one timeout report regardless of which runner
-            # produced it.
-            message = (
-                f"comfy-cli timed out after {timeout}s: {_cmd_for_message(cmd)}. "
-                f"stderr tail: {textutil._tail(stderr) or '<empty>'}; "
-                f"stdout tail: {textutil._tail(stdout) or '<empty>'}"
-            )
-            # `exit_code=None`: the child was killed at the deadline, so it never
-            # reported one. The log keeps a longer slice of both streams than the
-            # message above does — see `failure_log._FAILURE_LOG_TAIL_CHARS`.
-            failure_log._log_failure(
-                "timeout",
-                args,
-                message=message,
-                stdout=stdout,
-                stderr=stderr,
-            )
-            raise ComfyCliError(message, timed_out=True) from exc
+            # Same report as `_run_comfy_raw`'s timeout, formatted and logged by
+            # the one shared body — see `_timeout_failure`.
+            raise _timeout_failure(cmd, args, timeout, stdout, stderr) from exc
         # comfy-cli's output is forced to UTF-8 (see `_comfy_env`); decode with
         # `replace` rather than strict for the same reason the streaming reader
         # does — a truncated or mis-encoded byte must degrade the text, not raise

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -4710,6 +4710,51 @@ def test_sync_timeout_with_no_captures_is_sane(patched_run):
     assert "stdout tail: <empty>" in msg
 
 
+def test_timeout_failure_returns_the_error_instead_of_raising_it(monkeypatch):
+    """The shared timeout body RETURNS its `ComfyCliError` and logs one record.
+
+    Returning is what lets each runner keep `raise ... from exc` at its own call
+    site, so the traceback starts at the runner rather than inside a formatting
+    helper. The two runners' reports are pinned individually elsewhere
+    (`test_sync_timeout_*`, `test_download_model_legacy_timeout_*`); this pins
+    the body they share.
+    """
+    logged: list[dict] = []
+    monkeypatch.setattr(
+        failure_log,
+        "_log_failure",
+        lambda kind, args, **kwargs: logged.append(
+            {"kind": kind, "args": args, **kwargs}
+        ),
+    )
+
+    error = server._timeout_failure(
+        [server.COMFY_BIN, "--json", "--where", "local", "discover"],
+        ("discover",),
+        60.0,
+        "partial stdout",
+        "partial err",
+    )
+
+    assert isinstance(error, server.ComfyCliError)  # returned, never raised
+    assert error.timed_out is True
+    message = str(error)
+    assert "comfy-cli timed out after 60.0s" in message
+    assert "stderr tail: partial err" in message
+    assert "stdout tail: partial stdout" in message
+    # One record, `timeout`-kinded, carrying both untruncated streams — the log
+    # keeps a longer slice than the message does.
+    assert logged == [
+        {
+            "kind": "timeout",
+            "args": ("discover",),
+            "message": message,
+            "stdout": "partial stdout",
+            "stderr": "partial err",
+        }
+    ]
+
+
 def test_plain_spawn_leads_its_own_process_group(patched_run):
     """The plain path spawns with `start_new_session=True`, like the streaming one.
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -4888,6 +4888,41 @@ def test_timeout_failure_returns_the_error_instead_of_raising_it(monkeypatch):
     ]
 
 
+def test_timeout_failure_takes_the_bytes_and_none_captures_too(monkeypatch):
+    """The shared body handles what `_drain_timed_out` actually hands it.
+
+    `_run_comfy_raw` passes that function's result through verbatim, and on POSIX
+    a `TimeoutExpired` carries the partial read as raw *bytes* — or as `None` when
+    the child wrote nothing before it was killed. Both reach the shared body, so
+    pin them here rather than only the decoded-`str` case above: a future edit
+    doing string-only work on these parameters has to fail this test instead of
+    failing at a user's POSIX timeout.
+    """
+    logged: list[dict] = []
+    monkeypatch.setattr(
+        failure_log,
+        "_log_failure",
+        lambda kind, args, **kwargs: logged.append(
+            {"kind": kind, "args": args, **kwargs}
+        ),
+    )
+
+    error = server._timeout_failure(
+        [server.COMFY_BIN, "--json", "--where", "local", "discover"],
+        ("discover",),
+        60.0,
+        b"partial stdout bytes",
+        None,
+    )
+
+    message = str(error)
+    assert "stdout tail: partial stdout bytes" in message
+    # Nothing on stderr renders as the `<empty>` marker, not as a bare `None`.
+    assert "stderr tail: <empty>" in message
+    assert logged[0]["stdout"] == b"partial stdout bytes"
+    assert logged[0]["stderr"] is None
+
+
 def test_plain_spawn_leads_its_own_process_group(patched_run):
     """The plain path spawns with `start_new_session=True`, like the streaming one.
 


### PR DESCRIPTION
## ELI-5

Two different ways of running `comfy` both had the same "it timed out" paragraph copy-pasted into them — same sentence, same log line, same error. This moves that paragraph into one place both of them call, so the next time someone reword it, they only have to reword it once. Nothing a user sees changes.

## Summary

`_run_comfy_raw` (the sync `Popen` runner) and `_run_comfy_async` (the cancellable async twin) built a byte-identical timeout report: the same message f-string, the same `failure_log._log_failure("timeout", …)` record with the same `exit_code=None` rationale comment, and the same `raise ComfyCliError(message, timed_out=True) from exc`. The async copy was even commented as deliberately matching `_run_comfy_raw`'s shape — a comment is a weak way to hold two literals in sync.

This extracts `_timeout_failure(cmd, args, timeout, stdout, stderr) -> ComfyCliError`, which formats the message, writes the failure-log record, and **returns** the error. Each runner still does its own `raise … from exc`, so the traceback starts at the runner rather than inside a formatting helper and the chaining stays where the originating `TimeoutExpired` / `asyncio.TimeoutError` is actually bound.

## Changes

- `src/comfy_mcp/server.py`: new `_timeout_failure` next to `_cmd_for_message`; `_run_comfy_raw` and `_run_comfy_async` each collapse ~17 lines to one `raise _timeout_failure(...) from exc`.
- `tests/test_wrapper.py`: one test pinning the helper's contract — that it *returns* (never raises), that the returned error carries `timed_out=True` and the verbatim message, and that it writes exactly one `timeout`-kinded log record with both untruncated streams.

## Motivation

Closes #160. Duplicated failure-reporting text drifts silently: the two runners' timeout reports are supposed to be indistinguishable to a caller and to a QA log reader, and today only a comment says so.

## Scope calls (deliberately narrow)

- **The third timeout site is NOT shared.** `_run_comfy_streaming` also raises a timeout, but its report is genuinely different — it appends the progress snapshot and the "poll `wait_for_job` / `watch_job` instead" advice, logs `streaming=True`, and raises **without** `timed_out=True`. Folding it in would mean parameterising away the differences that are the point. Its independence is now stated in `_timeout_failure`'s docstring so a future reader does not "finish the job" by mistake.
- **No spawn-preamble consolidation.** The related suggestion to collapse the spawn sites behind a shared kwargs dict / `_comfy_cmd()` helper was not done, and the issue itself refutes it: the fourth spawn site (`_start_login`) deliberately omits `--where local`, the three remaining differ in the global flag (`--json` vs `--json-stream`) and in whether `limit=` is passed, and only the sync `Popen` takes `text=True` + `encoding="utf-8"`. The per-site comments explaining `stdin=DEVNULL` (the parent's stdin *is* the JSON-RPC channel) and `start_new_session=True` (process-group kill, else the drain never reaches EOF) are load-bearing documentation; collapsing them would trade that for a modest line saving on paths that are not uniform.

## Testing

- [x] Existing tests pass (`pytest`) — 1460 passed, 4 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually — not applicable; the timeout paths are exercised by the fixtures (`patched_run(raises=TimeoutExpired(...))` for the sync runner, `patched_async_run(hang=True)` for the async one), which already assert the exact message text and the failure-log record on both sides. A wording slip fails loudly.

## Additional Notes

Pure refactor: no message text, no control flow, and no public behaviour changed. Line numbers in the issue were from an older `origin/main` (`88a74b2`); re-verified against the current tip before the edit — both call sites still matched byte-for-byte.

Self-review notes worth a reviewer's eye: the riskiest line is `raise _timeout_failure(...) from exc`. It is safe because the helper *returns* rather than raises, so `__cause__` is still the original timeout exception and the `raise` statement is still in the runner's `except` block — the only observable difference is that the `ComfyCliError` instance is constructed one frame down, which does not appear in the traceback of a returned-then-raised exception. The `_log_failure` call also still happens before the raise, in the same order as before.
