### PR TITLE
fix: carry the remote-target provenance onto system_stats / free_memory errors

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -1323,6 +1323,32 @@ def _strip_brackets(host: str) -> str:
     return host
 
 
+def _redact_config_url(url: str) -> str:
+    """:func:`textutil._redact_url`, plus the query/fragment a secret also hides in.
+
+    :func:`_comfy_target`'s errors echo the offending ``COMFYUI_URL`` back, and
+    that text is quoted onward — into ``server_info``'s ``comfy_target`` block,
+    into :func:`_malformed_target_note`, and into the message
+    :func:`_target_provenance_suffix` appends to a raised error — so it reaches
+    the model's context and any transcript of it. Userinfo is not the only place
+    a credential rides in: an auth-proxied ComfyUI is routinely addressed as
+    ``https://host/?token=…``, and a value written that way is echoed back the
+    moment ANY of the checks below rejects it — the ``https`` scheme most of
+    all, which is what such a proxy is usually reached over.
+
+    The query and fragment are replaced WHOLESALE rather than parsed for
+    key names: what makes the value diagnosable is the scheme, host and port, so
+    nothing in either part is worth echoing — and a placeholder still tells the
+    user they wrote one, which "silently dropped" would not.
+    """
+    masked = textutil._redact_url(url)
+    cuts = [i for i in (masked.find("?"), masked.find("#")) if i != -1]
+    if not cuts:
+        return masked
+    cut = min(cuts)
+    return f"{masked[: cut + 1]}<redacted>"
+
+
 def _comfy_target() -> tuple[str, int, str] | None:
     """Resolve the configured ComfyUI ``(host, port, source)``, or None for local.
 
@@ -1350,31 +1376,31 @@ def _comfy_target() -> tuple[str, int, str] | None:
             host, port = parsed.hostname, parsed.port
         except ValueError as exc:  # bad port, or malformed URL (IPv6 brackets)
             raise ComfyCliError(
-                f"COMFYUI_URL is malformed: {textutil._redact_url(url)!r} ({exc})."
+                f"COMFYUI_URL is malformed: {_redact_config_url(url)!r} ({exc})."
             ) from exc
         if parsed.scheme and parsed.scheme != "http":
             raise ComfyCliError(
                 f"COMFYUI_URL scheme {parsed.scheme!r} is not supported "
-                f"({textutil._redact_url(url)!r}): comfy-cli's --host/--port speak plain "
+                f"({_redact_config_url(url)!r}): comfy-cli's --host/--port speak plain "
                 "http only, so an https:// target would be silently downgraded. "
                 "Use http://<host>:<port>."
             )
         if parsed.path not in ("", "/"):
             raise ComfyCliError(
-                f"COMFYUI_URL must not include a path ({textutil._redact_url(url)!r}): "
+                f"COMFYUI_URL must not include a path ({_redact_config_url(url)!r}): "
                 "comfy-cli forwards only host/port, so a reverse-proxy base path "
                 "would be dropped. Point COMFYUI_URL at the bare host:port."
             )
         if not host:
             raise ComfyCliError(
-                f"COMFYUI_URL is set but names no host: {textutil._redact_url(url)!r}. "
+                f"COMFYUI_URL is set but names no host: {_redact_config_url(url)!r}. "
                 "Use e.g. http://<host>:8188 (or set COMFYUI_HOST/COMFYUI_PORT)."
             )
         # `port or DEFAULT` alone would treat an explicit :0 as absent and
         # silently target 8188; reject it to match the COMFYUI_PORT path.
         if port == 0:
             raise ComfyCliError(
-                f"COMFYUI_URL port is out of range (1-65535): {textutil._redact_url(url)!r}."
+                f"COMFYUI_URL port is out of range (1-65535): {_redact_config_url(url)!r}."
             )
         return _strip_brackets(host), port or DEFAULT_COMFYUI_PORT, "COMFYUI_URL"
 
@@ -1410,11 +1436,34 @@ def _redact_target_host(host: str) -> str:
     drops userinfo — but ``COMFYUI_HOST`` is taken VERBATIM, so a value written
     URL-style (``<user>:<token>@host``) is carried into the tuple as-is and would
     otherwise reach the model's context, and any transcript of it, unmasked. The
-    same masking :func:`_comfy_target`'s own error messages already apply to the
+    same userinfo masking :func:`_comfy_target`'s own error messages apply to the
     raw value; a host with no ``@`` is returned unchanged, which is every real
     one.
+
+    Masked HERE rather than by delegating to :func:`textutil._redact_url`: that
+    helper stops inspecting at the first ``/``, ``?`` or ``#`` because it is
+    reading a URL, whose PATH may hold a stray ``@`` that is not userinfo. This
+    is a bare host, where there is no path for an ``@`` to belong to — so any
+    ``@`` is userinfo, and a token that happens to contain one of those
+    delimiters (base64 routinely contains ``/``) would otherwise fall outside
+    the inspected slice and be returned in full.
     """
-    return textutil._redact_url(host)
+    if "@" not in host:
+        return host
+    return f"***@{host.rsplit('@', 1)[1]}"
+
+
+def _format_target_endpoint(host: str, port: int) -> str:
+    """``host:port`` as ONE token, re-bracketing an IPv6 host so the port reads.
+
+    :func:`_strip_brackets` normalizes ``[2001:db8::1]`` to the bare form every
+    other consumer wants (comfy-cli re-brackets it when it builds a URL, and the
+    payload note keeps ``host`` and ``port`` as separate keys). Joined with a
+    colon for prose, though, that bare form renders ``2001:db8::1:8188``, where
+    the port is indistinguishable from a final hextet — so the brackets go back
+    on for the one caller that has to write the two as a single string.
+    """
+    return f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
 
 
 def _malformed_target_note(exc: ComfyCliError) -> dict[str, str]:
@@ -6572,22 +6621,56 @@ def _target_provenance_suffix() -> str:
     try:
         target = _comfy_target()
     except ComfyCliError as exc:
+        # Names all three knobs rather than the two that resolve a host: a lone
+        # `COMFYUI_PORT` raises out of `_comfy_target` too, and blaming
+        # `COMFYUI_URL`/`COMFYUI_HOST` for it points at variables that are not
+        # even set. The embedded message says which one it actually was.
         return (
-            " (note: COMFYUI_URL/COMFYUI_HOST is set but malformed, so no remote "
-            "is resolved and this error is comfy-cli's own, about whichever "
-            f"ComfyUI it itself targets; the config error is: {exc})"
+            " (note: the remote-target config (COMFYUI_URL / COMFYUI_HOST / "
+            "COMFYUI_PORT) is set but invalid, so no remote is resolved and this "
+            "error is comfy-cli's own, about whichever ComfyUI it itself targets; "
+            f"the config error is: {exc})"
         )
     if target is None:
         return ""
     host, port, source = target
+    endpoint = _format_target_endpoint(_redact_target_host(host), port)
+    # "not AIMED at it", not "did not REACH it": the absence of --host/--port is
+    # a fact about what this invocation asked for, whereas whether it reached
+    # that endpoint anyway is exactly what this server cannot know (the host may
+    # resolve to this box, `COMFY_LOCAL_URL` may point comfy-cli straight at it).
+    # Claiming non-reach would misclassify a genuine failure OF the target as
+    # unrelated to it — the same over-reach the closing clause avoids by saying
+    # this failure is not evidence either way rather than that the remote is up.
     return (
-        f" (note: {source} is set to {_redact_target_host(host)}:{port}, but this "
-        "probe did NOT reach it — `comfy system-stats` / `comfy free` take no "
-        "--host/--port, so this error is about whichever ComfyUI comfy-cli itself "
-        "targets. That may or may not be the same machine, and this server does "
-        "not verify which, so do not read this as the configured target being "
-        "down: the run/job tools do submit there.)"
+        f" (note: {source} is set to {endpoint}, but this probe was NOT aimed at "
+        "it — `comfy system-stats` / `comfy free` take no --host/--port, so this "
+        "error is about whichever ComfyUI comfy-cli itself targets. That may or "
+        "may not be the same machine, and this server does not verify which, so "
+        "do not read this as a verdict on the configured target: that is where "
+        "the run/job tools submit, and this failure is no evidence about it.)"
     )
+
+
+def _comfy_cli_ran(err: ComfyCliError) -> bool:
+    """True when *err* is a verdict from a comfy-cli child that actually RAN.
+
+    ``returncode`` is set wherever :func:`_unwrap_envelope` read a child's exit
+    status (the error-envelope path and the no-envelope path alike), and
+    ``timed_out`` marks the child we killed at our own deadline; neither can be
+    set unless comfy-cli was spawned.
+
+    The failures that leave both at their defaults are the ones raised about
+    this machine's INSTALL rather than about any ComfyUI —
+    :func:`_require_comfy_bin`'s missing binary and its macOS TCC denial,
+    :func:`_check_comfy_version`'s version floor, :func:`_unwrap_envelope`'s
+    refusal of an incompatible envelope schema. :func:`_target_provenance_suffix`
+    must not be appended to those: it says this failure is not a verdict on the
+    configured target, implying the submit tools are unaffected, and every one of
+    them breaks ``run_workflow`` in exactly the same way — there is no binary for
+    it to shell out to either.
+    """
+    return err.returncode is not None or err.timed_out
 
 
 def _with_target_provenance(err: ComfyCliError) -> ComfyCliError:
@@ -6599,7 +6682,13 @@ def _with_target_provenance(err: ComfyCliError) -> ComfyCliError:
     two :func:`_resource_verb_upgrade_error` needs — a timeout here really can
     set ``timed_out`` (both tools pass a ``timeout=``), and a message rewrite is
     no reason for the structured provenance to decay.
+
+    A failure comfy-cli never got to run is returned the same untouched way, for
+    the reason :func:`_comfy_cli_ran` gives: the note is about which ComfyUI a
+    dispatched verb spoke to, and a missing or unusable comfy-cli spoke to none.
     """
+    if not _comfy_cli_ran(err):
+        return err
     suffix = _target_provenance_suffix()
     if not suffix:
         return err
@@ -6659,7 +6748,9 @@ def system_stats() -> Any:
     ERRORS carry that provenance too: with a remote configured, a failure here
     (``server_not_running`` above all, the common shape when nothing is running
     locally) is appended with the same note, so it is not mistaken for a verdict
-    on the target the run/job tools submit to.
+    on the target the run/job tools submit to. Only a failure comfy-cli actually
+    ran, though — a missing or too-old comfy-cli breaks every tool alike and is
+    about no ComfyUI at all, so it is raised untouched.
     """
     try:
         data = _run_comfy("system-stats", timeout=60.0)
@@ -6719,7 +6810,8 @@ def free_memory(unload_models: bool = True, free_memory: bool | None = None) -> 
     ``note`` form). With no remote configured the key is absent and the payload
     is unchanged. ERRORS carry the same provenance note appended to their
     message, so a failure to reach the LOCAL ComfyUI is not read as the
-    configured remote being down.
+    configured remote being down — with the same carve-out ``system_stats``
+    documents for a comfy-cli that never ran at all.
     """
     if free_memory is None:
         # Mirror `unload_models` so the default call asks for both and

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -6540,6 +6540,79 @@ def _annotate_comfy_target(payload: Any) -> Any:
     }
 
 
+def _target_provenance_suffix() -> str:
+    """The same divergence :func:`_annotate_comfy_target` carries, for a FAILURE.
+
+    The note above only ever reaches a caller on the SUCCESS path, and the
+    common case with a remote configured is the failing one: ``comfy
+    system-stats`` / ``comfy free`` take no ``--host`` / ``--port``, so with no
+    local ComfyUI running they raise comfy-cli's bare ``server_not_running``
+    while the configured remote is up and serving the run/job tools perfectly
+    well. An agent reading that error alone concludes the remote is down and
+    abandons a ``run_workflow`` that would have worked — the provenance is
+    exactly as load-bearing on the error as it is on the payload.
+
+    Returns a suffix to append to the raised message, or ``""`` when nothing is
+    configured — in which case the caller must re-raise the original objects
+    untouched, so the local default stays byte-identical.
+
+    Fail-soft on a malformed config for the same reason
+    :func:`_annotate_comfy_target` is: these two tools never touch the remote,
+    so a bad ``COMFYUI_URL`` must not make them fail differently. But it does
+    not vanish either — a typo must not read as "nothing configured" — so it
+    becomes its own short suffix carrying :func:`_comfy_target`'s own
+    (already userinfo-masked) message, the same rationale as
+    :func:`_malformed_target_note`.
+
+    It does not ADJUDICATE, exactly as the success-path note does not: the two
+    ends are the same machine whenever the configured host resolves to this box
+    and this server cannot tell whether it does. What it rules out is the one
+    wrong inference — that this error is a verdict on the configured target.
+    """
+    try:
+        target = _comfy_target()
+    except ComfyCliError as exc:
+        return (
+            " (note: COMFYUI_URL/COMFYUI_HOST is set but malformed, so no remote "
+            "is resolved and this error is comfy-cli's own, about whichever "
+            f"ComfyUI it itself targets; the config error is: {exc})"
+        )
+    if target is None:
+        return ""
+    host, port, source = target
+    return (
+        f" (note: {source} is set to {_redact_target_host(host)}:{port}, but this "
+        "probe did NOT reach it — `comfy system-stats` / `comfy free` take no "
+        "--host/--port, so this error is about whichever ComfyUI comfy-cli itself "
+        "targets. That may or may not be the same machine, and this server does "
+        "not verify which, so do not read this as the configured target being "
+        "down: the run/job tools do submit there.)"
+    )
+
+
+def _with_target_provenance(err: ComfyCliError) -> ComfyCliError:
+    """*err* with :func:`_target_provenance_suffix` appended, or *err* itself.
+
+    Returning the SAME object when no remote is configured is the contract: the
+    unconfigured path must re-raise exactly what it raises today, message and
+    identity included. Every attribute is carried across rather than only the
+    two :func:`_resource_verb_upgrade_error` needs — a timeout here really can
+    set ``timed_out`` (both tools pass a ``timeout=``), and a message rewrite is
+    no reason for the structured provenance to decay.
+    """
+    suffix = _target_provenance_suffix()
+    if not suffix:
+        return err
+    return ComfyCliError(
+        f"{err}{suffix}",
+        code=err.code,
+        no_envelope=err.no_envelope,
+        returncode=err.returncode,
+        timed_out=err.timed_out,
+        data=err.data,
+    )
+
+
 @mcp.tool()
 def system_stats() -> Any:
     """Read the live local ComfyUI's VRAM per device and system RAM.
@@ -6583,14 +6656,19 @@ def system_stats() -> Any:
     error-shaped note (``error`` / ``note``) instead — the same shape
     ``server_info`` reports that breakage in — so an absent key means one thing
     only: no remote is configured. Nothing else about the payload changes.
+    ERRORS carry that provenance too: with a remote configured, a failure here
+    (``server_not_running`` above all, the common shape when nothing is running
+    locally) is appended with the same note, so it is not mistaken for a verdict
+    on the target the run/job tools submit to.
     """
     try:
         data = _run_comfy("system-stats", timeout=60.0)
     except ComfyCliError as exc:
         hinted = _resource_verb_upgrade_error(exc, "system-stats", "system_stats")
-        if hinted is not None:
-            raise hinted from exc
-        raise
+        annotated = _with_target_provenance(exc if hinted is None else hinted)
+        if annotated is exc:
+            raise
+        raise annotated from exc
     return _annotate_comfy_target(data)
 
 
@@ -6639,7 +6717,9 @@ def free_memory(unload_models: bool = True, free_memory: bool | None = None) -> 
     target and leaving the same-machine judgment to the caller exactly as
     ``system_stats`` does (a malformed value gives the error-shaped ``error`` /
     ``note`` form). With no remote configured the key is absent and the payload
-    is unchanged.
+    is unchanged. ERRORS carry the same provenance note appended to their
+    message, so a failure to reach the LOCAL ComfyUI is not read as the
+    configured remote being down.
     """
     if free_memory is None:
         # Mirror `unload_models` so the default call asks for both and
@@ -6661,9 +6741,10 @@ def free_memory(unload_models: bool = True, free_memory: bool | None = None) -> 
         data = _run_comfy(*args, timeout=60.0)
     except ComfyCliError as exc:
         hinted = _resource_verb_upgrade_error(exc, "free", "free_memory")
-        if hinted is not None:
-            raise hinted from exc
-        raise
+        annotated = _with_target_provenance(exc if hinted is None else hinted)
+        if annotated is exc:
+            raise
+        raise annotated from exc
     return _annotate_comfy_target(data)
 
 

--- a/tests/test_remote_host.py
+++ b/tests/test_remote_host.py
@@ -18,7 +18,9 @@ every ``comfy jobs`` subcommand). These lock in:
    other.
 6. The tools that CANNOT be diverted saying so themselves: ``download_model``
    refusing outright, and ``system_stats`` / ``free_memory`` annotating their
-   payload with a ``comfy_target_note``.
+   payload with a ``comfy_target_note`` — and, since a probe that cannot reach
+   the remote usually FAILS when one is configured, appending that same
+   provenance to the error they raise.
 """
 
 from __future__ import annotations
@@ -914,3 +916,164 @@ def test_resource_tools_do_not_clobber_a_colliding_key(patched_run, monkeypatch)
     patched_run(envelope(data=payload))
 
     assert server.system_stats() == payload
+
+
+# --- ...and the ERROR path carries the same provenance ----------------------
+#
+# The note above only reaches a caller when the call SUCCEEDS, and with a remote
+# configured the failing case is the common one: neither verb takes
+# `--host`/`--port`, so with no local ComfyUI running they raise comfy-cli's bare
+# `server_not_running` while the configured remote is up and serving the run/job
+# tools fine. Unannotated, that reads as "the remote is down" and an agent
+# abandons a `run_workflow` that would have worked.
+
+_FAILED_ENVELOPE = {
+    "type": "envelope",
+    "ok": False,
+    "error": {"code": "server_not_running", "message": "ComfyUI not running"},
+}
+
+_NO_VERB_REPLY = {
+    "system_stats": (
+        2,
+        "",
+        "Usage: comfy [OPTIONS] COMMAND\nNo such command 'system-stats'.",
+    ),
+    "free_memory": (2, "", "Usage: comfy [OPTIONS] COMMAND\nNo such command 'free'."),
+}
+
+
+@pytest.mark.parametrize("tool", ["system_stats", "free_memory"])
+def test_resource_tool_errors_name_the_configured_target(
+    patched_run, monkeypatch, tool
+):
+    """A raised error says WHICH ComfyUI it is (not) about, and keeps its own text."""
+    monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
+    monkeypatch.setenv("COMFYUI_PORT", "9001")
+    patched_run(_FAILED_ENVELOPE)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        getattr(server, tool)()
+
+    message = str(excinfo.value)
+    # comfy-cli's own verdict is still the primary text — the note is additive.
+    assert "server_not_running" in message
+    assert "gpu.example:9001" in message
+    assert "COMFYUI_HOST" in message
+    assert "did NOT reach it" in message
+    # ...and it does not adjudicate, exactly as the success-path note does not.
+    assert "may or may not be the same machine" in message
+
+
+@pytest.mark.parametrize("tool", ["system_stats", "free_memory"])
+def test_resource_tool_missing_verb_error_also_carries_the_target(
+    patched_run, monkeypatch, tool
+):
+    """The upgrade hint and the provenance note coexist — neither replaces the other.
+
+    A comfy-cli too old for the verb AND a configured remote are independent
+    facts, and the caller needs both: the one-command fix, and the fact that
+    fixing it still would not have probed the remote.
+    """
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
+    returncode, stdout, stderr = _NO_VERB_REPLY[tool]
+    patched_run(stdout, returncode=returncode, stderr=stderr)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        getattr(server, tool)()
+
+    message = str(excinfo.value)
+    assert "pip install -U comfy-cli" in message  # the hint survived
+    assert "gpu.example:9001" in message  # ...and gained the provenance
+    assert "COMFYUI_URL" in message
+    # The raw Click usage dump the hint replaces still must not leak through.
+    assert "No such command" not in message
+
+
+@pytest.mark.parametrize(
+    "tool, argv",
+    [
+        ("system_stats", "system-stats"),
+        ("free_memory", "free --unload-models --free-memory"),
+    ],
+)
+def test_resource_tool_errors_unconfigured_are_byte_identical(patched_run, tool, argv):
+    """Nothing configured -> the message is exactly what it was before this note.
+
+    The empty-suffix path must re-raise the SAME error object, so the local
+    default is untouched: full equality, not a substring.
+    """
+    patched_run(_FAILED_ENVELOPE)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        getattr(server, tool)()
+
+    assert str(excinfo.value) == (
+        f"comfy {argv} failed [server_not_running]: ComfyUI not running"
+    )
+
+
+@pytest.mark.parametrize("tool", ["system_stats", "free_memory"])
+def test_resource_tool_errors_report_a_malformed_target(patched_run, monkeypatch, tool):
+    """A broken config annotates the error; it never REPLACES comfy-cli's own.
+
+    Same fail-soft rule the success-path note follows: these two verbs never
+    touch the remote, so a typo in `COMFYUI_URL` must not change what they fail
+    with — only add that a target is configured-but-unreadable, which "no note
+    at all" would have read as "nothing configured".
+    """
+    monkeypatch.setenv("COMFYUI_URL", "::/bad")
+    patched_run(_FAILED_ENVELOPE)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        getattr(server, tool)()
+
+    message = str(excinfo.value)
+    assert message.startswith("comfy ")
+    assert "[server_not_running]: ComfyUI not running" in message
+    assert "COMFYUI_URL/COMFYUI_HOST is set but malformed" in message
+
+
+@pytest.mark.parametrize("tool", ["system_stats", "free_memory"])
+def test_resource_tool_errors_mask_credentials_in_the_host(
+    patched_run, monkeypatch, tool
+):
+    """`COMFYUI_HOST` is verbatim, so userinfo must not ride out on the error either.
+
+    Mirrors `test_target_note_masks_credentials_in_the_host`: the error message
+    reaches the model's context (and any transcript of it) exactly as the
+    payload note does.
+    """
+    monkeypatch.setenv("COMFYUI_HOST", "<user>:<token>@gpu.example")
+    patched_run(_FAILED_ENVELOPE)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        getattr(server, tool)()
+
+    message = str(excinfo.value)
+    assert "***@gpu.example" in message
+    assert "<token>" not in message
+
+
+@pytest.mark.parametrize("tool", ["system_stats", "free_memory"])
+def test_resource_tool_errors_keep_their_structured_fields(
+    patched_run, monkeypatch, tool
+):
+    """Rewriting the message must not decay the error's structured provenance.
+
+    `code` / `no_envelope` / `returncode` are what callers branch on instead of
+    string-matching, so the annotated error carries the originals rather than a
+    fresh set of defaults.
+    """
+    patched_run(_FAILED_ENVELOPE)
+    with pytest.raises(server.ComfyCliError) as bare:
+        getattr(server, tool)()
+
+    monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
+    patched_run(_FAILED_ENVELOPE)
+    with pytest.raises(server.ComfyCliError) as annotated:
+        getattr(server, tool)()
+
+    for attr in ("code", "no_envelope", "returncode", "timed_out", "data"):
+        assert getattr(annotated.value, attr) == getattr(bare.value, attr)
+    assert annotated.value.code == "server_not_running"

--- a/tests/test_remote_host.py
+++ b/tests/test_remote_host.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import subprocess
 
 import pytest
 from conftest import _OK_STREAM, envelope
@@ -927,10 +928,15 @@ def test_resource_tools_do_not_clobber_a_colliding_key(patched_run, monkeypatch)
 # tools fine. Unannotated, that reads as "the remote is down" and an agent
 # abandons a `run_workflow` that would have worked.
 
+# Hand-built rather than `envelope(ok=False, error=…)`: that builder carries
+# EITHER an error or a `data` payload, and the shape needed here is the one
+# `ComfyCliError.data` exists for — a failed envelope that still has a payload —
+# so the structured-field test below has a non-default `data` to prove survives.
 _FAILED_ENVELOPE = {
     "type": "envelope",
     "ok": False,
     "error": {"code": "server_not_running", "message": "ComfyUI not running"},
+    "data": {"probe": "partial"},
 }
 
 _NO_VERB_REPLY = {
@@ -960,9 +966,13 @@ def test_resource_tool_errors_name_the_configured_target(
     assert "server_not_running" in message
     assert "gpu.example:9001" in message
     assert "COMFYUI_HOST" in message
-    assert "did NOT reach it" in message
+    # "not AIMED at" is the claim this server can actually make — see the note
+    # in `_target_provenance_suffix`; asserting it here keeps a future reword
+    # from quietly upgrading it back into a claim about reachability.
+    assert "was NOT aimed at it" in message
     # ...and it does not adjudicate, exactly as the success-path note does not.
     assert "may or may not be the same machine" in message
+    assert "no evidence about it" in message
 
 
 @pytest.mark.parametrize("tool", ["system_stats", "free_memory"])
@@ -1031,7 +1041,10 @@ def test_resource_tool_errors_report_a_malformed_target(patched_run, monkeypatch
     message = str(excinfo.value)
     assert message.startswith("comfy ")
     assert "[server_not_running]: ComfyUI not running" in message
-    assert "COMFYUI_URL/COMFYUI_HOST is set but malformed" in message
+    assert "COMFYUI_PORT) is set but invalid" in message
+    # `_comfy_target`'s OWN message is interpolated, not just the static note —
+    # it is the only part that says which variable and what is wrong with it.
+    assert "COMFYUI_URL is malformed: '::/bad'" in message
 
 
 @pytest.mark.parametrize("tool", ["system_stats", "free_memory"])
@@ -1043,8 +1056,14 @@ def test_resource_tool_errors_mask_credentials_in_the_host(
     Mirrors `test_target_note_masks_credentials_in_the_host`: the error message
     reaches the model's context (and any transcript of it) exactly as the
     payload note does.
+
+    The token carries a `/` on purpose. `_redact_target_host` used to defer to
+    `textutil._redact_url`, which stops inspecting at the first `/` because in a
+    URL that is where the path starts — so a base64-ish token (they routinely
+    contain `/`) put the `@` outside the inspected slice and came back in full.
+    A bare host has no path, so every `@` in it is userinfo.
     """
-    monkeypatch.setenv("COMFYUI_HOST", "<user>:<token>@gpu.example")
+    monkeypatch.setenv("COMFYUI_HOST", "<user>:<tok/en>@gpu.example")
     patched_run(_FAILED_ENVELOPE)
 
     with pytest.raises(server.ComfyCliError) as excinfo:
@@ -1052,7 +1071,7 @@ def test_resource_tool_errors_mask_credentials_in_the_host(
 
     message = str(excinfo.value)
     assert "***@gpu.example" in message
-    assert "<token>" not in message
+    assert "<tok/en>" not in message
 
 
 @pytest.mark.parametrize("tool", ["system_stats", "free_memory"])
@@ -1063,7 +1082,11 @@ def test_resource_tool_errors_keep_their_structured_fields(
 
     `code` / `no_envelope` / `returncode` are what callers branch on instead of
     string-matching, so the annotated error carries the originals rather than a
-    fresh set of defaults.
+    fresh set of defaults. The fixture's failed envelope carries a `data`
+    payload so that attribute is compared at a NON-default value — equality
+    against a `None` both sides share would hold even if the rewrite dropped it.
+    (`timed_out` gets the same treatment in the timeout test below, which is the
+    only path that can set it.)
     """
     patched_run(_FAILED_ENVELOPE)
     with pytest.raises(server.ComfyCliError) as bare:
@@ -1077,3 +1100,99 @@ def test_resource_tool_errors_keep_their_structured_fields(
     for attr in ("code", "no_envelope", "returncode", "timed_out", "data"):
         assert getattr(annotated.value, attr) == getattr(bare.value, attr)
     assert annotated.value.code == "server_not_running"
+    assert annotated.value.data == {"probe": "partial"}  # not a shared default
+
+
+@pytest.mark.parametrize("tool", ["system_stats", "free_memory"])
+def test_resource_tool_timeout_keeps_the_note_and_its_timed_out_flag(
+    patched_run, monkeypatch, tool
+):
+    """A timeout is a verdict from a child that ran, so it is annotated too.
+
+    And `timed_out` — the one attribute the envelope fixtures leave at its
+    default on both sides — has to survive the rewrite: `wait_for_job` branches
+    on it instead of matching the message.
+    """
+    monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
+    patched_run(
+        "", raises=subprocess.TimeoutExpired(cmd=[server.COMFY_BIN], timeout=60.0)
+    )
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        getattr(server, tool)()
+
+    assert excinfo.value.timed_out is True
+    assert "gpu.example:8188" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("tool", ["system_stats", "free_memory"])
+def test_resource_tool_errors_skip_the_note_when_comfy_cli_never_ran(
+    patched_run, monkeypatch, tool
+):
+    """A missing comfy-cli is about no ComfyUI at all, so it is raised untouched.
+
+    The note tells the caller not to read the failure as a verdict on the
+    configured target, which implies the submit tools are unaffected. That is
+    true of a dispatched verb's failure and false of every failure raised before
+    a verb ran: `run_workflow` shells out to the same absent binary and dies the
+    same way. Appending it there would send an agent to retry against a remote
+    it equally cannot reach.
+    """
+    monkeypatch.setenv("COMFYUI_HOST", "gpu.example")
+    patched_run(_FAILED_ENVELOPE)
+    # After `patched_run`, so it overrides the fixture's resolvable stub.
+    monkeypatch.setattr(server.shutil, "which", lambda _: None)
+    # Keep the message the PATH one on every runner: on macOS `_require_comfy_bin`
+    # would otherwise probe for a TCC denial, which depends on the real PATH.
+    monkeypatch.setattr(server.tcc, "_is_macos", lambda: False)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        getattr(server, tool)()
+
+    message = str(excinfo.value)
+    assert "not found on PATH" in message
+    assert "gpu.example" not in message
+    assert "note:" not in message
+
+
+@pytest.mark.parametrize("tool", ["system_stats", "free_memory"])
+def test_resource_tool_error_note_brackets_an_ipv6_target(
+    patched_run, monkeypatch, tool
+):
+    """An IPv6 target is re-bracketed so the port is not read as a final hextet.
+
+    `_comfy_target` hands back the bracket-free host every other consumer wants
+    (the payload note keeps host and port as separate keys), but this note joins
+    the two into one string — where `2001:db8::1:8188` is ambiguous.
+    """
+    monkeypatch.setenv("COMFYUI_HOST", "[2001:db8::1]")
+    monkeypatch.setenv("COMFYUI_PORT", "8188")
+    patched_run(_FAILED_ENVELOPE)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        getattr(server, tool)()
+
+    assert "[2001:db8::1]:8188" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("tool", ["system_stats", "free_memory"])
+def test_resource_tool_malformed_target_error_redacts_a_query_secret(
+    patched_run, monkeypatch, tool
+):
+    """A token in the query string is masked, not just `user:pass@` userinfo.
+
+    An auth-proxied ComfyUI is routinely addressed as `https://host/?token=…`,
+    and a value written that way is echoed back the moment `_comfy_target`
+    rejects it — here for the `https` scheme, which is how such a proxy is
+    usually reached. The host is the whole diagnostic, so the query goes out as
+    a placeholder.
+    """
+    monkeypatch.setenv("COMFYUI_URL", "https://gpu.example:8188/?token=<sekret>")
+    patched_run(_FAILED_ENVELOPE)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        getattr(server, tool)()
+
+    message = str(excinfo.value)
+    assert "<sekret>" not in message
+    assert "?<redacted>" in message  # ...but the user still sees they wrote one


### PR DESCRIPTION
## ELI-5

`system_stats` and `free_memory` ask comfy-cli about a ComfyUI server. Unlike the run/job tools, they have no way to say *which* server — `comfy system-stats` and `comfy free` take no `--host`/`--port`, only `--where` — so they always report on whichever ComfyUI comfy-cli itself points at, which is usually the local one.

#167 taught them to say so, by adding a `comfy_target_note` to the payload when a remote is configured. But that only happens when the call *succeeds*, and with a remote configured the usual outcome is failure: nothing is running locally, so comfy-cli raises a bare `server_not_running`. An agent reads that, concludes the remote GPU is down, and gives up on a `run_workflow` that would have worked fine.

This PR appends the same provenance to the error. Now the message says which target is configured, that this probe did **not** reach it, and why — so "the local probe failed" is not mistaken for "the remote is down".

## What changed

- **`_target_provenance_suffix()`** — sits next to `_annotate_comfy_target` and mirrors its three cases: nothing configured → `""`; a resolved target → one sentence naming the (userinfo-masked) host, port and source var, and stating that this probe did not reach it; a malformed `COMFYUI_URL`/`COMFYUI_HOST` → a short suffix carrying `_comfy_target`'s own already-masked message, so a typo does not read as "nothing configured". It never re-raises the config error — same fail-soft rule as `_annotate_comfy_target`, since these two tools never touch the remote.
- **`_with_target_provenance(err)`** — the shared body both `except ComfyCliError` blocks use. It appends the suffix to whichever error is about to be raised (the `_resource_verb_upgrade_error` hinted one *or* the raw re-raise), and returns the **same object** when the suffix is empty, which is what lets the caller fall through to a bare `raise`.
- Both tools' docstrings gained a sentence noting that errors carry the same provenance.

Untouched, deliberately: the success path, `_annotate_comfy_target`, `free_memory`'s early `unload_models`/`free_memory` validation raise (a caller-argument error, not a probe result), and every other tool's error handling.

## Unconfigured behavior is byte-identical

With no remote configured the suffix is empty, both blocks re-raise the original objects, and the code path is exactly today's — bare `raise` for a real error (original traceback intact), `raise hinted from exc` for a missing verb. `test_resource_tool_errors_unconfigured_are_byte_identical` asserts **full string equality** on the raised message rather than a substring. The existing error-text assertions in `tests/test_wrapper.py` (`test_resource_tools_hint_at_the_upgrade_on_a_comfy_cli_without_the_verb`, `test_resource_tools_keep_a_real_error_raw`) pass unchanged — the autouse fixture in `tests/conftest.py` clears `COMFYUI_URL`/`COMFYUI_HOST`, so they exercise the empty-suffix path. A `git grep` confirms no other test asserts full equality on these two tools' error messages.

## Judgment calls

- **Two helpers, not one.** The ticket specified `_target_provenance_suffix()`; I added `_with_target_provenance` on top of it so the wrap-or-passthrough handling lives in one body instead of being copied into both `except` blocks — the same "one shared body, not a second copy" shape AGENTS.md asks for around `_elicit_approval`. The suffix helper is still separately testable and is what the note's wording lives in.
- **Every structured attribute is carried across, not just `no_envelope`/`returncode`.** The ticket named those two (the pair `_resource_verb_upgrade_error` preserves). The rebuilt error also carries `code`, `timed_out` and `data`. `timed_out` is the concrete motivation: both tools pass `timeout=60.0`, so a timeout really can reach this block, and it should not silently become `timed_out=False` just because the message got a suffix. `code` is what callers are told to branch on instead of string-matching. `test_resource_tool_errors_keep_their_structured_fields` pins all five against the unannotated error.
- **The suffix does not adjudicate**, matching `_annotate_comfy_target`'s wording: it says the two ends may or may not be the same machine and that this server does not verify which. The one inference it does rule out is the wrong one — that the error is a verdict on the configured target.

## Negative-claim falsification (self-review clause (e))

The trigger does not fire, and the check is worth stating explicitly because this PR touches error text. The diff adds **no** new failure, no throw/deny path, and flips no test to assert a dead-end — every failure it annotates already existed and is raised identically. The added text is capability-*affirming*: its entire purpose is to stop an agent from inferring a dead-end ("the remote is down") from a local probe, and it points at the run/job tools, which *do* submit to the configured target via `_with_target`. The one pre-existing "unavailable" string in this region (`_resource_verb_upgrade_error`'s `"<tool> unavailable: ..."`) is untouched, and this change makes it strictly more informative rather than more final.

## Testing

- `pytest` — **1484 passed, 3 skipped**.
- `ruff check .` and `ruff format --check .` — clean.
- Six new tests in `tests/test_remote_host.py`, parametrized over both tools: target named on a failing envelope; hint **and** provenance coexisting on the missing-verb reply; the byte-identical unconfigured message; a malformed `COMFYUI_URL` annotating rather than replacing comfy-cli's own error; credential masking in the raised message; and the structured-field preservation above.
