### PR TITLE
fix: extend the echoed-phrase forgery guard to the remaining caller-argv degrade sites

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -9168,14 +9168,27 @@ _MAX_NODE_PACK_ID_LEN = 128
 # degrade asserts NOTHING IS BROKEN (see `_is_missing_verb_error`), and their
 # `no_envelope` condition exists to keep a RELAYED "no such command" out. This
 # closes the one door that condition cannot: text the CALLER put on the command
-# line. `node deps` is the only degrade site whose argv carries caller-controlled
-# values — `outdated` / `notes` / `download-status` take none — and Click echoes
-# an offending value verbatim in its usage error (`Invalid value for '[PACK]':
-# …`), which lands on the same exit 2 with no envelope the matchers read. So a
-# caller passing `pack="no such command 'deps'"` could otherwise forge the
-# parser's own message about `deps` and convert a genuine usage failure into
-# "your comfy-cli is just too old". Local to this call site rather than folded
-# into the matchers, which have no way to know what their caller passed.
+# line. Click echoes an offending value verbatim in its usage error (`Invalid
+# value for '[PACK]': …`), which lands on the same exit 2 with no envelope the
+# matchers read — so a caller passing `pack="no such command 'deps'"` could
+# otherwise forge the parser's own message about `deps` and convert a genuine
+# usage failure into "your comfy-cli is just too old".
+#
+# The degrade sites, by what their argv carries: `outdated`
+# (`_freshness_report`) takes no caller text at all and needs no subtraction;
+# `notes` (`list_workflow_notes`) carries `workflow_path`; `download-status` /
+# `download-cancel` (`_download_verb_unsupported`) carry `download_id`; `node
+# deps` carries `pack` and `registry_id`. EVERY site whose argv carries caller
+# text applies this subtraction, passing its own values — the matchers see only
+# the exception and have no way to know what their caller put on the command
+# line, which is why the values are a per-site argument rather than folded in.
+#
+# For `notes` and the download verbs this is forward cover rather than a live
+# hole: on comfy-cli main those parameters are plain `str` Typer params
+# validated in the command body, so the failure is an enveloped exit 1 and Click
+# never echoes them at parse time. Retyping one to a parse-time-validated type
+# (`Path`, a `Choice`) is a one-line comfy-cli change that needs no coordination
+# with this repo — which is exactly the change that would open the door here.
 def _phrase_is_only_the_caller_s(
     exc: ComfyCliError, pattern: str, *values: str
 ) -> bool:
@@ -9298,9 +9311,9 @@ def node_dependencies(pack: str = "", registry_id: str = "") -> Any:
         # workspace, an unknown pack name, an unreachable registry) keeps the raw
         # raise instead of being waved through as a capability gap. On top of
         # that pair, `_phrase_is_only_the_caller_s` discounts a phrase Click
-        # merely echoed back out of `pack` / `registry_id` — the one route to a
-        # false `unsupported` those two conditions leave open here, and the
-        # reason this call site needs a check the other degrade sites do not.
+        # merely echoed back out of `pack` / `registry_id` — the same echoed-argv
+        # route every degrade site with caller text in its argv closes, here for
+        # this site's own two values.
         caller_values = (pack, registry_id)
         if _is_missing_verb_error(exc, "deps") and not _phrase_is_only_the_caller_s(
             exc,
@@ -9694,7 +9707,9 @@ async def _legacy_foreground_download(
     return legacy
 
 
-def _download_verb_unsupported(exc: ComfyCliError, verb: str) -> dict[str, Any] | None:
+def _download_verb_unsupported(
+    exc: ComfyCliError, verb: str, download_id: str
+) -> dict[str, Any] | None:
     """The capability-gap degrade for a ``model <verb>`` this comfy-cli lacks.
 
     Returns the ``{"error": ..., "unsupported": True}`` shape
@@ -9720,9 +9735,20 @@ def _download_verb_unsupported(exc: ComfyCliError, verb: str) -> dict[str, Any] 
     for the reason documented there: this shape asserts nothing is broken, so a
     failure that merely RELAYS a "no such command" — or any real error from a
     verb comfy-cli did dispatch, an unknown id included — must keep the raw
-    passthrough instead of being waved through as a capability gap.
+    passthrough instead of being waved through as a capability gap. On top of
+    that, the caller's own *download_id* is discounted the way
+    ``node_dependencies`` discounts ``pack`` / ``registry_id``: every verb here
+    takes the id as a bare positional and :func:`_guard_download_id`
+    deliberately permits any characters, so a Click usage error echoing it back
+    could otherwise carry the parser's own phrase. *download_id* is a required
+    argument rather than a defaulted one so a fourth caller cannot silently skip
+    the subtraction.
     """
-    if not _is_missing_verb_error(exc, verb):
+    if not _is_missing_verb_error(exc, verb) or _phrase_is_only_the_caller_s(
+        exc,
+        _MISSING_VERB_RE_TEMPLATE.format(verb=re.escape(verb)),
+        download_id,
+    ):
         return None
     return {
         "error": (
@@ -10201,7 +10227,7 @@ def download_status(download_id: str) -> Any:
     try:
         return _run_comfy("model", "download-status", download_id, timeout=60.0)
     except ComfyCliError as exc:
-        degraded = _download_verb_unsupported(exc, "download-status")
+        degraded = _download_verb_unsupported(exc, "download-status", download_id)
         if degraded is None:
             raise
         return degraded
@@ -10237,7 +10263,7 @@ def wait_for_download(download_id: str, timeout_seconds: float = 25.0) -> Any:
     try:
         return _poll_download(download_id, timeout_seconds)
     except ComfyCliError as exc:
-        degraded = _download_verb_unsupported(exc, "download-status")
+        degraded = _download_verb_unsupported(exc, "download-status", download_id)
         if degraded is None:
             raise
         return degraded
@@ -10261,7 +10287,7 @@ def cancel_download(download_id: str) -> Any:
     try:
         return _run_comfy("model", "download-cancel", download_id, timeout=60.0)
     except ComfyCliError as exc:
-        degraded = _download_verb_unsupported(exc, "download-cancel")
+        degraded = _download_verb_unsupported(exc, "download-cancel", download_id)
         if degraded is None:
             raise
         return degraded
@@ -10452,8 +10478,16 @@ def list_workflow_notes(workflow_path: str) -> Any:
         # `_download_verb_unsupported`: `_is_missing_verb_error` requires the
         # no-envelope + Click-usage-exit pair, so a real failure from a verb
         # comfy-cli DID dispatch (a missing file, an API-format export) keeps
-        # the raw raise instead of being waved through as a capability gap.
-        if not _is_missing_verb_error(exc, "notes"):
+        # the raw raise instead of being waved through as a capability gap. On
+        # top of that pair, `_phrase_is_only_the_caller_s` subtracts the one
+        # thing this argv carries from the caller — `workflow_path`, a bare
+        # positional — so a path Click merely echoed back in a usage error
+        # cannot forge the phrase and turn a real failure into a version gap.
+        if not _is_missing_verb_error(exc, "notes") or _phrase_is_only_the_caller_s(
+            exc,
+            _MISSING_VERB_RE_TEMPLATE.format(verb=re.escape("notes")),
+            workflow_path,
+        ):
             raise
         # The degrade names the path that still works rather than dead-ending:
         # the notes are IN the frontend-format file `fetch_template` already

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -9347,21 +9347,32 @@ _MAX_NODE_PACK_ID_LEN = 128
 # otherwise forge the parser's own message about `deps` and convert a genuine
 # usage failure into "your comfy-cli is just too old".
 #
-# The degrade sites, by what their argv carries: `outdated`
-# (`_freshness_report`) takes no caller text at all and needs no subtraction;
-# `notes` (`list_workflow_notes`) carries `workflow_path`; `download-status` /
+# The degrade sites, by what their argv carries — the VERB-shaped ones first:
+# `outdated` (`_freshness_report`) takes no caller text at all; `notes`
+# (`list_workflow_notes`) carries `workflow_path`; `download-status` /
 # `download-cancel` (`_download_verb_unsupported`) carry `download_id`; `node
-# deps` carries `pack` and `registry_id`. EVERY site whose argv carries caller
-# text applies this subtraction, passing its own values — the matchers see only
-# the exception and have no way to know what their caller put on the command
-# line, which is why the values are a per-site argument rather than folded in.
+# deps` carries `pack` and `registry_id`. Then the OPTION-shaped siblings, which
+# read `_is_missing_option_error` and are in the same set for the same reason:
+# `--registry` (`node_dependencies`) carries those same two values, and
+# `--background` (`download_model`) carries `url` / `relative_path` /
+# `filename`. The remaining two option sites need no subtraction because their
+# values CANNOT spell the phrase, not because nobody supplied them: `--port`
+# (`get_logs`) forwards a `_guard_log_port`-normalized int, and `--version`
+# (`_run_version_switch`) a `_guard_version`-constrained token (`nightly` /
+# `latest` / a semver tag).
 #
-# For `notes` and the download verbs this is forward cover rather than a live
-# hole: on comfy-cli main those parameters are plain `str` Typer params
-# validated in the command body, so the failure is an enveloped exit 1 and Click
-# never echoes them at parse time. Retyping one to a parse-time-validated type
-# (`Path`, a `Choice`) is a one-line comfy-cli change that needs no coordination
-# with this repo — which is exactly the change that would open the door here.
+# EVERY site whose argv can carry the phrase applies this subtraction, passing
+# its own values — the matchers see only the exception and have no way to know
+# what their caller put on the command line, which is why the values are a
+# per-site argument rather than folded in.
+#
+# For `notes`, the download verbs and `--background` this is forward cover
+# rather than a live hole: on comfy-cli main those parameters are plain `str`
+# Typer params validated in the command body, so the failure is an enveloped
+# exit 1 and Click never echoes them at parse time. Retyping one to a
+# parse-time-validated type (`Path`, a `Choice`) is a one-line comfy-cli change
+# that needs no coordination with this repo — which is exactly the change that
+# would open the door here.
 def _phrase_is_only_the_caller_s(
     exc: ComfyCliError, pattern: str, *values: str
 ) -> bool:
@@ -9382,15 +9393,39 @@ def _phrase_is_only_the_caller_s(
     get), which is what Click's ``repr`` of an offending value gives for the
     shapes that can carry the phrase at all — the value needs a quote, and
     ``repr`` answers a single-quoted value with double quotes rather than
-    backslashes. A value carrying BOTH quote styles would come back re-escaped
-    and survive this subtraction. That residual is left as-is: the caller would
-    be deceiving only itself, since the degrade it forges is returned to the
-    same caller that crafted the argument.
+    backslashes. Three ways the echo can fail to be verbatim are known and left
+    as-is, for one shared reason: each is SELF-inflicted, because the degrade a
+    caller forges is returned to the same caller that crafted the argument.
+
+    - A value carrying BOTH quote styles comes back re-escaped, so the raw value
+      is no longer a substring of the message.
+    - Click does not always echo the value byte-for-byte. The retype this is
+      forward cover for is exactly where that shows: a Typer
+      ``Path(..., resolve_path=True)`` echoes the RESOLVED path, and ``repr``
+      doubles a backslash. Either way the subtraction is a no-op and the forged
+      phrase survives.
+    - The message this reads is a bounded ``textutil._tail`` (500 chars), so a
+      value longer than the tail arrives clipped and the whole-value replace
+      matches nothing. The id-shaped values are already capped well under that
+      bound (``_MAX_DOWNLOAD_ID_LEN``, ``_MAX_NODE_PACK_ID_LEN``);
+      ``workflow_path`` and ``download_model``'s ``url`` / ``relative_path`` /
+      ``filename`` are not, and are left uncapped deliberately — a cap tight
+      enough to close the gap would have to sit under 500 characters, and would
+      start refusing legitimately deep paths and long CivitAI/HuggingFace URLs
+      to buy nothing but protection from a caller's own crafted argument.
     """
     normalized = _normalize_cli_text(str(exc))
     for value in values:
-        if value:
-            normalized = normalized.replace(_normalize_cli_text(value), " ")
+        # Emptiness is tested on the NORMALIZED value, not the raw one. A value
+        # that is only whitespace or panel glyphs — `" "`, which
+        # `_guard_download_id` accepts and `list_workflow_notes` does not
+        # reject — is truthy but normalizes to `""`, and `str.replace("", " ")`
+        # interleaves a space between EVERY character of the message. That
+        # shreds comfy-cli's own phrase and would suppress the GENUINE degrade,
+        # handing the caller Click's raw usage dump instead.
+        echoed = _normalize_cli_text(value)
+        if echoed:
+            normalized = normalized.replace(echoed, " ")
     return re.search(pattern, normalized, re.IGNORECASE) is None
 
 
@@ -10304,8 +10339,24 @@ async def download_model(
         # to the old synchronous call costs nothing and keeps old CLIs working.
         # Narrow on purpose (see `_is_missing_option_error`): any OTHER failure
         # may have already started a transfer, and re-running it here would
-        # download the same file twice.
-        if not _is_missing_option_error(exc, "--background"):
+        # download the same file twice. On top of that pair,
+        # `_phrase_is_only_the_caller_s` discounts a phrase Click merely echoed
+        # back out of this argv's three caller-supplied values — the same
+        # echoed-argv route every degrade site with caller text closes, and the
+        # one with the worst consequence in that set, since a false positive
+        # here does not just mislabel an error but silently re-runs a multi-GB
+        # transfer. `relative_path` / `filename` are `None` when unset and only
+        # reach argv when they are not, so they are passed as `""` — which the
+        # subtraction skips.
+        if not _is_missing_option_error(
+            exc, "--background"
+        ) or _phrase_is_only_the_caller_s(
+            exc,
+            _MISSING_OPTION_RE_TEMPLATE.format(option=re.escape("--background")),
+            url,
+            relative_path or "",
+            filename or "",
+        ):
             raise
         # The whole pre-`--background` contract — its own deadline arithmetic,
         # pre-spawn refusal, timeout wrapping and payload marker — lives in

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1331,6 +1331,33 @@ def test_download_companions_echoed_phrase_is_not_unsupported(patched_run, tool,
         getattr(server, tool)(download_id)
 
 
+@pytest.mark.parametrize(
+    "tool, verb",
+    [
+        ("download_status", "download-status"),
+        ("wait_for_download", "download-status"),
+        ("cancel_download", "download-cancel"),
+    ],
+)
+def test_download_companions_degrade_with_a_blank_download_id(patched_run, tool, verb):
+    """A whitespace-only id must not cost the genuine degrade.
+
+    `_guard_download_id` accepts `" "` (it is truthy, dash-free and NUL-free),
+    and `_normalize_cli_text` folds it to `""`. Subtracting an empty string is
+    `str.replace("", " ")`, which interleaves a space between EVERY character of
+    comfy-cli's message — shredding the parser's own phrase and suppressing the
+    version gap. `_phrase_is_only_the_caller_s` skips a value whose NORMALIZED
+    form is empty for exactly that reason.
+    """
+    patched_run(
+        "",
+        returncode=2,
+        stderr=f"Usage: comfy model [OPTIONS] COMMAND\nNo such command '{verb}'.",
+    )
+
+    assert getattr(server, tool)(" ")["unsupported"] is True
+
+
 def test_wait_for_download_returns_the_terminal_payload(monkeypatch):
     """wait_for_download polls until terminal and returns that final payload."""
     calls = _sequenced(monkeypatch, [_status("downloading"), _status("completed")])
@@ -1456,6 +1483,38 @@ def test_download_model_guards_the_id_comfy_cli_hands_back(monkeypatch):
 # no-envelope handling below — which is now scoped to it alone, since a
 # `--background` submit returns a real envelope. `legacy_comfy_cli` is what
 # makes the installed CLI look that old.
+
+
+def test_download_model_echoed_phrase_does_not_reach_the_fallback(
+    patched_run, monkeypatch
+):
+    """A caller cannot forge the version gap through its own `url`.
+
+    The stake here is the highest of the echoed-argv group: the degrade is not a
+    label but a re-run, so a false `--background` gap would silently repeat a
+    multi-GB transfer the failed submit may already have started. `url` /
+    `relative_path` / `filename` are the caller's, and Click echoing one back in
+    a usage error lands on the same exit 2 with no envelope
+    `_is_missing_option_error` reads — so the subtraction has to run before the
+    fallback does.
+    """
+
+    async def _never(*args, **kwargs):
+        raise AssertionError("the legacy foreground fallback must not run")
+
+    monkeypatch.setattr(server, "_run_comfy_async", _never)
+    url = "https://hf.co/x.safetensors?q=No such option: --background"
+    patched_run(
+        "",
+        returncode=2,
+        stderr=(
+            "Usage: comfy model download [OPTIONS]\n"
+            f"Error: Invalid value for '--url': {url!r} is not reachable."
+        ),
+    )
+
+    with pytest.raises(server.ComfyCliError):
+        _download_model(url)
 
 
 def test_download_model_synthesizes_success_on_plain_exit(

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1300,6 +1300,37 @@ def test_download_companions_keep_a_real_error_raw(patched_run, tool):
         getattr(server, tool)("a1b2c3d4e5f6")
 
 
+@pytest.mark.parametrize(
+    "tool, verb",
+    [
+        ("download_status", "download-status"),
+        ("wait_for_download", "download-status"),
+        ("cancel_download", "download-cancel"),
+    ],
+)
+def test_download_companions_echoed_phrase_is_not_unsupported(patched_run, tool, verb):
+    """A caller cannot forge the version gap through its own `download_id`.
+
+    The id is a bare positional and `_guard_download_id` deliberately permits
+    any characters, so Click echoing an offending value verbatim lands on the
+    same exit 2 with no envelope `_is_missing_verb_error` reads — the one route
+    to a false `unsupported` its two conditions cannot close. Subtracting the
+    caller's own text keeps a real failure a real failure.
+    """
+    download_id = f"no such command {verb!r}"
+    patched_run(
+        "",
+        returncode=2,
+        stderr=(
+            f"Usage: comfy model {verb} [OPTIONS] DOWNLOAD_ID\n"
+            f"Error: Invalid value for 'DOWNLOAD_ID': {download_id!r} does not exist."
+        ),
+    )
+
+    with pytest.raises(server.ComfyCliError):
+        getattr(server, tool)(download_id)
+
+
 def test_wait_for_download_returns_the_terminal_payload(monkeypatch):
     """wait_for_download polls until terminal and returns that final payload."""
     calls = _sequenced(monkeypatch, [_status("downloading"), _status("completed")])

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -15,7 +15,9 @@ that same template carries. The behaviors they own on top of the passthrough:
    here instead of failing opaquely (or behind a server-connection error) later.
 4. ``list_workflow_notes`` degrades to the ``unsupported`` shape on a comfy-cli
    that predates the ``workflow notes`` verb, instead of relaying Click's raw
-   usage dump — the common case while the verb is newer than the version floor.
+   usage dump — the common case while the verb is newer than the version floor
+   — and refuses to fire that degrade for a phrase Click merely echoed back out
+   of the caller's own ``workflow_path``.
 """
 
 from __future__ import annotations
@@ -161,6 +163,45 @@ def test_list_workflow_notes_relayed_phrase_is_not_unsupported(patched_run):
 
     with pytest.raises(server.ComfyCliError, match="workflow_read_failed"):
         server.list_workflow_notes("/tmp/flux.json")
+
+
+def test_list_workflow_notes_echoed_phrase_is_not_unsupported(patched_run):
+    """A caller cannot forge the version gap through its own `workflow_path`.
+
+    The path is a bare positional, and Click echoes an offending value verbatim
+    in a usage error — the same exit 2 with no envelope `_is_missing_verb_error`
+    reads, which is the one route to a false `unsupported` its two conditions
+    cannot close. `_phrase_is_only_the_caller_s` subtracts the caller's own text
+    so a real failure stays a real failure.
+    """
+    path = "no such command 'notes'"
+    patched_run(
+        "",
+        returncode=2,
+        stderr=(
+            "Usage: comfy workflow notes [OPTIONS] FILE\n"
+            f"Error: Invalid value for 'FILE': {path!r} does not exist."
+        ),
+    )
+
+    with pytest.raises(server.ComfyCliError):
+        server.list_workflow_notes(workflow_path=path)
+
+
+def test_list_workflow_notes_degrades_with_an_ordinary_path(patched_run):
+    """The echoed-input check must not cost the genuine degrade.
+
+    Discounting the caller's own text is subtraction, not a veto: an ordinary
+    `workflow_path` shares no wording with Click's message, so the parser's own
+    phrase survives and the version gap still reports as one.
+    """
+    patched_run(
+        "",
+        returncode=2,
+        stderr="Usage: comfy workflow [OPTIONS] COMMAND\nNo such command 'notes'.",
+    )
+
+    assert server.list_workflow_notes("workflow.json")["unsupported"] is True
 
 
 def test_set_workflow_slot_argv_default_stdout(patched_run):


### PR DESCRIPTION
## ELI-5

Four tools quietly say "your comfy-cli is just too old" instead of showing a scary error, but only when nothing is actually broken. The way they tell is by looking for the phrase `No such command 'notes'` in what the CLI printed. Trouble: if *you* put that exact phrase into an argument you pass in, the CLI's argument parser can print it back at you — and the tool would then mistake your own words for the CLI's, and tell you a comforting lie instead of the real error. One of the four tools already subtracted the caller's own text before looking. This PR does it for the other three, and fixes a comment that claimed they didn't need it.

## Summary

`_phrase_is_only_the_caller_s` closes the one route past `_is_missing_verb_error`'s two conditions (no envelope + Click usage exit): text the CALLER put on the command line, echoed back verbatim by Click in an envelope-less exit-2 usage error. Until now only `node_dependencies` applied it, and the inventory comment above the helper asserted that `node deps` was the only degrade site whose argv carries caller-controlled values — "`outdated` / `notes` / `download-status` take none".

That assertion was false. `list_workflow_notes` passes the caller's `workflow_path` as a bare positional, and `download_status` / `wait_for_download` / `cancel_download` pass the caller's `download_id` as a bare positional (`_guard_download_id` is deliberately not a hex-shape match — its docstring says so). Only `outdated` genuinely takes no caller text.

## Changes

- **`list_workflow_notes`** — its `except ComfyCliError` gate now subtracts `workflow_path` before accepting the missing-verb read, matching the pattern-building style used at the `node_dependencies` site. Comment updated; degrade message text untouched.
- **`_download_verb_unsupported`** — signature becomes `(exc, verb, download_id)` and the gate subtracts `download_id`. `download_id` is a **required** positional, not defaulted, so a future fourth caller cannot silently skip the subtraction. Docstring gains the sentence documenting it. All three callers pass the id. Message text untouched.
- **The inventory comment above `_phrase_is_only_the_caller_s`** — rewritten with the accurate inventory (`outdated` takes no caller text; `notes` carries `workflow_path`; `download-status`/`download-cancel` carry `download_id`; `node deps` carries `pack`/`registry_id`), stating that every site with caller argv now applies the subtraction. The "local to this call site" clause is gone now that there are several call sites; the reason the values are passed per-site — the matchers only see the exception and cannot know what their caller put on the command line — is kept.
- **The `node_dependencies` except-block comment** — the clause claiming this was "the reason this call site needs a check the other degrade sites do not" is replaced with the accurate framing: the same echoed-argv route every caller-argv degrade site closes.
- `_freshness_report` is untouched — `comfy outdated` takes no caller argv.

## Motivation

Defense in depth, not a live hole. On comfy-cli main today, `workflow notes`'s `file` and `download-status`'s `download_id` are plain `str` Typer params validated in the command body, so the failure is an enveloped exit 1 and Click never echoes them at parse time. The guard protects against comfy-cli retyping either to a parse-time-validated type (`Path`, a `Choice`) — a one-line change on that side that needs no coordination with this repo, and would open the door here silently. That reasoning is now recorded in the comment rather than left implicit.

## Testing

- [x] Existing tests pass (`pytest` — 1477 passed, 3 skipped; all pre-existing assertions unmodified)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)

New tests, modelled on the existing `test_node_dependencies_echoed_phrase_is_not_unsupported` / `..._degrades_with_a_pack_argument` pair:

- `tests/test_workflow.py::test_list_workflow_notes_echoed_phrase_is_not_unsupported` — `workflow_path="no such command 'notes'"` with the fake CLI exiting 2, no envelope, stderr in Click's `Invalid value for 'FILE': …` shape → raises `ComfyCliError`, not `unsupported: True`.
- `tests/test_workflow.py::test_list_workflow_notes_degrades_with_an_ordinary_path` — an ordinary `workflow.json` with Click's real `No such command 'notes'.` still degrades (`unsupported is True`). This is the risk constraint: the change may only make degrades fire LESS often.
- `tests/test_downloads.py::test_download_companions_echoed_phrase_is_not_unsupported` — parametrized over all three download tools with a forged `download_id`, same assertion.

I verified the two forgery tests are real rather than self-satisfying: reverting `server.py` alone makes all four forgery cases fail with `DID NOT RAISE ComfyCliError`, while the genuine-degrade tests pass either way (as they must — they pin the one-directional constraint).

The download-side "genuine degrade survives" case is already covered by the existing `test_download_companions_degrade_on_a_comfy_cli_without_the_verb`, which uses the ordinary hex-ish id `a1b2c3d4e5f6` against Click's real phrase and stays green — so I did not add a duplicate of it.

## Additional Notes

**Risk — one-directional by construction.** `_phrase_is_only_the_caller_s` returning `True` converts a would-be degrade into the raw honest re-raise. No path makes a degrade fire more often. For a well-behaved caller the visible behavior change is none at all; a caller embedding the parser's own phrasing in `workflow_path` / `download_id` now gets the real error instead of a forged "too old".

**Not a capability denial (negative-claim falsification, per the regression case in comfy-cloud-mcp-server#581).** The trigger heuristic — a diff adding "unavailable"/"not supported"/"STOP" strings, a deny dead-end, or tests flipped to assert a dead-end — does not fire in substance here. This diff adds no denial strings (all four degrade messages are byte-identical to before) and adds no dead-end path. Its direction is the exact opposite of a capability denial: it makes the "unavailable" claim fire strictly *less* often and surfaces the engine's real error instead. The new `pytest.raises` assertions assert that the honest error reaches the caller, not that a capability is absent. So there is no denied capability to go empirically falsify via the server's own discovery tools.

**The `_is_missing_option_error` siblings** — revised in the review round below. `download_model`'s `--background` was originally left out on the grounds that it is not an `{"error": ..., "unsupported": True}` degrade site. Two reviewers pointed out that its argv carries three caller-supplied values (`url` / `relative_path` / `filename`) and that its consequence is the worst in the group: a false positive does not mislabel an error, it silently re-runs a multi-GB transfer via `_legacy_foreground_download`. It now applies the subtraction, matching the `--registry` site next to it, which already did.

The other two option sites stay untouched, and the comment now says WHY: their values cannot spell the phrase at all. `get_logs`' `--port` forwards a `_guard_log_port`-normalized int, and `_run_version_switch`'s `--version` a `_guard_version`-constrained token (`nightly` / `latest` / a semver tag, checked before the spawn).

## Review round

- **`_phrase_is_only_the_caller_s` tested truthiness on the RAW value but subtracted the NORMALIZED one** (real bug, fixed). `_normalize_cli_text` folds a whitespace-only value to `""`, and `" "` is an id `_guard_download_id` accepts — so the subtraction became `str.replace("", " ")`, which interleaves a space between every character of the message, shredding comfy-cli's own phrase and suppressing the GENUINE degrade. Emptiness is now tested on the normalized form. New test `test_download_companions_degrade_with_a_blank_download_id`.
- **`--background` now subtracts its three values**, as above. New test `test_download_model_echoed_phrase_does_not_reach_the_fallback`, which stubs `_run_comfy_async` so reaching the fallback fails the test.
- **The inventory comment** now covers both matcher families instead of claiming a verb-only inventory was exhaustive.
- **The docstring's verbatim-echo residual** grows from one case to three: the both-quote-styles re-escape it already listed, an echo that is not byte-for-byte (a Typer `Path(resolve_path=True)` echoes the RESOLVED path; `repr` doubles a backslash), and a value longer than the 500-char `textutil._tail` arriving clipped. All three are self-inflicted only, which is the shared reason they are accepted — and the last is why the uncapped values stay uncapped here: a cap tight enough to close it would sit under 500 characters and refuse legitimately deep paths and long model URLs.
- **Not changed:** the short-substring erosion (a one-character `download_id` erodes letters out of Click's own phrase) is the one-directional trade the docstring already states — it fails toward the noisier true error, never toward a false "nothing is broken", and comfy-cli mints ids as `uuid4().hex[:12]`.

Both new tests were verified to fail without their fix. `main` is merged in and the merged tree is green (1500 passed, 4 skipped), so the merge queue sees what CI saw.

