### PR TITLE
refactor: collapse the six-way workflow_path argv guard into _guard_workflow_path

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -622,6 +622,32 @@ def _reject_option_like(label: str, value: str, expected: str = "") -> str:
     return value
 
 
+def _guard_workflow_path(workflow_path: str, *, frontend: bool = False) -> str:
+    """Run the shared argv guards on a ``workflow_path`` tool argument.
+
+    ``frontend=True`` selects the error wording for the tools that require the
+    frontend-format (UI export) workflow ``fetch_template`` writes;
+    ``frontend=False`` for the tools that accept API-format or UI-export files
+    (``run_workflow`` / ``validate_workflow``). The two wordings track that
+    real format difference — do not merge them. WHY each site guards (bare
+    positional = mandatory injection defence vs ``--workflow`` option value =
+    input hygiene, see :func:`_reject_option_like`) stays in the per-site
+    comments; this helper only owns WHAT runs.
+    """
+    if frontend:
+        expected = (
+            "a path to a frontend-format workflow JSON file "
+            "(prefix a dash-leading name with './')"
+        )
+    else:
+        expected = (
+            "a path to a workflow JSON file (prefix a dash-leading name with './')"
+        )
+    _reject_option_like("workflow_path", workflow_path, expected=expected)
+    _reject_nul("workflow_path", workflow_path)
+    return workflow_path
+
+
 # Generous ceiling on a `prompt_id`'s length. Real ids are the server's UUIDs
 # (36 chars), and comfy-cli's own sanity check for one is `^[A-Za-z0-9_-]{1,128}$`
 # — so this deliberately sits at twice the engine's ceiling and can only refuse
@@ -4096,14 +4122,7 @@ async def run_workflow(
     # `workflow_path` rides behind `--workflow` as an option value (Click takes
     # that verbatim), so this is input hygiene, not injection defense — see
     # `_reject_option_like`.
-    _reject_option_like(
-        "workflow_path",
-        workflow_path,
-        expected=(
-            "a path to a workflow JSON file (prefix a dash-leading name with './')"
-        ),
-    )
-    _reject_nul("workflow_path", workflow_path)
+    _guard_workflow_path(workflow_path)
     if not workflow_path.strip():
         # Before the consent gate below, deliberately: an empty path cannot
         # possibly spend, and comfy-cli will reject it anyway, so raising a
@@ -10511,14 +10530,7 @@ def validate_workflow(workflow_path: str) -> Any:
     # the same call the guarded `search_templates` filters and `download_model`'s
     # `filename` make. A dash-leading path reaches comfy-cli as a usage error (or
     # prints `--help`) that fails envelope parsing; a named error is better.
-    _reject_option_like(
-        "workflow_path",
-        workflow_path,
-        expected=(
-            "a path to a workflow JSON file (prefix a dash-leading name with './')"
-        ),
-    )
-    _reject_nul("workflow_path", workflow_path)
+    _guard_workflow_path(workflow_path)
     return _run_comfy("validate", "--workflow", workflow_path, timeout=60.0)
 
 
@@ -10549,15 +10561,7 @@ def list_workflow_slots(workflow_path: str) -> Any:
     """
     # Bare positional, same as `set_workflow_slot` — a leading-dash path is read
     # as a flag rather than the path comfy-cli is meant to read.
-    _reject_option_like(
-        "workflow_path",
-        workflow_path,
-        expected=(
-            "a path to a frontend-format workflow JSON file "
-            "(prefix a dash-leading name with './')"
-        ),
-    )
-    _reject_nul("workflow_path", workflow_path)
+    _guard_workflow_path(workflow_path, frontend=True)
     return _run_comfy("workflow", "slots", workflow_path, timeout=60.0)
 
 
@@ -10603,15 +10607,7 @@ def list_workflow_notes(workflow_path: str) -> Any:
     """
     # Bare positional, same as `list_workflow_slots` — a leading-dash path is
     # read as a flag rather than the path comfy-cli is meant to read.
-    _reject_option_like(
-        "workflow_path",
-        workflow_path,
-        expected=(
-            "a path to a frontend-format workflow JSON file "
-            "(prefix a dash-leading name with './')"
-        ),
-    )
-    _reject_nul("workflow_path", workflow_path)
+    _guard_workflow_path(workflow_path, frontend=True)
     try:
         return _run_comfy("workflow", "notes", workflow_path, timeout=60.0)
     except ComfyCliError as exc:
@@ -10843,15 +10839,7 @@ def set_workflow_slot(
     # argument owns. Guarding only the overrides would leave the path as an
     # equivalent way in: consumed as a flag, it shifts the first override into
     # the path slot.
-    _reject_option_like(
-        "workflow_path",
-        workflow_path,
-        expected=(
-            "a path to a frontend-format workflow JSON file "
-            "(prefix a dash-leading name with './')"
-        ),
-    )
-    _reject_nul("workflow_path", workflow_path)
+    _guard_workflow_path(workflow_path, frontend=True)
     rendered = []
     for item in overrides:
         # Rendered per item, then guarded, so the argv guards read what actually
@@ -11104,15 +11092,7 @@ def vary_workflow(
     # / `--out-dir` as option VALUES, which Click takes verbatim, so they are
     # already injection-safe; they are guarded below as input hygiene, matching
     # `search_templates`' filters. See `_reject_option_like` for the two cases.
-    _reject_option_like(
-        "workflow_path",
-        workflow_path,
-        expected=(
-            "a path to a frontend-format workflow JSON file "
-            "(prefix a dash-leading name with './')"
-        ),
-    )
-    _reject_nul("workflow_path", workflow_path)
+    _guard_workflow_path(workflow_path, frontend=True)
     args = ["workflow", "vary", workflow_path]
     for index, item in enumerate(slots):
         # Rendered first so every guard below reads what actually reaches argv,

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -227,6 +227,16 @@ def test_workflow_path_positional_rejects_option_like(no_spawn):
         server.vary_workflow("--out-dir", ["3.seed=[1,2]"])
 
 
+def test_workflow_path_guard_message_tracks_format_requirement(no_spawn):
+    """Frontend-only tools name the frontend format; dual-format tools do not."""
+    with pytest.raises(server.ComfyCliError, match="frontend-format"):
+        server.list_workflow_slots("--stdout")
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.validate_workflow("--stdout")
+    assert "frontend-format" not in str(excinfo.value)
+
+
 def test_workflow_path_guard_allows_dot_slash_dash_name(patched_run):
     """The documented escape hatch actually works: `./-flux.json` is not refused."""
     calls = patched_run(envelope(data={"modified": True}))


### PR DESCRIPTION
## ELI-5

Six different tools all took the same "path to a workflow file" argument, and each one had its own hand-copied eight-line block checking that the path is not secretly a command-line flag and contains no NUL byte. Six copies of the same check is six places to forget when one of them needs a fix. This PR writes that check once, as `_guard_workflow_path`, and has all six tools call it. Nothing behaves differently — the same inputs are rejected with the exact same error text as before.

## Summary

Pure refactor. The `_reject_option_like("workflow_path", ..., expected=...)` + `_reject_nul("workflow_path", ...)` pair was copy-pasted at six tool sites; it now lives in one composed helper, following the existing `_guard_prompt_id` / `_guard_download_id` precedents it sits beside. Zero behavior change, error messages byte-for-byte identical.

## Changes

- `src/comfy_mcp/server.py`: add `_guard_workflow_path(workflow_path, *, frontend=False)` immediately after `_reject_option_like`. `frontend=True` selects the frontend-format (UI export) wording; `frontend=False` the dual-format one used by the tools that also accept API-format files.
- Replace the copied block at all six sites: `run_workflow` and `validate_workflow` (generic wording), `list_workflow_slots`, `list_workflow_notes`, `set_workflow_slot`, and `vary_workflow` (frontend wording).
- `tests/test_workflow.py`: add `test_workflow_path_guard_message_tracks_format_requirement`, which asserts a frontend-only tool names the frontend format and a dual-format tool does not — so a future edit cannot silently merge the two wordings into one.

## Motivation

Follow-up to the copy-paste sweep tracked in #122. The six copies had already drifted into being maintained by hand, and a seventh (`list_workflow_notes`) shipped with the same block after the original survey was written.

Deliberately **not** widened into a blanket `_guard_arg(label, value, expected=)` over the ~28 other `_reject_option_like` / `_reject_nul` pair sites: `_reject_option_like`'s policy docstring separates bare positionals (mandatory injection defence) from option values (input hygiene), and a generic helper would flatten that distinction. The nul-only sites (`search_models`'s `--text` query, `_guard_extra_args`) are dash-legal by design and are untouched, as is `_local_template_check`, whose path is server-generated and deliberately unguarded.

## Testing

- [x] Existing tests pass (`pytest`) — 1492 passed, 4 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually (mocked-CLI test suite only, per this repo's convention)

Behavioral coverage that had to stay green unchanged, and did: `tests/test_workflow.py::test_workflow_path_positional_rejects_option_like` (all four frontend tools), `::test_workflow_path_guard_allows_dot_slash_dash_name` (the `./-flux.json` escape hatch), plus the `run_workflow` and wrapper-level guard tests.

## Additional Notes

Three properties worth checking at review, all verified locally:

- **Messages survive byte-for-byte.** An exact-string grep counted 2 generic + 4 frontend occurrences before, and exactly 1 of each after — both inside the helper.
- **Each guard fires at the same program point.** In particular `run_workflow`'s stays where it was: outside `_attempt` (line comment explains why — it covers both the `wait=False` submit and the streaming path, and fails once up front rather than re-raising through the credential retry loop), and still ahead of the empty-path check that follows it. Guard order within the helper is unchanged too — option-like first, then NUL — so a value that is both still raises the same error it did before.
- **No comment text moved into the helper.** The six per-site comments carry five different justifications (outside-`_attempt` placement, hygiene-vs-mandatory category, the override-shift injection in `set_workflow_slot`) that one helper cannot carry, so they stay at their sites; the helper's docstring only documents WHAT runs.

The helper returns `workflow_path` for symmetry with `_reject_option_like` / `_guard_prompt_id`; every call site discards it, exactly as the replaced code did.
