### PR TITLE
test: pin download_model's mid-path-colon rejections before the guard extraction

### DIFF
--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from pathlib import PurePosixPath
+from pathlib import PurePosixPath, PureWindowsPath
 
 import pytest
 from conftest import NO_SUCH_OPTION_STDERR, envelope
@@ -261,6 +261,65 @@ def test_download_model_rejects_windows_drive_relative_path(bad_path, patched_ru
 
     with pytest.raises(server.ComfyCliError, match="invalid relative_path"):
         _download_model("https://hf.co/x.safetensors", relative_path=bad_path)
+
+    assert calls == []
+
+
+# --- A colon ANYWHERE, not just a leading drive ------------------------------
+#
+# `ntpath.splitdrive` only ever reads a LEADING drive, so it sees nothing in
+# `models/C:evil` — every colon case pinned above (`C:evil`, `C:/Windows`,
+# `C:\Windows`) happens to carry that leading drive, and would still be refused
+# with the `":" in relative_path` term deleted. These are the shapes that term
+# alone catches, so it cannot be dropped as redundant with the drive check.
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "models/C:evil",  # drive-relative in a LATER segment: splitdrive is blind
+        "models/loras:ads",  # NTFS alternate-data-stream syntax (`name:stream`)
+        "models/x:y",
+        "models/evil:",  # trailing colon — still an ADS name on NTFS
+    ],
+)
+def test_download_model_rejects_mid_path_colon_relative_path(bad_path, patched_run):
+    """A colon in a NON-leading segment is refused before any child spawns.
+
+    Regression pin for the `":" in relative_path` term specifically:
+    `ntpath.splitdrive` reads only a leading drive, so it reports no drive for
+    any value here and these shapes are refused by that term ALONE. Without this
+    test the whole suite stays green with the term deleted as "redundant with
+    splitdrive", and `models/C:evil` / `models/loras:ads` start being accepted.
+    The colon term lives in the FIRST raise, so the diagnosis is traversal.
+    """
+    calls = patched_run(envelope(data=_submit()))
+
+    with pytest.raises(server.ComfyCliError, match=r"invalid relative_path.*traversal"):
+        _download_model("https://hf.co/x.safetensors", relative_path=bad_path)
+
+    assert calls == []
+
+
+def test_download_model_rejects_mid_path_colon_resetting_the_anchor(patched_run):
+    """Named regression pin for what the mid-path colon rejection prevents.
+
+    A drive-carrying component joined on Windows does not extend the path — it
+    RESETS the anchor to that drive's own working directory, discarding the
+    workspace entirely. `<workspace>/models/C:evil` is not a folder under the
+    models dir; it is whatever `C:evil` resolves to on drive C:, outside the
+    workspace the guard claims to confine the write to.
+    """
+    calls = patched_run(envelope(data=_submit()))
+
+    # Pin the mechanism, so this test fails loudly if pathlib ever changes: the
+    # workspace anchor is discarded by the drive-carrying component.
+    assert PureWindowsPath("D:/ws") / "C:evil" == PureWindowsPath("C:evil")
+
+    with pytest.raises(server.ComfyCliError, match=r"invalid relative_path.*traversal"):
+        _download_model(
+            "https://attacker.example/payload", relative_path="models/C:evil"
+        )
 
     assert calls == []
 
@@ -541,6 +600,24 @@ def test_download_model_rejects_pathy_filename(bad_name, patched_run):
 def test_download_model_rejects_windows_drive_relative_filename(bad_name, patched_run):
     """A Windows drive/UNC/root-relative ``filename`` is refused before any child
     spawns — on Linux CI as much as on Windows."""
+    calls = patched_run(envelope(data=_submit()))
+
+    with pytest.raises(server.ComfyCliError, match="invalid filename"):
+        _download_model("https://hf.co/x.safetensors", filename=bad_name)
+
+    assert calls == []
+
+
+@pytest.mark.parametrize("bad_name", ["evil:ads", "model:stream.safetensors"])
+def test_download_model_rejects_non_drive_colon_filename(bad_name, patched_run):
+    """The bare-name colon check reaches past a drive prefix.
+
+    The drive shapes (`C:evil.dll`, `C:evil.exe`) are pinned above, but every one
+    of them is also what `ntpath.splitdrive` would report — so they leave the
+    colon term free to be narrowed to a drive check. These are `name:stream`
+    NTFS alternate-data-stream values with no drive at all: refused by the `":"
+    in filename` term alone.
+    """
     calls = patched_run(envelope(data=_submit()))
 
     with pytest.raises(server.ComfyCliError, match="invalid filename"):


### PR DESCRIPTION
## ELI-5

`download_model` refuses a `relative_path` with a colon in it, anywhere. But every colon example the test suite actually checked — `C:evil`, `C:/Windows`, `C:\Windows` — starts with a drive letter, and a *different* check already catches those. So the colon rule was doing real work that no test noticed: nothing was stopping someone from deleting it as "redundant". This PR adds the tests that notice. Same story for `filename`. No behavior changes — the code already refuses all of these today.

## What

Test-only. Adds three tests to the `download_model` argument-guard block:

1. `test_download_model_rejects_mid_path_colon_relative_path` — parametrized over `models/C:evil`, `models/loras:ads`, `models/x:y`, `models/evil:`; each must raise `ComfyCliError` matching `invalid relative_path.*traversal` and spawn no child (`calls == []`). `ntpath.splitdrive` reads only a *leading* drive, so it reports no drive for any of these — they are refused by the `":" in relative_path` term alone.
2. `test_download_model_rejects_mid_path_colon_resetting_the_anchor` — the named mechanism pin, mirroring the style of the neighbouring `test_download_model_rejects_backslash_escaping_models_tree`: asserts `PureWindowsPath("D:/ws") / "C:evil" == PureWindowsPath("C:evil")` inline (a drive-carrying component joined on Windows *resets* the anchor to that drive's own working directory rather than extending the path, discarding the workspace entirely), then asserts the guard refuses `models/C:evil`.
3. `test_download_model_rejects_non_drive_colon_filename` — `evil:ads`, `model:stream.safetensors` raising `invalid filename`. The already-pinned `C:evil.dll` / `C:evil.exe` are both drive shapes, so they left the colon term free to be narrowed to a drive check; these `name:stream` NTFS alternate-data-stream values have no drive at all.

These land **before** the planned guard-extraction refactor so a predicate rewrite during the move cannot survive the suite.

## Why it works — mutation evidence

The premise ("these terms are load-bearing but untested") was verified empirically, not asserted. Deleting each colon term from `src/comfy_mcp/server.py` and probing the guard directly:

| value | current `main` | `":" in relative_path` deleted | `":" in filename` deleted |
|---|---|---|---|
| `models/C:evil` | rejected (traversal) | **ACCEPTED** → forwarded as `--relative-path models/C:evil` | rejected |
| `models/loras:ads` | rejected (traversal) | **ACCEPTED** → forwarded | rejected |
| `models/x:y` | rejected (traversal) | **ACCEPTED** → forwarded | rejected |
| `models/evil:` | rejected (traversal) | **ACCEPTED** → forwarded | rejected |
| `filename=evil:ads` | rejected | rejected | **ACCEPTED** → forwarded |
| `filename=model:stream.safetensors` | rejected | rejected | **ACCEPTED** → forwarded |

Each new test asserts both `pytest.raises` and `calls == []`, so every "ACCEPTED" row is a failure the new tests catch and the pre-existing suite did not.

## Verification

`pytest -q` → 1498 passed, 4 skipped. `ruff check .` and `ruff format --check .` clean. `git diff --stat` shows only `tests/test_downloads.py` (+78/-1); `src/` is untouched.

## Judgment calls

**The tests are in `tests/test_downloads.py`, not `tests/test_wrapper.py`.** The plan named `test_wrapper.py` (and a line range in it), which was accurate at the commit it was written against — but #174 has since split the whole `download_model` / `download_status` / `wait_for_download` / `cancel_download` family into `tests/test_downloads.py`, including every neighbouring guard test the plan describes and the `test_download_model_rejects_backslash_escaping_models_tree` pin it says to mirror. Adding these to `test_wrapper.py` would have separated them from the block they belong to and re-imported `_download_model` / `_submit` across modules. Everything else follows the plan as written: shared `conftest` fixtures only (`patched_run` + `envelope`), module-level test functions, `assert calls == []`, comment density matched to the neighbours.

**One observation, deliberately not acted on:** a colon is a legal filename character on POSIX, so `models/loras:ads` names a directory a Linux/macOS user could legitimately want. That trade-off is the production guard's existing, documented design call ("Decide this the same way on every host rather than deferring to `os.path.isabs`" — the guard runs where the MCP server runs, the write happens where comfy-cli runs) and ships on `main` today. This PR pins the behavior that exists; it does not widen or narrow it. Flagging it because the follow-up refactor will move these lines and someone should decide it deliberately rather than inherit it.
