### PR TITLE
fix: only subtract a caller value that carries the echoed phrase itself

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -715,7 +715,12 @@ def _guard_download_id(download_id: str) -> str:
     ARGUMENT. Whether it names a real download is comfy-cli's answer to give
     (``download_not_found``), not this wrapper's to guess.
     """
-    if not download_id or download_id.startswith("-"):
+    # `strip()`, not just falsiness: a whitespace-only id is the same caller
+    # mistake as an empty one — comfy-cli's store resolves `[A-Za-z0-9_-]{1,64}`,
+    # so a blank can never name a real download — but it is truthy, and letting
+    # it through forwards `comfy model download-status " "` and hands
+    # `_phrase_is_only_the_caller_s` a value that normalizes to `""`.
+    if not download_id.strip() or download_id.startswith("-"):
         raise ComfyCliError(
             f"invalid download_id: {download_id!r} (empty or leading '-')"
         )
@@ -9367,7 +9372,8 @@ _MAX_NODE_PACK_ID_LEN = 128
 # usage failure into "your comfy-cli is just too old".
 #
 # The degrade sites, by what their argv carries — the VERB-shaped ones first:
-# `outdated` (`_freshness_report`) takes no caller text at all; `notes`
+# `outdated` (`_freshness_report`) and `system-stats` / `free`
+# (`_resource_verb_upgrade_error`) take no caller text at all; `notes`
 # (`list_workflow_notes`) carries `workflow_path`; `download-status` /
 # `download-cancel` (`_download_verb_unsupported`) carry `download_id`; `node
 # deps` carries `pack` and `registry_id`. Then the OPTION-shaped siblings, which
@@ -9408,42 +9414,62 @@ def _phrase_is_only_the_caller_s(
     false "nothing is broken" — and here it is also the only self-inflicted way
     to reach it.
 
+    Only a value that MATCHES *pattern* on its own is subtracted, which is the
+    load-bearing half of this function. ``str.replace`` is global, so
+    subtracting unconditionally would delete a caller's value from comfy-cli's
+    OWN phrase whenever the value happened to be a substring of it — and the
+    values that collide are ordinary, not crafted: ``filename="background"``
+    erases the flag out of ``No such option: --background``,
+    ``workflow_path="notes"`` and ``download_status("a")`` do the same to
+    ``No such command 'notes'`` and ``'download-status'``. A value that does not
+    contain the phrase cannot have forged the phrase, so there is nothing to
+    discount and it is left alone. The cost of getting this wrong is not
+    symmetric: at the verb sites an over-subtraction only costs the friendly
+    message, but at ``download_model``'s ``--background`` the suppressed degrade
+    is the only path that PERFORMS the transfer, so a benign ``filename`` would
+    have turned a working legacy-CLI download into an outright failure.
+
     Matching is on the echo being VERBATIM (modulo the normalization both sides
     get), which is what Click's ``repr`` of an offending value gives for the
     shapes that can carry the phrase at all — the value needs a quote, and
     ``repr`` answers a single-quoted value with double quotes rather than
-    backslashes. Three ways the echo can fail to be verbatim are known and left
-    as-is, for one shared reason: each is SELF-inflicted, because the degrade a
-    caller forges is returned to the same caller that crafted the argument.
+    backslashes. Three ways the echo can fail to be verbatim are known and
+    accepted; in each the subtraction is a no-op, so the result is exactly the
+    behaviour that site had BEFORE this discount existed, and reaching it at all
+    is self-inflicted — the degrade a caller forges is returned to the same
+    caller that crafted the argument.
 
     - A value carrying BOTH quote styles comes back re-escaped, so the raw value
       is no longer a substring of the message.
     - Click does not always echo the value byte-for-byte. The retype this is
       forward cover for is exactly where that shows: a Typer
       ``Path(..., resolve_path=True)`` echoes the RESOLVED path, and ``repr``
-      doubles a backslash. Either way the subtraction is a no-op and the forged
-      phrase survives.
+      doubles a backslash.
     - The message this reads is a bounded ``textutil._tail`` (500 chars), so a
-      value longer than the tail arrives clipped and the whole-value replace
-      matches nothing. The id-shaped values are already capped well under that
-      bound (``_MAX_DOWNLOAD_ID_LEN``, ``_MAX_NODE_PACK_ID_LEN``);
-      ``workflow_path`` and ``download_model``'s ``url`` / ``relative_path`` /
-      ``filename`` are not, and are left uncapped deliberately — a cap tight
-      enough to close the gap would have to sit under 500 characters, and would
-      start refusing legitimately deep paths and long CivitAI/HuggingFace URLs
-      to buy nothing but protection from a caller's own crafted argument.
+      value longer than the tail arrives clipped. The id-shaped values are
+      already capped well under that bound (``_MAX_DOWNLOAD_ID_LEN``,
+      ``_MAX_NODE_PACK_ID_LEN``); ``workflow_path`` and ``download_model``'s
+      ``url`` / ``relative_path`` / ``filename`` are not, and are left uncapped
+      deliberately — a cap tight enough to close the gap would have to sit under
+      500 characters, and would start refusing legitimately deep paths and long
+      CivitAI/HuggingFace URLs to buy nothing but protection from a caller's own
+      crafted argument.
+
+    One residual runs the other way and is also accepted: the phrase could in
+    principle be assembled ACROSS the boundary, half from Click's template and
+    half from the echoed value, in which case neither the value nor this check
+    sees it whole. That needs Click's fixed wording to end mid-phrase exactly
+    where it interpolates the value, which none of its usage templates do.
     """
     normalized = _normalize_cli_text(str(exc))
     for value in values:
-        # Emptiness is tested on the NORMALIZED value, not the raw one. A value
-        # that is only whitespace or panel glyphs — `" "`, which
-        # `_guard_download_id` accepts and `list_workflow_notes` does not
-        # reject — is truthy but normalizes to `""`, and `str.replace("", " ")`
-        # interleaves a space between EVERY character of the message. That
-        # shreds comfy-cli's own phrase and would suppress the GENUINE degrade,
-        # handing the caller Click's raw usage dump instead.
         echoed = _normalize_cli_text(value)
-        if echoed:
+        # A value that does not carry the phrase itself could not have forged
+        # it — see above. This also disposes of the empty-normalization case
+        # (`" "`, which normalizes to `""`): `str.replace("", " ")` would
+        # interleave a space between EVERY character of the message, and an
+        # empty string never matches *pattern*, so it is skipped here.
+        if echoed and re.search(pattern, echoed, re.IGNORECASE):
             normalized = normalized.replace(echoed, " ")
     return re.search(pattern, normalized, re.IGNORECASE) is None
 

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -715,20 +715,37 @@ def _guard_download_id(download_id: str) -> str:
     ARGUMENT. Whether it names a real download is comfy-cli's answer to give
     (``download_not_found``), not this wrapper's to guess.
     """
-    # `strip()`, not just falsiness: a whitespace-only id is the same caller
-    # mistake as an empty one — comfy-cli's store resolves `[A-Za-z0-9_-]{1,64}`,
-    # so a blank can never name a real download — but it is truthy, and letting
-    # it through forwards `comfy model download-status " "` and hands
-    # `_phrase_is_only_the_caller_s` a value that normalizes to `""`.
-    if not download_id.strip() or download_id.startswith("-"):
+    # Type FIRST, the way `_guard_version` does it: every test below is a `str`
+    # method, so a non-string would leave as a bare `AttributeError` rather than
+    # the `ComfyCliError` this guard exists to produce. MCP-level validation
+    # keeps that off the tool paths, but the guard's contract is total for
+    # in-process callers.
+    if not isinstance(download_id, str):
         raise ComfyCliError(
-            f"invalid download_id: {download_id!r} (empty or leading '-')"
+            f"invalid download_id: expected a string, got {type(download_id).__name__}."
         )
+    # LENGTH first among the value checks, so the error reports a size instead of
+    # echoing an oversized value back through the tool response and the failure
+    # log — see `_guard_prompt_id`. Ordered ahead of the shape checks because
+    # those interpolate `{download_id!r}` in full, so a multi-megabyte blank
+    # would otherwise be mirrored back verbatim by the branch below.
     if len(download_id) > _MAX_DOWNLOAD_ID_LEN:
-        # Report the length, not the value — see `_guard_prompt_id`.
         raise ComfyCliError(
             f"invalid download_id: {len(download_id)} characters exceeds the "
             f"{_MAX_DOWNLOAD_ID_LEN}-character maximum."
+        )
+    # Both shape tests read the STRIPPED value, so they cannot disagree about
+    # what the id is. `strip()` rather than falsiness because a whitespace-only
+    # id is the same caller mistake as an empty one — comfy-cli's store resolves
+    # `[A-Za-z0-9_-]{1,64}`, so a blank can never name a real download — and
+    # applying it to the dash test too keeps the docstring's invariant true for
+    # `" -x"`, which Click only defuses by accident (it keys option detection on
+    # the first character). The ORIGINAL value is what gets forwarded and
+    # returned: this guard refuses input, it does not rewrite it.
+    stripped = download_id.strip()
+    if not stripped or stripped.startswith("-"):
+        raise ComfyCliError(
+            f"invalid download_id: {download_id!r} (empty or leading '-')"
         )
     return _reject_nul("download_id", download_id)
 
@@ -9403,9 +9420,11 @@ def _phrase_is_only_the_caller_s(
 ) -> bool:
     """Does *pattern* match only text the CALLER supplied, not comfy-cli's own?
 
-    Removes every non-empty entry of *values* from the normalized message and
+    Removes every qualifying entry of *values* from the normalized message and
     re-runs *pattern*. No match afterwards means the sole occurrence came from an
-    echoed argument, and the degrade must not fire.
+    echoed argument, and the degrade must not fire. Only entries that match
+    *pattern* THEMSELVES are subtracted — see below for why that qualifier is
+    the load-bearing part rather than an optimization.
 
     A value that is itself a substring of comfy-cli's genuine message deletes
     that occurrence too, so a caller who passes the parser's exact wording gets
@@ -9455,11 +9474,25 @@ def _phrase_is_only_the_caller_s(
       CivitAI/HuggingFace URLs to buy nothing but protection from a caller's own
       crafted argument.
 
-    One residual runs the other way and is also accepted: the phrase could in
-    principle be assembled ACROSS the boundary, half from Click's template and
-    half from the echoed value, in which case neither the value nor this check
-    sees it whole. That needs Click's fixed wording to end mid-phrase exactly
-    where it interpolates the value, which none of its usage templates do.
+    One residual runs the other way and is also accepted: requiring the value to
+    carry the phrase whole means a value holding only a FRAGMENT is never
+    discounted, so the phrase could be assembled ACROSS a join that neither the
+    value nor this check sees whole. Three joins exist and none is reachable
+    today:
+
+    - Click's own template, if its fixed wording ended mid-phrase exactly where
+      it interpolates the value. None of its usage templates do.
+    - Two caller values landing adjacently in one message. Click echoes only the
+      ONE value it rejected, so the sites passing two (``pack`` /
+      ``registry_id``, and ``download_model``'s three) never get both echoed.
+    - The wrapper's own ``"stderr: … | stdout: …"`` framing, whose ``" | "``
+      :func:`_normalize_cli_text` folds to a single space. Splitting the phrase
+      there needs a fragment at the very END of the stderr tail and its
+      completion at the very START of stdout — and the caller supplies argv, not
+      the child's stdout, so it does not control both sides.
+
+    All three would need the retype this is forward cover for to have happened
+    first, since without it Click never echoes these values at parse time at all.
     """
     normalized = _normalize_cli_text(str(exc))
     for value in values:

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1373,6 +1373,48 @@ def test_download_companions_reject_a_blank_download_id(blank):
         server.download_status(blank)
 
 
+@pytest.mark.parametrize("dash_led", [" -x", "\t--help"])
+def test_download_companions_reject_a_padded_dash_led_id(dash_led):
+    """Both shape tests read the STRIPPED value, so they cannot disagree.
+
+    The guard's docstring says a dash-led id stays out of argv. Testing that on
+    the raw string while testing emptiness on the stripped one let `" -x"`
+    through — defused today only by accident, because Click keys option
+    detection on the first character.
+    """
+    with pytest.raises(server.ComfyCliError, match="invalid download_id"):
+        server.download_status(dash_led)
+
+
+def test_guard_download_id_reports_a_size_not_an_oversized_value():
+    """The length check runs BEFORE the shape checks, which echo the value.
+
+    The shape branch interpolates `{download_id!r}` in full, so an oversized
+    blank would otherwise be mirrored back verbatim through the tool response
+    and the failure log — defeating the "report the length, not the value" rule
+    the cap exists to enforce.
+    """
+    oversized_blank = " " * (server._MAX_DOWNLOAD_ID_LEN + 50)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._guard_download_id(oversized_blank)
+
+    assert "exceeds the" in str(excinfo.value)
+    assert oversized_blank not in str(excinfo.value)
+
+
+@pytest.mark.parametrize("bad", [None, 12, ["a1b2c3"]])
+def test_guard_download_id_rejects_a_non_string(bad):
+    """The guard's contract is total: a non-string raises ComfyCliError.
+
+    Every check in the guard is a `str` method, so testing shape before type
+    would leave a bare `AttributeError` for an in-process caller instead of the
+    error every other bad input produces.
+    """
+    with pytest.raises(server.ComfyCliError, match="expected a string"):
+        server._guard_download_id(bad)
+
+
 def test_wait_for_download_returns_the_terminal_payload(monkeypatch):
     """wait_for_download polls until terminal and returns that final payload."""
     calls = _sequenced(monkeypatch, [_status("downloading"), _status("completed")])

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1339,15 +1339,18 @@ def test_download_companions_echoed_phrase_is_not_unsupported(patched_run, tool,
         ("cancel_download", "download-cancel"),
     ],
 )
-def test_download_companions_degrade_with_a_blank_download_id(patched_run, tool, verb):
-    """A whitespace-only id must not cost the genuine degrade.
+def test_download_companions_degrade_with_a_colliding_download_id(
+    patched_run, tool, verb
+):
+    """A short id that COLLIDES with Click's phrase must not cost the degrade.
 
-    `_guard_download_id` accepts `" "` (it is truthy, dash-free and NUL-free),
-    and `_normalize_cli_text` folds it to `""`. Subtracting an empty string is
-    `str.replace("", " ")`, which interleaves a space between EVERY character of
-    comfy-cli's message — shredding the parser's own phrase and suppressing the
-    version gap. `_phrase_is_only_the_caller_s` skips a value whose NORMALIZED
-    form is empty for exactly that reason.
+    The subtraction is a global `str.replace`, so discounting a value that is
+    merely a substring of comfy-cli's own message would shred the parser's
+    phrase and suppress the genuine version gap. `"a"` is an id
+    `_guard_download_id` accepts and comfy-cli's `[A-Za-z0-9_-]{1,64}` store
+    resolves, and it appears in both `download-status` and `download-cancel`.
+    `_phrase_is_only_the_caller_s` only subtracts a value that matches the
+    pattern ITSELF — one that cannot carry the phrase cannot have forged it.
     """
     patched_run(
         "",
@@ -1355,7 +1358,19 @@ def test_download_companions_degrade_with_a_blank_download_id(patched_run, tool,
         stderr=f"Usage: comfy model [OPTIONS] COMMAND\nNo such command '{verb}'.",
     )
 
-    assert getattr(server, tool)(" ")["unsupported"] is True
+    assert getattr(server, tool)("a")["unsupported"] is True
+
+
+@pytest.mark.parametrize("blank", ["", " ", "\t\n"])
+def test_download_companions_reject_a_blank_download_id(blank):
+    """A whitespace-only id is the same caller mistake as an empty one.
+
+    `_guard_download_id`'s docstring says an empty id can only be a caller
+    mistake, but `" "` is truthy — so it took a `strip()` to refuse it rather
+    than forward `comfy model download-status " "`.
+    """
+    with pytest.raises(server.ComfyCliError, match="invalid download_id"):
+        server.download_status(blank)
 
 
 def test_wait_for_download_returns_the_terminal_payload(monkeypatch):
@@ -1515,6 +1530,29 @@ def test_download_model_echoed_phrase_does_not_reach_the_fallback(
 
     with pytest.raises(server.ComfyCliError):
         _download_model(url)
+
+
+def test_download_model_falls_back_with_a_colliding_filename(
+    patched_async_run, legacy_comfy_cli
+):
+    """A benign `filename` that COLLIDES with Click's phrase keeps the fallback.
+
+    The regression this pins is the sharpest consequence of an unbounded
+    subtraction: `filename="background"` is an ordinary bare name, but it is
+    also a substring of `No such option: --background`, so discounting it
+    unconditionally would erase the flag out of comfy-cli's OWN message, make
+    `_phrase_is_only_the_caller_s` report a forgery, and `raise` past
+    `_legacy_foreground_download` — turning a download that works on a
+    pre-`--background` comfy-cli into an outright failure. Unlike the verb
+    sites, where an over-subtraction costs only the friendly message, here the
+    suppressed degrade is the only path that performs the transfer.
+    """
+    patched_async_run(stderr="Done in 9.1s. Saved to /models/background")
+
+    result = _download_model("https://hf.co/background", filename="background")
+
+    assert result["ok"] is True
+    assert result["background_unsupported"] is True
 
 
 def test_download_model_synthesizes_success_on_plain_exit(


### PR DESCRIPTION
## ELI-5

#176 taught four tools to ignore a scary-error phrase when *you* were the one who put that phrase into an argument. It did that by deleting your argument's text from the message before looking. Trouble: deleting is blind, so if your argument happened to be an ordinary word that *also* appears in the CLI's own message — like naming a file `background` — it deleted part of the CLI's real message too, and the tool stopped recognising a message it should have recognised. For downloads on an older comfy-cli that didn't just make the error uglier: it skipped the fallback that actually performs the download, so the download failed outright. This PR only deletes your text when your text actually contains the phrase.

## The regression

#176 merged with the subtraction applied unconditionally. `str.replace` is global, so a caller value that is merely a SUBSTRING of comfy-cli's own message is deleted out of the parser's phrase — defeating the degrade the phrase should have triggered. The colliding values are ordinary, not crafted:

| value | erases | from |
|---|---|---|
| `filename="background"` | `--background` | `No such option: --background` |
| `workflow_path="notes"` | `notes` | `No such command 'notes'` |
| `download_status("a")` | every `a` | `No such command 'download-status'` |

At the verb sites this costs only the friendly message — the raw usage dump is noisy but honest, which is the one-directional trade `_is_missing_verb_error` documents. At `download_model`'s `--background` it costs a **capability**: the suppressed degrade is the only path that PERFORMS the transfer, so a benign `filename` makes the tool `raise` past `_legacy_foreground_download` and turns a download that works on a pre-`--background` comfy-cli into an outright failure.

Six of eight reviewers on #176's final panel flagged the collision; that panel's review POST failed with HTTP 422, so its findings never reached the PR as threads and #176 merged before this was addressed. Findings are in [run 30768851338](https://github.com/Comfy-Org/comfy-mcp/actions/runs/30768851338)'s artifacts.

## Changes

- **`_phrase_is_only_the_caller_s`** — only a value that matches *pattern* ITSELF is subtracted. A value that does not carry the phrase cannot have forged the phrase, so there is nothing to discount and it is left alone. This is the rule the check already meant; the unconditional version was a stronger claim than the threat model needs.

  It also subsumes two other cases: the empty-normalization guard #176 added (`" "` normalizes to `""`, and an empty string never matches the pattern), and the order-dependence between overlapping values that two reviewers raised (a value that cannot forge is no longer removed ahead of one that can).

- **`_guard_download_id`** — rejects a whitespace-only id via `strip()`. Its docstring already said an empty id can only be a caller mistake, but `" "` is truthy, so it was forwarded as `comfy model download-status " "`. Fixing the guard beats papering over the blank inside the subtraction.

- **The inventory comment** — gains the fifth `_is_missing_verb_error` consumer, `_resource_verb_upgrade_error` (`system-stats` / `free`). It takes no caller text so there is no hole, but the comment claims to enumerate every site.

- **The docstring** — records the one residual running the other way: the phrase could in principle be assembled ACROSS the value boundary, half from Click's template and half from the echo, in which case neither the value nor this check sees it whole. That needs Click's fixed wording to end mid-phrase exactly where it interpolates the value, which none of its usage templates do.

## Not changed

The escaping / tail-clipping bypasses (a value carrying both quote styles, or longer than the 500-char `textutil._tail`) stay documented as accepted residuals. In each the subtraction is a no-op, so the outcome is exactly what that site did before the discount existed — this removes cover from nothing — and reaching one requires crafting the argument whose forged degrade is returned to you.

The missing length caps on `workflow_path` / `url` / `relative_path` / `filename` are a real pre-existing gap (past `MAX_ARG_STRLEN`, `execve` raises a bare `OSError` no handler converts to `ComfyCliError`), but they are a separate concern, and a cap tight enough to close the clipping residual would have to sit under 500 characters and start refusing legitimately deep paths and long model URLs. #177's new `_guard_workflow_path` is the natural home for the generous version; tracked separately.

## Testing

- [x] `pytest` — 1505 passed, 4 skipped
- [x] `ruff check .` / `ruff format --check .`

New tests, all verified to fail without the fix:

- `test_download_model_falls_back_with_a_colliding_filename` — `filename="background"` on a pre-`--background` comfy-cli still reaches `_legacy_foreground_download` and returns the `background_unsupported` payload. This is the capability regression.
- `test_download_companions_degrade_with_a_colliding_download_id` — `download_status("a")` etc. still report the version gap rather than Click's raw dump.
- `test_download_companions_reject_a_blank_download_id` — `""` / `" "` / `"\t\n"` are refused.

#176's forgery tests are unmodified and still pass: a `download_id` / `workflow_path` / `url` that spells out the parser's phrase is still discounted, so the guard #176 added is intact.