### PR TITLE
fix: scrub URLs and bound argv in client-facing error messages (BE-6074)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ dependency edges only ever point one way:
 |---|---|
 | `textutil.py` | pure text helpers: `_tail` / `_stream_tail` (bounded stream tails) and `_redact_url` (userinfo masking) |
 | `tcc.py` | macOS protected-folder (TCC) detection + the guidance message |
-| `failure_log.py` | the opt-in `COMFY_MCP_DEBUG_LOG` failure log: its config, its module state, and `_log_failure` |
+| `failure_log.py` | the opt-in `COMFY_MCP_DEBUG_LOG` failure log (its config, its module state, and `_log_failure`) **and the URL scrubbers** — `_scrub_text` / `_scrubbed_stream_tail` also mask credentials on the way to the MCP CLIENT, not just to disk |
 
 `server` reaches them **module-qualified** (`tcc._tcc_guidance(...)`,
 `failure_log._log_failure(...)`) and re-exports nothing. That is deliberate: a

--- a/src/comfy_mcp/failure_log.py
+++ b/src/comfy_mcp/failure_log.py
@@ -139,15 +139,37 @@ _URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
 # `_scrubbed_stream_tail`.
 _LEADING_TOKEN_RE = re.compile(r"\S*")
 
+# Closing punctuation, peeled off the END of a `_URL_RE` match before scrubbing
+# and re-attached after. `\S+` cannot tell a URL from the character that merely
+# FOLLOWS it, and `_scrub_url` deletes everything from the first `?` — so
+# without this, comfy-cli's `Invalid value for '--url': 'https://h/x?q=1'`
+# comes back having lost its closing quote and the rest of the sentence glued
+# to it, and `_render_error_details`' `", "`-joined entries merge into one
+# token. These messages now go to the MCP CLIENT, not just to the log, so that
+# rewrite is no longer something only a maintainer reading a JSONL trail sees.
+# Re-attaching gives nothing back: none of these characters is credential
+# material, and the peel is lossless for a URL with no query at all (they are
+# scrubbed to themselves and then restored).
+_URL_TRAILING_PUNCT = "'\"`,;:!.)]}>"
+
+
+def _scrub_url_match(match: re.Match[str]) -> str:
+    """Scrub one :data:`_URL_RE` hit, keeping the punctuation glued to its end."""
+    token = match.group(0)
+    kept = token.rstrip(_URL_TRAILING_PUNCT)
+    # `_URL_RE` anchors on `https?://`, so `kept` can never strip to empty.
+    return _scrub_url(kept) + token[len(kept) :]
+
 
 def _scrub_text(text: str) -> str:
     """Apply :func:`_scrub_url` to every URL embedded anywhere in ``text``.
 
     Only URL-shaped substrings are touched; everything around them (a path, a
     subcommand, a flag name, the prose of a message — the point of keeping the
-    field at all) is preserved byte-for-byte.
+    field at all) is preserved byte-for-byte, down to the quote or comma that
+    closes a URL the surrounding text quoted (:data:`_URL_TRAILING_PUNCT`).
     """
-    return _URL_RE.sub(lambda match: _scrub_url(match.group(0)), text)
+    return _URL_RE.sub(_scrub_url_match, text)
 
 
 def _scrub_arg(arg: str) -> str:
@@ -182,13 +204,34 @@ def _scrubbed_stream_tail(stream: str | bytes | None, limit: int) -> str:
     and only then clip.
 
     The generous bound is NOT on its own enough, which is why the head fragment
-    is masked explicitly below rather than left for the re-clip to push out of
+    is handled explicitly below rather than left for the re-clip to push out of
     range: scrubbing SHRINKS the window — ``_scrub_url`` deletes whole query
     strings and userinfo — so a URL-dense capture can come out of it already at
     or under ``limit``, take the early return, and be written with its
     scheme-shorn head still attached. The re-clip is safe by contrast:
     everything it can cut has been scrubbed already, so a URL it bisects has no
     userinfo or query left to leak.
+
+    That head fragment is DROPPED, not masked. Masking it (running the token
+    through ``_scrub_url`` as if it were a whole URL) covers a clip that landed
+    before the ``?`` and no further: a window cut PAST it arrives as
+    ``token=…&x=1`` — or, cut mid-value, as a bare suffix of the secret — with
+    no delimiter left for ``_scrub_url`` to anchor on, so the query it exists to
+    delete survives verbatim. A clipped leading token is a fragment of something
+    we cannot identify, and the ``...`` marker already says so; the host it
+    might have named is still legible in the same message, which renders the
+    argv through :func:`_scrub_text`. The cost is one partial token of a debug
+    tail, and a capture whose real first line happens to start with ``...``
+    loses its first token the same way.
+
+    Unless that token is the WHOLE window — a capture with no whitespace in its
+    last ``limit * 2`` chars — in which case dropping would return a bare
+    ``...`` and throw away the error the tail exists to keep (a single unbroken
+    blob is exactly the shape a chatty child's last line takes). There it falls
+    back to masking, accepting the narrower residual: a lone unbroken token that
+    is a scheme-shorn URL fragment clipped past its ``?`` keeps that remnant.
+    Losing the entire capture is the worse failure of the two, and every
+    multi-token case — which is every real CLI stderr — takes the drop.
     """
     if limit <= 0:
         # Mirror `_stream_tail`'s own non-positive guard: `[-0:]` is the WHOLE
@@ -201,14 +244,15 @@ def _scrubbed_stream_tail(stream: str | bytes | None, limit: int) -> str:
         # `_stream_tail` prefixes that marker onto a window it CLIPPED, and a
         # clipped window can begin part-way through a URL — past the `https://`
         # that `_URL_RE` anchors on, which is precisely why the scrub above
-        # cannot see a credential sitting in that leading remainder.
-        # `_scrub_url` handles a scheme-less string (it reads offset 0 as the
-        # netloc's start), so mask the head token as if it were a whole URL.
-        # A capture whose real first line happens to start with `...` is masked
-        # the same way; over-redacting one debug-log token is the right side to
-        # err on.
+        # cannot see a credential sitting in that leading remainder. Drop the
+        # token outright rather than trying to mask it: see the docstring for
+        # why no anchor is left to mask it ON. Over-redacting one debug-log
+        # token is the right side to err on — but only while something else
+        # survives it, hence the `rest` test: a whitespace-free window is one
+        # token, and dropping it would hand back a bare `...`.
         head = _LEADING_TOKEN_RE.match(scrubbed, 3).group(0)
-        scrubbed = "..." + _scrub_url(head) + scrubbed[3 + len(head) :]
+        rest = scrubbed[3 + len(head) :]
+        scrubbed = "..." + (rest if rest.strip() else _scrub_url(head) + rest)
     if len(scrubbed) <= limit:
         return scrubbed
     # Re-clipping loses the marker `_stream_tail` may have added, so re-add it:

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -1232,7 +1232,15 @@ def _check_comfy_version() -> None:
         raise ComfyCliError(
             f"`{COMFY_BIN}` could not start.\n\n"
             f"{tcc._tcc_guidance(tcc._tcc_path_from(proc.stderr))}\n\n"
-            f"Original error: {textutil._tail(proc.stderr)}"
+            # Same rule as `_unwrap_envelope`'s TCC branch: a captured stream is
+            # scrubbed on its way to the client, a filesystem path
+            # (`tcc._tcc_guidance` above, and the `{exc}` of the spawn-denied
+            # branch) is not. This probe is only `comfy --version`, so it carries
+            # no caller URL of its own — but comfy-cli reads its config at
+            # startup, so a warning naming a configured server URL can land on
+            # this stderr, and the asymmetry is not worth preserving.
+            "Original error: "
+            f"{failure_log._scrubbed_stream_tail(proc.stderr, _MAX_ERROR_FIELD_CHARS)}"
         )
     version = _parse_version(f"{proc.stdout}\n{proc.stderr}")
     if version is not None and version < _MIN_COMFY_CLI:
@@ -1635,9 +1643,19 @@ def _cmd_for_message(cmd: list[str]) -> str:
     string, so reuse it rather than growing a second redactor —
     :func:`_synthesize_plain_result` omits raw args altogether for the same
     reason. Everything that is not URL-shaped survives byte-for-byte, so the flags
-    and the subcommand stay legible.
+    and the subcommand stay legible. The result is also bounded to
+    :data:`_MAX_ERROR_FIELD_CHARS` like every other field of that message —
+    ``run_workflow``'s rendered ``--param`` values are caller-supplied and can
+    inflate one argv arbitrarily, and it was the last unbounded piece of the
+    timeout sentence. The slice takes the HEAD, not the tail: the identifying
+    ``comfy --json --where local <subcommand>`` prefix sits at the front, and
+    everything a head slice can cut has already been scrubbed, so a URL it
+    bisects has no userinfo or query left to leak (the same scrub-then-cap
+    ordering :func:`failure_log._scrubbed_stream_tail` documents). The cap is
+    read at call time, so its definition sitting further down the module is
+    fine.
     """
-    return failure_log._scrub_text(" ".join(cmd))
+    return failure_log._scrub_text(" ".join(cmd))[:_MAX_ERROR_FIELD_CHARS]
 
 
 def _timeout_failure(
@@ -1663,10 +1681,18 @@ def _timeout_failure(
     ``str`` first, but :func:`_drain_timed_out` can return ``None`` (nothing
     written) or ``bytes`` (POSIX attaches the undecoded partial read to
     ``TimeoutExpired``), and :func:`_run_comfy_raw` passes that through verbatim.
-    Both consumers below — :func:`textutil._tail` and
+    Both consumers below — :func:`failure_log._scrubbed_stream_tail` and
     :func:`failure_log._log_failure` — already declare that same union, so
     narrowing it here would only mislead a later edit into string-only work that
     blows up on exactly the POSIX timeout path.
+
+    The tails go through :func:`failure_log._scrubbed_stream_tail` rather than
+    :func:`textutil._tail` because comfy-cli echoes the URL it is fetching to
+    stderr, and this message goes straight to the MCP client — the same
+    credential the failure log has always masked on its way to disk. It renders
+    the ``<empty>`` marker itself, so there is no ``or '<empty>'`` fallback to
+    apply, and it takes the same ``str | bytes | None`` the POSIX timeout path
+    hands over.
 
     Not shared with :func:`_run_comfy_streaming`, whose timeout is deliberately a
     different report — it adds the progress snapshot and the poll-instead advice,
@@ -1674,8 +1700,8 @@ def _timeout_failure(
     """
     message = (
         f"comfy-cli timed out after {timeout}s: {_cmd_for_message(cmd)}. "
-        f"stderr tail: {textutil._tail(stderr) or '<empty>'}; "
-        f"stdout tail: {textutil._tail(stdout) or '<empty>'}"
+        f"stderr tail: {failure_log._scrubbed_stream_tail(stderr, _MAX_ERROR_FIELD_CHARS)}; "
+        f"stdout tail: {failure_log._scrubbed_stream_tail(stdout, _MAX_ERROR_FIELD_CHARS)}"
     )
     # `exit_code=None`: the child was killed at the deadline, so it never
     # reported one. The log keeps a longer slice of both streams than the
@@ -2144,14 +2170,19 @@ def _unwrap_envelope(
             message = (
                 f"comfy-cli could not run (exit {returncode}).\n\n"
                 f"{tcc._tcc_guidance(tcc._tcc_path_from(stderr))}\n\n"
-                # `textutil._stream_tail` for the truncation marker:
+                # `failure_log._scrubbed_stream_tail` for the truncation marker:
                 # `tcc._looks_like_tcc_denial` only fires on a non-empty stderr,
                 # so the `<empty>` half is unreachable here — but a long denial
                 # traceback still gets clipped, and silently is how you misread
-                # it as the whole thing.
+                # it as the whole thing. Scrubbed for the same reason the log
+                # record below is: a denial traceback can quote the URL comfy-cli
+                # was fetching, credential and all.
                 # No stdout here on purpose: this branch has already identified
                 # the cause, so its curated guidance beats a second raw stream.
-                f"Original error: {textutil._stream_tail(stderr)}"
+                # `tcc._tcc_guidance` above is left alone — it renders a
+                # filesystem path, not a captured stream.
+                "Original error: "
+                f"{failure_log._scrubbed_stream_tail(stderr, _MAX_ERROR_FIELD_CHARS)}"
             )
             # Still `no_json` — a TCC denial is the *reason* comfy-cli emitted no
             # envelope, not a different kind of failure. Unlike the message, the
@@ -2172,11 +2203,14 @@ def _unwrap_envelope(
         # Typer/click usage error or a plain-text status line on stdout), and
         # `_last_json_object` has already discarded the stdout text by the time
         # we get here. Rendering only stderr — and rendering an empty one as
-        # nothing at all — is what made this error opaque.
+        # nothing at all — is what made this error opaque. Both go through
+        # `failure_log._scrubbed_stream_tail`: a comfy-cli that dies mid-fetch
+        # prints the URL it was fetching, and this message is what the MCP
+        # client renders.
         message = (
             f"comfy-cli returned no JSON (exit {returncode}). "
-            f"stderr: {textutil._stream_tail(stderr)} | "
-            f"stdout: {textutil._stream_tail(stdout)}"
+            f"stderr: {failure_log._scrubbed_stream_tail(stderr, _MAX_ERROR_FIELD_CHARS)} | "
+            f"stdout: {failure_log._scrubbed_stream_tail(stdout, _MAX_ERROR_FIELD_CHARS)}"
         )
         failure_log._log_failure(
             "no_json",
@@ -2228,12 +2262,22 @@ def _unwrap_envelope(
         # credential) — dropping them was the exact workaround testers needed.
         # Each field is length-capped so a huge/malformed envelope can't bloat
         # the message propagated to the MCP client.
-        # The stderr fallback goes through `textutil._stream_tail` so an envelope
-        # with an empty `error.message` AND an empty stderr can't render a bare
-        # trailing colon with nothing after it. Note the cap is applied to the
-        # envelope's own message only — `textutil._stream_tail` already bounds
-        # its result, and re-slicing its HEAD here would chop off the truncation
-        # marker plus the very end of the tail, i.e. the part worth keeping.
+        # The stderr fallback goes through `failure_log._scrubbed_stream_tail` so
+        # an envelope with an empty `error.message` AND an empty stderr can't
+        # render a bare trailing colon with nothing after it. Note the cap is
+        # applied to the envelope's own message only — `_scrubbed_stream_tail`
+        # already bounds its result, and re-slicing its HEAD here would chop off
+        # the truncation marker plus the very end of the tail, i.e. the part
+        # worth keeping.
+        # Every field here is SCRUBBED on the way out, matching what
+        # `failure_log._log_failure` has always done on the way to disk: comfy-cli
+        # scrubs its own envelope fields today, but this server only floor-checks
+        # the child's version, so a URL in `error.message`/`hint` — or echoed to
+        # stderr by a child that died mid-fetch — is not something the client path
+        # may assume away. The scrub runs BEFORE each cap, never after: capping
+        # first can bisect a URL so its `https://` is gone and
+        # `failure_log._URL_RE` can no longer see the credential remainder (the
+        # same ordering `_scrubbed_stream_tail` documents).
         # Strip BEFORE the truthiness test: a whitespace-only `error.message`
         # ("   ") is truthy, so it would keep the fallback from firing and render
         # exactly the dangling-colon message this branch exists to prevent —
@@ -2242,14 +2286,25 @@ def _unwrap_envelope(
         raw_message = err.get("message")
         message = str(raw_message).strip() if raw_message else ""
         message = (
-            message[:_MAX_ERROR_FIELD_CHARS]
+            failure_log._scrub_text(message)[:_MAX_ERROR_FIELD_CHARS]
             if message
-            else textutil._stream_tail(stderr, _MAX_ERROR_FIELD_CHARS)
+            else failure_log._scrubbed_stream_tail(stderr, _MAX_ERROR_FIELD_CHARS)
         )
-        parts = [f"comfy {' '.join(args)} failed [{code or 'unknown'}]: {message}"]
+        # `_cmd_for_message` renders the argv with the same masking, so a
+        # `model download --url https://<user>:<pass>@host/x?token=…` reads back
+        # as `model download --url https://***@host/x`: masked, not dropped, so
+        # the reader can still tell WHICH call failed. It is handed the
+        # subcommand tail only (the spawn's `--json --where local` prefix is the
+        # caller's), which is what keeps the `comfy <args> failed` reading;
+        # `list(args)` because it takes a list and `args` is a tuple.
+        parts = [
+            f"comfy {_cmd_for_message(list(args))} failed [{code or 'unknown'}]: {message}"
+        ]
         hint = err.get("hint")
         if hint:
-            parts.append(f"hint: {str(hint)[:_MAX_ERROR_FIELD_CHARS]}")
+            parts.append(
+                f"hint: {failure_log._scrub_text(str(hint))[:_MAX_ERROR_FIELD_CHARS]}"
+            )
         detail_str = _render_error_details(err.get("details"))
         if detail_str:
             parts.append(detail_str)
@@ -2557,7 +2612,14 @@ _MAX_ERROR_FIELD_CHARS = 500
 
 
 def _render_error_details(details: Any) -> str | None:
-    """Render the useful keys of an envelope's ``error.details`` for the message."""
+    """Render the useful keys of an envelope's ``error.details`` for the message.
+
+    Scrubbed before the cap like every other envelope-derived field
+    :func:`_unwrap_envelope` renders — today ``_SURFACED_DETAIL_KEYS`` is only
+    node names, so it masks nothing in practice, but this string lands in the
+    same client-facing sentence as ``error.message``/``hint`` and a later key
+    added to that tuple should not have to remember to redact separately.
+    """
     if not isinstance(details, dict):
         return None
     parts: list[str] = []
@@ -2567,7 +2629,8 @@ def _render_error_details(details: Any) -> str | None:
             continue
         if isinstance(value, (list, tuple)):
             value = ", ".join(str(v) for v in value)
-        parts.append(f"{key}: {str(value)[:_MAX_ERROR_FIELD_CHARS]}")
+        rendered = failure_log._scrub_text(str(value))[:_MAX_ERROR_FIELD_CHARS]
+        parts.append(f"{key}: {rendered}")
     return "; ".join(parts) if parts else None
 
 
@@ -3079,8 +3142,11 @@ async def _run_comfy_streaming(
                 f"Progress so far: {tracker.snapshot()}. The run may still be "
                 "going — check `job_status`, or for long generations submit "
                 "with `wait=False` and poll `wait_for_job` / `watch_job`. "
-                f"stderr tail: {textutil._tail(stderr_text) or '<empty>'}; "
-                f"stdout tail: {textutil._tail(timeout_stdout) or '<empty>'}"
+                # Scrubbed, not raw: comfy-cli echoes the URL it is fetching to
+                # stderr, and this sentence goes straight to the MCP client. See
+                # `_timeout_failure`, whose two fragments this mirrors.
+                f"stderr tail: {failure_log._scrubbed_stream_tail(stderr_text, _MAX_ERROR_FIELD_CHARS)}; "
+                f"stdout tail: {failure_log._scrubbed_stream_tail(timeout_stdout, _MAX_ERROR_FIELD_CHARS)}"
             )
             failure_log._log_failure(
                 "timeout",
@@ -9464,15 +9530,25 @@ def _phrase_is_only_the_caller_s(
       forward cover for is exactly where that shows: a Typer
       ``Path(..., resolve_path=True)`` echoes the RESOLVED path, and ``repr``
       doubles a backslash.
-    - The message this reads is a bounded ``textutil._tail`` (500 chars), so a
-      value longer than the tail arrives clipped. The id-shaped values are
-      already capped well under that bound (``_MAX_DOWNLOAD_ID_LEN``,
-      ``_MAX_NODE_PACK_ID_LEN``); ``workflow_path`` and ``download_model``'s
-      ``url`` / ``relative_path`` / ``filename`` are not, and are left uncapped
-      deliberately — a cap tight enough to close the gap would have to sit under
-      500 characters, and would start refusing legitimately deep paths and long
-      CivitAI/HuggingFace URLs to buy nothing but protection from a caller's own
-      crafted argument.
+    - The message this reads is a bounded 500-char tail, so a value longer than
+      the tail arrives clipped. The id-shaped values are already capped well
+      under that bound (``_MAX_DOWNLOAD_ID_LEN``, ``_MAX_NODE_PACK_ID_LEN``);
+      ``workflow_path`` and ``download_model``'s ``url`` / ``relative_path`` /
+      ``filename`` are not, and are left uncapped deliberately — a cap tight
+      enough to close the gap would have to sit under 500 characters, and would
+      start refusing legitimately deep paths and long CivitAI/HuggingFace URLs
+      to buy nothing but protection from a caller's own crafted argument.
+    - That tail is now URL-SCRUBBED on its way to the client
+      (``failure_log._scrubbed_stream_tail``), so a value whose echo carries
+      credential material — userinfo or a query string, the only two things
+      ``failure_log._scrub_url`` rewrites — comes back masked rather than
+      verbatim. Only ``download_model``'s ``url`` is URL-shaped at all; the
+      other sites pass identifiers and filesystem paths, which need the
+      ``https?://`` scheme ``failure_log._URL_RE`` anchors on and so survive
+      byte-for-byte. Reaching the no-op needs the forged phrase to sit OUTSIDE
+      the URL token too, since ``_URL_RE`` stops at whitespace and the Click
+      phrases all contain spaces — at which point the scrub has already removed
+      a forgery planted in the query, which is the commoner shape.
 
     One residual runs the other way and is also accepted: requiring the value to
     carry the phrase whole means a value holding only a FRAGMENT is never

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -1231,14 +1231,14 @@ def _check_comfy_version() -> None:
         # Full Disk Access and retrying in the same process must re-check.
         raise ComfyCliError(
             f"`{COMFY_BIN}` could not start.\n\n"
-            f"{tcc._tcc_guidance(tcc._tcc_path_from(proc.stderr))}\n\n"
+            f"{tcc._tcc_guidance(_scrubbed_tcc_path(proc.stderr))}\n\n"
             # Same rule as `_unwrap_envelope`'s TCC branch: a captured stream is
-            # scrubbed on its way to the client, a filesystem path
-            # (`tcc._tcc_guidance` above, and the `{exc}` of the spawn-denied
-            # branch) is not. This probe is only `comfy --version`, so it carries
-            # no caller URL of its own — but comfy-cli reads its config at
-            # startup, so a warning naming a configured server URL can land on
-            # this stderr, and the asymmetry is not worth preserving.
+            # scrubbed on its way to the client, and so is the path pulled OUT
+            # of one (`_scrubbed_tcc_path`, a no-op on a real filesystem path).
+            # This probe is only `comfy --version`, so it carries no caller URL
+            # of its own — but comfy-cli reads its config at startup, so a
+            # warning naming a configured server URL can land on this stderr,
+            # and the asymmetry is not worth preserving.
             "Original error: "
             f"{failure_log._scrubbed_stream_tail(proc.stderr, _MAX_ERROR_FIELD_CHARS)}"
         )
@@ -1630,6 +1630,22 @@ def _reject_remote_model_download() -> None:
     )
 
 
+def _scrubbed_tcc_path(text: str | None) -> str | None:
+    """The denied path ``tcc._tcc_path_from`` found in ``text``, URL-masked.
+
+    ``tcc._tcc_guidance`` renders this token verbatim into a client-facing
+    message, and ``tcc._TCC_PATH_RE`` accepts ANY quoted string after the EPERM
+    marker — it is CPython's ``repr`` of an ``OSError`` filename in every case
+    that matters, but nothing structurally stops a credentialed URL landing
+    there and being echoed unmasked right above the scrubbed ``Original
+    error:``. A real filesystem path has no ``https://`` for
+    :data:`failure_log._URL_RE` to anchor on and so survives byte-for-byte,
+    which is what keeps the guidance naming the exact file the user has to move.
+    """
+    path = tcc._tcc_path_from(text)
+    return failure_log._scrub_text(path) if path else None
+
+
 def _cmd_for_message(cmd: list[str]) -> str:
     """The spawned argv rendered for an error message, credentials masked.
 
@@ -1642,7 +1658,8 @@ def _cmd_for_message(cmd: list[str]) -> str:
     (userinfo masked, query and fragment dropped) for every URL anywhere in a
     string, so reuse it rather than growing a second redactor —
     :func:`_synthesize_plain_result` omits raw args altogether for the same
-    reason. Everything that is not URL-shaped survives byte-for-byte, so the flags
+    reason (and scrubs its captured text, which omitting args does not cover).
+    Everything that is not URL-shaped survives byte-for-byte, so the flags
     and the subcommand stay legible. The result is also bounded to
     :data:`_MAX_ERROR_FIELD_CHARS` like every other field of that message —
     ``run_workflow``'s rendered ``--param`` values are caller-supplied and can
@@ -1654,8 +1671,18 @@ def _cmd_for_message(cmd: list[str]) -> str:
     ordering :func:`failure_log._scrubbed_stream_tail` documents). The cap is
     read at call time, so its definition sitting further down the module is
     fine.
+
+    A cut is MARKED with a trailing ``...``, like every other bounded field in
+    the same sentence (:func:`textutil._stream_tail` prefixes one onto a tail
+    it clipped). A silently clipped argv reads as the COMPLETE invocation, so a
+    reader working out what wedged would conclude the wrong flags were passed.
+    The marker sits outside the cap rather than inside it, so the bound still
+    describes the argv itself.
     """
-    return failure_log._scrub_text(" ".join(cmd))[:_MAX_ERROR_FIELD_CHARS]
+    rendered = failure_log._scrub_text(" ".join(cmd))
+    if len(rendered) > _MAX_ERROR_FIELD_CHARS:
+        return rendered[:_MAX_ERROR_FIELD_CHARS] + "..."
+    return rendered
 
 
 def _timeout_failure(
@@ -2169,7 +2196,7 @@ def _unwrap_envelope(
             # can fix, not the opaque "returned no JSON" this would otherwise be.
             message = (
                 f"comfy-cli could not run (exit {returncode}).\n\n"
-                f"{tcc._tcc_guidance(tcc._tcc_path_from(stderr))}\n\n"
+                f"{tcc._tcc_guidance(_scrubbed_tcc_path(stderr))}\n\n"
                 # `failure_log._scrubbed_stream_tail` for the truncation marker:
                 # `tcc._looks_like_tcc_denial` only fires on a non-empty stderr,
                 # so the `<empty>` half is unreachable here — but a long denial
@@ -2179,8 +2206,10 @@ def _unwrap_envelope(
                 # was fetching, credential and all.
                 # No stdout here on purpose: this branch has already identified
                 # the cause, so its curated guidance beats a second raw stream.
-                # `tcc._tcc_guidance` above is left alone — it renders a
-                # filesystem path, not a captured stream.
+                # `tcc._tcc_guidance` above renders a filesystem path rather than
+                # a captured stream, but it PULLS that path out of this same
+                # stderr, so it gets the scrub too (`_scrubbed_tcc_path`) — a no-op
+                # on any real path, which is the only thing that lands there.
                 "Original error: "
                 f"{failure_log._scrubbed_stream_tail(stderr, _MAX_ERROR_FIELD_CHARS)}"
             )
@@ -2297,8 +2326,22 @@ def _unwrap_envelope(
         # subcommand tail only (the spawn's `--json --where local` prefix is the
         # caller's), which is what keeps the `comfy <args> failed` reading;
         # `list(args)` because it takes a list and `args` is a tuple.
+        # `code` gets the same scrub-then-cap as every other envelope field
+        # rendered here, and for the same reason: comfy-cli's own codes are
+        # short slugs, but this server only floor-checks the child's version, so
+        # a version-skewed or malformed envelope can put anything in it —
+        # including a URL, or a multi-KB blob that would bloat the sentence past
+        # every other field's bound. Rendered only: `code` itself rides on to
+        # `ComfyCliError.code` and the log record RAW, so the retry checks
+        # (`_RETRYABLE_*`) and a `jq 'select(.error_code == …)'` keep matching
+        # comfy-cli's literal value rather than a redacted echo of it.
+        rendered_code = (
+            failure_log._scrub_text(code)[:_MAX_ERROR_FIELD_CHARS]
+            if code
+            else "unknown"
+        )
         parts = [
-            f"comfy {_cmd_for_message(list(args))} failed [{code or 'unknown'}]: {message}"
+            f"comfy {_cmd_for_message(list(args))} failed [{rendered_code}]: {message}"
         ]
         hint = err.get("hint")
         if hint:
@@ -2570,6 +2613,18 @@ def _synthesize_plain_result(args: tuple[str, ...], stdout: str, stderr: str) ->
     # `model download` URL can carry a signed token / userinfo in its query
     # string, and this message lands in the tool response and host-side logs.
     message = text or f"comfy {' '.join(action_parts)} completed (exit 0)."
+    # Omitting the raw args is not on its own enough, because the captured text
+    # above is the OTHER side of the same credential: comfy-cli echoes the URL
+    # it is fetching (`Downloading <url>`) to stderr, so `model download`'s
+    # legacy foreground fallback and `partner_generate` would hand a signed
+    # CivitAI/HuggingFace URL straight back on the SUCCESS path — the one path
+    # the failure-side scrubbing this module does never sees. Scrubbed BEFORE
+    # the tail cap below, never after: capping first can bisect a URL so its
+    # `https://` is gone and `failure_log._URL_RE` can no longer see the
+    # credential remainder (the ordering `failure_log._scrubbed_stream_tail`
+    # documents). `saved_paths` below is parsed from the RAW text on purpose —
+    # those are local filesystem paths, and the caller needs them exact.
+    message = failure_log._scrub_text(message)
     result = {
         "ok": True,
         "action": " ".join(action_parts),
@@ -9538,17 +9593,16 @@ def _phrase_is_only_the_caller_s(
       enough to close the gap would have to sit under 500 characters, and would
       start refusing legitimately deep paths and long CivitAI/HuggingFace URLs
       to buy nothing but protection from a caller's own crafted argument.
-    - That tail is now URL-SCRUBBED on its way to the client
+      That tail is also URL-SCRUBBED on its way to the client
       (``failure_log._scrubbed_stream_tail``), so a value whose echo carries
       credential material — userinfo or a query string, the only two things
       ``failure_log._scrub_url`` rewrites — comes back masked rather than
-      verbatim. Only ``download_model``'s ``url`` is URL-shaped at all; the
-      other sites pass identifiers and filesystem paths, which need the
-      ``https?://`` scheme ``failure_log._URL_RE`` anchors on and so survive
-      byte-for-byte. Reaching the no-op needs the forged phrase to sit OUTSIDE
-      the URL token too, since ``_URL_RE`` stops at whitespace and the Click
-      phrases all contain spaces — at which point the scrub has already removed
-      a forgery planted in the query, which is the commoner shape.
+      verbatim. That is NOT a fourth way to reach the no-op, because the
+      subtraction below scrubs the value too, so the two sides are rewritten
+      identically and still cancel. Only ``download_model``'s ``url`` is
+      URL-shaped at all; the other sites pass identifiers and filesystem paths,
+      which need the ``https?://`` scheme ``failure_log._URL_RE`` anchors on and
+      so survive byte-for-byte.
 
     One residual runs the other way and is also accepted: requiring the value to
     carry the phrase whole means a value holding only a FRAGMENT is never
@@ -9572,7 +9626,16 @@ def _phrase_is_only_the_caller_s(
     """
     normalized = _normalize_cli_text(str(exc))
     for value in values:
-        echoed = _normalize_cli_text(value)
+        # SCRUBBED before normalizing, because the message being subtracted from
+        # is scrubbed too: `download_model`'s `url` is the one caller value that
+        # is URL-shaped, and `failure_log._scrub_url` rewrites it (userinfo
+        # masked, query dropped) on its way into `str(exc)`. Subtracting the RAW
+        # value would then miss its own echo — `str.replace` finds nothing — and
+        # the forged phrase would survive the discount, which at this site means
+        # a crafted `url` re-enables the legacy foreground transfer the
+        # `--background` degrade exists to gate. Both sides through the same two
+        # passes is what keeps the comparison honest.
+        echoed = _normalize_cli_text(failure_log._scrub_text(value))
         # A value that does not carry the phrase itself could not have forged
         # it — see above. This also disposes of the empty-normalization case
         # (`" "`, which normalizes to `""`): `str.replace("", " ")` would

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1651,6 +1651,39 @@ def test_download_model_echoed_phrase_does_not_reach_the_fallback(
         _download_model(url)
 
 
+def test_download_model_echoed_phrase_survives_the_url_scrub(patched_run, monkeypatch):
+    """The forgery guard subtracts a SCRUBBED value, because it reads a scrubbed message.
+
+    The message `_phrase_is_only_the_caller_s` searches is masked on its way to
+    the client, so a `url` whose echo is rewritten there — query dropped — no
+    longer matches the raw value the subtraction removes. Left unscrubbed on the
+    value side, `str.replace` finds nothing, the forged phrase survives the
+    discount, and the fallback re-runs the transfer this guard exists to refuse.
+    The phrase sits OUTSIDE the URL token (`_URL_RE` stops at whitespace), which
+    is what keeps it legible in the scrubbed message at all.
+    """
+
+    async def _never(*args, **kwargs):
+        raise AssertionError("the legacy foreground fallback must not run")
+
+    monkeypatch.setattr(server, "_run_comfy_async", _never)
+    url = "https://hf.co/x.safetensors?token=SECRETTOKEN No such option: --background"
+    patched_run(
+        "",
+        returncode=2,
+        stderr=(
+            "Usage: comfy model download [OPTIONS]\n"
+            f"Error: Invalid value for '--url': {url!r} is not reachable."
+        ),
+    )
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        _download_model(url)
+
+    # ...and the raise that refused the forgery still masks the credential.
+    assert "SECRETTOKEN" not in str(excinfo.value)
+
+
 def test_download_model_falls_back_with_a_colliding_filename(
     patched_async_run, legacy_comfy_cli
 ):

--- a/tests/test_failure_log.py
+++ b/tests/test_failure_log.py
@@ -451,6 +451,39 @@ def test_scrub_arg_finds_a_url_anywhere_in_the_token(arg, expected):
     assert failure_log._scrub_arg(arg) == expected
 
 
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # Click quotes the offending value; `\S+` swallows the closing quote and
+        # `_scrub_url` cuts from the `?`, so the rest of the sentence went with
+        # the query. These messages reach the MCP CLIENT now, not just the log.
+        (
+            "Invalid value for '--url': 'https://h/x?q=1' is not reachable.",
+            "Invalid value for '--url': 'https://h/x' is not reachable.",
+        ),
+        # `_render_error_details` joins list entries with `", "` — without the
+        # peel the comma is eaten and two entries merge into one token.
+        ("https://h/a?t=1, https://h/b?t=2", "https://h/a, https://h/b"),
+        ("see https://h/p?q=1.", "see https://h/p."),
+        ("(https://h/p?q=1)", "(https://h/p)"),
+        # Lossless where there is no query to cut: the peeled characters are
+        # scrubbed to themselves and put straight back.
+        ("https://h/p.", "https://h/p."),
+        ("'https://<u>:<p>@h/p'", "'https://***@h/p'"),
+        # Punctuation INSIDE the URL is still dropped with the rest of the query.
+        ("https://h/x?a=1,2,3 next", "https://h/x next"),
+    ],
+)
+def test_scrub_text_keeps_the_punctuation_glued_to_a_url(text, expected):
+    """`_URL_RE`'s `\\S+` cannot tell a URL from what merely FOLLOWS it.
+
+    None of the peeled characters is credential material, so restoring them
+    gives nothing back — and without them a scrubbed message loses the quote,
+    comma or full stop that made it a sentence.
+    """
+    assert failure_log._scrub_text(text) == expected
+
+
 def test_message_is_scrubbed_before_it_is_capped(log_path):
     """A URL straddling the message cap is masked, not cut into an unmasked half.
 
@@ -518,7 +551,7 @@ def test_stream_tail_scrubs_a_url_straddling_the_tail_cut(log_path):
     assert len(entry["stderr_tail"]) == limit + 3
 
 
-def test_stream_tail_scrubs_the_head_fragment_of_a_url_dense_capture(log_path):
+def test_stream_tail_drops_the_head_fragment_of_a_url_dense_capture(log_path):
     """The straddling-URL guard holds even when scrubbing shrinks the window.
 
     The double-width window is bounded generously so a half-URL at its head
@@ -545,8 +578,53 @@ def test_stream_tail_scrubs_the_head_fragment_of_a_url_dense_capture(log_path):
     (entry,) = _entries(log_path)
     assert len(entry["stderr_tail"]) <= limit  # it DID take the early return
     assert "user:tok" not in log_path.read_text()
-    # Masked rather than dropped: the host still says which fetch was in flight.
-    assert entry["stderr_tail"].startswith("...***@host/x ")
+    # Dropped, not masked — see the next test for why masking is not enough.
+    # What follows the fragment is intact, so the tail still reads.
+    assert entry["stderr_tail"].startswith("... https://h/a ")
+
+
+def test_stream_tail_drops_a_head_fragment_clipped_past_its_query_marker(log_path):
+    """Masking the head fragment covers a clip BEFORE the `?` and no further.
+
+    ``_scrub_url`` deletes from the first ``?``, so a window whose cut landed
+    PAST one arrives as a bare ``token=…`` remnant with no delimiter left to
+    anchor on — masking it is a no-op and the credential is written verbatim.
+    Dropping the fragment is what closes that, and it is the case the log's
+    own `Downloading <signed url>` progress lines make reachable.
+    """
+    limit = failure_log._FAILURE_LOG_TAIL_CHARS
+    remnant = "tok=SECRETVALUE&x=1 "
+    # Same shrink-to-under-`limit` trick as above: it is the early return that
+    # would otherwise carry the head fragment out to disk.
+    unit = "https://h/a?token=" + "A" * 100 + " "
+    filler = unit * ((limit * 2 - len(remnant)) // len(unit))
+    window = remnant + filler
+    stderr = "Z" * 10_000 + window.ljust(limit * 2, "B")
+
+    failure_log._log_failure("no_json", ("run",), stderr=stderr)
+
+    (entry,) = _entries(log_path)
+    assert len(entry["stderr_tail"]) <= limit  # it DID take the early return
+    assert "SECRETVALUE" not in log_path.read_text()
+    assert entry["stderr_tail"].startswith("... https://h/a ")
+
+
+def test_stream_tail_keeps_a_whitespace_free_window_rather_than_emptying_it(log_path):
+    """The head-fragment drop stops short of throwing the whole capture away.
+
+    A capture with no whitespace in its last ``limit * 2`` chars is ONE token,
+    so dropping it would return a bare ``...`` and lose the error the tail
+    exists to keep. There the fragment is masked instead — the narrower
+    residual the docstring accepts.
+    """
+    limit = failure_log._FAILURE_LOG_TAIL_CHARS
+    stderr = "x" * (limit * 3) + "THE-REAL-ERROR"
+
+    failure_log._log_failure("no_json", ("run",), stderr=stderr)
+
+    (entry,) = _entries(log_path)
+    assert entry["stderr_tail"].endswith("THE-REAL-ERROR")
+    assert len(entry["stderr_tail"]) == limit + len("...")
 
 
 # --- best-effort + rotation --------------------------------------------------

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -271,6 +271,29 @@ def test_version_guard_translates_the_fatal_startup_error(on_macos, monkeypatch)
     assert server._version_checked is False
 
 
+def test_version_guard_masks_a_credential_in_the_quoted_stderr(on_macos, monkeypatch):
+    """`Original error:` quotes a captured stream, so it is scrubbed like the rest.
+
+    The probe is only `comfy --version` and carries no caller URL of its own, but
+    comfy-cli reads its config at startup — a warning naming a configured server
+    URL can land on this stderr. The guidance beside it is left alone: it renders
+    a filesystem path, not a stream.
+    """
+    url = "https://<user>:<pw>@gpu.example:8188/api?token=SECRETTOKEN"
+    _patch_version_probe(monkeypatch, 1, f"{_FATAL_STDERR}\nconfigured server: {url}")
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._check_comfy_version()
+
+    message = str(excinfo.value)
+    assert "SECRETTOKEN" not in message
+    assert "<user>:<pw>" not in message
+    # Masked, not dropped — and the actual diagnosis still survives beside it.
+    assert "configured server: https://***@gpu.example:8188/api" in message
+    assert "init_import_site" in message
+    _assert_actionable(message)
+
+
 def test_version_guard_translates_a_denied_spawn(on_macos, monkeypatch):
     """The probe can be denied at exec time, never reaching a returncode.
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -2414,6 +2414,126 @@ def test_error_envelope_stderr_fallback_keeps_its_tail():
     assert "[x]: ..." in msg
 
 
+# The credential-in-URL fixtures below use the `https://<user>:<pass>@host` shape
+# the repo's destined-public hygiene mandates: a bare `user:pass@` trips the
+# secret-scanning diff gate, and `failure_log._URL_RE` needs the `https?://`
+# scheme to match at all.
+_CREDENTIALED_URL = (
+    "https://<user>:<pw>@civitai.example/api/download/models/1?token=SECRETTOKEN"
+)
+_MASKED_URL = "https://***@civitai.example/api/download/models/1"
+
+
+def test_error_envelope_masks_the_credential_in_its_echoed_argv():
+    """`ok: false` echoes the argv — a signed model URL must not ride along.
+
+    The failure log has always scrubbed this on its way to disk; the message the
+    MCP client renders carries the same bytes, so it gets the same masking.
+    Masked, not dropped: which call failed is still legible.
+    """
+    envelope = {
+        "type": "envelope",
+        "ok": False,
+        "error": {"code": "http_error", "message": "403 from the CDN"},
+    }
+    args = ("model", "download", "--url", _CREDENTIALED_URL)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(envelope, args, 1, "")
+
+    msg = str(excinfo.value)
+    assert "SECRETTOKEN" not in msg
+    assert "<user>:<pw>" not in msg
+    assert f"comfy model download --url {_MASKED_URL} failed [http_error]" in msg
+    assert "403 from the CDN" in msg  # the diagnosis itself is untouched
+
+
+def test_error_envelope_stderr_fallback_masks_a_credentialed_url():
+    """An empty `error.message` falls back to stderr — comfy-cli echoes URLs there."""
+    envelope = {"type": "envelope", "ok": False, "error": {"code": "x", "message": ""}}
+    stderr = f"downloading {_CREDENTIALED_URL}\nrequest failed"
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(envelope, ("model", "download"), 1, stderr)
+
+    msg = str(excinfo.value)
+    assert "SECRETTOKEN" not in msg
+    assert "<user>:<pw>" not in msg
+    assert _MASKED_URL in msg  # masked, not dropped
+    assert "request failed" in msg
+
+
+def test_error_envelope_masks_its_own_message_hint_and_details():
+    """comfy-cli's own envelope fields are scrubbed too — the version is only floor-checked.
+
+    A newer comfy-cli scrubs these itself, but this server does not pin the child's
+    exact version, so the client path cannot assume that. Scrub-before-cap is what
+    makes it work at the boundary: capping first can bisect a URL so its `https://`
+    is gone and `failure_log._URL_RE` can no longer see the remainder.
+    """
+    envelope = {
+        "type": "envelope",
+        "ok": False,
+        "error": {
+            "code": "x",
+            "message": f"could not fetch {_CREDENTIALED_URL}",
+            "hint": f"retry with {_CREDENTIALED_URL}",
+            "details": {"partner_nodes": [f"node fetching {_CREDENTIALED_URL}"]},
+        },
+    }
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(envelope, ("env",), 1, "")
+
+    msg = str(excinfo.value)
+    assert "SECRETTOKEN" not in msg
+    assert "<user>:<pw>" not in msg
+    # All three fields still render, masked rather than dropped.
+    assert f"could not fetch {_MASKED_URL}" in msg
+    assert f"hint: retry with {_MASKED_URL}" in msg
+    assert f"partner_nodes: node fetching {_MASKED_URL}" in msg
+
+
+def test_no_envelope_error_masks_credentials_on_both_streams(patched_plain_run):
+    """The no-JSON path renders both raw streams — both need the same masking."""
+    patched_plain_run(
+        1,
+        stdout=f"fetching {_CREDENTIALED_URL}",
+        stderr=f"curl: (22) on {_CREDENTIALED_URL}",
+    )
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._run_comfy("model", "download")
+
+    msg = str(excinfo.value)
+    assert "SECRETTOKEN" not in msg
+    assert "<user>:<pw>" not in msg
+    # Both sections still render, each masked rather than emptied.
+    assert f"stderr: curl: (22) on {_MASKED_URL}" in msg
+    assert f"stdout: fetching {_MASKED_URL}" in msg
+
+
+def test_tcc_denial_message_masks_the_credential_in_its_original_error(monkeypatch):
+    """The TCC branch quotes stderr verbatim as `Original error:` — scrub that too.
+
+    `tcc._tcc_guidance` is deliberately left alone: it renders a filesystem path,
+    not a captured stream.
+    """
+    monkeypatch.setattr(tcc, "_looks_like_tcc_denial", lambda _: True)
+    stderr = f"PermissionError: /Users/x/Documents while fetching {_CREDENTIALED_URL}"
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(None, ("model", "download"), 1, stderr)
+
+    msg = str(excinfo.value)
+    assert "SECRETTOKEN" not in msg
+    assert "<user>:<pw>" not in msg
+    assert (
+        f"Original error: PermissionError: /Users/x/Documents while fetching {_MASKED_URL}"
+        in msg
+    )
+
+
 def test_streaming_no_envelope_error_includes_both_stream_tails(monkeypatch):
     """The streaming EOF path produces the same enriched message as `_run_comfy`."""
     procs: list[_FakeProc] = []
@@ -3265,6 +3385,107 @@ def test_timeout_failure_takes_the_bytes_and_none_captures_too(monkeypatch):
     assert "stderr tail: <empty>" in message
     assert logged[0]["stdout"] == b"partial stdout bytes"
     assert logged[0]["stderr"] is None
+
+
+def test_timeout_failure_masks_credentials_in_both_stream_tails(monkeypatch):
+    """comfy-cli echoes the URL it is fetching — the timeout tails must mask it.
+
+    The disk record and the client message are built from the same captures, so
+    the tails go through `failure_log._scrubbed_stream_tail` rather than
+    `textutil._tail`. The log call is unchanged and re-scrubs its own inputs,
+    which is idempotent.
+    """
+    logged: list[dict] = []
+    monkeypatch.setattr(
+        failure_log,
+        "_log_failure",
+        lambda kind, args, **kwargs: logged.append(
+            {"kind": kind, "args": args, **kwargs}
+        ),
+    )
+
+    error = server._timeout_failure(
+        [server.COMFY_BIN, "--json", "--where", "local", "model", "download"],
+        ("model", "download"),
+        60.0,
+        f"resolving {_CREDENTIALED_URL}",
+        f"stalled on {_CREDENTIALED_URL}",
+    )
+
+    message = str(error)
+    assert "comfy-cli timed out after 60.0s" in message  # existing wording, unchanged
+    assert "SECRETTOKEN" not in message
+    assert "<user>:<pw>" not in message
+    assert f"stderr tail: stalled on {_MASKED_URL}" in message
+    assert f"stdout tail: resolving {_MASKED_URL}" in message
+    # The log still receives the RAW captures — `_log_failure` owns scrubbing on
+    # its own side, and the disk record deliberately keeps a longer slice.
+    assert logged[0]["stderr"] == f"stalled on {_CREDENTIALED_URL}"
+
+
+def test_sync_timeout_masks_a_credential_in_a_bytes_stderr_capture(patched_run):
+    """POSIX hands the tails over as bytes — the scrub has to reach that shape too."""
+    patched_run(
+        raises=_timeout(
+            stderr=f"curl: (22) on {_CREDENTIALED_URL}".encode(),
+            stdout=b"partial stdout",
+        )
+    )
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        server._run_comfy("model", "download", timeout=60.0)
+
+    msg = str(exc.value)
+    assert "comfy-cli timed out after 60.0s" in msg
+    assert "SECRETTOKEN" not in msg
+    assert "<user>:<pw>" not in msg
+    assert f"stderr tail: curl: (22) on {_MASKED_URL}" in msg
+
+
+def test_cmd_for_message_bounds_a_huge_argv_from_the_head():
+    """`run_workflow`'s `--param` values are caller-supplied and otherwise unbounded.
+
+    The slice takes the HEAD because the identifying
+    `comfy --json --where local <subcommand>` prefix sits at the front — and
+    everything it can cut has already been scrubbed, so a bisected URL has no
+    userinfo or query left to leak.
+    """
+    cmd = [
+        server.COMFY_BIN,
+        "--json",
+        "--where",
+        "local",
+        "run",
+        "--workflow",
+        "wf.json",
+        "--param",
+        "prompt=" + "x" * 2000,
+    ]
+
+    rendered = server._cmd_for_message(cmd)
+
+    assert len(rendered) == server._MAX_ERROR_FIELD_CHARS
+    assert rendered.startswith(
+        f"{server.COMFY_BIN} --json --where local run --workflow"
+    )
+
+
+def test_timeout_message_stays_bounded_on_a_huge_argv(monkeypatch):
+    """The whole timeout sentence is bounded now that its last raw field is capped."""
+    monkeypatch.setattr(failure_log, "_log_failure", lambda *a, **k: None)
+
+    error = server._timeout_failure(
+        [server.COMFY_BIN, "--json", "--where", "local", "run", "p=" + "x" * 5000],
+        ("run",),
+        60.0,
+        "y" * 5000,
+        "z" * 5000,
+    )
+
+    message = str(error)
+    # cmd + both tails, each capped, plus the fixed prose around them.
+    assert len(message) < 4 * server._MAX_ERROR_FIELD_CHARS
+    assert f"{server.COMFY_BIN} --json --where local run" in message  # head survives
 
 
 def test_plain_spawn_leads_its_own_process_group(patched_run):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -2494,6 +2494,62 @@ def test_error_envelope_masks_its_own_message_hint_and_details():
     assert f"partner_nodes: node fetching {_MASKED_URL}" in msg
 
 
+def test_error_envelope_masks_and_bounds_its_code():
+    """`error.code` renders in the same sentence, so it gets the same treatment.
+
+    comfy-cli's own codes are short slugs, but this server only floor-checks the
+    child's version — a version-skewed or malformed envelope can put a URL or a
+    multi-KB blob in that field, and it was the one interpolated without either
+    guard.
+    """
+    envelope = {
+        "type": "envelope",
+        "ok": False,
+        "error": {"code": f"fetch_failed {_CREDENTIALED_URL}", "message": "nope"},
+    }
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(envelope, ("env",), 1, "")
+
+    msg = str(excinfo.value)
+    assert "SECRETTOKEN" not in msg
+    assert "<user>:<pw>" not in msg
+    assert f"[fetch_failed {_MASKED_URL}]" in msg
+
+
+def test_error_envelope_code_rides_on_raw_for_the_retry_checks():
+    """Only the RENDERED code is rewritten — `ComfyCliError.code` stays comfy-cli's.
+
+    `run_workflow`'s `_RETRYABLE_*` membership tests and the failure log's
+    `error_code` both key on the literal value, so scrubbing it in place would
+    stop them matching.
+    """
+    envelope = {
+        "type": "envelope",
+        "ok": False,
+        "error": {"code": f"x {_CREDENTIALED_URL}", "message": "nope"},
+    }
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(envelope, ("env",), 1, "")
+
+    assert excinfo.value.code == f"x {_CREDENTIALED_URL}"
+
+
+def test_error_envelope_bounds_a_huge_code():
+    """A pathological `code` cannot bloat the message past every other field's cap."""
+    envelope = {
+        "type": "envelope",
+        "ok": False,
+        "error": {"code": "z" * 5000, "message": "nope"},
+    }
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._unwrap_envelope(envelope, ("env",), 1, "")
+
+    assert f"[{'z' * server._MAX_ERROR_FIELD_CHARS}]" in str(excinfo.value)
+
+
 def test_no_envelope_error_masks_credentials_on_both_streams(patched_plain_run):
     """The no-JSON path renders both raw streams — both need the same masking."""
     patched_plain_run(
@@ -2516,8 +2572,9 @@ def test_no_envelope_error_masks_credentials_on_both_streams(patched_plain_run):
 def test_tcc_denial_message_masks_the_credential_in_its_original_error(monkeypatch):
     """The TCC branch quotes stderr verbatim as `Original error:` — scrub that too.
 
-    `tcc._tcc_guidance` is deliberately left alone: it renders a filesystem path,
-    not a captured stream.
+    `tcc._tcc_guidance` renders a filesystem path rather than a captured stream,
+    but it pulls that path out of this same stderr, so it gets the scrub too —
+    see `test_scrubbed_tcc_path_*`.
     """
     monkeypatch.setattr(tcc, "_looks_like_tcc_denial", lambda _: True)
     stderr = f"PermissionError: /Users/x/Documents while fetching {_CREDENTIALED_URL}"
@@ -3442,6 +3499,79 @@ def test_sync_timeout_masks_a_credential_in_a_bytes_stderr_capture(patched_run):
     assert f"stderr tail: curl: (22) on {_MASKED_URL}" in msg
 
 
+def test_scrubbed_tcc_path_leaves_a_real_filesystem_path_alone():
+    """The guidance names the file the user has to move, so it must stay exact.
+
+    A path has no `https://` for `failure_log._URL_RE` to anchor on, which is
+    what makes the scrub a no-op on every input that actually lands here.
+    """
+    stderr = (
+        "PermissionError: [Errno 1] Operation not permitted: "
+        "'/Users/x/Documents/ComfyUI/venv/pyvenv.cfg'"
+    )
+
+    assert (
+        server._scrubbed_tcc_path(stderr)
+        == "/Users/x/Documents/ComfyUI/venv/pyvenv.cfg"
+    )
+
+
+def test_scrubbed_tcc_path_masks_a_credentialed_url():
+    """`tcc._TCC_PATH_RE` accepts any quoted string after the EPERM marker.
+
+    It is CPython's `repr` of an `OSError` filename in every case that matters,
+    but nothing structurally stops a credentialed URL landing there — and
+    `tcc._tcc_guidance` renders it verbatim, right above the scrubbed
+    `Original error:`.
+    """
+    stderr = f"[Errno 1] Operation not permitted: '{_CREDENTIALED_URL}'"
+
+    scrubbed = server._scrubbed_tcc_path(stderr)
+
+    assert "SECRETTOKEN" not in scrubbed
+    assert "<user>:<pw>" not in scrubbed
+    assert scrubbed == _MASKED_URL
+
+
+def test_scrubbed_tcc_path_is_none_when_stderr_named_no_path():
+    """`tcc._tcc_guidance` falls back to its general wording on `None`."""
+    assert server._scrubbed_tcc_path("something else entirely") is None
+
+
+def test_synthesize_plain_result_masks_a_credential_in_its_captured_text():
+    """The exit-0 path returns the captured stream, and that stream carries the URL.
+
+    Omitting the raw args covers one side; comfy-cli echoing `Downloading <url>`
+    to stderr is the other, and it reaches `model download`'s legacy foreground
+    fallback and `partner_generate` on SUCCESS — the one path none of the
+    failure-side scrubbing sees.
+    """
+    result = server._synthesize_plain_result(
+        ("model", "download", "--url", _CREDENTIALED_URL),
+        "",
+        f"Downloading {_CREDENTIALED_URL}\nDone in 55.8s",
+    )
+
+    assert "SECRETTOKEN" not in result["message"]
+    assert "<user>:<pw>" not in result["message"]
+    # Masked, not dropped: which fetch succeeded is still legible, and the
+    # `Done in …` metadata this payload exists to surface survives.
+    assert f"Downloading {_MASKED_URL}" in result["message"]
+    assert result["message"].endswith("Done in 55.8s")
+
+
+def test_synthesize_plain_result_scrubs_before_its_tail_cap():
+    """Capping first would bisect a URL past its scheme, leaving the remainder raw."""
+    noise = "n" * 1200
+    result = server._synthesize_plain_result(
+        ("model", "download"), "", f"{noise} fetching {_CREDENTIALED_URL} ok"
+    )
+
+    assert "SECRETTOKEN" not in result["message"]
+    assert "<user>:<pw>" not in result["message"]
+    assert len(result["message"]) <= 1000
+
+
 def test_cmd_for_message_bounds_a_huge_argv_from_the_head():
     """`run_workflow`'s `--param` values are caller-supplied and otherwise unbounded.
 
@@ -3449,6 +3579,10 @@ def test_cmd_for_message_bounds_a_huge_argv_from_the_head():
     `comfy --json --where local <subcommand>` prefix sits at the front — and
     everything it can cut has already been scrubbed, so a bisected URL has no
     userinfo or query left to leak.
+
+    The cut is MARKED: an argv clipped silently reads as the whole invocation,
+    so a reader diagnosing the wedge would blame flags that were never passed.
+    The marker is additive to the bound, like `textutil._stream_tail`'s.
     """
     cmd = [
         server.COMFY_BIN,
@@ -3464,10 +3598,29 @@ def test_cmd_for_message_bounds_a_huge_argv_from_the_head():
 
     rendered = server._cmd_for_message(cmd)
 
-    assert len(rendered) == server._MAX_ERROR_FIELD_CHARS
+    assert len(rendered) == server._MAX_ERROR_FIELD_CHARS + len("...")
+    assert rendered.endswith("...")
     assert rendered.startswith(
         f"{server.COMFY_BIN} --json --where local run --workflow"
     )
+
+
+def test_cmd_for_message_leaves_a_fitting_argv_unmarked():
+    """The `...` is evidence of a cut, so an argv under the bound must not carry one."""
+    rendered = server._cmd_for_message(
+        [
+            server.COMFY_BIN,
+            "--json",
+            "--where",
+            "local",
+            "model",
+            "download-status",
+            "x",
+        ]
+    )
+
+    assert not rendered.endswith("...")
+    assert rendered.endswith("model download-status x")
 
 
 def test_timeout_message_stays_bounded_on_a_huge_argv(monkeypatch):


### PR DESCRIPTION
## ELI-5

When comfy-cli fails, this server tells the agent *why* — and that sentence quotes the command it ran plus whatever comfy-cli printed. Those quotes can contain a model URL with a password or a `?token=` in it. We already scrubbed that on the way to the debug log on disk, but not on the way to the agent, even though both were built from the same bytes. Now both get scrubbed. The URL still shows up (masked, `https://***@host/path`), so you can still tell which call broke — the secret just doesn't come with it.

## Summary

`failure_log._log_failure` scrubs argv, `message`, and both stream tails before writing to disk, but the client-facing `ComfyCliError` messages built right beside those calls embedded raw argv and raw stream tails. Verified reachable on `main`: `download_model` with a credentialed URL hitting any error envelope raised `comfy model download --url https://...?token=<secret> failed [...]` straight to the MCP client. This routes every client-facing field through the scrubbers that already existed for the disk path — no new machinery, no new comfy-cli surface, no architecture-rule impact.

## Changes

- **Timeout messages** — both sentences (`_timeout_failure` and the streaming site in `_run_comfy_streaming`) take their stream tails from `failure_log._scrubbed_stream_tail` instead of `textutil._tail`. It renders the `<empty>` marker itself (so the `or '<empty>'` fallback is gone) and declares the same `str | bytes | None` union the POSIX `TimeoutExpired` path actually hands over.
- **`_unwrap_envelope`** — the echoed argv renders through `_cmd_for_message(list(args))`; the stderr fallback uses `_scrubbed_stream_tail`; the envelope-derived `message` and `hint` are scrubbed **before** their cap. Scrub-then-cap is load-bearing: capping first can bisect a URL so its `https://` is gone and `failure_log._URL_RE` can no longer see the credential remainder — the same ordering `_scrubbed_stream_tail` already documents.
- **No-JSON and TCC branches** — both quoted streams scrubbed. `tcc._tcc_guidance` is deliberately untouched: it renders a filesystem path, not a stream.
- **`_cmd_for_message` is now bounded** to `_MAX_ERROR_FIELD_CHARS`, closing the one unbounded field in the timeout sentence (`run_workflow`'s rendered `--param` values are caller-supplied and can inflate an argv arbitrarily). The slice takes the **head**: the identifying `comfy --json --where local <subcommand>` prefix sits at the front, and everything a head slice can cut has already been scrubbed, so a bisected URL has no userinfo or query left to leak.
- No `failure_log._log_failure(...)` call changed — the disk path was already correct, and it re-scrubs its inputs anyway (idempotent).

## Motivation

Follow-up to the spike that verified this, and to the review thread that deferred the scrub half: https://github.com/Comfy-Org/comfy-mcp/pull/173#discussion_r3698567632. #173 (which extracted `_timeout_failure`) is merged, so this completes the scrub half its reviewers deferred, and lands as one body rather than three inline copies.

## Testing

- [x] Existing tests pass (`pytest`) — 1539 passed, 4 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually — not applicable; the tests mock comfy-cli through the shared `tests/conftest.py` fixtures per AGENTS.md, and never require a real ComfyUI or the `comfy` binary.

10 new tests. Credential-in-URL fixtures use the repo's mandated `https://<user>:<pass>@host` shape — a bare `user:pass@` trips the secret-scanning diff gate, and `_URL_RE` needs the `https?://` scheme to match at all. Every new test was confirmed to **fail** against unfixed `src/` and pass with it, so none of them is asserting its own premise. No existing assertion was changed: the `<empty>` marker semantics are preserved by `_scrubbed_stream_tail`, and no test was asserting an exact unscrubbed clipped tail.

Coverage: envelope-path argv masking, envelope stderr fallback, envelope `message`/`hint`/`details`, the no-JSON path (both streams), the TCC branch, `_timeout_failure` tails (str and the POSIX bytes shape), the argv cap, and the whole-sentence bound.

## Additional Notes

Three judgment calls, all beyond the letter of the plan — flagging rather than burying:

1. **`_render_error_details` is scrubbed too.** The plan enumerated `message` and `hint`. `details` is rendered into the *same* client-facing sentence from the same envelope, and the disk path already scrubs it (it is part of the `message` `_log_failure` receives), so leaving it raw would have re-created the exact asymmetry this PR closes — one field down. Today `_SURFACED_DETAIL_KEYS` is only `partner_nodes` (node names), so it masks nothing in practice; it is there so a later key added to that tuple doesn't have to remember to redact separately.

2. **The `comfy --version` probe's own `Original error:` line is scrubbed** (`_check_comfy_version`, outside the plan's enumerated sites). There are three `Original error:` renderings; scrubbing only the one in `_unwrap_envelope` would read as an oversight. The line drawn is **captured streams are scrubbed, filesystem paths are not** — so the version probe's stderr is scrubbed, while `tcc._tcc_guidance` and the spawn-denied branch's `PermissionError` repr (both paths) are not. The probe takes no caller URL of its own, but comfy-cli reads its config at startup, so a warning naming a configured server URL can land on that stderr.

3. **One documented behavior interaction, worth a reviewer's eye.** `_phrase_is_only_the_caller_s` decides whether a Click usage phrase came from comfy-cli or was merely echoed out of a caller's argument, by subtracting the caller's value from the message — which assumes the echo is **verbatim**. Scrubbing can now make one value non-verbatim. I checked every call site: only `download_model`'s `url` is URL-shaped; the others pass identifiers and filesystem paths, which need the `https?://` scheme `_URL_RE` anchors on and so survive byte-for-byte. Reaching a no-op additionally requires the forged phrase to sit *outside* the URL token (`_URL_RE` stops at whitespace and every Click phrase contains spaces) — and in the commoner shape, a forgery planted in the query, the scrub removes the phrase outright so the guard is *strengthened*, not weakened. The residual has the same direction and the same self-inflicted character as the three the function's docstring already accepts, so I added it to that list rather than changing behavior. Called out here because it is the one place this PR touches logic beyond message text.

**Negative-claim falsification (regression case: comfy-cloud-mcp-server#581):** the trigger does not fire for this diff, and I want to be explicit rather than silent about it. This change adds no `not supported` / `unavailable` / `STOP`-class string, no throw or deny dead-end, and flips no test to assert one. Every path that raised before still raises with the same exception type, the same flags, and the same sentence shape; every path that succeeded still succeeds. The only user-visible delta is that credential substrings inside those messages are masked and two fields are bounded — no capability is denied, so there is nothing to go falsify.

`AGENTS.md` module table updated in the same PR per its own keep-in-sync rule: `failure_log`'s scrubbers now serve the client path, not just the disk record. Module layering is unchanged and still one-way — no leaf module imports `server`.
