### PR TITLE
fix: reject a COMFYUI_URL carrying a query, fragment or ;params (BE-6154)

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,9 +665,13 @@ By default the server drives ComfyUI on the local `127.0.0.1:8188`. Point it at 
 
 - **`COMFYUI_URL`** — a full URL, e.g. `http://gpu-box:8188` (host-only is fine; port defaults to
   `8188`). Takes precedence over the pair below. Only the **host and port** are forwarded to
-  comfy-cli, so the URL must be plain `http://` with **no base path**: an `https://` scheme or a
-  reverse-proxy path (`http://gpu-box:8188/comfyui`) is rejected rather than silently downgraded to
-  http / dropped. Front a TLS/base-path proxy locally if you need one.
+  comfy-cli, so the URL must be plain `http://` with **no base path** and **no query or fragment**:
+  an `https://` scheme, a reverse-proxy path (`http://gpu-box:8188/comfyui`), or a query / fragment /
+  `;params` (`http://gpu-box:8188/?token=…`) is rejected rather than silently downgraded to http /
+  dropped. That last one is the shape an auth-proxied ComfyUI is usually written as, and comfy-cli
+  has nowhere to put it — a dropped token would submit every run unauthenticated and fail later as a
+  401/403 naming nothing — so it is refused up front. Front a TLS/base-path/auth proxy locally if you
+  need one, and point `COMFYUI_URL` at that.
 - **`COMFYUI_HOST`** (+ optional **`COMFYUI_PORT`**, default `8188`) — e.g. `COMFYUI_HOST=gpu-box`.
   A port without a host (setting only `COMFYUI_PORT`) is rejected — set the host too.
 

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -1380,7 +1380,7 @@ def _strip_brackets(host: str) -> str:
 
 
 def _redact_config_url(url: str) -> str:
-    """:func:`textutil._redact_url`, plus the query/fragment a secret also hides in.
+    """:func:`textutil._redact_url`, plus the query/fragment/params a secret hides in.
 
     :func:`_comfy_target`'s errors echo the offending ``COMFYUI_URL`` back, and
     that text is quoted onward — into ``server_info``'s ``comfy_target`` block,
@@ -1392,13 +1392,26 @@ def _redact_config_url(url: str) -> str:
     moment ANY of the checks below rejects it — the ``https`` scheme most of
     all, which is what such a proxy is usually reached over.
 
-    The query and fragment are replaced WHOLESALE rather than parsed for
-    key names: what makes the value diagnosable is the scheme, host and port, so
-    nothing in either part is worth echoing — and a placeholder still tells the
-    user they wrote one, which "silently dropped" would not.
+    ``;`` is cut alongside them because ``urlparse`` splits ``;params`` off the
+    last path segment: ``http://host:8188/;token=…`` carries a secret with no
+    ``?`` anywhere in it, and is rejected (and echoed) by the same check. It is
+    searched only from after the scheme separator, the way
+    :func:`textutil._redact_url` bounds its own netloc scan — a ``;`` before that
+    is inside the scheme, and cutting there would take the host and port with it.
+
+    All three are replaced WHOLESALE rather than parsed for key names: what makes
+    the value diagnosable is the scheme, host and port, so nothing in any of them
+    is worth echoing — and a placeholder still tells the user they wrote one,
+    which "silently dropped" would not.
     """
     masked = textutil._redact_url(url)
-    cuts = [i for i in (masked.find("?"), masked.find("#")) if i != -1]
+    scheme_sep = masked.find("://")
+    semi_from = scheme_sep + 3 if scheme_sep != -1 else 0
+    cuts = [
+        i
+        for i in (masked.find("?"), masked.find("#"), masked.find(";", semi_from))
+        if i != -1
+    ]
     if not cuts:
         return masked
     cut = min(cuts)
@@ -1416,9 +1429,11 @@ def _comfy_target() -> tuple[str, int, str] | None:
     malformed value rather than silently retargeting to the wrong place.
 
     comfy-cli's ``--host`` / ``--port`` carry only a host and port, so a
-    ``COMFYUI_URL`` that also names a non-``http`` scheme (``https://``) or a base
-    path (``/comfyui``) is REJECTED rather than silently dropped — otherwise a
-    user asking for TLS or a reverse-proxy path would be quietly downgraded.
+    ``COMFYUI_URL`` that also names a non-``http`` scheme (``https://``), a base
+    path (``/comfyui``), or a query / fragment / ``;params`` (``?token=…``) is
+    REJECTED rather than silently dropped — otherwise a user asking for TLS, a
+    reverse-proxy path, or an auth proxy's token would be quietly downgraded to a
+    plain unauthenticated request against the bare host.
     """
     url = os.environ.get("COMFYUI_URL", "").strip()
     if url:
@@ -1446,6 +1461,20 @@ def _comfy_target() -> tuple[str, int, str] | None:
                 f"COMFYUI_URL must not include a path ({_redact_config_url(url)!r}): "
                 "comfy-cli forwards only host/port, so a reverse-proxy base path "
                 "would be dropped. Point COMFYUI_URL at the bare host:port."
+            )
+        # `params` is the `;token=abc` spelling: `urlparse` splits it off the
+        # last path segment, so `http://host:8188/;token=abc` leaves `path` at
+        # "/" and slips past the check above. Same silent drop, same rejection.
+        if parsed.query or parsed.fragment or parsed.params:
+            raise ComfyCliError(
+                f"COMFYUI_URL must not include a query or fragment "
+                f"({_redact_config_url(url)!r}): comfy-cli forwards only "
+                "host/port, so a query or fragment (e.g. a proxy auth "
+                "?token=...) would be silently dropped. The ';token=...' "
+                "spelling goes the same way — it is a path parameter, so it is "
+                "neither the path this checks above nor a query. Point "
+                "COMFYUI_URL at the bare host:port and carry the credential "
+                "another way."
             )
         if not host:
             raise ComfyCliError(

--- a/tests/test_remote_host.py
+++ b/tests/test_remote_host.py
@@ -125,8 +125,51 @@ def test_target_url_with_path_rejected(monkeypatch):
         server._comfy_target()
 
 
+def test_target_url_with_query_rejected(monkeypatch):
+    """An auth proxy's `?token=…` can't be forwarded -> reject, don't drop it silently.
+
+    The realistic shape for an auth-proxied ComfyUI. `_with_target` forwards only
+    `--host` / `--port`, so accepting this would submit every run unauthenticated
+    and surface as a 401/403 that names nothing about the dropped credential.
+    """
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:8188/?token=<SECRETTOKEN>")
+    with pytest.raises(server.ComfyCliError, match="query or fragment") as excinfo:
+        server._comfy_target()
+    # The rejection must not echo back the secret it exists to protect.
+    assert "SECRETTOKEN" not in str(excinfo.value)
+
+
+def test_target_url_with_fragment_rejected(monkeypatch):
+    """A fragment is dropped just as silently as a query -> same rejection."""
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:8188/#SECRETFRAG")
+    with pytest.raises(server.ComfyCliError, match="query or fragment") as excinfo:
+        server._comfy_target()
+    assert "SECRETFRAG" not in str(excinfo.value)
+
+
+def test_target_url_with_params_rejected(monkeypatch):
+    """`;params` is the spelling that slips past the path check.
+
+    `urlparse` splits `;token=abc` off the last path segment, so this value's
+    `path` is a bare "/" — accepted by the path check above — while `params`
+    carries the credential. It must be rejected alongside query/fragment, and
+    redacted the same way even though there is no `?` to cut at.
+    """
+    monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:8188/;token=<SECRETTOKEN>")
+    with pytest.raises(server.ComfyCliError, match="query or fragment") as excinfo:
+        server._comfy_target()
+    assert "SECRETTOKEN" not in str(excinfo.value)
+    # The host:port — the whole diagnostic — survives the cut.
+    assert "http://gpu.example:8188/;<redacted>" in str(excinfo.value)
+
+
 def test_target_url_root_path_allowed(monkeypatch):
-    """A bare trailing slash is not a real base path -> accepted."""
+    """A bare trailing slash is not a real base path -> accepted.
+
+    The counter-case to the three rejections above: an empty query, fragment and
+    `params` alongside a `/` path must stay accepted, so the new check cannot
+    turn the documented `http://host:port/` form into a hard error.
+    """
     monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001/")
     assert server._comfy_target() == ("gpu.example", 9001, "COMFYUI_URL")
 


### PR DESCRIPTION
## ELI-5

If you point this server at a ComfyUI sitting behind an auth proxy, you naturally write the address the way the proxy hands it to you: `COMFYUI_URL=http://gpu.example:8188/?token=abc123`. Until now that was accepted — and the `?token=abc123` was thrown away, because all this server can hand comfy-cli is a host and a port. Every run then submitted with no credential and eventually came back as a 401/403 that said nothing about a dropped token. Now the server refuses the value up front and tells you why.

## Changes

- `_comfy_target` rejects a `COMFYUI_URL` that carries a query, a fragment, or a `;params` segment, immediately after the existing base-path check. Its docstring's rejection sentence now names all three alongside the scheme and path.
- `;` joins `?` and `#` in `_redact_config_url`'s cut list, so the token in `http://host:8188/;token=…` is not echoed back by the very error that exists to protect it. The `;` is searched only from after the scheme separator, so the cut can never truncate the host and port — the whole diagnostic — away.
- README's `COMFYUI_URL` bullet documents the new rejection and points at fronting the proxy locally.
- Three new tests in `tests/test_remote_host.py` (query, fragment, `;params`), each asserting the secret is absent from the message; the existing `test_target_url_root_path_allowed` is the counter-case and still passes.

`;params` needs its own mention because `urlparse` splits it off the *last path segment*: `http://gpu.example:8188/;token=abc` yields `path='/'` and `params='token=abc'`, so it sails past the path check and — before this PR — past redaction too, since there is no `?` to cut at.

## Motivation

`_comfy_target` already refuses what `--host`/`--port` cannot forward: a non-`http` scheme and a base path both raise, precisely so a user asking for TLS or a reverse-proxy path is not quietly downgraded. A query/fragment was the one member of that family still missing, and it is the one that silently discards a credential. Deferred from a review thread on #175.

## Testing

- [x] Existing tests pass (`pytest` — 1561 passed, 4 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — drove `_comfy_target` over a table of values in a venv:

| `COMFYUI_URL` | result |
|---|---|
| `http://gpu.example:8188/?token=SECRET` | raises; echoes `'http://gpu.example:8188/?<redacted>'` |
| `http://gpu.example:8188/#FRAG` | raises; echoes `…/#<redacted>` |
| `http://gpu.example:8188/;token=SECRET` | raises; echoes `…/;<redacted>` |
| `https://gpu.example:8188/;token=SECRET` | scheme check still wins; echoes `…/;<redacted>` |
| `http://gpu.example:8188;token=SECRET` | malformed (bad port); echoes `…:8188;<redacted>` — previously echoed the raw token |
| `http://<u>:<p>@gpu.example:8188/?token=SECRET` | raises; echoes `'http://***@gpu.example:8188/?<redacted>'` |
| `http://gpu.example:9001/`, `http://gpu.example:8188`, `gpu.example:8188`, `http://[::1]:8188/` | all still accepted, unchanged |

## Blast radius — a previously-accepted config now fails fast

This narrows the accepted-config contract for every target-aware tool (`_TARGET_AWARE_SUBCOMMANDS = {"run", "run-template", "jobs"}` — so `run_workflow`, `run_template`, `generate_image` and the jobs/queue family) and for everywhere `_comfy_target`'s errors surface (`server_info`'s `comfy_target` block, `_malformed_target_note`, which degrade to an error-shaped note rather than breaking those local-only calls). A `COMFYUI_URL` with a query/fragment that used to resolve silently now raises with an actionable message. That is the intent — the previous behavior was a dropped credential, not a working configuration. `git grep` confirms no existing test or doc sets such a value.

## Negative-claim falsification

This change denies a capability ("carry a proxy token in `COMFYUI_URL`"), so per the loop's falsification rule I went looking for any product path that actually delivers it before shipping the dead-end. `comfy` is **not installed in this environment** (`which comfy` → not found), so the server's own tools could not be driven live; the probe was done against comfy-cli's `origin/main` source, which is the authority for what `--host`/`--port` can carry. Every path fails, and none of them fails silently in a way I could redirect to:

- **`--host` / `--port`** (the only thing `_with_target` forwards): `comfy_cli/host_port.py` defines `_UNSAFE_HOST_CHARS = frozenset("/@?#")` and `validate_host` raises `typer.BadParameter` on any of them, because the value is interpolated straight into `http://{host}:{port}/prompt`. A query cannot ride through that flag even if this server tried to smuggle it.
- **`COMFY_LOCAL_URL`** (the other address lever this server exposes — comfy-cli's own env override, forwarded untouched by `_comfy_env`): `comfy_cli/local_address.py::parse_local_url` drops it explicitly — `# Drop any path / query / fragment — only the authority carries host:port.` So redirecting the user there would reproduce the same silent drop.
- **`comfy run --api-key` / `COMFY_API_KEY`**: documented as "Comfy API key for API Nodes (Partner Nodes). Embedded in the POST /prompt request body as `extra_data.api_key_comfy_org`" — a partner-node credential inside the prompt body, not an auth credential for the ComfyUI server itself, so it cannot stand in for the dropped `?token=`.

Nothing to redirect to inside the wrapper, so the message says what does work: front the TLS/base-path/auth proxy locally and point `COMFYUI_URL` at that. Note this is not the removal of a working feature — the capability never worked; the change is silent-drop-then-401 → fail-fast-with-a-reason.

## Additional Notes

Judgment calls, both flagged rather than assumed:

- **The message text.** The plan prescribed a message naming only "query or fragment". A user who wrote `;token=…` would then be told about something they did not write, so I appended one clause — "The ';token=...' spelling goes the same way — it is a path parameter, so it is neither the path this checks above nor a query." The prescribed sentence (and the `query or fragment` substring the tests match on) is unchanged.
- **`_redact_config_url` widening.** Adding `;` touches the helper #175 introduced, and therefore the four pre-existing `_comfy_target` messages that call it. It only ever widens redaction, and it fixed one adjacent leak on the way: `http://host:8188;token=…` (no path, so no `?`/`#`) used to echo the raw token in the malformed-port error and now echoes `…:8188;<redacted>`.
- **`COMFYUI_HOST` is deliberately untouched.** A `?`/`#`/`;` in that variable is not silently dropped — it is forwarded as `--host` and comfy-cli's own `validate_host` rejects it loudly via the `_UNSAFE_HOST_CHARS` guard above. Duplicating that validation here would be this repo re-deriving a verdict the engine already owns (AGENTS.md thin-wrapper rule), so the asymmetry is intentional: `COMFYUI_URL` needs the check because its query is *parsed off and discarded* here, before comfy-cli ever sees it.
