### PR TITLE
fix: cap workflow_path and download_model's url/relative_path/filename before they reach argv (BE-6181)

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -622,6 +622,22 @@ def _reject_option_like(label: str, value: str, expected: str = "") -> str:
     return value
 
 
+# Generous ceiling on a `workflow_path`'s length, set the same way
+# :data:`_MAX_DOWNLOAD_ID_LEN` is: PATH_MAX is 4096 on Linux and 1024 on macOS,
+# so a value past this ceiling can only name a path the filesystem would refuse
+# anyway (`ENAMETOOLONG`) — while still catching the oversized string before it
+# reaches argv, where the OS rejects the exec with an `OSError` (`E2BIG`) no
+# caller converts to a :class:`ComfyCliError`.
+#
+# It stays this GENEROUS on purpose. It is an argv-safety guard, NOT an attempt
+# to close the residual forgery window in :func:`_phrase_is_only_the_caller_s` —
+# that discount reads a bounded 500-char message tail, so only a cap BELOW 500
+# characters would close it, and that trade-off (refusing legitimately deep
+# paths to buy protection from a caller's own crafted argument) is recorded and
+# declined in that function's docstring. Do not reopen it by tightening this.
+_MAX_WORKFLOW_PATH_LEN = 4096
+
+
 def _guard_workflow_path(workflow_path: str, *, frontend: bool = False) -> str:
     """Run the shared argv guards on a ``workflow_path`` tool argument.
 
@@ -633,7 +649,22 @@ def _guard_workflow_path(workflow_path: str, *, frontend: bool = False) -> str:
     positional = mandatory injection defence vs ``--workflow`` option value =
     input hygiene, see :func:`_reject_option_like`) stays in the per-site
     comments; this helper only owns WHAT runs.
+
+    LENGTH runs first, ahead of both the wording branch and the value checks —
+    see :data:`_MAX_WORKFLOW_PATH_LEN` for what the cap buys, and the ordering
+    comment below for why it is first.
     """
+    if len(workflow_path) > _MAX_WORKFLOW_PATH_LEN:
+        # Report the length, not the value, and check it BEFORE the two value
+        # guards — `_reject_option_like` interpolates `{value!r}` whole, so a
+        # megabyte-long dash-leading path would otherwise be echoed back through
+        # the tool response and the failure log. Same reasoning as
+        # `_guard_prompt_id`. One wording for both `frontend` variants: a size
+        # error has nothing format-specific to say.
+        raise ComfyCliError(
+            f"invalid workflow_path: {len(workflow_path)} characters exceeds the "
+            f"{_MAX_WORKFLOW_PATH_LEN}-character maximum."
+        )
     if frontend:
         expected = (
             "a path to a frontend-format workflow JSON file "
@@ -9618,10 +9649,13 @@ def _phrase_is_only_the_caller_s(
       the tail arrives clipped. The id-shaped values are already capped well
       under that bound (``_MAX_DOWNLOAD_ID_LEN``, ``_MAX_NODE_PACK_ID_LEN``);
       ``workflow_path`` and ``download_model``'s ``url`` / ``relative_path`` /
-      ``filename`` are not, and are left uncapped deliberately — a cap tight
-      enough to close the gap would have to sit under 500 characters, and would
-      start refusing legitimately deep paths and long CivitAI/HuggingFace URLs
-      to buy nothing but protection from a caller's own crafted argument.
+      ``filename`` carry only the far more generous argv-safety ceilings
+      (``_MAX_WORKFLOW_PATH_LEN``, ``_MAX_URL_LEN``), which sit thousands of
+      characters ABOVE the tail and so leave this window exactly as open as it
+      was uncapped. That is deliberate — a cap tight enough to close the gap
+      would have to sit under 500 characters, and would start refusing
+      legitimately deep paths and long CivitAI/HuggingFace URLs to buy nothing
+      but protection from a caller's own crafted argument.
       That tail is also URL-SCRUBBED on its way to the client
       (``failure_log._scrubbed_stream_tail``), so a value whose echo carries
       credential material — userinfo or a query string, the only two things
@@ -10243,6 +10277,18 @@ def _poll_download(download_id: str, timeout_seconds: float) -> Any:
     )
 
 
+# Generous ceiling on `download_model`'s `url`, set the same way
+# :data:`_MAX_WORKFLOW_PATH_LEN` is. 8 KiB sits past the request-line limit
+# common HTTP servers enforce (nginx's `large_client_header_buffers` and
+# Apache's `LimitRequestLine` both default to 8 KiB), so a URL past this ceiling
+# can only be one the remote server would refuse anyway — while real
+# HuggingFace / CivitAI URLs, signed and query-tokened forms included, sit far
+# below it. What it buys is the same thing the id caps buy: the oversized string
+# fails as a clean :class:`ComfyCliError` instead of reaching argv, where the OS
+# rejects the exec with an `OSError` no caller converts.
+_MAX_URL_LEN = 8192
+
+
 def _guard_model_relative_path(relative_path: str) -> str:
     """Reject a ``relative_path`` that would write outside the models tree.
 
@@ -10262,7 +10308,20 @@ def _guard_model_relative_path(relative_path: str) -> str:
     Raises :class:`ComfyCliError` on any of the three; otherwise returns the
     value UNCHANGED — this guard never rewrites an untrusted argument, for the
     reason the bare-``loras`` comment gives.
+
+    LENGTH runs first, ahead of all three — see :data:`_MAX_WORKFLOW_PATH_LEN`,
+    whose ceiling this reuses: both are path-shaped values headed for argv, and
+    a NAME_MAX-tight cap of its own would be tighter than the argv hazard needs.
     """
+    if len(relative_path) > _MAX_WORKFLOW_PATH_LEN:
+        # First, and reporting the length rather than the value, for the reason
+        # `_guard_prompt_id` gives: every check below interpolates the value
+        # whole, so an oversized one would be mirrored back through the tool
+        # response and the failure log.
+        raise ComfyCliError(
+            f"invalid relative_path: {len(relative_path)} characters exceeds the "
+            f"{_MAX_WORKFLOW_PATH_LEN}-character maximum."
+        )
     _reject_option_like("relative_path", relative_path)
     _reject_nul("relative_path", relative_path)
     # relative_path is a models-dir SUBFOLDER (e.g. `models/loras`), enforced
@@ -10406,7 +10465,17 @@ def _guard_model_filename(filename: str) -> str:
 
     Raises :class:`ComfyCliError` when the value is anything but a bare
     filename; otherwise returns it UNCHANGED, like the guard above.
+
+    LENGTH runs first here too, against the same :data:`_MAX_WORKFLOW_PATH_LEN`
+    ceiling the guard above uses — deliberately not a NAME_MAX-tight cap of its
+    own, which would be tighter than the argv hazard requires.
     """
+    if len(filename) > _MAX_WORKFLOW_PATH_LEN:
+        # Length before shape, reporting the size — see the guard above.
+        raise ComfyCliError(
+            f"invalid filename: {len(filename)} characters exceeds the "
+            f"{_MAX_WORKFLOW_PATH_LEN}-character maximum."
+        )
     _reject_option_like("filename", filename)
     _reject_nul("filename", filename)
     # filename is a single output name, not a path; reject separators, `..`,
@@ -10561,6 +10630,18 @@ async def download_model(
     # submit below). See `_reject_remote_model_download` for why it cannot be
     # made to work instead.
     _reject_remote_model_download()
+    # Length before every value check, and reporting the size rather than the
+    # value: an oversized `url` reaches argv, where the OS rejects the exec with
+    # an `OSError` (`E2BIG`) that neither `_run_comfy` nor this tool's own
+    # `except ComfyCliError` converts — and both checks below interpolate the
+    # value whole, so ordering the size check first also keeps a megabyte-long
+    # "URL" out of the tool response and the failure log. Same shape and same
+    # reasoning as `_guard_prompt_id`; see `_MAX_URL_LEN` for the ceiling.
+    if len(url) > _MAX_URL_LEN:
+        raise ComfyCliError(
+            f"invalid url: {len(url)} characters exceeds the "
+            f"{_MAX_URL_LEN}-character maximum."
+        )
     # comfy-cli parses a leading-dash value as an option/flag; reject any so a
     # crafted argument can't be smuggled in as a CLI flag (argument injection).
     _reject_option_like("url", url)

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -615,10 +615,22 @@ def _reject_option_like(label: str, value: str, expected: str = "") -> str:
       than name a mistake. ``_reject_nul`` still applies there — a NUL cannot ride
       in argv at all. Weigh a new option-value call site the same way before
       copying the hygiene guard into it.
+
+    The echoed value is rendered through :func:`_clip_for_error`, so this message
+    honors the module's :data:`_MAX_ERROR_FIELD_CHARS` bound like every other
+    field that quotes caller input. It is the widest-reach echo in the module —
+    over twenty call sites, most of them values with no length cap of their own —
+    and a bare ``{value!r}`` would mirror one back whole, ``repr`` escaping
+    included (a control character expands 4-to-10x, so even a capped 4096-char
+    value can render as ~16 KB). Output is byte-identical to the old ``!r`` for
+    anything whose rendered form already fits the bound, which is every real
+    argument.
     """
     if value.startswith("-"):
         hint = f" — expected {expected}" if expected else ""
-        raise ComfyCliError(f"invalid {label}: {value!r} (leading '-'){hint}")
+        raise ComfyCliError(
+            f"invalid {label}: {_clip_for_error(value)} (leading '-'){hint}"
+        )
     return value
 
 
@@ -635,6 +647,26 @@ def _reject_option_like(label: str, value: str, expected: str = "") -> str:
 # characters would close it, and that trade-off (refusing legitimately deep
 # paths to buy protection from a caller's own crafted argument) is recorded and
 # declined in that function's docstring. Do not reopen it by tightening this.
+#
+# Measured in CHARACTERS, like every id cap above it and unlike
+# :data:`_MAX_PRECHECKED_SLOT_BYTES`, which encodes first because it is sized
+# against the kernel's per-argument limit DIRECTLY and has to land on that exact
+# boundary. Nothing here does: a character cap is strictly conservative for the
+# hazard it guards. Worst case is 4 bytes/character, so 4096 characters is at
+# most 16 KiB on the wire — an order of magnitude under Linux's 128 KiB
+# `MAX_ARG_STRLEN`. The byte figures the paragraph above cites (`PATH_MAX`,
+# `ENAMETOOLONG`) are therefore ANCHORS for where a generous ceiling belongs,
+# not boundaries this check claims to sit exactly on: a multibyte path between
+# 4096 characters and 4096 bytes rides through and fails as comfy-cli's own
+# `ENAMETOOLONG`, which is an ordinary engine error, not the unconverted
+# `OSError` this cap exists to prevent.
+#
+# `PATH_MAX` is also the POSIX figure. Windows with long paths enabled (or a
+# `\\?\` prefix) admits up to 32,767 characters, so on that host this cap can
+# refuse a path the filesystem would have opened. Accepted: a path that deep is
+# not a real caller's, and the alternative — a per-platform ceiling — would make
+# the same tool argument legal on one host and not another for no gain, since
+# the argv hazard is what is being guarded and it does not vary that way.
 _MAX_WORKFLOW_PATH_LEN = 4096
 
 
@@ -656,11 +688,12 @@ def _guard_workflow_path(workflow_path: str, *, frontend: bool = False) -> str:
     """
     if len(workflow_path) > _MAX_WORKFLOW_PATH_LEN:
         # Report the length, not the value, and check it BEFORE the two value
-        # guards — `_reject_option_like` interpolates `{value!r}` whole, so a
-        # megabyte-long dash-leading path would otherwise be echoed back through
-        # the tool response and the failure log. Same reasoning as
-        # `_guard_prompt_id`. One wording for both `frontend` variants: a size
-        # error has nothing format-specific to say.
+        # guards: a dash-leading oversized path would otherwise be named as a
+        # SHAPE mistake, and `_reject_option_like`'s echo — bounded by
+        # `_clip_for_error`, but still a 500-character preview of a value whose
+        # only problem is its size — tells the caller nothing the length does.
+        # Same reasoning as `_guard_prompt_id`. One wording for both `frontend`
+        # variants: a size error has nothing format-specific to say.
         raise ComfyCliError(
             f"invalid workflow_path: {len(workflow_path)} characters exceeds the "
             f"{_MAX_WORKFLOW_PATH_LEN}-character maximum."
@@ -10286,6 +10319,22 @@ def _poll_download(download_id: str, timeout_seconds: float) -> Any:
 # below it. What it buys is the same thing the id caps buy: the oversized string
 # fails as a clean :class:`ComfyCliError` instead of reaching argv, where the OS
 # rejects the exec with an `OSError` no caller converts.
+#
+# Characters, not bytes, for the reason :data:`_MAX_WORKFLOW_PATH_LEN` gives:
+# 8192 characters is at most 32 KiB on the wire, still well under the 128 KiB
+# per-argument argv limit, so the character count is the conservative measure
+# and the 8 KiB request-line figure is an anchor rather than a boundary this
+# check claims to sit on. (A URL is percent-encoded ASCII on the wire anyway, so
+# the two counts coincide for anything a server would actually accept.)
+#
+# SCOPE: this and `_MAX_WORKFLOW_PATH_LEN` cover the four values BE-6181 names —
+# `workflow_path` and `download_model`'s `url` / `relative_path` / `filename`.
+# The other caller-supplied strings that reach argv (`fetch_template`'s and
+# `emit_partner_workflow`'s `out_path`, `fetch_outputs`'s and `vary_workflow`'s
+# `out_dir`, each entry of `upload_file`'s `paths`) are `_reject_option_like` /
+# `_reject_nul` guarded but still uncapped, so a megabyte-long one still surfaces
+# as the unconverted `OSError`. That sweep is deliberately separate, not an
+# oversight — extending the cap to them is mechanical, not a new decision.
 _MAX_URL_LEN = 8192
 
 
@@ -10315,9 +10364,9 @@ def _guard_model_relative_path(relative_path: str) -> str:
     """
     if len(relative_path) > _MAX_WORKFLOW_PATH_LEN:
         # First, and reporting the length rather than the value, for the reason
-        # `_guard_prompt_id` gives: every check below interpolates the value
-        # whole, so an oversized one would be mirrored back through the tool
-        # response and the failure log.
+        # `_guard_prompt_id` gives: every check below names the value instead of
+        # its size, so an oversized one would come back described as the wrong
+        # mistake — with a 500-character preview that says nothing.
         raise ComfyCliError(
             f"invalid relative_path: {len(relative_path)} characters exceeds the "
             f"{_MAX_WORKFLOW_PATH_LEN}-character maximum."
@@ -10633,10 +10682,10 @@ async def download_model(
     # Length before every value check, and reporting the size rather than the
     # value: an oversized `url` reaches argv, where the OS rejects the exec with
     # an `OSError` (`E2BIG`) that neither `_run_comfy` nor this tool's own
-    # `except ComfyCliError` converts — and both checks below interpolate the
-    # value whole, so ordering the size check first also keeps a megabyte-long
-    # "URL" out of the tool response and the failure log. Same shape and same
-    # reasoning as `_guard_prompt_id`; see `_MAX_URL_LEN` for the ceiling.
+    # `except ComfyCliError` converts — and both checks below name the value
+    # rather than its size, so ordering the size check first is also what makes
+    # the error say what is actually wrong. Same shape and same reasoning as
+    # `_guard_prompt_id`; see `_MAX_URL_LEN` for the ceiling.
     if len(url) > _MAX_URL_LEN:
         raise ComfyCliError(
             f"invalid url: {len(url)} characters exceeds the "
@@ -11316,6 +11365,9 @@ def _clip_for_error(text: str) -> str:
     A slot's value list is caller-sized — a sweep over long prompts is KBs of
     text — and the whole point of naming the offending entry is lost if the
     message it rides in is unreadable. Same per-field cap the envelope errors use.
+    :func:`_reject_option_like` renders through this too, which is what applies
+    the bound to the module's widest echo: most of its call sites guard values
+    with no length cap of their own.
 
     This quotes the fragment itself rather than leaving that to an ``!r`` at the
     call site, because the cap has to apply to what is actually RENDERED. ``repr``

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -377,12 +377,19 @@ def no_spawn(monkeypatch):
     pre-flight check is lost if the argv still goes out. Failing inside the fake
     puts the assertion at the moment of the spawn, so a guard that stops
     refusing surfaces as a spawn, not as a vague missing error.
+
+    BOTH spawn paths are blocked, because a guard is usually shared by tools on
+    either side of the split: ``_guard_workflow_path`` covers the five tools that
+    reach the CLI through :func:`_run_comfy` *and* ``run_workflow``, which streams
+    through ``asyncio.create_subprocess_exec``. Patching only the first would let
+    a parametrized guard test silently spawn for the streaming member.
     """
 
     def boom(*args, **kwargs):
         raise AssertionError("no comfy-cli child may be spawned")
 
     monkeypatch.setattr(server, "_run_comfy", boom)
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", boom)
 
 
 @pytest.fixture

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -205,6 +205,67 @@ def test_download_model_rejects_option_like_filename(patched_run):
     assert calls == []
 
 
+def test_download_model_rejects_an_oversized_url(patched_run):
+    """A url far past any real one is refused before it can reach argv.
+
+    An oversized argv is rejected by the OS with an `OSError` (`E2BIG`) that
+    neither `_run_comfy` nor this tool's own `except ComfyCliError` converts,
+    rather than failing as a clean `ComfyCliError` like every other bad input.
+    """
+    calls = patched_run(envelope(data=_submit()))
+    oversized = "https://hf.co/" + "u" * server._MAX_URL_LEN
+
+    with pytest.raises(server.ComfyCliError, match="exceeds") as excinfo:
+        _download_model(oversized)
+
+    assert calls == []
+    # Length, not value — see `_guard_prompt_id`.
+    assert oversized not in str(excinfo.value)
+
+    # The cap is generous enough that the boundary value itself rides through
+    # to argv — real signed CivitAI/HuggingFace URLs sit far below it.
+    at_ceiling = "https://hf.co/" + "u" * (server._MAX_URL_LEN - len("https://hf.co/"))
+    assert len(at_ceiling) == server._MAX_URL_LEN
+    _download_model(at_ceiling, wait=False)
+    assert calls[0]["cmd"][4:8] == ["model", "download", "--url", at_ceiling]
+
+
+def test_download_model_rejects_an_oversized_relative_path(patched_run):
+    """An oversized `relative_path` is capped ahead of the models-tree check.
+
+    Prefixed with `models/` so it would otherwise pass every containment check
+    and land in argv — the size refusal is what stops it, not the tree guard.
+    """
+    calls = patched_run(envelope(data=_submit()))
+    oversized = "models/" + "d" * server._MAX_WORKFLOW_PATH_LEN
+
+    with pytest.raises(server.ComfyCliError, match="exceeds") as excinfo:
+        _download_model("https://hf.co/x.safetensors", relative_path=oversized)
+
+    assert calls == []
+    assert oversized not in str(excinfo.value)
+    # Generous boundary: the value at exactly the ceiling still passes.
+    at_ceiling = "models/" + "d" * (server._MAX_WORKFLOW_PATH_LEN - len("models/"))
+    assert server._guard_model_relative_path(at_ceiling) == at_ceiling
+
+
+def test_download_model_rejects_an_oversized_filename(patched_run):
+    """An oversized `filename` is capped ahead of the bare-name shape check."""
+    calls = patched_run(envelope(data=_submit()))
+    oversized = "f" * (server._MAX_WORKFLOW_PATH_LEN + 1) + ".safetensors"
+
+    with pytest.raises(server.ComfyCliError, match="exceeds") as excinfo:
+        _download_model("https://hf.co/x.safetensors", filename=oversized)
+
+    assert calls == []
+    assert oversized not in str(excinfo.value)
+    # Generous boundary: the name at exactly the ceiling still passes — the cap
+    # is the argv one, deliberately not a NAME_MAX-tight one of its own.
+    suffix = ".safetensors"
+    at_ceiling = "f" * (server._MAX_WORKFLOW_PATH_LEN - len(suffix)) + suffix
+    assert server._guard_model_filename(at_ceiling) == at_ceiling
+
+
 @pytest.mark.parametrize(
     "bad_url", ["file:///etc/passwd", "ftp://host/x", "/etc/passwd"]
 )

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -295,6 +295,65 @@ def test_workflow_path_guard_allows_dot_slash_dash_name(patched_run):
     assert calls[1]["cmd"][4:] == ["workflow", "notes", "./-flux.json"]
 
 
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(
+            lambda path: asyncio.run(server.run_workflow(path)), id="run_workflow"
+        ),
+        pytest.param(server.validate_workflow, id="validate_workflow"),
+        pytest.param(server.list_workflow_slots, id="list_workflow_slots"),
+        pytest.param(server.list_workflow_notes, id="list_workflow_notes"),
+        pytest.param(
+            lambda path: server.set_workflow_slot(path, ["6.text=x"]),
+            id="set_workflow_slot",
+        ),
+        pytest.param(
+            lambda path: server.vary_workflow(path, ["3.seed=[1,2]"]),
+            id="vary_workflow",
+        ),
+    ],
+)
+def test_workflow_path_guard_rejects_an_oversized_path(call, no_spawn, monkeypatch):
+    """A path far past PATH_MAX is refused before it can reach argv.
+
+    An oversized argv is rejected by the OS with an `OSError` (`E2BIG`) no
+    caller converts, rather than failing as a clean `ComfyCliError` like every
+    other bad input. One check in `_guard_workflow_path` covers all six tools
+    that take a `workflow_path`, so all six are exercised here.
+    """
+
+    def boom_async(*args, **kwargs):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    # `run_workflow` streams through `asyncio.create_subprocess_exec` rather
+    # than `_run_comfy`, so `no_spawn` alone would not prove it never spawned.
+    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", boom_async)
+
+    oversized = "w" * (server._MAX_WORKFLOW_PATH_LEN + 1)
+
+    with pytest.raises(server.ComfyCliError, match="exceeds") as excinfo:
+        call(oversized)
+
+    # Length-not-value: `_reject_option_like` would echo `{value!r}` whole, so
+    # the size check runs first precisely to keep the oversized string out of
+    # the tool response and the failure log.
+    assert oversized not in str(excinfo.value)
+
+
+def test_workflow_path_guard_allows_a_path_at_the_ceiling():
+    """The cap is generous enough that no real path is anywhere near it.
+
+    It is an argv-safety guard, not an attempt to close the residual
+    `_phrase_is_only_the_caller_s` forgery window — which would need a cap under
+    500 characters. The boundary value itself passes.
+    """
+    at_ceiling = "w" * server._MAX_WORKFLOW_PATH_LEN
+
+    assert server._guard_workflow_path(at_ceiling)
+    assert server._guard_workflow_path(at_ceiling, frontend=True)
+
+
 def test_workflow_tools_reject_embedded_nul(no_spawn):
     """A NUL anywhere surfaces as ComfyCliError, not subprocess's bare ValueError.
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -314,30 +314,25 @@ def test_workflow_path_guard_allows_dot_slash_dash_name(patched_run):
         ),
     ],
 )
-def test_workflow_path_guard_rejects_an_oversized_path(call, no_spawn, monkeypatch):
+def test_workflow_path_guard_rejects_an_oversized_path(call, no_spawn):
     """A path far past PATH_MAX is refused before it can reach argv.
 
     An oversized argv is rejected by the OS with an `OSError` (`E2BIG`) no
     caller converts, rather than failing as a clean `ComfyCliError` like every
     other bad input. One check in `_guard_workflow_path` covers all six tools
-    that take a `workflow_path`, so all six are exercised here.
+    that take a `workflow_path`, so all six are exercised here — `no_spawn`
+    blocks both spawn paths, which is what makes `run_workflow` (which streams
+    rather than going through `_run_comfy`) provable in the same parametrization.
     """
-
-    def boom_async(*args, **kwargs):
-        raise AssertionError("no comfy-cli child may be spawned")
-
-    # `run_workflow` streams through `asyncio.create_subprocess_exec` rather
-    # than `_run_comfy`, so `no_spawn` alone would not prove it never spawned.
-    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", boom_async)
-
     oversized = "w" * (server._MAX_WORKFLOW_PATH_LEN + 1)
 
     with pytest.raises(server.ComfyCliError, match="exceeds") as excinfo:
         call(oversized)
 
-    # Length-not-value: `_reject_option_like` would echo `{value!r}` whole, so
-    # the size check runs first precisely to keep the oversized string out of
-    # the tool response and the failure log.
+    # Length-not-value: the size check runs first so the failure is named as a
+    # size rather than as whatever shape complaint the value happens to also
+    # trip, and so the refused string itself stays out of the tool response and
+    # the failure log.
     assert oversized not in str(excinfo.value)
 
 
@@ -352,6 +347,40 @@ def test_workflow_path_guard_allows_a_path_at_the_ceiling():
 
     assert server._guard_workflow_path(at_ceiling)
     assert server._guard_workflow_path(at_ceiling, frontend=True)
+
+
+def test_option_like_rejection_bounds_the_value_it_echoes():
+    """A value UNDER the cap is still bounded on its way into the error.
+
+    The length guards above stop the megabyte case, but a dash-leading value at
+    the 4096-character ceiling is legal input to `_reject_option_like`, whose
+    echo has the widest reach in the module — most of its twenty-odd call sites
+    guard values with no length cap at all. It renders through
+    `_clip_for_error`, so the message honors `_MAX_ERROR_FIELD_CHARS` like every
+    other field that quotes caller input.
+    """
+    at_ceiling = "-" + "w" * (server._MAX_WORKFLOW_PATH_LEN - 1)
+
+    with pytest.raises(server.ComfyCliError, match="leading '-'") as excinfo:
+        server._guard_workflow_path(at_ceiling)
+
+    message = str(excinfo.value)
+    assert at_ceiling not in message
+    # A few words of prose around the bounded field, not 4 KB of `w`.
+    assert len(message) < server._MAX_ERROR_FIELD_CHARS + 200
+
+
+def test_option_like_rejection_is_unchanged_for_an_ordinary_value():
+    """Bounding the echo did not change the message any real caller sees.
+
+    `_clip_for_error` quotes the fragment itself, so for anything whose rendered
+    form already fits the bound it is byte-identical to the `{value!r}` this
+    used to interpolate — the wording every other guard test asserts on.
+    """
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server._guard_workflow_path("-flux.json")
+
+    assert repr("-flux.json") in str(excinfo.value)
 
 
 def test_workflow_tools_reject_embedded_nul(no_spawn):


### PR DESCRIPTION
## ELI-5

If you hand one of these tools an absurdly long string — a workflow path or a model URL a megabyte long — the server used to blow up in a confusing way: the crash happened while *starting* the `comfy` process, as a raw operating-system error nobody translates, instead of the tidy "invalid argument" message every other bad input gets. This PR puts a (very roomy) length limit on the four remaining strings that could do that, so they now fail politely and immediately. The limits are set far above anything real, so nothing that works today stops working.

## Summary

Four caller-supplied strings still reached `subprocess` argv uncapped: the `workflow_path` shared by the six workflow tools, and `download_model`'s `url` / `relative_path` / `filename`. `subprocess.Popen` raises `OSError` (`E2BIG`) at CONSTRUCTION time, outside the `try` in `_run_comfy` that only wraps `communicate()` — and `download_model`'s `except ComfyCliError` does not catch it either — so an oversized value surfaced as an internal error rather than the clean `ComfyCliError` every other bad input produces. This completes the guard family that `_MAX_PROMPT_ID_LEN` / `_MAX_DOWNLOAD_ID_LEN` / `_MAX_NODE_PACK_ID_LEN` already establish.

## Changes

- **`_MAX_WORKFLOW_PATH_LEN = 4096`** — new module constant above `_guard_workflow_path`. PATH_MAX-shaped, so it can only refuse a path the filesystem would refuse anyway (`ENAMETOOLONG`).
- **Length check FIRST in `_guard_workflow_path`** — ahead of the `frontend` wording branch and ahead of `_reject_option_like` / `_reject_nul`. One edit covers all six callers: `run_workflow`, `validate_workflow`, `list_workflow_slots`, `list_workflow_notes`, `set_workflow_slot`, `vary_workflow`.
- **`_MAX_URL_LEN = 8192`** — new constant beside the `download_model` guards. 8 KiB sits past the request-line limit common HTTP servers enforce (nginx `large_client_header_buffers`, Apache `LimitRequestLine`), so it only refuses a URL the remote server would refuse anyway; real HuggingFace/CivitAI URLs, signed and query-tokened forms included, sit far below it.
- **`download_model`** — `url` length checked after `_reject_remote_model_download()` and before `_reject_option_like("url", …)`; `relative_path` and `filename` capped as the FIRST check in `_guard_model_relative_path` / `_guard_model_filename`, reusing `_MAX_WORKFLOW_PATH_LEN`.
- Every message reports the **LENGTH, not the value** (same rationale as `_guard_prompt_id`), and the size check is ordered first precisely because `_reject_option_like` interpolates `{value!r}` whole — so a megabyte-long dash-leading argument is no longer echoed back through the tool response and the failure log.
- Tests: one parametrized test over all six `workflow_path` tools plus a boundary test (`tests/test_workflow.py`), and three `download_model` tests with their own boundary assertions (`tests/test_downloads.py`).

## Motivation

An oversized argument is the one bad-input class this module did not convert into a `ComfyCliError`. It is a legibility/robustness fix, not a security fix — the caps sit far above anything usable, so they close the unconverted-`OSError` path without changing what the wrapper will actually run.

## Testing

- [x] Existing tests pass (`pytest`) — **1572 passed, 3 skipped** on Python 3.11 and 3.14 (the two versions CI runs)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — see the falsification evidence below

**Mutation-checked, not just green.** With the four new `if len(...) >` checks disabled, all six parametrized `workflow_path` cases fail, and both the `relative_path` and `filename` download tests fail (after falling through to the 110s poll they were previously short-circuiting). The two boundary tests pass either way by design — they assert the ceilings are generous, not that they fire.

**Empirical falsification of the capability denial** (this diff adds refusals, so per the negative-claim rule the denial was checked rather than assumed). On this machine:

- `os.pathconf('/tmp','PC_PATH_MAX')` = 1024, `PC_NAME_MAX` = 255. Opening `/tmp/<255 chars>` succeeds; `/tmp/<256 chars>`, `/tmp/<4096 chars>` and `/tmp/<4097 chars>` all fail `OSError 63 File name too long`. So no path the 4096 cap refuses is one the filesystem can open — on Linux `PATH_MAX` is 4096, giving the same conclusion at the same boundary.
- `subprocess.run(["/bin/echo", "x"*n])` spawns fine at n=8192 and n=200000, and raises `OSError: [Errno 7] Argument list too long` at n=2000000 — i.e. the unconverted `OSError` this PR converts is real and reachable, and both ceilings sit comfortably below the hard limit.
- The `url` ceiling is not empirically falsifiable here (it would need a live remote), so it rests on the documented 8 KiB request-line defaults cited above rather than a measurement — stated as such in the constant's comment.

No path that works today is removed: every newly refused value either fails the exec with the unconverted `OSError`, or reaches comfy-cli and fails `ENAMETOOLONG` / HTTP 414.

## Additional Notes

Judgment calls, flagged for review:

1. **The ticket's "add the check as the first guard in the `if relative_path:` / `if filename:` block" no longer maps literally.** Those blocks were refactored into `_guard_model_relative_path` / `_guard_model_filename` after the ticket was written. The checks went in as the first statement of each helper — the equivalent placement, and it keeps every caller of those helpers covered rather than just the inline site. Both helpers are called only from `download_model` today.
2. **`_phrase_is_only_the_caller_s`'s docstring was updated — its LOGIC was not touched.** The ticket says not to touch that helper, and the phrase subtraction is byte-for-byte unchanged. But its docstring asserted these four values "are not [capped], and are left uncapped deliberately", which this PR makes false. It now says they carry the generous argv-safety ceilings, which sit thousands of characters ABOVE the 500-char message tail and therefore leave that forgery window exactly as open as it was uncapped. The reason it stays open — a cap tight enough to close it would have to sit under 500 characters and would start refusing legitimately deep paths and long signed URLs — is preserved verbatim, and `_MAX_WORKFLOW_PATH_LEN`'s own comment points back at it and says not to reopen it by tightening.
3. **`_MAX_WORKFLOW_PATH_LEN` is reused for `relative_path` and `filename`,** so the constant's name is narrower than its use. That is the ticket's explicit instruction and the right trade: all three are path-shaped values headed for argv, and a NAME_MAX-tight cap for `filename` would be tighter than the argv hazard requires. Kept the ticket's name for traceability; renaming it to something like `_MAX_PATH_ARG_LEN` would be a fine follow-up but was not in scope here.
4. **Caps are measured in CHARACTERS, not bytes,** matching the ticket and the existing id guards (`_MAX_PRECHECKED_SLOT_BYTES` is the one place that measures bytes, because it is sized against the kernel limit directly). Worst case here is 4 bytes/char: 4096 chars = 16 KiB and 8192 chars = 32 KiB, both well under Linux's 128 KiB `MAX_ARG_STRLEN` per argument, so the character cap is strictly conservative.
5. **Deliberately out of scope, per the ticket:** no caps added to `out_dir`, `out_path`, `--text` or the other argv-bound strings. Worth noting one concrete instance for whoever picks up that sweep — `fetch_template`'s `out_path` is a caller-supplied string that reaches argv (and then `_local_template_check`) uncapped, exactly like the four fixed here.


---

## Review round 2 (661c2c7)

Six review threads, all addressed and resolved.

- **`_reject_option_like` now renders its echo through `_clip_for_error`.** The length caps stop the megabyte case, but a dash-leading value *at* the 4096-character ceiling was still mirrored back whole — and `repr` escaping expands a control character 4-to-10x, so it could render past the module's own `_MAX_ERROR_FIELD_CHARS` bound. This is the module's widest echo (24 call sites, most guarding values with no length cap of their own), so bounding it there rather than narrowing the comment. Output is byte-identical to the old `{value!r}` for anything whose rendered form already fits — every real argument, and every existing guard-message assertion. Two new tests pin both halves: a value at the ceiling comes back bounded, an ordinary `-flux.json` keeps the exact `repr` wording.
- **The ordering comments were re-grounded.** They no longer claim the size check is what keeps the value out of the response (`_clip_for_error` does that now); they say it is what makes the failure be *named* as a size — a 500-character preview of a value whose only problem is its length tells the caller nothing.
- **`_MAX_WORKFLOW_PATH_LEN` / `_MAX_URL_LEN` comments now carry the three answers that were only in this PR body.** That the caps are measured in CHARACTERS and why that is strictly conservative (worst case 4 bytes/char = 16 KiB / 32 KiB, an order of magnitude under Linux's 128 KiB `MAX_ARG_STRLEN`), so the byte figures cited are anchors rather than boundaries. That `PATH_MAX` is the POSIX figure and Windows long paths can legally exceed it, with the reason a per-platform ceiling is declined. And which sibling argv values (`out_path`, `out_dir`, `upload_file`'s `paths`) are left for a separate sweep — filed as a follow-up rather than widened into this diff.
- **`no_spawn` blocks both spawn paths** (`_run_comfy` *and* `asyncio.create_subprocess_exec`), so the parametrized `workflow_path` guard test no longer needs a local stub for `run_workflow`'s streaming path.
- **Declined:** adding an `isinstance` check ahead of `len()` in the three guards. `_guard_download_id` documents its contract as total; these do not, the tool arguments are `str`-annotated so FastMCP validates upstream, and pre-PR the first statement was `_reject_option_like`, whose `.startswith` already raised a bare `AttributeError` on a non-string — so it is not a regression.

Mutation-checked again: reverting the `_clip_for_error` call fails the new bounding test, and disabling the `workflow_path` length check fails all six parametrized cases. **1573 passed, 4 skipped**; `ruff check` and `ruff format --check` clean.
