### PR TITLE
fix: cap the remaining path-shaped argv strings behind a shared _guard_arg_len (BE-6339)

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -652,6 +652,11 @@ def _reject_option_like(label: str, value: str, expected: str = "") -> str:
 # ``limit``. Keep this list in sync — the SCOPE note at :data:`_MAX_URL_LEN`
 # points here for exactly the values that are covered.
 #
+# ``upload_file``'s ``paths`` is the one entry that needs MORE than this: it is
+# splatted into many argv slots, so a per-entry ceiling leaves the sum unbounded
+# and :data:`_MAX_UPLOAD_PATHS` / :data:`_MAX_UPLOAD_PATHS_TOTAL_BYTES` bound
+# the list itself, the way :data:`_MAX_EXTRA_ARGS` does for ``extra_args``.
+#
 # It stays this GENEROUS on purpose. It is an argv-safety guard, NOT an attempt
 # to close the residual forgery window in :func:`_phrase_is_only_the_caller_s` —
 # that discount reads a bounded 500-char message tail, so only a cap BELOW 500
@@ -681,7 +686,7 @@ def _reject_option_like(label: str, value: str, expected: str = "") -> str:
 _MAX_PATH_ARG_LEN = 4096
 
 
-def _guard_arg_len(label: str, value: str, limit: int = _MAX_PATH_ARG_LEN) -> str:
+def _guard_arg_len(label: str, value: str, limit: int | None = None) -> str:
     """Refuse a caller-supplied argv string too long to survive ``execve``.
 
     The one length check every path-shaped tool argument runs, so the family
@@ -690,6 +695,13 @@ def _guard_arg_len(label: str, value: str, limit: int = _MAX_PATH_ARG_LEN) -> st
     default ceiling buys and which values carry it; ``limit`` exists for
     ``download_model``'s ``url``, whose ceiling is :data:`_MAX_URL_LEN` rather
     than the path one.
+
+    ``None`` rather than ``limit: int = _MAX_PATH_ARG_LEN`` because a default
+    argument is bound once at DEFINITION time: the constant would be copied into
+    the signature, and this repo's documented convention of patching the owning
+    module (``monkeypatch.setattr(server, "_MAX_PATH_ARG_LEN", …)``) would then
+    move the name while leaving every call reading the old 4096. Resolving it in
+    the body keeps :data:`_MAX_PATH_ARG_LEN` the single source of truth.
 
     Reports the LENGTH, never the value — echoing a megabyte-long "path" back is
     the same denial-of-legibility the cap exists to prevent, and every other
@@ -701,6 +713,8 @@ def _guard_arg_len(label: str, value: str, limit: int = _MAX_PATH_ARG_LEN) -> st
     Returns the value UNCHANGED when it fits, so it can wrap an assignment the
     way the other ``_guard_*`` helpers do.
     """
+    if limit is None:
+        limit = _MAX_PATH_ARG_LEN
     if len(value) > limit:
         raise ComfyCliError(
             f"invalid {label}: {len(value)} characters exceeds the "
@@ -9387,10 +9401,13 @@ def fetch_template(name: str, out_path: str, check_local: bool = True) -> dict:
     # an option value, which Click takes verbatim — guarding it is input hygiene
     # (a file literally named `-x` is a caller mistake worth naming), matching
     # `download_model`'s `filename`. See `_reject_option_like` for the split.
-    # The size cap runs first, for the ordering reason `_guard_arg_len` gives:
-    # both guards below name the value rather than its size.
-    _guard_arg_len("out_path", out_path)
     _reject_option_like("name", name, expected="a template name (e.g. 'image_flux2')")
+    # `out_path`'s size cap runs ahead of `out_path`'s OWN two guards, for the
+    # ordering reason `_guard_arg_len` gives: both name the value rather than its
+    # size. Ahead of those two and no further — that rule is per-value, so
+    # hoisting it above `name`'s check would make a call with a dash-leading
+    # `name` AND an oversized `out_path` report the wrong argument.
+    _guard_arg_len("out_path", out_path)
     _reject_option_like(
         "out_path",
         out_path,
@@ -9730,8 +9747,10 @@ def _phrase_is_only_the_caller_s(
       every PATH-shaped value carries only the far more generous argv-safety
       ceiling ``_MAX_PATH_ARG_LEN`` — ``workflow_path``, ``download_model``'s
       ``relative_path`` and ``filename``, the three ``out_path`` values, the two
-      ``out_dir`` values and each entry of ``upload_file``'s ``paths`` — as
-      ``download_model``'s ``url`` carries ``_MAX_URL_LEN``. Both ceilings sit
+      ``out_dir`` values, each entry of ``upload_file``'s ``paths`` and
+      ``search_models``' ``folder`` — as ``download_model``'s ``url`` carries
+      ``_MAX_URL_LEN``. (That list and the one at :data:`_MAX_PATH_ARG_LEN` are
+      the same set, and are meant to stay in sync.) Both ceilings sit
       thousands of characters ABOVE the tail and so leave this window exactly as
       open as it was uncapped. That is deliberate — a cap tight enough to close
       the gap would have to sit under 500 characters, and would start refusing
@@ -10015,8 +10034,13 @@ def search_models(query: str = "", folder: str = "") -> Any:
     if folder:
         # `folder` rides as a bare positional, so its leading-dash guard is the
         # mandatory kind. Size runs ahead of it: this is a models-subfolder path,
-        # the same shape as `download_model`'s `relative_path`, so it takes the
-        # same ceiling for the same reason — see `_guard_arg_len`.
+        # so it takes the same argv-safety CEILING as `download_model`'s
+        # `relative_path` for the same reason — see `_guard_arg_len`. Only the
+        # ceiling is shared: `_guard_model_relative_path`'s traversal and
+        # models-tree checks are deliberately NOT applied here, because this
+        # value picks which folder to LIST rather than where to write a
+        # downloaded file, and `comfy models list-folder` resolving it is the
+        # engine's call to make, not this wrapper's.
         _guard_arg_len("folder", folder)
         _reject_option_like(
             "folder", folder, expected="a model folder (e.g. 'checkpoints')"
@@ -10386,16 +10410,25 @@ def _poll_download(download_id: str, timeout_seconds: float) -> Any:
 #
 # What remains deliberately UNCAPPED is the FREE-FORM half: `search_models`'
 # `--text` query, the enumerated `search_templates` / `search_nodes` filter
-# values, and the params `_generate_param_args` renders. Those are prompt- and
-# query-shaped rather than path-shaped, so a path-sized ceiling would be the
-# wrong instrument — it would refuse a legitimately long prompt while buying
-# nothing a caller cannot already spend by sending more of them. The one
-# free-form value whose size genuinely matters is the JSON slot, and it is
-# bounded on its own terms by `_MAX_PRECHECKED_SLOT_BYTES`, which is measured in
-# BYTES against the kernel's per-argument limit directly because it has to land
-# on that exact boundary. The identifier-shaped names (a template name, a node
-# class name, a slot `address`) are likewise uncapped and likewise not
-# path-shaped; capping them is a separate call, not part of this sweep.
+# values, the params `_generate_param_args` renders, and `vary_workflow`'s /
+# `set_workflow_slot`'s JSON slot. Those are prompt- and query-shaped rather
+# than path-shaped, so a path-sized ceiling would be the wrong instrument — it
+# would refuse a legitimately long prompt to buy a bound the argv hazard does
+# not, on its own, justify putting there.
+#
+# Be precise about what that leaves open, because the obvious defense of it is
+# WRONG: "a caller can spend the same bytes by sending more, smaller values" is
+# true of the TOTAL `ARG_MAX` and false of Linux's PER-ARGUMENT `MAX_ARG_STRLEN`
+# (128 KiB), which one oversized string trips on its own and which no number of
+# smaller ones can reach. So a >128 KiB query, filter value, param or slot does
+# still die as the unconverted `OSError` — the residue of this sweep, not
+# something it covers. Leaving it is a scope call (these are the values a
+# path-sized ceiling would misjudge, and the right bound for them is a separate
+# decision), NOT a claim that they are safe. `_MAX_PRECHECKED_SLOT_BYTES` is not
+# that bound either: it gates only whether `_reject_non_json_array_slot` bothers
+# to PARSE, ABSTAINING above it, and the slot still reaches argv. The
+# identifier-shaped names (a template name, a node class name, a slot
+# `address`) sit in the same residue for the same reason.
 _MAX_URL_LEN = 8192
 
 
@@ -10982,6 +11015,45 @@ def cancel_download(download_id: str) -> Any:
         return degraded
 
 
+# Ceilings on `upload_file`'s `paths` LIST, alongside the per-entry
+# `_MAX_PATH_ARG_LEN` each path carries. The per-entry cap alone does not bound
+# the argv this tool builds: `paths` is the one caller-supplied value here that
+# is splatted into MANY argv slots, so a list of individually-legal paths still
+# sums past the kernel's TOTAL `ARG_MAX` (256 KiB on macOS, typically 2 MiB on
+# Linux) and dies as the `OSError` (`E2BIG`) `_run_comfy_raw` never converts —
+# its `try` wraps `communicate()`, not the `Popen(...)` that raises. That is the
+# same reason `_guard_extra_args` caps `_MAX_EXTRA_ARGS` as well as
+# `_MAX_EXTRA_ARG_LEN`, and this is the same pair of caps for the same hazard.
+#
+# TWO of them, because either alone leaves the other open, and between them they
+# are DERIVED rather than picked: `ARG_MAX` counts each entry's bytes plus its
+# terminator and its pointer, so the aggregate bounds the bytes and the count
+# bounds the per-entry overhead the aggregate cannot see (a list of a million
+# EMPTY strings sums to zero bytes and still blows the limit on pointers alone).
+# 128 KiB of path bytes plus 4096 entries of overhead — call it 32 KiB of
+# pointers and 4 KiB of terminators — lands around 164 KiB, comfortably under
+# the 256 KiB that is the SMALLEST `ARG_MAX` of the two platforms.
+#
+# BYTES, not characters, and this is the one place in this module where that
+# distinction bites. The per-value ceilings above count characters and say why:
+# each sits so far under the limit it is guarding that a 4x UTF-8 expansion
+# still cannot reach it. An AGGREGATE has no such headroom — it is sized against
+# `ARG_MAX` directly, so 128 KiB of CHARACTERS would be up to 512 KiB of
+# multibyte path on the wire and would sail past the very limit it exists to
+# hold. Encoded with `surrogatepass` for the reason
+# `_reject_non_json_array_slot` encodes that way: a lone surrogate can arrive
+# over the wire, and this guard must not be the thing that raises on it.
+#
+# Both are backstops, deliberately sized so that no upload a caller would
+# actually make can reach them: a 4096-file batch at a roomy 200 bytes of path
+# each is 800 KiB and so is refused by the aggregate, but the same batch at a
+# realistic ~30 bytes is 120 KiB and rides through. A caller who does reach one
+# is told to split the batch — the tool takes any number of files across several
+# calls, so neither cap makes an upload impossible, only unbatched.
+_MAX_UPLOAD_PATHS = 4096
+_MAX_UPLOAD_PATHS_TOTAL_BYTES = 128 * 1024
+
+
 @mcp.tool()
 def upload_file(paths: list[str], overwrite: bool = False) -> Any:
     """Upload local files into the LOCAL ComfyUI ``input`` directory.
@@ -10998,8 +11070,18 @@ def upload_file(paths: list[str], overwrite: bool = False) -> Any:
     # to that (it is refused wherever it rides, positional or not): `subprocess`
     # raises a bare `ValueError` on one, which would escape as an internal error
     # instead of the `ComfyCliError` every other bad input produces.
-    # The size cap names the INDEX the way `_reject_non_json_array_slot` names
-    # `slots[i]`: the list is splatted, so "which of the paths" is the first
+    # COUNT first, ahead of the per-entry loop: it is the whole-list mistake, and
+    # checking it first is what keeps the loop below proportional to a plausible
+    # command line rather than to whatever the caller sent. See
+    # `_MAX_UPLOAD_PATHS`.
+    if len(paths) > _MAX_UPLOAD_PATHS:
+        raise ComfyCliError(
+            f"invalid paths: {len(paths)} entries exceeds the "
+            f"{_MAX_UPLOAD_PATHS}-entry maximum (they are forwarded to comfy-cli "
+            "as command-line arguments) — upload in batches."
+        )
+    # The per-entry size cap names the INDEX the way `_reject_non_json_array_slot`
+    # names `slots[i]`: the list is splatted, so "which of the paths" is the first
     # thing a caller with several needs to know. It runs before the two value
     # guards for the ordering reason `_guard_arg_len` gives.
     for index, p in enumerate(paths):
@@ -11010,6 +11092,19 @@ def upload_file(paths: list[str], overwrite: bool = False) -> Any:
             expected="a file path (prefix a dash-leading name with './')",
         )
         _reject_nul("upload path", p)
+    # AGGREGATE last, once every entry is known to be a legal path: this is the
+    # bound that actually holds the splatted argv under `ARG_MAX`, and reporting
+    # it before the per-entry checks would name the sum for a list whose real
+    # problem is one bad member. Encoded, because the kernel counts bytes — see
+    # `_MAX_UPLOAD_PATHS_TOTAL_BYTES`. Reports the total, never the paths.
+    total = sum(len(p.encode("utf-8", "surrogatepass")) for p in paths)
+    if total > _MAX_UPLOAD_PATHS_TOTAL_BYTES:
+        raise ComfyCliError(
+            f"invalid paths: {len(paths)} entries totalling {total} bytes exceeds "
+            f"the {_MAX_UPLOAD_PATHS_TOTAL_BYTES}-byte maximum for the whole list "
+            "(the paths are forwarded to comfy-cli as command-line arguments) — "
+            "upload in batches."
+        )
     args = ["upload", *paths]
     if overwrite:
         args.append("--overwrite")

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -11021,18 +11021,18 @@ def cancel_download(download_id: str) -> Any:
 # is splatted into MANY argv slots, so a list of individually-legal paths still
 # sums past the kernel's TOTAL `ARG_MAX` (256 KiB on macOS, typically 2 MiB on
 # Linux) and dies as the `OSError` (`E2BIG`) `_run_comfy_raw` never converts —
-# its `try` wraps `communicate()`, not the `Popen(...)` that raises. That is the
-# same reason `_guard_extra_args` caps `_MAX_EXTRA_ARGS` as well as
-# `_MAX_EXTRA_ARG_LEN`, and this is the same pair of caps for the same hazard.
+# its `try` wraps `communicate()`, not the `Popen(...)` that raises. Bounding
+# both the count and the size of a splatted list is the same thing
+# `_guard_extra_args` does for `extra_args`, for the same reason.
 #
-# TWO of them, because either alone leaves the other open, and between them they
-# are DERIVED rather than picked: `ARG_MAX` counts each entry's bytes plus its
-# terminator and its pointer, so the aggregate bounds the bytes and the count
-# bounds the per-entry overhead the aggregate cannot see (a list of a million
-# EMPTY strings sums to zero bytes and still blows the limit on pointers alone).
-# 128 KiB of path bytes plus 4096 entries of overhead — call it 32 KiB of
-# pointers and 4 KiB of terminators — lands around 164 KiB, comfortably under
-# the 256 KiB that is the SMALLEST `ARG_MAX` of the two platforms.
+# TWO of them, because either alone leaves the other open: the aggregate bounds
+# the path BYTES, and the count bounds the per-entry overhead the aggregate
+# cannot see, since `execve` charges a pointer and a terminator per entry (a
+# list of a million EMPTY strings sums to zero bytes and still blows the limit).
+# `_guard_extra_args` splits the same job differently — count plus PER-ENTRY
+# length, no aggregate — so the two are the same pair of concerns rather than
+# literally the same pair of caps; its own worst case is a residue of the kind
+# the last paragraph describes.
 #
 # BYTES, not characters, and this is the one place in this module where that
 # distinction bites. The per-value ceilings above count characters and say why:
@@ -11040,16 +11040,34 @@ def cancel_download(download_id: str) -> Any:
 # still cannot reach it. An AGGREGATE has no such headroom — it is sized against
 # `ARG_MAX` directly, so 128 KiB of CHARACTERS would be up to 512 KiB of
 # multibyte path on the wire and would sail past the very limit it exists to
-# hold. Encoded with `surrogatepass` for the reason
-# `_reject_non_json_array_slot` encodes that way: a lone surrogate can arrive
-# over the wire, and this guard must not be the thing that raises on it.
+# hold. Measured with `os.fsencode`, which is what `subprocess` itself uses to
+# render argv, so the count is the kernel's rather than a near-enough proxy:
+# `surrogatepass` would charge 3 bytes for each surrogate in the
+# `surrogateescape` range that `os.fsencode` renders back as the SINGLE
+# undecodable filename byte it came from, over-counting a path with non-UTF-8
+# bytes in its name threefold and refusing a batch that fits.
 #
-# Both are backstops, deliberately sized so that no upload a caller would
-# actually make can reach them: a 4096-file batch at a roomy 200 bytes of path
-# each is 800 KiB and so is refused by the aggregate, but the same batch at a
-# realistic ~30 bytes is 120 KiB and rides through. A caller who does reach one
-# is told to split the batch — the tool takes any number of files across several
-# calls, so neither cap makes an upload impossible, only unbatched.
+# NOT a proof that the spawn fits, and the comment must not pretend otherwise.
+# `execve` charges the inherited ENVIRONMENT against the same budget and
+# `_comfy_env` forwards a copy of `os.environ`, which on a loaded shell is tens
+# of KiB on its own; Windows does not work like this at all, capping the whole
+# rendered command line at 32,767 UTF-16 code units. A ceiling that actually
+# held under all of that would have to be computed per-spawn against the live
+# environment, which is a different mechanism from a tool-argument guard. What
+# these two DO buy is what the id caps buy: a runaway list is refused as a clean
+# `ComfyCliError` naming the mistake, rather than reaching a spawn that fails
+# with an unconverted `OSError`. Converting that `OSError` at the spawn site is
+# the airtight backstop underneath them, and is tracked separately.
+#
+# Sized so that no upload a caller would plausibly make reaches them: a
+# 4096-file batch at a roomy 200 bytes of path each is 800 KiB and so is refused
+# by the aggregate, but the same batch at a realistic ~30 bytes is 120 KiB and
+# clears both. Clearing these caps is not a promise the upload COMPLETES —
+# `upload_file`'s 300s timeout is the binding constraint on a batch that large,
+# and it is comfy-cli's transfer being timed, not this guard's business. A
+# caller who does reach one is told to split the batch; the tool takes any
+# number of files across several calls, so neither cap makes an upload
+# impossible, only unbatched.
 _MAX_UPLOAD_PATHS = 4096
 _MAX_UPLOAD_PATHS_TOTAL_BYTES = 128 * 1024
 
@@ -11070,7 +11088,16 @@ def upload_file(paths: list[str], overwrite: bool = False) -> Any:
     # to that (it is refused wherever it rides, positional or not): `subprocess`
     # raises a bare `ValueError` on one, which would escape as an internal error
     # instead of the `ComfyCliError` every other bad input produces.
-    # COUNT first, ahead of the per-entry loop: it is the whole-list mistake, and
+    # SHAPE first, the way `_guard_extra_args` checks it: a bare `str` would pass
+    # `len()` and then be splatted one CHARACTER per argv slot (`"a.png"` ->
+    # `a`, `.`, `p`, …), and a non-string entry dies inside `subprocess` with a
+    # `TypeError` this module's error contract never promised. This is the block
+    # where list-level mistakes are named, so they are both named here.
+    if isinstance(paths, str) or not isinstance(paths, (list, tuple)):
+        raise ComfyCliError(
+            f"invalid paths: expected a list of strings, got {type(paths).__name__}."
+        )
+    # COUNT next, ahead of the per-entry loop: it is the whole-list mistake, and
     # checking it first is what keeps the loop below proportional to a plausible
     # command line rather than to whatever the caller sent. See
     # `_MAX_UPLOAD_PATHS`.
@@ -11080,24 +11107,41 @@ def upload_file(paths: list[str], overwrite: bool = False) -> Any:
             f"{_MAX_UPLOAD_PATHS}-entry maximum (they are forwarded to comfy-cli "
             "as command-line arguments) — upload in batches."
         )
-    # The per-entry size cap names the INDEX the way `_reject_non_json_array_slot`
+    # Every per-entry failure names the INDEX the way `_reject_non_json_array_slot`
     # names `slots[i]`: the list is splatted, so "which of the paths" is the first
-    # thing a caller with several needs to know. It runs before the two value
-    # guards for the ordering reason `_guard_arg_len` gives.
+    # thing a caller with several needs to know, and that is as true of a
+    # dash-leading or NUL-bearing entry as of an oversized one. Size runs ahead
+    # of the two value guards for the ordering reason `_guard_arg_len` gives.
+    total = 0
     for index, p in enumerate(paths):
-        _guard_arg_len(f"upload path paths[{index}]", p)
+        label = f"upload path paths[{index}]"
+        if not isinstance(p, str):
+            raise ComfyCliError(
+                f"invalid {label}: expected a string, got {type(p).__name__}."
+            )
+        _guard_arg_len(label, p)
         _reject_option_like(
-            "upload path",
+            label,
             p,
             expected="a file path (prefix a dash-leading name with './')",
         )
-        _reject_nul("upload path", p)
-    # AGGREGATE last, once every entry is known to be a legal path: this is the
-    # bound that actually holds the splatted argv under `ARG_MAX`, and reporting
-    # it before the per-entry checks would name the sum for a list whose real
-    # problem is one bad member. Encoded, because the kernel counts bytes — see
-    # `_MAX_UPLOAD_PATHS_TOTAL_BYTES`. Reports the total, never the paths.
-    total = sum(len(p.encode("utf-8", "surrogatepass")) for p in paths)
+        _reject_nul(label, p)
+        # Encoded exactly as `subprocess` will encode it, so the running total is
+        # the kernel's count — see `_MAX_UPLOAD_PATHS_TOTAL_BYTES`. `os.fsencode`
+        # is also the one thing here that can REFUSE a path: a lone surrogate
+        # outside the `surrogateescape` range cannot be rendered into argv at all
+        # and would otherwise reach `Popen` as an uncaught `UnicodeEncodeError` —
+        # the same unconverted-spawn-failure class `_reject_nul` exists to close.
+        try:
+            total += len(os.fsencode(p))
+        except UnicodeEncodeError:
+            raise ComfyCliError(
+                f"invalid {label}: contains characters that cannot be encoded as "
+                "a filesystem path (unpaired surrogate)."
+            ) from None
+    # AGGREGATE last, once every entry is known to be a legal path: reporting it
+    # before the per-entry checks would name the sum for a list whose real
+    # problem is one bad member. Reports the total, never the paths.
     if total > _MAX_UPLOAD_PATHS_TOTAL_BYTES:
         raise ComfyCliError(
             f"invalid paths: {len(paths)} entries totalling {total} bytes exceeds "

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -634,12 +634,23 @@ def _reject_option_like(label: str, value: str, expected: str = "") -> str:
     return value
 
 
-# Generous ceiling on a `workflow_path`'s length, set the same way
-# :data:`_MAX_DOWNLOAD_ID_LEN` is: PATH_MAX is 4096 on Linux and 1024 on macOS,
-# so a value past this ceiling can only name a path the filesystem would refuse
-# anyway (`ENAMETOOLONG`) — while still catching the oversized string before it
-# reaches argv, where the OS rejects the exec with an `OSError` (`E2BIG`) no
-# caller converts to a :class:`ComfyCliError`.
+# Generous ceiling on EVERY path-shaped argv value this module forwards, set the
+# same way :data:`_MAX_DOWNLOAD_ID_LEN` is: PATH_MAX is 4096 on Linux and 1024 on
+# macOS, so a value past this ceiling can only name a path the filesystem would
+# refuse anyway (`ENAMETOOLONG`) — while still catching the oversized string
+# before it reaches argv, where the OS rejects the exec with an `OSError`
+# (`E2BIG`) no caller converts to a :class:`ComfyCliError`.
+#
+# The full set it covers, all of them through :func:`_guard_arg_len`:
+# ``run_workflow`` / ``validate_workflow`` / the four other ``workflow_path``
+# tools, ``download_model``'s ``relative_path`` and ``filename``,
+# ``fetch_template``'s / ``emit_partner_workflow``'s / ``partner_generate``'s
+# ``out_path``, ``fetch_outputs``'s and ``vary_workflow``'s ``out_dir``, each
+# entry of ``upload_file``'s ``paths``, and ``search_models``' ``folder``.
+# ``download_model``'s ``url`` is the one path-adjacent value with a ceiling of
+# its own (:data:`_MAX_URL_LEN`), passed to the same helper as an explicit
+# ``limit``. Keep this list in sync — the SCOPE note at :data:`_MAX_URL_LEN`
+# points here for exactly the values that are covered.
 #
 # It stays this GENEROUS on purpose. It is an argv-safety guard, NOT an attempt
 # to close the residual forgery window in :func:`_phrase_is_only_the_caller_s` —
@@ -667,7 +678,35 @@ def _reject_option_like(label: str, value: str, expected: str = "") -> str:
 # not a real caller's, and the alternative — a per-platform ceiling — would make
 # the same tool argument legal on one host and not another for no gain, since
 # the argv hazard is what is being guarded and it does not vary that way.
-_MAX_WORKFLOW_PATH_LEN = 4096
+_MAX_PATH_ARG_LEN = 4096
+
+
+def _guard_arg_len(label: str, value: str, limit: int = _MAX_PATH_ARG_LEN) -> str:
+    """Refuse a caller-supplied argv string too long to survive ``execve``.
+
+    The one length check every path-shaped tool argument runs, so the family
+    stays uniform the way :func:`_guard_prompt_id` / :func:`_guard_download_id`
+    do for the id-shaped ones. See :data:`_MAX_PATH_ARG_LEN` for what the
+    default ceiling buys and which values carry it; ``limit`` exists for
+    ``download_model``'s ``url``, whose ceiling is :data:`_MAX_URL_LEN` rather
+    than the path one.
+
+    Reports the LENGTH, never the value — echoing a megabyte-long "path" back is
+    the same denial-of-legibility the cap exists to prevent, and every other
+    guard at these sites names the value instead of its size, so an oversized
+    one would otherwise come back described as the wrong mistake. That is also
+    why callers run this FIRST, ahead of :func:`_reject_option_like` /
+    :func:`_reject_nul`.
+
+    Returns the value UNCHANGED when it fits, so it can wrap an assignment the
+    way the other ``_guard_*`` helpers do.
+    """
+    if len(value) > limit:
+        raise ComfyCliError(
+            f"invalid {label}: {len(value)} characters exceeds the "
+            f"{limit}-character maximum."
+        )
+    return value
 
 
 def _guard_workflow_path(workflow_path: str, *, frontend: bool = False) -> str:
@@ -683,21 +722,16 @@ def _guard_workflow_path(workflow_path: str, *, frontend: bool = False) -> str:
     comments; this helper only owns WHAT runs.
 
     LENGTH runs first, ahead of both the wording branch and the value checks —
-    see :data:`_MAX_WORKFLOW_PATH_LEN` for what the cap buys, and the ordering
+    see :data:`_MAX_PATH_ARG_LEN` for what the cap buys, and the ordering
     comment below for why it is first.
     """
-    if len(workflow_path) > _MAX_WORKFLOW_PATH_LEN:
-        # Report the length, not the value, and check it BEFORE the two value
-        # guards: a dash-leading oversized path would otherwise be named as a
-        # SHAPE mistake, and `_reject_option_like`'s echo — bounded by
-        # `_clip_for_error`, but still a 500-character preview of a value whose
-        # only problem is its size — tells the caller nothing the length does.
-        # Same reasoning as `_guard_prompt_id`. One wording for both `frontend`
-        # variants: a size error has nothing format-specific to say.
-        raise ComfyCliError(
-            f"invalid workflow_path: {len(workflow_path)} characters exceeds the "
-            f"{_MAX_WORKFLOW_PATH_LEN}-character maximum."
-        )
+    # BEFORE the two value guards: a dash-leading oversized path would otherwise
+    # be named as a SHAPE mistake, and `_reject_option_like`'s echo — bounded by
+    # `_clip_for_error`, but still a 500-character preview of a value whose only
+    # problem is its size — tells the caller nothing the length does. One
+    # wording for both `frontend` variants: a size error has nothing
+    # format-specific to say.
+    _guard_arg_len("workflow_path", workflow_path)
     if frontend:
         expected = (
             "a path to a frontend-format workflow JSON file "
@@ -5561,6 +5595,10 @@ async def partner_generate(
                 "invalid out_path: empty path — omit `out_path` to let comfy-cli "
                 "choose the default location, or pass a real path."
             )
+        # Size next — after the empty branch, which carries the distinct
+        # None-vs-empty semantics above, and before `_reject_nul`, whose message
+        # names the value rather than its size. See `_guard_arg_len`.
+        _guard_arg_len("out_path", out_path)
         _reject_nul("out_path", out_path)
         # `--flag=value` so a path beginning with `-` stays the value.
         args.append(f"--download={out_path}")
@@ -5761,6 +5799,9 @@ async def emit_partner_workflow(
             "invalid out_path: empty path — pass the workflow JSON file to write "
             "(e.g. '/tmp/flux.json'), which run_workflow then takes."
         )
+    # Size first, ahead of both value guards, which name the value rather than
+    # its size — see `_guard_arg_len`.
+    _guard_arg_len("out_path", out_path)
     # Rides behind `--emit-workflow=`, which Click takes verbatim, so this is
     # input hygiene rather than an injection guard — the same posture as
     # `fetch_template`'s `out_path`, the other file this server writes and then
@@ -7228,7 +7269,9 @@ def fetch_outputs(
     # `TimeoutExpired`, leaving `subprocess.Popen`'s bare "embedded null byte"
     # ValueError to escape as an internal error. A leading dash is NOT rejected
     # here — `-o` takes a value, so comfy-cli reads even a dash-led one as this
-    # option's argument, and a relative path is legitimate input.
+    # option's argument, and a relative path is legitimate input. Size runs
+    # ahead of the NUL refusal for the ordering reason `_guard_arg_len` gives.
+    _guard_arg_len("out_dir", out_dir)
     out_dir = _reject_nul("out_dir", out_dir)
     args = ["download", prompt_id, "-o", out_dir]
     if url_only:
@@ -9344,6 +9387,9 @@ def fetch_template(name: str, out_path: str, check_local: bool = True) -> dict:
     # an option value, which Click takes verbatim — guarding it is input hygiene
     # (a file literally named `-x` is a caller mistake worth naming), matching
     # `download_model`'s `filename`. See `_reject_option_like` for the split.
+    # The size cap runs first, for the ordering reason `_guard_arg_len` gives:
+    # both guards below name the value rather than its size.
+    _guard_arg_len("out_path", out_path)
     _reject_option_like("name", name, expected="a template name (e.g. 'image_flux2')")
     _reject_option_like(
         "out_path",
@@ -9681,12 +9727,14 @@ def _phrase_is_only_the_caller_s(
     - The message this reads is a bounded 500-char tail, so a value longer than
       the tail arrives clipped. The id-shaped values are already capped well
       under that bound (``_MAX_DOWNLOAD_ID_LEN``, ``_MAX_NODE_PACK_ID_LEN``);
-      ``workflow_path`` and ``download_model``'s ``url`` / ``relative_path`` /
-      ``filename`` carry only the far more generous argv-safety ceilings
-      (``_MAX_WORKFLOW_PATH_LEN``, ``_MAX_URL_LEN``), which sit thousands of
-      characters ABOVE the tail and so leave this window exactly as open as it
-      was uncapped. That is deliberate — a cap tight enough to close the gap
-      would have to sit under 500 characters, and would start refusing
+      every PATH-shaped value carries only the far more generous argv-safety
+      ceiling ``_MAX_PATH_ARG_LEN`` — ``workflow_path``, ``download_model``'s
+      ``relative_path`` and ``filename``, the three ``out_path`` values, the two
+      ``out_dir`` values and each entry of ``upload_file``'s ``paths`` — as
+      ``download_model``'s ``url`` carries ``_MAX_URL_LEN``. Both ceilings sit
+      thousands of characters ABOVE the tail and so leave this window exactly as
+      open as it was uncapped. That is deliberate — a cap tight enough to close
+      the gap would have to sit under 500 characters, and would start refusing
       legitimately deep paths and long CivitAI/HuggingFace URLs to buy nothing
       but protection from a caller's own crafted argument.
       That tail is also URL-SCRUBBED on its way to the client
@@ -9966,7 +10014,10 @@ def search_models(query: str = "", folder: str = "") -> Any:
         return _run_comfy("models", "search", "--text", query, timeout=60.0)
     if folder:
         # `folder` rides as a bare positional, so its leading-dash guard is the
-        # mandatory kind.
+        # mandatory kind. Size runs ahead of it: this is a models-subfolder path,
+        # the same shape as `download_model`'s `relative_path`, so it takes the
+        # same ceiling for the same reason — see `_guard_arg_len`.
+        _guard_arg_len("folder", folder)
         _reject_option_like(
             "folder", folder, expected="a model folder (e.g. 'checkpoints')"
         )
@@ -10311,7 +10362,7 @@ def _poll_download(download_id: str, timeout_seconds: float) -> Any:
 
 
 # Generous ceiling on `download_model`'s `url`, set the same way
-# :data:`_MAX_WORKFLOW_PATH_LEN` is. 8 KiB sits past the request-line limit
+# :data:`_MAX_PATH_ARG_LEN` is. 8 KiB sits past the request-line limit
 # common HTTP servers enforce (nginx's `large_client_header_buffers` and
 # Apache's `LimitRequestLine` both default to 8 KiB), so a URL past this ceiling
 # can only be one the remote server would refuse anyway — while real
@@ -10320,21 +10371,31 @@ def _poll_download(download_id: str, timeout_seconds: float) -> Any:
 # fails as a clean :class:`ComfyCliError` instead of reaching argv, where the OS
 # rejects the exec with an `OSError` no caller converts.
 #
-# Characters, not bytes, for the reason :data:`_MAX_WORKFLOW_PATH_LEN` gives:
+# Characters, not bytes, for the reason :data:`_MAX_PATH_ARG_LEN` gives:
 # 8192 characters is at most 32 KiB on the wire, still well under the 128 KiB
 # per-argument argv limit, so the character count is the conservative measure
 # and the 8 KiB request-line figure is an anchor rather than a boundary this
 # check claims to sit on. (A URL is percent-encoded ASCII on the wire anyway, so
 # the two counts coincide for anything a server would actually accept.)
 #
-# SCOPE: this and `_MAX_WORKFLOW_PATH_LEN` cover the four values BE-6181 names —
-# `workflow_path` and `download_model`'s `url` / `relative_path` / `filename`.
-# The other caller-supplied strings that reach argv (`fetch_template`'s and
-# `emit_partner_workflow`'s `out_path`, `fetch_outputs`'s and `vary_workflow`'s
-# `out_dir`, each entry of `upload_file`'s `paths`) are `_reject_option_like` /
-# `_reject_nul` guarded but still uncapped, so a megabyte-long one still surfaces
-# as the unconverted `OSError`. That sweep is deliberately separate, not an
-# oversight — extending the cap to them is mechanical, not a new decision.
+# SCOPE: this and `_MAX_PATH_ARG_LEN` cover the PATH-SHAPED values, which are
+# enumerated at `_MAX_PATH_ARG_LEN` rather than described, so the list can be
+# checked. `search_models`' `folder` is on it too — a models-subfolder positional
+# the sweep's own ticket did not name, added because it is the same shape and the
+# same hazard as `relative_path`.
+#
+# What remains deliberately UNCAPPED is the FREE-FORM half: `search_models`'
+# `--text` query, the enumerated `search_templates` / `search_nodes` filter
+# values, and the params `_generate_param_args` renders. Those are prompt- and
+# query-shaped rather than path-shaped, so a path-sized ceiling would be the
+# wrong instrument — it would refuse a legitimately long prompt while buying
+# nothing a caller cannot already spend by sending more of them. The one
+# free-form value whose size genuinely matters is the JSON slot, and it is
+# bounded on its own terms by `_MAX_PRECHECKED_SLOT_BYTES`, which is measured in
+# BYTES against the kernel's per-argument limit directly because it has to land
+# on that exact boundary. The identifier-shaped names (a template name, a node
+# class name, a slot `address`) are likewise uncapped and likewise not
+# path-shaped; capping them is a separate call, not part of this sweep.
 _MAX_URL_LEN = 8192
 
 
@@ -10358,19 +10419,14 @@ def _guard_model_relative_path(relative_path: str) -> str:
     value UNCHANGED — this guard never rewrites an untrusted argument, for the
     reason the bare-``loras`` comment gives.
 
-    LENGTH runs first, ahead of all three — see :data:`_MAX_WORKFLOW_PATH_LEN`,
+    LENGTH runs first, ahead of all three — see :data:`_MAX_PATH_ARG_LEN`,
     whose ceiling this reuses: both are path-shaped values headed for argv, and
     a NAME_MAX-tight cap of its own would be tighter than the argv hazard needs.
     """
-    if len(relative_path) > _MAX_WORKFLOW_PATH_LEN:
-        # First, and reporting the length rather than the value, for the reason
-        # `_guard_prompt_id` gives: every check below names the value instead of
-        # its size, so an oversized one would come back described as the wrong
-        # mistake — with a 500-character preview that says nothing.
-        raise ComfyCliError(
-            f"invalid relative_path: {len(relative_path)} characters exceeds the "
-            f"{_MAX_WORKFLOW_PATH_LEN}-character maximum."
-        )
+    # First, for the reason `_guard_arg_len` gives: every check below names the
+    # value instead of its size, so an oversized one would come back described
+    # as the wrong mistake — with a 500-character preview that says nothing.
+    _guard_arg_len("relative_path", relative_path)
     _reject_option_like("relative_path", relative_path)
     _reject_nul("relative_path", relative_path)
     # relative_path is a models-dir SUBFOLDER (e.g. `models/loras`), enforced
@@ -10515,16 +10571,12 @@ def _guard_model_filename(filename: str) -> str:
     Raises :class:`ComfyCliError` when the value is anything but a bare
     filename; otherwise returns it UNCHANGED, like the guard above.
 
-    LENGTH runs first here too, against the same :data:`_MAX_WORKFLOW_PATH_LEN`
+    LENGTH runs first here too, against the same :data:`_MAX_PATH_ARG_LEN`
     ceiling the guard above uses — deliberately not a NAME_MAX-tight cap of its
     own, which would be tighter than the argv hazard requires.
     """
-    if len(filename) > _MAX_WORKFLOW_PATH_LEN:
-        # Length before shape, reporting the size — see the guard above.
-        raise ComfyCliError(
-            f"invalid filename: {len(filename)} characters exceeds the "
-            f"{_MAX_WORKFLOW_PATH_LEN}-character maximum."
-        )
+    # Length before shape, reporting the size — see the guard above.
+    _guard_arg_len("filename", filename)
     _reject_option_like("filename", filename)
     _reject_nul("filename", filename)
     # filename is a single output name, not a path; reject separators, `..`,
@@ -10685,12 +10737,9 @@ async def download_model(
     # `except ComfyCliError` converts — and both checks below name the value
     # rather than its size, so ordering the size check first is also what makes
     # the error say what is actually wrong. Same shape and same reasoning as
-    # `_guard_prompt_id`; see `_MAX_URL_LEN` for the ceiling.
-    if len(url) > _MAX_URL_LEN:
-        raise ComfyCliError(
-            f"invalid url: {len(url)} characters exceeds the "
-            f"{_MAX_URL_LEN}-character maximum."
-        )
+    # `_guard_prompt_id`; see `_MAX_URL_LEN` for the ceiling, which is why this
+    # is the one `_guard_arg_len` call that passes an explicit `limit`.
+    _guard_arg_len("url", url, _MAX_URL_LEN)
     # comfy-cli parses a leading-dash value as an option/flag; reject any so a
     # crafted argument can't be smuggled in as a CLI flag (argument injection).
     _reject_option_like("url", url)
@@ -10949,7 +10998,12 @@ def upload_file(paths: list[str], overwrite: bool = False) -> Any:
     # to that (it is refused wherever it rides, positional or not): `subprocess`
     # raises a bare `ValueError` on one, which would escape as an internal error
     # instead of the `ComfyCliError` every other bad input produces.
-    for p in paths:
+    # The size cap names the INDEX the way `_reject_non_json_array_slot` names
+    # `slots[i]`: the list is splatted, so "which of the paths" is the first
+    # thing a caller with several needs to know. It runs before the two value
+    # guards for the ordering reason `_guard_arg_len` gives.
+    for index, p in enumerate(paths):
+        _guard_arg_len(f"upload path paths[{index}]", p)
         _reject_option_like(
             "upload path",
             p,
@@ -11594,6 +11648,8 @@ def vary_workflow(
         _reject_non_json_array_slot(index, slot)
         args += ["--slot", slot]
     if out_dir:
+        # Size first, ahead of both value guards — see `_guard_arg_len`.
+        _guard_arg_len("out_dir", out_dir)
         _reject_option_like(
             "out_dir",
             out_dir,

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -720,7 +720,52 @@ def _guard_arg_len(label: str, value: str, limit: int | None = None) -> str:
             f"invalid {label}: {len(value)} characters exceeds the "
             f"{limit}-character maximum."
         )
+    # Length is not the only way a string fails to reach `execve`: one that
+    # cannot be ENCODED never becomes an argv entry at all. Checked here so the
+    # whole path-shaped family is covered in one place, and after the size check
+    # so an oversized value is still named as a size.
+    _encode_argv(label, value)
     return value
+
+
+def _encode_argv(label: str, value: str) -> bytes:
+    """Render a tool argument the way ``subprocess`` will, or refuse it.
+
+    ``subprocess`` encodes POSIX argv with :func:`os.fsencode`, so this is both
+    the CHECK that a value can become an argv entry and the only honest way to
+    MEASURE one in the bytes the kernel counts. :func:`upload_file` uses it for
+    the second — its aggregate is sized against ``ARG_MAX`` directly and cannot
+    afford a proxy — and :func:`_guard_arg_len` for the first.
+
+    Refusing matters because the alternative is not a bad answer but an
+    unconverted one: an unencodable argument raises :class:`UnicodeEncodeError`
+    inside ``Popen``, which sits OUTSIDE the ``try`` in :func:`_run_comfy_raw`,
+    so it escapes as an internal error rather than the :class:`ComfyCliError`
+    every other bad input produces. Exactly the reason :func:`_reject_nul`
+    exists for the bare ``ValueError`` on an embedded NUL.
+
+    POSIX only, and deliberately not papered over. On Windows ``subprocess``
+    builds a UTF-16 command line for ``CreateProcessW`` and never calls
+    :func:`os.fsencode` at all, and that platform's filesystem error handler is
+    ``surrogatepass`` — so nothing here raises and the byte count is a UTF-8
+    estimate of a limit Windows does not express in bytes. The guard is a no-op
+    there rather than wrong, and the Windows command-line limit is out of scope
+    for the same reason :data:`_MAX_UPLOAD_PATHS_TOTAL_BYTES` says it is.
+    """
+    try:
+        return os.fsencode(value)
+    except UnicodeEncodeError:
+        # NOT diagnosed as "unpaired surrogate": `os.fsencode` uses the
+        # interpreter's filesystem encoding, inherited from the environment this
+        # server was launched in, so under a non-UTF-8 locale an ordinary
+        # multibyte filename raises the same error. Name the encoding and offer
+        # the usual cause rather than asserting one.
+        raise ComfyCliError(
+            f"invalid {label}: cannot be encoded with this system's filesystem "
+            f"encoding ({sys.getfilesystemencoding()}), so it cannot be passed to "
+            "comfy-cli as a command-line argument — usually an unpaired "
+            "surrogate, or a character the current locale cannot represent."
+        ) from None
 
 
 def _guard_workflow_path(workflow_path: str, *, frontend: bool = False) -> str:
@@ -10041,6 +10086,16 @@ def search_models(query: str = "", folder: str = "") -> Any:
         # value picks which folder to LIST rather than where to write a
         # downloaded file, and `comfy models list-folder` resolving it is the
         # engine's call to make, not this wrapper's.
+        #
+        # That deferral is checked, not assumed. comfy-cli's `list_folder_cmd`
+        # runs `_reject_unsafe_path_segment(folder, kind="folder", ...)` as its
+        # FIRST statement, which refuses an empty value, one containing `..`,
+        # `/` or `\`, or anything outside `[alnum _ - .]` — a stricter rule than
+        # the one this module applies to `relative_path`. And the value is never
+        # joined onto a filesystem path: it becomes a URL path segment for an
+        # HTTP GET against the ComfyUI server, so there is no models root for
+        # `..` to escape. Duplicating that here would be this wrapper deriving
+        # an answer it should be asking the engine for.
         _guard_arg_len("folder", folder)
         _reject_option_like(
             "folder", folder, expected="a model folder (e.g. 'checkpoints')"
@@ -10427,8 +10482,16 @@ def _poll_download(download_id: str, timeout_seconds: float) -> Any:
 # decision), NOT a claim that they are safe. `_MAX_PRECHECKED_SLOT_BYTES` is not
 # that bound either: it gates only whether `_reject_non_json_array_slot` bothers
 # to PARSE, ABSTAINING above it, and the slot still reaches argv. The
-# identifier-shaped names (a template name, a node class name, a slot
+# identifier-shaped names (`fetch_template`'s `name`, a node class name, a slot
 # `address`) sit in the same residue for the same reason.
+#
+# SIZE is not the only axis, and the residue is the same shape on the other one:
+# a string that cannot be ENCODED never becomes an argv entry either.
+# `_guard_arg_len` runs `_encode_argv` for every value listed at
+# `_MAX_PATH_ARG_LEN`, so the path-shaped family is covered on BOTH axes; the
+# free-form and identifier-shaped values above are uncovered on both. Converting
+# the spawn failure itself is what would close the residue on either axis at
+# once, and that is deliberately a separate change from this sweep.
 _MAX_URL_LEN = 8192
 
 
@@ -11059,10 +11122,14 @@ def cancel_download(download_id: str) -> Any:
 # with an unconverted `OSError`. Converting that `OSError` at the spawn site is
 # the airtight backstop underneath them, and is tracked separately.
 #
-# Sized so that no upload a caller would plausibly make reaches them: a
-# 4096-file batch at a roomy 200 bytes of path each is 800 KiB and so is refused
-# by the aggregate, but the same batch at a realistic ~30 bytes is 120 KiB and
-# clears both. Clearing these caps is not a promise the upload COMPLETES —
+# The AGGREGATE is the one that binds in practice, and the count is the backstop
+# under it rather than a second ceiling a caller meets. At a typical absolute
+# path — `/home/user/Pictures/comfy-inputs/IMG_20260804_123456.png` is about 58
+# bytes — 128 KiB is reached around 2,200 files, well before the 4096-entry cap,
+# so that entry count is only reachable with short paths (a `/tmp/frames/NNNN.png`
+# sequence is ~20 bytes and does fit). Read the count cap as what stops a list of
+# a million tiny or empty strings, not as a promise that 4096 real files fit.
+# Clearing these caps is not a promise the upload COMPLETES —
 # `upload_file`'s 300s timeout is the binding constraint on a batch that large,
 # and it is comfy-cli's transfer being timed, not this guard's business. A
 # caller who does reach one is told to split the batch; the tool takes any
@@ -11097,6 +11164,15 @@ def upload_file(paths: list[str], overwrite: bool = False) -> Any:
         raise ComfyCliError(
             f"invalid paths: expected a list of strings, got {type(paths).__name__}."
         )
+    # The emptiest list-level mistake, and the one every cap below waves through:
+    # `[]` builds `comfy upload` with no positionals, so the caller gets either a
+    # success-shaped result for an upload that moved nothing or comfy-cli's raw
+    # Click usage dump. Name it here like the rest.
+    if not paths:
+        raise ComfyCliError(
+            "invalid paths: empty list — pass at least one file to upload "
+            "(e.g. ['/tmp/source.png'])."
+        )
     # COUNT next, ahead of the per-entry loop: it is the whole-list mistake, and
     # checking it first is what keeps the loop below proportional to a plausible
     # command line rather than to whatever the caller sent. See
@@ -11127,18 +11203,12 @@ def upload_file(paths: list[str], overwrite: bool = False) -> Any:
         )
         _reject_nul(label, p)
         # Encoded exactly as `subprocess` will encode it, so the running total is
-        # the kernel's count — see `_MAX_UPLOAD_PATHS_TOTAL_BYTES`. `os.fsencode`
-        # is also the one thing here that can REFUSE a path: a lone surrogate
-        # outside the `surrogateescape` range cannot be rendered into argv at all
-        # and would otherwise reach `Popen` as an uncaught `UnicodeEncodeError` —
-        # the same unconverted-spawn-failure class `_reject_nul` exists to close.
-        try:
-            total += len(os.fsencode(p))
-        except UnicodeEncodeError:
-            raise ComfyCliError(
-                f"invalid {label}: contains characters that cannot be encoded as "
-                "a filesystem path (unpaired surrogate)."
-            ) from None
+        # the kernel's count rather than a proxy — see
+        # `_MAX_UPLOAD_PATHS_TOTAL_BYTES` for why this aggregate cannot afford
+        # one. The encodability REFUSAL already happened inside `_guard_arg_len`
+        # above, which runs `_encode_argv` for every path-shaped value; this is
+        # the same call for its byte count.
+        total += len(_encode_argv(label, p))
     # AGGREGATE last, once every entry is known to be a legal path: reporting it
     # before the per-entry checks would name the sum for a list whose real
     # problem is one bad member. Reports the total, never the paths.

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -551,6 +551,54 @@ def test_search_models_rejects_leading_dash_folder(patched_run, folder):
     assert calls == []
 
 
+def test_search_models_rejects_an_oversized_folder(no_spawn):
+    """An oversized `folder` is refused before it can reach argv.
+
+    `folder` is a models-SUBFOLDER positional — path-shaped, so it takes the
+    same ceiling as `download_model`'s `relative_path` and for the same reason:
+    an oversized argv string is rejected by the OS with an `OSError` (`E2BIG`)
+    `_run_comfy_raw` never converts, because its `try` wraps only
+    `communicate()` and not the `Popen(...)` that raises.
+    """
+    oversized = "checkpoints/" + "f" * server._MAX_PATH_ARG_LEN
+
+    with pytest.raises(server.ComfyCliError, match="exceeds") as excinfo:
+        server.search_models(folder=oversized)
+
+    # Length-not-value: the size check runs ahead of both value guards, whose
+    # echoes would name the value instead of its size.
+    assert oversized not in str(excinfo.value)
+
+
+def test_search_models_allows_a_folder_at_the_ceiling(patched_run):
+    """The boundary value itself rides through as the `list-folder` positional."""
+    calls = patched_run(envelope(data=[]))
+    prefix = "checkpoints/"
+    at_ceiling = prefix + "f" * (server._MAX_PATH_ARG_LEN - len(prefix))
+    assert len(at_ceiling) == server._MAX_PATH_ARG_LEN
+
+    server.search_models(folder=at_ceiling)
+
+    assert calls[0]["cmd"][4:] == ["models", "list-folder", at_ceiling]
+
+
+def test_search_models_leaves_the_free_form_query_uncapped(patched_run):
+    """The `--text` query is deliberately NOT capped — it is prompt-shaped.
+
+    The counterpart to the `folder` cap above, and the reason the sweep is
+    scoped to path-shaped values: a path-sized ceiling on a free-form search
+    term would refuse a legitimately long query while buying nothing a caller
+    cannot already spend by sending more of them. See the SCOPE note at
+    `_MAX_URL_LEN`.
+    """
+    calls = patched_run(envelope(data=[]))
+    long_query = "q" * (server._MAX_PATH_ARG_LEN + 1)
+
+    server.search_models(query=long_query)
+
+    assert calls[0]["cmd"][4:] == ["models", "search", "--text", long_query]
+
+
 @pytest.mark.parametrize("query", ["-fp16", "-fp8-e4m3fn", "--help"])
 def test_search_models_allows_leading_dash_query(patched_run, query):
     """`--text` is free-form filename matching: a leading dash is data, not a flag.

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -237,7 +237,7 @@ def test_download_model_rejects_an_oversized_relative_path(patched_run):
     and land in argv — the size refusal is what stops it, not the tree guard.
     """
     calls = patched_run(envelope(data=_submit()))
-    oversized = "models/" + "d" * server._MAX_WORKFLOW_PATH_LEN
+    oversized = "models/" + "d" * server._MAX_PATH_ARG_LEN
 
     with pytest.raises(server.ComfyCliError, match="exceeds") as excinfo:
         _download_model("https://hf.co/x.safetensors", relative_path=oversized)
@@ -245,14 +245,14 @@ def test_download_model_rejects_an_oversized_relative_path(patched_run):
     assert calls == []
     assert oversized not in str(excinfo.value)
     # Generous boundary: the value at exactly the ceiling still passes.
-    at_ceiling = "models/" + "d" * (server._MAX_WORKFLOW_PATH_LEN - len("models/"))
+    at_ceiling = "models/" + "d" * (server._MAX_PATH_ARG_LEN - len("models/"))
     assert server._guard_model_relative_path(at_ceiling) == at_ceiling
 
 
 def test_download_model_rejects_an_oversized_filename(patched_run):
     """An oversized `filename` is capped ahead of the bare-name shape check."""
     calls = patched_run(envelope(data=_submit()))
-    oversized = "f" * (server._MAX_WORKFLOW_PATH_LEN + 1) + ".safetensors"
+    oversized = "f" * (server._MAX_PATH_ARG_LEN + 1) + ".safetensors"
 
     with pytest.raises(server.ComfyCliError, match="exceeds") as excinfo:
         _download_model("https://hf.co/x.safetensors", filename=oversized)
@@ -262,7 +262,7 @@ def test_download_model_rejects_an_oversized_filename(patched_run):
     # Generous boundary: the name at exactly the ceiling still passes — the cap
     # is the argv one, deliberately not a NAME_MAX-tight one of its own.
     suffix = ".safetensors"
-    at_ceiling = "f" * (server._MAX_WORKFLOW_PATH_LEN - len(suffix)) + suffix
+    at_ceiling = "f" * (server._MAX_PATH_ARG_LEN - len(suffix)) + suffix
     assert server._guard_model_filename(at_ceiling) == at_ceiling
 
 

--- a/tests/test_emit_partner_workflow.py
+++ b/tests/test_emit_partner_workflow.py
@@ -205,6 +205,35 @@ def test_emit_requires_an_out_path(patched_run, bad):
     assert calls == []
 
 
+def test_emit_rejects_an_oversized_out_path(no_spawn):
+    """An oversized `out_path` is refused before it can reach argv.
+
+    It rides `--emit-workflow=<path>`, so its size lands in a single argv
+    string, where the OS rejects the exec with an `OSError` (`E2BIG`)
+    `_run_comfy_raw` never converts — its `try` wraps only `communicate()`, not
+    the `Popen(...)` that raises.
+    """
+    oversized = "/tmp/" + "e" * server._MAX_PATH_ARG_LEN + ".json"
+
+    with pytest.raises(server.ComfyCliError, match="exceeds") as excinfo:
+        _emit("flux-pro", oversized)
+
+    # Length-not-value: the size check runs ahead of the two value guards,
+    # whose echoes would name the value instead of its size.
+    assert oversized not in str(excinfo.value)
+
+
+def test_emit_allows_an_out_path_at_the_ceiling(patched_run):
+    """The boundary value itself rides through into `--emit-workflow=`."""
+    calls = patched_run(envelope(data=_EMIT_DATA))
+    at_ceiling = "/tmp/" + "e" * (server._MAX_PATH_ARG_LEN - len("/tmp/"))
+    assert len(at_ceiling) == server._MAX_PATH_ARG_LEN
+
+    _emit("flux-pro", at_ceiling)
+
+    assert calls[0]["cmd"][-1] == f"--emit-workflow={at_ceiling}"
+
+
 def test_emit_rejects_an_option_like_out_path(patched_run):
     """A dash-leading destination is a caller mistake worth naming."""
     calls = patched_run(envelope(data=_EMIT_DATA))

--- a/tests/test_partner_generate.py
+++ b/tests/test_partner_generate.py
@@ -620,6 +620,38 @@ def test_partner_generate_rejects_an_empty_out_path(patched_plain_run):
     assert calls == []
 
 
+def test_partner_generate_rejects_an_oversized_out_path(no_spawn):
+    """An oversized `out_path` is refused before it can reach argv.
+
+    The sixth of the path-shaped siblings, and the one whose empty-string branch
+    runs FIRST: `out_path=""` carries distinct None-vs-empty semantics, so the
+    size cap sits between that branch and `_reject_nul` rather than at the top.
+    """
+    oversized = "/tmp/" + "p" * server._MAX_PATH_ARG_LEN + ".png"
+
+    with pytest.raises(server.ComfyCliError, match="exceeds") as excinfo:
+        _generate("flux-pro", out_path=oversized)
+
+    # Length-not-value: `_reject_nul`'s message would name the value instead.
+    assert oversized not in str(excinfo.value)
+
+
+def test_partner_generate_allows_an_out_path_at_the_ceiling(patched_plain_run):
+    """The boundary value itself rides through into `--download=`."""
+    calls = patched_plain_run(0, stdout="done")
+    at_ceiling = "/tmp/" + "p" * (server._MAX_PATH_ARG_LEN - len("/tmp/"))
+    assert len(at_ceiling) == server._MAX_PATH_ARG_LEN
+
+    _generate("flux-pro", out_path=at_ceiling)
+
+    assert calls[0]["cmd"][4:] == [
+        "generate",
+        "flux-pro",
+        f"--download={at_ceiling}",
+        "--timeout=600.0",
+    ]
+
+
 def test_partner_generate_clamps_timeout(patched_plain_run):
     """An absurd timeout is clamped, so no `comfy generate` child runs forever."""
     calls = patched_plain_run(0, stdout="done")

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -392,6 +392,21 @@ def test_fetch_template_rejects_an_oversized_out_path(no_spawn):
     assert oversized not in str(excinfo.value)
 
 
+def test_fetch_template_reports_a_bad_name_ahead_of_an_oversized_out_path(no_spawn):
+    """Size-before-value is a PER-VALUE rule, not a whole-function one.
+
+    `out_path`'s cap sits ahead of `out_path`'s own guards so an oversized path
+    is named as a size rather than as a shape. Hoisting it above `name`'s check
+    too would make a call with both mistakes report the wrong argument.
+    """
+    oversized = "/tmp/" + "o" * server._MAX_PATH_ARG_LEN + ".json"
+
+    with pytest.raises(server.ComfyCliError, match="invalid name") as excinfo:
+        server.fetch_template("--help", oversized)
+
+    assert "exceeds" not in str(excinfo.value)
+
+
 def test_fetch_template_allows_an_out_path_at_the_ceiling(patched_run):
     """The boundary value itself rides through to argv — the cap is generous."""
     calls = patched_run(envelope(data=None))

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -374,6 +374,41 @@ def test_fetch_template_rejects_option_like_name_and_out_path(monkeypatch):
         server.fetch_template("flux_dev", "--help")
 
 
+def test_fetch_template_rejects_an_oversized_out_path(no_spawn):
+    """An oversized `out_path` is refused before it can reach argv.
+
+    `--out`'s value rides the same argv as everything else, where the OS rejects
+    an oversized exec with an `OSError` (`E2BIG`) that `_run_comfy_raw` does not
+    convert — its `try` wraps only `communicate()`, not the `Popen(...)` that
+    raises. The cap is what turns that into a clean `ComfyCliError`.
+    """
+    oversized = "/tmp/" + "o" * server._MAX_PATH_ARG_LEN + ".json"
+
+    with pytest.raises(server.ComfyCliError, match="exceeds") as excinfo:
+        server.fetch_template("flux_dev", oversized)
+
+    # Length-not-value: the size check runs ahead of `_reject_option_like` /
+    # `_reject_nul`, whose echoes would name the value instead of its size.
+    assert oversized not in str(excinfo.value)
+
+
+def test_fetch_template_allows_an_out_path_at_the_ceiling(patched_run):
+    """The boundary value itself rides through to argv — the cap is generous."""
+    calls = patched_run(envelope(data=None))
+    at_ceiling = "/tmp/" + "o" * (server._MAX_PATH_ARG_LEN - len("/tmp/"))
+    assert len(at_ceiling) == server._MAX_PATH_ARG_LEN
+
+    server.fetch_template("flux_dev", at_ceiling, check_local=False)
+
+    assert calls[0]["cmd"][4:] == [
+        "templates",
+        "fetch",
+        "flux_dev",
+        "--out",
+        at_ceiling,
+    ]
+
+
 def test_template_tools_reject_embedded_nul(monkeypatch):
     """A NUL surfaces as ComfyCliError, not subprocess's bare ValueError."""
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -324,7 +324,7 @@ def test_workflow_path_guard_rejects_an_oversized_path(call, no_spawn):
     blocks both spawn paths, which is what makes `run_workflow` (which streams
     rather than going through `_run_comfy`) provable in the same parametrization.
     """
-    oversized = "w" * (server._MAX_WORKFLOW_PATH_LEN + 1)
+    oversized = "w" * (server._MAX_PATH_ARG_LEN + 1)
 
     with pytest.raises(server.ComfyCliError, match="exceeds") as excinfo:
         call(oversized)
@@ -343,7 +343,7 @@ def test_workflow_path_guard_allows_a_path_at_the_ceiling():
     `_phrase_is_only_the_caller_s` forgery window — which would need a cap under
     500 characters. The boundary value itself passes.
     """
-    at_ceiling = "w" * server._MAX_WORKFLOW_PATH_LEN
+    at_ceiling = "w" * server._MAX_PATH_ARG_LEN
 
     assert server._guard_workflow_path(at_ceiling)
     assert server._guard_workflow_path(at_ceiling, frontend=True)
@@ -359,7 +359,7 @@ def test_option_like_rejection_bounds_the_value_it_echoes():
     `_clip_for_error`, so the message honors `_MAX_ERROR_FIELD_CHARS` like every
     other field that quotes caller input.
     """
-    at_ceiling = "-" + "w" * (server._MAX_WORKFLOW_PATH_LEN - 1)
+    at_ceiling = "-" + "w" * (server._MAX_PATH_ARG_LEN - 1)
 
     with pytest.raises(server.ComfyCliError, match="leading '-'") as excinfo:
         server._guard_workflow_path(at_ceiling)
@@ -505,6 +505,35 @@ def test_vary_workflow_rejects_option_like_slot_and_out_dir(no_spawn):
 
     with pytest.raises(server.ComfyCliError, match=r"leading '-'.*\./"):
         server.vary_workflow("/tmp/flux.json", ["3.seed=[1,2]"], out_dir="--help")
+
+
+def test_vary_workflow_rejects_an_oversized_out_dir(no_spawn):
+    """An oversized `out_dir` is refused before it can reach argv.
+
+    The sibling of the `workflow_path` cap above, on the OTHER caller-supplied
+    path this tool forwards: an oversized argv string is rejected by the OS with
+    an `OSError` (`E2BIG`) `_run_comfy_raw` never converts, because its `try`
+    wraps only `communicate()` and not the `Popen(...)` that raises.
+    """
+    oversized = "/tmp/" + "v" * server._MAX_PATH_ARG_LEN
+
+    with pytest.raises(server.ComfyCliError, match="exceeds") as excinfo:
+        server.vary_workflow("/tmp/flux.json", ["3.seed=[1,2]"], out_dir=oversized)
+
+    # Length-not-value: the size check runs ahead of both value guards, whose
+    # echoes would name the value instead of its size.
+    assert oversized not in str(excinfo.value)
+
+
+def test_vary_workflow_allows_an_out_dir_at_the_ceiling(patched_run):
+    """The boundary value itself rides through to `--out-dir`."""
+    calls = patched_run(envelope(data=None))
+    at_ceiling = "/tmp/" + "v" * (server._MAX_PATH_ARG_LEN - len("/tmp/"))
+    assert len(at_ceiling) == server._MAX_PATH_ARG_LEN
+
+    server.vary_workflow("/tmp/flux.json", ["3.seed=[1,2]"], out_dir=at_ceiling)
+
+    assert calls[0]["cmd"][-2:] == ["--out-dir", at_ceiling]
 
 
 def test_vary_workflow_accepts_json_quoted_comma_bearing_prompt(patched_run):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 
 import pytest
 from conftest import envelope
@@ -295,25 +296,30 @@ def test_workflow_path_guard_allows_dot_slash_dash_name(patched_run):
     assert calls[1]["cmd"][4:] == ["workflow", "notes", "./-flux.json"]
 
 
-@pytest.mark.parametrize(
-    "call",
-    [
-        pytest.param(
-            lambda path: asyncio.run(server.run_workflow(path)), id="run_workflow"
-        ),
-        pytest.param(server.validate_workflow, id="validate_workflow"),
-        pytest.param(server.list_workflow_slots, id="list_workflow_slots"),
-        pytest.param(server.list_workflow_notes, id="list_workflow_notes"),
-        pytest.param(
-            lambda path: server.set_workflow_slot(path, ["6.text=x"]),
-            id="set_workflow_slot",
-        ),
-        pytest.param(
-            lambda path: server.vary_workflow(path, ["3.seed=[1,2]"]),
-            id="vary_workflow",
-        ),
-    ],
-)
+# The six tools that take a `workflow_path`. One guard covers all of them, so
+# every test of that guard runs against the whole set rather than a
+# representative — `no_spawn` blocks both spawn paths, which is what makes
+# `run_workflow` (which streams rather than going through `_run_comfy`) provable
+# in the same parametrization.
+_WORKFLOW_PATH_CALLS = [
+    pytest.param(
+        lambda path: asyncio.run(server.run_workflow(path)), id="run_workflow"
+    ),
+    pytest.param(server.validate_workflow, id="validate_workflow"),
+    pytest.param(server.list_workflow_slots, id="list_workflow_slots"),
+    pytest.param(server.list_workflow_notes, id="list_workflow_notes"),
+    pytest.param(
+        lambda path: server.set_workflow_slot(path, ["6.text=x"]),
+        id="set_workflow_slot",
+    ),
+    pytest.param(
+        lambda path: server.vary_workflow(path, ["3.seed=[1,2]"]),
+        id="vary_workflow",
+    ),
+]
+
+
+@pytest.mark.parametrize("call", _WORKFLOW_PATH_CALLS)
 def test_workflow_path_guard_rejects_an_oversized_path(call, no_spawn):
     """A path far past PATH_MAX is refused before it can reach argv.
 
@@ -364,6 +370,38 @@ def test_guard_arg_len_reads_the_module_constant_at_call_time(monkeypatch):
     assert server._guard_arg_len("workflow_path", "w" * 8) == "w" * 8
     # An explicit `limit` still wins over the module default.
     assert server._guard_arg_len("url", "u" * 9, 16) == "u" * 9
+
+
+@pytest.mark.parametrize("call", _WORKFLOW_PATH_CALLS)
+def test_workflow_path_guard_rejects_an_unencodable_path(call, no_spawn):
+    """Length is not the only way a string fails to reach `execve`.
+
+    A lone surrogate survives the MCP JSON wire intact — `json.loads` accepts
+    `"\\ud800"` — and passes every value guard, but `subprocess` encodes POSIX
+    argv with `os.fsencode`, which cannot render it. That raises
+    `UnicodeEncodeError` from the `Popen(...)` OUTSIDE `_run_comfy_raw`'s `try`,
+    so it escapes as an internal error rather than a `ComfyCliError`. Covered
+    for the whole path-shaped family in `_guard_arg_len`, so all six
+    `workflow_path` tools are exercised here.
+    """
+    with pytest.raises(server.ComfyCliError, match="cannot be encoded") as excinfo:
+        call("/tmp/\ud800.json")
+
+    # The message names the encoding rather than asserting a cause: under a
+    # non-UTF-8 filesystem encoding an ordinary multibyte name fails the same way.
+    assert sys.getfilesystemencoding() in str(excinfo.value)
+
+
+def test_guard_arg_len_reports_size_before_encodability():
+    """A value that is BOTH oversized and unencodable is named as a size.
+
+    Same per-value ordering rule the rest of these guards follow: the size is
+    the more actionable of the two, and it is what the caller can see.
+    """
+    oversized = "\ud800" + "w" * server._MAX_PATH_ARG_LEN
+
+    with pytest.raises(server.ComfyCliError, match="exceeds"):
+        server._guard_arg_len("workflow_path", oversized)
 
 
 def test_option_like_rejection_bounds_the_value_it_echoes():

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -349,6 +349,23 @@ def test_workflow_path_guard_allows_a_path_at_the_ceiling():
     assert server._guard_workflow_path(at_ceiling, frontend=True)
 
 
+def test_guard_arg_len_reads_the_module_constant_at_call_time(monkeypatch):
+    """The default ceiling is resolved in the BODY, not bound at definition.
+
+    `limit: int = _MAX_PATH_ARG_LEN` would copy the constant into the signature
+    once, so the repo's patch-the-owning-module convention would move the name
+    while every call kept reading the old 4096 — a guard that silently tests
+    nothing. `_MAX_PATH_ARG_LEN` stays the single source of truth instead.
+    """
+    monkeypatch.setattr(server, "_MAX_PATH_ARG_LEN", 8)
+
+    with pytest.raises(server.ComfyCliError, match="exceeds"):
+        server._guard_arg_len("workflow_path", "w" * 9)
+    assert server._guard_arg_len("workflow_path", "w" * 8) == "w" * 8
+    # An explicit `limit` still wins over the module default.
+    assert server._guard_arg_len("url", "u" * 9, 16) == "u" * 9
+
+
 def test_option_like_rejection_bounds_the_value_it_echoes():
     """A value UNDER the cap is still bounded on its way into the error.
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1395,6 +1395,37 @@ def test_upload_file_rejects_option_like_path_among_valid_ones():
         server.upload_file(["/tmp/a.png", "--overwrite"])
 
 
+def test_upload_file_rejects_an_oversized_path(no_spawn):
+    """An oversized entry is refused, and the error NAMES WHICH ONE.
+
+    The list is splatted into argv, so "which of the paths" is the first thing a
+    caller with several needs to know — the label carries the index the way
+    `_reject_non_json_array_slot` names `slots[i]`. A good first entry proves
+    the guard scans past it rather than stopping at `paths[0]`.
+    """
+    oversized = "/tmp/" + "u" * server._MAX_PATH_ARG_LEN + ".png"
+
+    with pytest.raises(server.ComfyCliError, match="exceeds") as excinfo:
+        server.upload_file(["/tmp/ok.png", oversized])
+
+    message = str(excinfo.value)
+    assert "paths[1]" in message
+    # Length-not-value: the size check runs ahead of both per-entry value
+    # guards, whose echoes would name the value instead of its size.
+    assert oversized not in message
+
+
+def test_upload_file_allows_a_path_at_the_ceiling(patched_run):
+    """The boundary value itself rides through as a positional."""
+    calls = patched_run(envelope(data={"uploaded": 1}))
+    at_ceiling = "/tmp/" + "u" * (server._MAX_PATH_ARG_LEN - len("/tmp/"))
+    assert len(at_ceiling) == server._MAX_PATH_ARG_LEN
+
+    server.upload_file(["/tmp/ok.png", at_ceiling])
+
+    assert calls[0]["cmd"][4:] == ["upload", "/tmp/ok.png", at_ceiling]
+
+
 def test_upload_file_rejects_embedded_nul_path():
     """A NUL surfaces as ComfyCliError, not subprocess's bare ValueError."""
     with pytest.raises(server.ComfyCliError, match="embedded NUL"):
@@ -1940,6 +1971,35 @@ def test_fetch_outputs_rejects_a_nul_in_out_dir(monkeypatch):
 
     with pytest.raises(server.ComfyCliError, match="out_dir"):
         server.fetch_outputs("pid", "/tmp/o\x00ut")
+
+
+def test_fetch_outputs_rejects_an_oversized_out_dir(no_spawn):
+    """An oversized `out_dir` is refused before it can reach argv.
+
+    `-o`'s value is the one caller-supplied string here with no `-` guard (a
+    dash-leading directory is legitimate input for an option that takes a
+    value), so the size cap is the only thing standing between it and the
+    `OSError` (`E2BIG`) `_run_comfy_raw` never converts — its `try` wraps
+    `communicate()`, not the `Popen(...)` that raises.
+    """
+    oversized = "/tmp/" + "d" * server._MAX_PATH_ARG_LEN
+
+    with pytest.raises(server.ComfyCliError, match="exceeds") as excinfo:
+        server.fetch_outputs("pid", oversized)
+
+    # Length-not-value: `_reject_nul`'s message would name the value instead.
+    assert oversized not in str(excinfo.value)
+
+
+def test_fetch_outputs_allows_an_out_dir_at_the_ceiling(patched_run):
+    """The boundary value itself rides through to `-o`."""
+    calls = patched_run(envelope(data={"files": []}))
+    at_ceiling = "/tmp/" + "d" * (server._MAX_PATH_ARG_LEN - len("/tmp/"))
+    assert len(at_ceiling) == server._MAX_PATH_ARG_LEN
+
+    server.fetch_outputs("pid", at_ceiling)
+
+    assert calls[0]["cmd"][4:] == ["download", "pid", "-o", at_ceiling]
 
 
 def test_fetch_outputs_wraps_comfy_download(patched_run):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1481,6 +1481,16 @@ def test_upload_file_rejects_a_bare_string_for_paths(no_spawn):
         server.upload_file("a.png")
 
 
+def test_upload_file_rejects_an_empty_list(no_spawn):
+    """`[]` clears every cap and builds `comfy upload` with no positionals.
+
+    The emptiest list-level mistake, so it is named here with the rest rather
+    than surfacing as a success-shaped result for an upload that moved nothing.
+    """
+    with pytest.raises(server.ComfyCliError, match="empty list"):
+        server.upload_file([])
+
+
 def test_upload_file_rejects_a_non_string_entry(no_spawn):
     """A non-string entry dies inside `subprocess` with a bare `TypeError`.
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1470,6 +1470,65 @@ def test_upload_file_measures_the_aggregate_in_bytes_not_characters(no_spawn):
         server.upload_file(paths)
 
 
+def test_upload_file_rejects_a_bare_string_for_paths(no_spawn):
+    """A bare `str` would be splatted one CHARACTER per argv slot.
+
+    `len()` accepts it and iteration yields characters, so every per-entry guard
+    passes and `comfy upload a . p n g` is what gets spawned. Same refusal
+    `_guard_extra_args` makes, for the same reason.
+    """
+    with pytest.raises(server.ComfyCliError, match="expected a list of strings"):
+        server.upload_file("a.png")
+
+
+def test_upload_file_rejects_a_non_string_entry(no_spawn):
+    """A non-string entry dies inside `subprocess` with a bare `TypeError`.
+
+    That is an internal error rather than the `ComfyCliError` every other bad
+    input produces, and the message names WHICH entry.
+    """
+    with pytest.raises(server.ComfyCliError, match=r"paths\[1\].*expected a string"):
+        server.upload_file(["/tmp/ok.png", 42])
+
+
+def test_upload_file_rejects_an_unencodable_path(no_spawn):
+    """A lone surrogate cannot be rendered into argv at all.
+
+    It survives the MCP JSON wire intact, passes the length and NUL guards, and
+    then makes `Popen` raise an uncaught `UnicodeEncodeError` — the same
+    unconverted-spawn-failure class `_reject_nul` exists to close. `os.fsencode`
+    is what refuses it here, because it is also what `subprocess` would use.
+    """
+    with pytest.raises(server.ComfyCliError, match=r"paths\[1\].*cannot be encoded"):
+        server.upload_file(["/tmp/ok.png", "/tmp/\ud800.png"])
+
+
+def test_upload_file_counts_undecodable_filename_bytes_as_subprocess_would(patched_run):
+    """The aggregate uses `os.fsencode`, not a near-enough proxy.
+
+    A filename byte that is not valid UTF-8 arrives as a `surrogateescape`
+    surrogate and `os.fsencode` renders it back as the SINGLE byte it came from.
+    Measuring with `surrogatepass` instead would charge 3 bytes for each of
+    those, over-counting such a path threefold and refusing a batch that fits.
+    """
+    calls = patched_run(envelope(data={"uploaded": 1}))
+    # One undecodable byte (0xFF) per character of name, at a size that fits
+    # under the cap when counted as `subprocess` counts it and blows past it
+    # when counted with `surrogatepass`.
+    per_entry = "/tmp/" + "\udcff" * 2000
+    count = 60
+    paths = [per_entry] * count
+    assert (
+        sum(len(os.fsencode(p)) for p in paths) < server._MAX_UPLOAD_PATHS_TOTAL_BYTES
+    )
+    surrogatepass_total = sum(len(p.encode("utf-8", "surrogatepass")) for p in paths)
+    assert surrogatepass_total > server._MAX_UPLOAD_PATHS_TOTAL_BYTES
+
+    server.upload_file(paths)
+
+    assert calls[0]["cmd"][4:] == ["upload", *paths]
+
+
 def test_upload_file_reports_a_bad_entry_ahead_of_the_aggregate(no_spawn):
     """A list that is BOTH too large and holds a bad entry names the entry.
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1415,6 +1415,95 @@ def test_upload_file_rejects_an_oversized_path(no_spawn):
     assert oversized not in message
 
 
+def test_upload_file_rejects_too_many_paths(no_spawn):
+    """The per-entry cap does not bound the LIST — the count cap does.
+
+    `paths` is splatted into many argv slots, so entries that are each legal
+    still sum past the kernel's total `ARG_MAX` and die as the `OSError`
+    (`E2BIG`) `_run_comfy_raw` never converts. Same pair of caps, for the same
+    reason, as `_guard_extra_args`' `_MAX_EXTRA_ARGS`.
+    """
+    paths = [f"/tmp/{index}.png" for index in range(server._MAX_UPLOAD_PATHS + 1)]
+
+    with pytest.raises(server.ComfyCliError, match="entries exceeds") as excinfo:
+        server.upload_file(paths)
+
+    assert str(server._MAX_UPLOAD_PATHS) in str(excinfo.value)
+
+
+def test_upload_file_rejects_paths_totalling_past_the_aggregate_cap(no_spawn):
+    """A short-enough list of individually-legal paths is still bounded.
+
+    The count cap alone leaves this open — a mere 33 entries at the per-entry
+    ceiling already pass it while summing past `ARG_MAX` — so the aggregate is
+    what actually holds the splatted command line under the kernel's limit.
+    """
+    entry = "/tmp/" + "u" * (server._MAX_PATH_ARG_LEN - len("/tmp/"))
+    count = server._MAX_UPLOAD_PATHS_TOTAL_BYTES // len(entry) + 1
+    paths = [entry] * count
+    assert count <= server._MAX_UPLOAD_PATHS, "must clear the count cap first"
+
+    with pytest.raises(server.ComfyCliError, match="totalling") as excinfo:
+        server.upload_file(paths)
+
+    # Reports the total, never the paths.
+    assert entry not in str(excinfo.value)
+
+
+def test_upload_file_measures_the_aggregate_in_bytes_not_characters(no_spawn):
+    """The aggregate is sized against `ARG_MAX`, which counts BYTES.
+
+    The per-value ceilings in this module count characters and can afford to —
+    each sits far enough under the limit it guards that a 4x UTF-8 expansion
+    cannot reach it. This one has no such headroom, so a list of multibyte paths
+    whose CHARACTER count is comfortably legal is still refused when its encoded
+    size is not — otherwise the cap would sail past the very limit it holds.
+    """
+    # 3 bytes per character, so this is a third of the cap in characters and
+    # just past it in bytes.
+    entry = "/tmp/" + "中" * 1000
+    count = server._MAX_UPLOAD_PATHS_TOTAL_BYTES // (3 * 1000) + 1
+    paths = [entry] * count
+    assert sum(len(p) for p in paths) < server._MAX_UPLOAD_PATHS_TOTAL_BYTES
+
+    with pytest.raises(server.ComfyCliError, match="bytes exceeds"):
+        server.upload_file(paths)
+
+
+def test_upload_file_reports_a_bad_entry_ahead_of_the_aggregate(no_spawn):
+    """A list that is BOTH too large and holds a bad entry names the entry.
+
+    The aggregate is a property of the whole list; a dash-leading path is a
+    property of one member, and that is the more actionable of the two — so the
+    per-entry loop runs before the sum is judged.
+    """
+    entry = "/tmp/" + "u" * (server._MAX_PATH_ARG_LEN - len("/tmp/"))
+    count = server._MAX_UPLOAD_PATHS_TOTAL_BYTES // len(entry) + 1
+    paths = [*[entry] * count, "--overwrite"]
+
+    with pytest.raises(server.ComfyCliError, match="leading '-'"):
+        server.upload_file(paths)
+
+
+def test_upload_file_allows_a_full_batch_of_real_paths(patched_run):
+    """Both caps are backstops: a real batch AT the count boundary rides through.
+
+    The whole point of sizing them the way `_MAX_UPLOAD_PATHS` documents is that
+    no upload a caller would actually make reaches either — a frame sequence
+    filling the count cap at realistic path lengths is still well inside the
+    aggregate, so the caps refuse runaway argv rather than bulk uploads.
+    """
+    calls = patched_run(envelope(data={"uploaded": server._MAX_UPLOAD_PATHS}))
+    paths = [
+        f"/tmp/frames/{index:04d}.png" for index in range(server._MAX_UPLOAD_PATHS)
+    ]
+    assert sum(len(p) for p in paths) < server._MAX_UPLOAD_PATHS_TOTAL_BYTES
+
+    server.upload_file(paths)
+
+    assert calls[0]["cmd"][4:] == ["upload", *paths]
+
+
 def test_upload_file_allows_a_path_at_the_ceiling(patched_run):
     """The boundary value itself rides through as a positional."""
     calls = patched_run(envelope(data={"uploaded": 1}))


### PR DESCRIPTION
## ELI-5

Some of these tools take a file path from the caller — where to save a template, where to put downloaded outputs, which files to upload. If you handed one of them an absurdly long path (say a megabyte of characters), the server blew up in a confusing way: the crash happened while *starting* the `comfy` process, as a raw operating-system error nobody translates, instead of the tidy "invalid argument" message every other bad input gets. A previous PR fixed four such strings; this one finishes the job for the remaining six (plus one more it found while checking), and moves the shared length check into a single helper so every one of them behaves identically. The limits are set far above anything real, so nothing that works today stops working.

## Summary

Six caller-supplied path-shaped strings still reached `subprocess` argv with `_reject_option_like` / `_reject_nul` hygiene but no length cap. All funnel into `_run_comfy` → `_run_comfy_raw`, where `subprocess.Popen(...)` sits OUTSIDE the `try` that wraps only `communicate()` — so an oversized value raises `OSError` (`E2BIG`) at construction time and escapes as a raw internal error instead of the clean `ComfyCliError` every other bad input produces. `_MAX_EXTRA_ARG_LEN`'s own comment in `main` documents this exact hazard.

**Severity of the underlying issue is low** — this is error-quality/robustness, not injection. The caps sit far above anything usable, so they close the unconverted-`OSError` path without changing what the wrapper will actually run.

## Changes

- **Renamed `_MAX_WORKFLOW_PATH_LEN` → `_MAX_PATH_ARG_LEN`** (same value, 4096). #183's body item 3 flagged the old name as narrower than its use and endorsed this rename as the follow-up. The constant's comment now enumerates every value it covers. `_MAX_URL_LEN`'s value and the characters-vs-bytes choice are untouched.
- **Extracted `_guard_arg_len(label, value, limit=_MAX_PATH_ARG_LEN) -> str`**, following the shape of `_guard_model_relative_path` / `_guard_model_filename`. It reports the LENGTH, never the value (matching `_guard_prompt_id` / `_guard_download_id`), and returns the value unchanged otherwise. **Messages are byte-identical to the inline checks it replaces**, which is why #183's four tests stayed green through the reroute with no edits.
- **Rerouted #183's four existing cap sites** through it: `_guard_workflow_path`, `_guard_model_relative_path`, `_guard_model_filename`, and `download_model`'s `url` (which passes `_MAX_URL_LEN` via the `limit` parameter).
- **Added the cap at each of the six new sites**, as the FIRST hygiene statement ahead of `_reject_option_like` / `_reject_nul`, so the error reports a size rather than echoing a huge value: `fetch_template`'s, `emit_partner_workflow`'s and `partner_generate`'s `out_path`; `fetch_outputs`'s and `vary_workflow`'s `out_dir`; each entry of `upload_file`'s `paths`.
- **`upload_file` caps per entry and names the index** — label `upload path paths[1]`, via `enumerate`, the way `_reject_non_json_array_slot` names `slots[i]`. The list is splatted into argv, so "which of the paths" is the first thing a caller with several needs to know. The per-entry option-like/NUL guards stay after it.
- **Updated `_MAX_URL_LEN`'s SCOPE comment** and **`_phrase_is_only_the_caller_s`'s docstring enumeration** (item 3 of its known-accepted list, which enumerates which values carry caps). Its LOGIC is untouched.
- Eleven `_guard_arg_len` call sites total: 4 rerouted + 6 from the ticket + 1 found in self-review (below).

Two placements differ deliberately, per the ticket:

- **`partner_generate`** keeps its `if not out_path:` empty-string branch FIRST (it carries distinct None-vs-empty semantics), then the length cap, then `_reject_nul`.
- **`fetch_outputs`** gains the cap but NOT `_reject_option_like` — `-o` takes a value, so comfy-cli reads even a dash-leading directory as this option's argument, and a relative path is legitimate input. The existing comment explains that and is preserved.

## Motivation

An oversized argument is the one bad-input class this module still did not convert into a `ComfyCliError` at these six sites. #183 fixed four values and explicitly deferred this sweep (its body item 5 even named `fetch_template`'s `out_path` as a concrete instance for whoever picked it up). Extracting the shared helper at the same time is what makes the family uniform rather than seven copies of the same three lines.

## Testing

- [x] Existing tests pass (`pytest`) — **1588 passed, 4 skipped**
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Mutation-checked, not just green

**Mutation check.** With `_guard_arg_len`'s `if len(value) > limit:` disabled, **13 tests fail**: all seven new rejection tests (`fetch_template`, `emit_partner_workflow`, `partner_generate`, `fetch_outputs`, `vary_workflow`, `upload_file`, `search_models`) plus all six parametrized `workflow_path` cases from #183 — confirming the reroute is load-bearing and every new test genuinely exercises the guard rather than passing incidentally. The boundary tests pass either way by design; they assert the ceilings are generous, not that they fire.

**Tests added.** One rejection test per site, each asserting `pytest.raises(ComfyCliError, match="exceeds")`, **no spawn** via the shared `no_spawn` fixture, and that a sentinel substring of the oversized value is ABSENT from the message. `upload_file`'s passes a good first entry and an oversized second and asserts `paths[1]` appears. Plus a boundary test per site proving a value of EXACTLY `_MAX_PATH_ARG_LEN` characters passes the guard and reaches argv (asserted against the recorded `cmd`), and one pinning that the free-form `--text` query stays uncapped.

**Negative-claim falsification** (this diff adds refusals, so the denial was checked rather than assumed). The only "capability" denied is passing a path longer than 4096 characters. Each of the seven boundary tests empirically demonstrates the exact-ceiling value still reaches argv, so no working call is removed. `PATH_MAX` is 4096 on Linux and 1024 on macOS, so no path this cap refuses is one the filesystem could open — it would fail `ENAMETOOLONG` anyway. No discovery path, tool, or product surface is foreclosed: this is input validation matching eleven sibling guards, not a capability dead-end.

## Additional Notes

Judgment calls, flagged for review:

1. **One site beyond the ticket's six: `search_models`' `folder`.** The ticket's item 5 asked the SCOPE comment to say the remaining uncapped values are "only the free-form strings". Before writing that I swept every `_reject_option_like` / `_reject_nul` call site to check the claim — and it was false. `search_models`' `folder` is a models-subfolder positional (`comfy models list-folder <folder>`), path-shaped, the same shape and the same hazard as `download_model`'s `relative_path`, and uncapped. Shipping a comment that asserts completeness while a known identical hole sits one screen away is the worse outcome, so I capped it (one line + two tests) and made the comment accurate. Flagged as a deliberate one-site scope addition rather than a silent widening.
2. **The SCOPE comment ENUMERATES rather than universally quantifies.** Related to the above: rather than claiming "every path-shaped value is now capped" — a sweeping claim that is hard to check and was already wrong once — the covered list lives at `_MAX_PATH_ARG_LEN` as an explicit enumeration the `_MAX_URL_LEN` note points at, with a "keep this list in sync" instruction. The uncapped remainder is now split honestly into two groups: the free-form values (`--text` query, the enumerated search filters, `_generate_param_args`' params) with the reason they stay uncapped, and the **identifier-shaped** names (a template name, a node class name, a slot `address`) which are also uncapped and also not path-shaped. Capping those identifiers is a separate call I did not make here.
3. **`_phrase_is_only_the_caller_s`'s docstring was updated — its LOGIC was not touched.** Same posture #183 took. Item 3 of its known-accepted list enumerates which values carry caps and at what ceiling; that enumeration is extended to the newly-capped values. The reason the forgery window stays open (a cap tight enough to close it would have to sit under 500 characters, refusing legitimately deep paths) is preserved verbatim, and nothing about the phrase subtraction changes.
4. **Messages are unchanged, deliberately.** `_guard_arg_len`'s f-string reproduces the four inline messages byte-for-byte, so the reroute is a pure refactor at those sites. That is what let #183's four tests stay green untouched — a useful signal, since a message drift there would have been silent.
5. **No `isinstance` check ahead of `len()`.** Consistent with #183's explicit decline of the same suggestion: the tool arguments are `str`-annotated so FastMCP validates upstream, and pre-PR the first statement at these sites was `_reject_option_like` / `_reject_nul`, which already raised on a non-string — so it is not a regression.
6. **Full suite run, not scoped.** Per the ticket. 1588 passed, 4 skipped on Python 3.14 locally; CI runs 3.10 and 3.14.

## Provenance

Follow-up to #183 (which introduced `_MAX_WORKFLOW_PATH_LEN` / `_MAX_URL_LEN` and the four original cap sites). Its merge was verified as the precondition for this work before starting — merged 2026-08-03, commit `48b4432`, which is this branch's base. This PR implements the rename that #183's body item 3 endorsed and the sweep its item 5 deferred.
