### PR TITLE
fix: bound install_node's consent prompt and correct what the update gate claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,14 +78,14 @@ SIGNAL: `run_template` can trust the verb, `run_workflow` must PROBE `comfy run
 --help` for the flag — its docstring says why, and what an engine without it
 means. `switch_comfyui_version`, `install_node` and `update_comfyui` sit outside
 that axis: none spends credits, the CLI gates none of them, so their prompt is
-this server's only gate, with no always-proceed to read. Three are
+this server's only gate, with no always-proceed to read. TWO gates are
 ARGUMENT-scoped, the danger being the argument and not the verb: the launch pair
 prompts only for `extra_args` that would publish an unauthenticated ComfyUI
-(`_network_exposing_args`); `update_comfyui` only for `target="all"`, which
-pip-installs every third-party pack (`comfy`/`cli` never prompt); and
-`install_node` pins `names` to registry slugs, refusing a URL — stricter than
-the engine, since the prompt promises a REGISTRY pack. Mirror the engine's
-contract per tool; do not generalize one tool's consent rules onto another.
+(`_network_exposing_args`), `update_comfyui` only for `target="all"`, which
+pip-installs every third-party pack (`comfy`/`cli` never prompt). `install_node`
+is NOT one: it prompts on EVERY call, and its argument is a RESTRICTION — `names`
+pinned to registry slugs, refusing a URL, as the prompt promises a REGISTRY pack.
+Mirror the engine's contract per tool; never generalize one gate onto another.
 
 The local differentiator: discovery tools (`search_nodes`, `get_node`,
 `search_models`) read the **user's live install** — custom nodes included — via

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ server has no path to is Comfy Cloud itself: no cloud-hosted execution, no cloud
 cross-session cloud batches. Every tool here shells out to `comfy --where local`. Pick by where you
 want the work to run, or [install the cloud server too](#comfy-cloud-mcp).
 
-> **Status:** beta. 50 tools; core loop validated end-to-end against a live local ComfyUI
+> **Status:** beta. 51 tools; core loop validated end-to-end against a live local ComfyUI
 > (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on
 > Python 3.10 and 3.14.
 
@@ -693,9 +693,11 @@ machines.
 **Not remoted (this repo is a thin wrapper and never opens its own socket):**
 
 - **Lifecycle** (`launch_comfyui`, `stop_comfyui`, `restart_comfyui`, `update_comfyui`,
-  `switch_comfyui_version`, `get_logs`) — these manage a **local** ComfyUI process/install and stay
-  local-only; they cannot start/stop, update, version-switch, or read logs from a remote box. Start
-  and update ComfyUI on the remote host yourself.
+  `switch_comfyui_version`, `install_node`, `get_logs`) — these manage a **local** ComfyUI
+  process/install and stay local-only; they cannot start/stop, update, version-switch, install node
+  packs into, or read logs from a remote box. Start and update ComfyUI, and install its node packs,
+  on the remote host yourself. `install_node` in particular writes into *this* machine's ComfyUI
+  workspace and venv, so with `COMFYUI_URL` set the pack lands where the run isn't.
 - **Catalog / partner verbs** — `search_templates` / `search_models` / `download_model` /
   `partner_generate` — this server forwards **no** `--host`/`--port` to these verbs (they accept
   none at all), so they run against comfy-cli's local default. A model must be installed on the
@@ -817,7 +819,7 @@ MCP client config today, it keeps working unchanged.
 
 ## Tools
 
-50 tools, grouped below by what they do. Every tool runs `comfy` with the global
+51 tools, grouped below by what they do. Every tool runs `comfy` with the global
 `--json --where local` flags, unwraps comfy-cli's `envelope/1`, and returns its `data`.
 
 **Argument naming** is uniform, so an agent never has to guess it (the server's handshake

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -22,10 +22,12 @@ user to confirm any flag that would publish the unauthenticated local ComfyUI to
 the network) with ``get_logs`` (``comfy logs``) to read a
 detached launch's captured output, the install verbs ``update_comfyui``
 (``comfy update``, forward-only — and its ``target="all"`` rebuilds every
-installed third-party node pack, so that target asks the user to confirm) and
+installed third-party node pack, so that target asks the user to confirm),
 ``switch_comfyui_version``
 (``comfy update comfy --version <X>``, which can also roll BACK and so asks the
-user to confirm per call), and the
+user to confirm per call) and ``install_node`` (``comfy node install``, the
+acquisition half of the missing-node story — it downloads and runs third-party
+pack code, so it asks the user to confirm every call), and the
 ``discover`` / ``which`` introspection pair (``comfy discover`` /
 ``comfy which``) that lets an agent learn the CLI's own contract and selection.
 ``partner_generate`` (``comfy generate <model>``) reaches the hosted PARTNER
@@ -127,8 +129,9 @@ flows:
   install does not have yet — clearing `local_check` is MANDATORY, not advisory,
   and "the fetch succeeded" is not a substitute. On
   `{"checked": true, "runnable": false}` tell the USER what is missing (update
-  ComfyUI / custom nodes, or pick another template) instead of running it and
-  hitting the failure deep in execution; `{"checked": false}` is "could not
+  ComfyUI / custom nodes, `install_node` a missing pack, or pick another template)
+  instead of running it and hitting the failure deep in execution;
+  `{"checked": false}` is "could not
   compare", not a verdict — it leaves the gate UNDONE, so run
   `validate_workflow(result["path"])` yourself before running anything. Read that
   block with `.get("runnable")`: a `checked: false` block has no `runnable` key.
@@ -164,7 +167,12 @@ flows:
   `definitions.subgraphs` — tweak it through `set_workflow_slot` /
   `run_template(params=...)` like any other template.
 - When custom nodes or models may be missing, pre-flight with `validate_workflow`
-  before running.
+  before running. A missing node PACK is not a dead end: `install_node(names=[...])`
+  installs it from the registry (registry pack ids, never URLs; the USER is asked
+  to confirm every call because it runs third-party code), and the flow is
+  `install_node` -> `restart_comfyui` -> `validate_workflow` again, since a running
+  ComfyUI cannot see new nodes until it restarts. A missing MODEL is
+  `download_model`.
 - Manage in-flight work with `get_queue` (list jobs) and `cancel_job`.
 - VRAM is shared with everything else on the machine. Before a heavy run, read
   `system_stats` for per-device `vram_free`; if it is short, `free_memory`
@@ -8258,11 +8266,17 @@ _UPDATE_LOCK = threading.Lock()
 # The busy refusal, shared by the advisory peek before the confirmation prompt and
 # the authoritative acquire after it, so the two cannot drift into telling the
 # caller different things about the same condition.
+#
+# Names all three lock sharers, not just "an update": `switch_comfyui_version` and
+# `install_node` take the same `_UPDATE_LOCK`, so a 25-minute node install is
+# enough to refuse this call — and a caller told only about "an update" would go
+# hunting for an in-flight call that does not exist. Same reasoning as
+# `_SWITCH_UPDATE_BUSY` / `_INSTALL_UPDATE_BUSY`; keep the three in step.
 _UPDATE_BUSY = (
-    "an update is already running in this server; `comfy update` mutates the "
-    "ComfyUI git checkout and Python environment, so two at once can corrupt the "
-    "install. Wait for the in-flight update to finish (up to 30 minutes for a "
-    "core update) and call again."
+    "an update, version switch or node install is already running in this server; "
+    "`comfy update` mutates the ComfyUI git checkout and Python environment, so "
+    "two at once can corrupt the install. Wait for the in-flight call to finish "
+    "(up to 30 minutes for a core update) and call again. Nothing was updated."
 )
 
 # Kept OFF asyncio's shared default executor for the reason `_SWITCH_EXECUTOR`
@@ -8462,9 +8476,26 @@ async def update_comfyui(
 
     Like ``launch_comfyui`` / ``stop_comfyui``, ``comfy update`` prints human
     text and exits 0 without a JSON envelope, so success returns a synthesized
-    ``{"ok": True, ...}`` payload carrying that text. A failed update (a dirty
-    git tree, a broken requirements install, an unreachable network) exits
-    non-zero and still raises a :class:`ComfyCliError`.
+    ``{"ok": True, ...}`` payload carrying that text.
+
+    **What ``ok`` actually proves depends on the target.** For ``"comfy"`` and
+    ``"cli"`` a failed update (a dirty git tree, a broken requirements install, an
+    unreachable network) exits non-zero and raises a :class:`ComfyCliError`.
+    ``"all"`` currently CANNOT distinguish a failed pack update from a clean one:
+    comfy-cli hands that target to the node manager without its
+    ``raise_on_error``, and that handler swallows a failed exit — it prints the
+    failure to stderr and returns — so ``comfy update all`` exits 0 either way and
+    the synthesized ``{"ok": True}`` is not evidence the packs updated. Read the
+    returned ``message`` text, and re-check ``server_info``'s
+    ``freshness.packs``, rather than trusting the ok on that one target. Note what
+    this costs the gate above: a false success rides on the approval the USER just
+    gave, so an agent that reports "updated" from ``ok`` alone can tell them their
+    consent achieved something it did not. ``install_node`` does not have this
+    problem because ``comfy node install`` takes ``--exit-on-fail``; ``comfy
+    update all`` has no such flag, and adding one is a comfy-cli change (filed as
+    a comfy-cli follow-up) rather than something this wrapper may synthesize —
+    deciding here whether the packs moved would mean deriving the verdict instead
+    of asking the engine.
     """
     normalized = target.strip().lower() if isinstance(target, str) else ""
     if normalized not in _UPDATE_TARGETS:
@@ -8770,11 +8801,14 @@ _RUNNING_REFUSAL = (
 )
 
 # Shared by the advisory pre-consent peek and the authoritative acquire below.
+# Names all three lock sharers for the reason `_UPDATE_BUSY` spells out: a node
+# install holds `_UPDATE_LOCK` too, and "an update is already running" would send
+# the caller looking for the wrong in-flight call.
 _SWITCH_UPDATE_BUSY = (
-    "an update is already running in this server; switching versions mutates the "
-    "same ComfyUI git checkout and Python environment, so the two at once can "
-    "corrupt the install. Wait for the in-flight update to finish and call "
-    "again. Nothing was changed."
+    "an update or node install is already running in this server; switching "
+    "versions mutates the same ComfyUI git checkout and Python environment, so "
+    "the two at once can corrupt the install. Wait for the in-flight call to "
+    "finish and call again. Nothing was changed."
 )
 
 
@@ -8954,7 +8988,8 @@ _INSTALL_TIMEOUT = _UPDATE_TIMEOUT
 # the two cannot drift into telling the caller different things — the same reason
 # `_SWITCH_UPDATE_BUSY` exists. Names `switch_comfyui_version` alongside
 # `update_comfyui` because all three share `_UPDATE_LOCK`, and a caller told only
-# about "an update" would go looking for the wrong in-flight call.
+# about "an update" would go looking for the wrong in-flight call. The other two
+# messages name this tool for the same reason; keep the three in step.
 _INSTALL_UPDATE_BUSY = (
     "an update or version switch is already running in this server; installing a "
     "pack pip-installs into the same Python environment, so the two at once can "
@@ -8980,10 +9015,36 @@ _INSTALL_EXECUTOR = ThreadPoolExecutor(
 # packs" true rather than nominal.
 _MAX_NODE_PACK_NAMES = 32
 
-# A registry node id: an alphanumeric-led slug. Anchored end-to-end, so a value
-# that matches carries no whitespace, no NUL, no shell metacharacter, no leading
-# dash, and — the load-bearing exclusion — no `/`, `:` or `@`, which is what keeps
-# a git URL or a filesystem path off this argv.
+# The same readability bound applied to the JOINED prompt text, because neither cap
+# on its own reaches it: `_MAX_NODE_PACK_NAMES` bounds the COUNT and
+# `_MAX_NODE_PACK_ID_LEN` bounds each ENTRY, but nothing bounded their product, and
+# 32 ids of 128 characters is a 4,698-character prompt — the exact "scrolls past
+# rather than reads" failure the count cap exists to prevent, reached by padding
+# instead of by counting. 1024 characters clears any realistic batch (registry
+# slugs run ~15-30 characters, so even a full 32-pack call of real ids lands near
+# 900) while refusing the padded one.
+#
+# REFUSED rather than elided, which is where this parts company with
+# `_display_extra_args`: eliding a long argument list still shows the user the
+# flags that make it dangerous, so prompting beats refusing to prompt. Eliding a
+# PACK LIST would do the opposite — it would collect an approval for names the
+# prompt never showed, which is how a batch padded with look-alike slugs hides the
+# one pack the user would have declined. The enumeration IS the consent here, so an
+# over-long list never reaches the prompt at all.
+_MAX_NODE_PACK_NAMES_CHARS = 1024
+
+# A registry node id: an alphanumeric-led slug. Matched with `re.fullmatch` (see
+# `_guard_node_names`), so a value that matches carries no whitespace, no NUL, no
+# shell metacharacter, no leading dash, and — the load-bearing exclusion — no `/`,
+# `:` or `@`, which is what keeps a git URL or a filesystem path off this argv.
+#
+# `fullmatch` rather than a `^…$` + `.match()` pair, because that pair does NOT
+# carry the claim above: Python's `$` also matches just before a trailing newline,
+# so `.match("pack\n")` succeeded. Nothing reached argv with a newline in it even
+# then — `_guard_node_names` strips each entry first, and a full sweep of the code
+# points that survive `str.strip()` found no other character this pattern would
+# admit — but the invariant was being carried by that `strip()` while this comment
+# credited the anchors. `fullmatch` puts it where the comment says it is.
 #
 # This is DELIBERATELY narrower than the engine, which is normally this repo's
 # anti-pattern (see `_VERSION_RE`, which refuses to out-strict comfy-cli). The
@@ -8994,7 +9055,7 @@ _MAX_NODE_PACK_NAMES = 32
 # given for something other than what happened. A wrapper may not narrow the
 # engine to invent product behavior; it must narrow the engine where a wider
 # input would make its own consent prompt lie.
-_REGISTRY_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_REGISTRY_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 
 # What the caller is really being stopped from doing, repeated in both the
 # unpromptable-client refusal and the prompt itself. Hoisted for the reason
@@ -9048,9 +9109,18 @@ async def _elicit_node_install_consent(ctx: Context, names_display: str) -> bool
     """Ask the USER to approve this one install. True = approved.
 
     ``names_display`` is interpolated directly rather than through
-    :func:`_display_model`: every entry has already been pinned by
-    :data:`_REGISTRY_ID_RE`, so it cannot carry the backticks or newlines that
-    sanitizer exists to neutralize.
+    :func:`_display_caller_text`, and it needs BOTH halves of that function's job
+    covered elsewhere:
+
+    * the CHARACTER SET, by :data:`_REGISTRY_ID_RE` — every entry is pinned to a
+      registry slug, so it cannot carry the backticks or newlines that sanitizer
+      exists to neutralize;
+    * the LENGTH, by :data:`_MAX_NODE_PACK_NAMES_CHARS` — a bounded count of
+      bounded ids still multiplies out to a prompt nobody reads, so
+      :func:`_guard_node_names` refuses the over-long JOIN before it gets here.
+
+    That second one is why this is not merely "the regex makes it safe". The cap is
+    a refusal rather than a truncation on purpose: see the constant.
     """
     return await _elicit_approval(
         ctx,
@@ -9115,9 +9185,19 @@ def _guard_node_names(names: Any) -> list[str]:
     """Validate ``install_node``'s pack list, or raise before anything is spawned.
 
     Ordered so the message a caller gets names the most useful problem: the list
-    shape first, then each entry's LENGTH (reported as a size, never by echoing a
-    megabyte-long "pack name" back through the tool response and the failure log —
-    see :data:`_MAX_NODE_PACK_ID_LEN`), then ``all``, then the id shape.
+    shape first, then each entry's LENGTH, then ``all``, then the id shape, and
+    last the length of the whole JOINED list
+    (:data:`_MAX_NODE_PACK_NAMES_CHARS`).
+
+    **The length check must stay AHEAD of the id-shape check**, which is the one
+    ordering here that is load-bearing rather than cosmetic. The shape refusal
+    echoes the value so the caller can see what was wrong with it; the length
+    refusal reports a SIZE and never echoes, so a megabyte-long "pack name" does
+    not come back through the tool response and the failure log (see
+    :data:`_MAX_NODE_PACK_ID_LEN`). Reversed, an oversized *invalid* value would
+    take the echoing branch. The echo is clipped by :func:`_clip_for_error` as a
+    second line of defense, but the bound stays where it is: a 4096-character
+    preview of a caller's junk is not what the message is for.
 
     ``all`` is rejected here with its own message even though comfy-cli refuses it
     too (```install all` is not allowed``): the engine's refusal arrives as plain
@@ -9145,8 +9225,9 @@ def _guard_node_names(names: Any) -> list[str]:
                 "(e.g. 'comfyui-impact-pack')."
             )
         value = entry.strip()
+        # BEFORE the id-shape check below, which echoes the value — see the
+        # docstring. Report the length, not the value: `_MAX_NODE_PACK_ID_LEN`.
         if len(value) > _MAX_NODE_PACK_ID_LEN:
-            # Report the length, not the value — see `_MAX_NODE_PACK_ID_LEN`.
             raise ComfyCliError(
                 f"invalid names: {len(value)} characters exceeds the "
                 f"{_MAX_NODE_PACK_ID_LEN}-character maximum for a pack id."
@@ -9162,17 +9243,32 @@ def _guard_node_names(names: Any) -> list[str]:
             "names", value, expected="a registry pack id (e.g. 'comfyui-impact-pack')"
         )
         _reject_nul("names", value)
-        if not _REGISTRY_ID_RE.match(value):
+        if not _REGISTRY_ID_RE.fullmatch(value):
             raise ComfyCliError(
-                f"invalid names: {value!r} is not a registry pack id. Expected a "
-                "slug like 'comfyui-impact-pack' (letters, digits, '.', '_', "
-                "'-'). A git URL or a filesystem path is deliberately refused: "
-                "the confirmation prompt tells the user they are approving a "
-                "named pack from the registry, so it must not be able to carry "
-                "anything else. To install from a URL, run `comfy node install` "
-                "in a terminal, where your shell is the confirmation."
+                f"invalid names: {_clip_for_error(value)} is not a registry pack "
+                "id. Expected a slug like 'comfyui-impact-pack' (letters, digits, "
+                "'.', '_', '-'). A git URL, a filesystem path, or a "
+                "'<pack>@<version>' pin is deliberately refused: the confirmation "
+                "prompt tells the user they are approving a named pack from the "
+                "registry, so it must not be able to carry anything else. To "
+                "install from a URL, or to pin a specific pack version, run "
+                "`comfy node install` in a terminal, where your shell is the "
+                "confirmation."
             )
         guarded.append(value)
+    # Last, because it is a property of the whole list rather than of any entry —
+    # and the one bound that makes the prompt's enumeration readable rather than
+    # merely finite. See `_MAX_NODE_PACK_NAMES_CHARS` for why this refuses instead
+    # of truncating the display.
+    joined = len(", ".join(guarded))
+    if joined > _MAX_NODE_PACK_NAMES_CHARS:
+        raise ComfyCliError(
+            f"invalid names: {len(guarded)} pack ids join to {joined} characters, "
+            f"past the {_MAX_NODE_PACK_NAMES_CHARS}-character maximum for one "
+            "call. The confirmation prompt has to stay readable for the approval "
+            "to mean anything, and it names every pack it installs; install them "
+            "in smaller batches."
+        )
     return guarded
 
 
@@ -9184,9 +9280,22 @@ def _run_node_install(names: list[str]) -> Any:
     swallows a ``CalledProcessError`` with ``returncode == 1`` — it prints the
     failure to stderr and returns ``None``, so the command exits 0. A tool that
     omitted the flag would tell an agent the pack is installed when it is not, and
-    the agent's next call would fail somewhere much less informative. The flag
-    ships in comfy-cli 1.13.0, this server's floor, so there is no capability
-    degrade to write for it.
+    the agent's next call would fail somewhere much less informative.
+
+    What this server's comfy-cli floor (1.13.0) establishes is narrower than "the
+    flag works", and worth stating exactly, because there is no capability degrade
+    written for it. The floor guarantees two things: comfy-cli's own parser ACCEPTS
+    ``--exit-on-fail``, and comfy-cli itself acts on it (it is what sets
+    ``raise_on_error``, which is what makes a non-zero exit reach this wrapper at
+    all). What it does NOT establish is the other end: the flag is also forwarded
+    verbatim to ComfyUI-Manager's ``cm_cli``, whose version is a property of the
+    user's ComfyUI install rather than of comfy-cli, so a Manager old enough not to
+    know the option fails EVERY call here with its own usage error — relayed raw,
+    with no remap of the kind :func:`_run_version_switch` writes for
+    ``--version`` (:func:`_is_missing_option_error`). That is accepted rather than
+    handled because comfy-cli's own e2e suite exercises the flag, so in practice
+    the Manager floor travels with the comfy-cli floor; it is not something this
+    docstring can claim the version pin proves.
 
     Like ``launch``/``stop``/``update``, ``node install`` prints human text and
     emits no envelope — ``execute_cm_cli`` writes the node manager's output
@@ -9223,7 +9332,12 @@ async def install_node(
     ``names`` are REGISTRY PACK IDS (slugs like ``"comfyui-impact-pack"``), not
     node class names and not URLs. A git URL or filesystem path is refused before
     anything is spawned; run ``comfy node install`` in a terminal for those, where
-    your shell is the confirmation. ``"all"`` is refused too — to update the packs
+    your shell is the confirmation. So is a VERSION PIN: cm-cli's
+    ``<pack-id>@<version>`` form needs an ``@``, which the id guard excludes for
+    the same reason it excludes ``:`` and ``/`` (that is what keeps
+    ``git@github.com:…`` off argv), so pinning a pack to a specific version is
+    terminal-only exactly the way a URL is — this tool always installs whatever
+    version the registry serves. ``"all"`` is refused too — to update the packs
     you already have, call ``update_comfyui(target="all")``.
 
     **This does not restart anything, deliberately.** A running ComfyUI builds its
@@ -9237,6 +9351,18 @@ async def install_node(
     reason), and because a user who said "install it, I'll restart the server
     myself" must be obeyed.
 
+    **It does NOT refuse while ComfyUI is running**, and that is a deliberate
+    difference from ``switch_comfyui_version``, which does — worth saying out loud
+    because the two share a lock precisely because they pip-install into the same
+    venv. The switch REPLACES the dependency set the live process already imported,
+    which can leave it serving half-replaced code; an install ADDS a pack the
+    running process has never loaded, which is ComfyUI-Manager's normal operating
+    mode (it installs into a running server from the UI). The failure mode a
+    running server does have here is milder and is handled by telling you about it
+    rather than by refusing: the new nodes are invisible until the restart above.
+    A pack that upgrades a dependency ComfyUI has already imported is the one case
+    that can disturb a live process, which is another reason to restart promptly.
+
     **Consent is per call, and the USER gives it — not the agent.** On a client
     that supports MCP elicitation the human is shown a prompt naming the exact
     packs and what installing them does, and a decline installs nothing. That
@@ -9247,6 +9373,12 @@ async def install_node(
     ``confirm_install=True`` is the documented fallback — set it ONLY when the
     user has actually agreed, never to clear the error — and its ``False`` default
     means a bare call from such a client installs nothing.
+
+    Because that prompt has to NAME every pack to be worth answering, an unreadable
+    batch is refused rather than shown truncated: at most
+    :data:`_MAX_NODE_PACK_NAMES` ids per call, and at most
+    :data:`_MAX_NODE_PACK_NAMES_CHARS` characters once they are joined. Both errors
+    say to install in smaller batches.
 
     comfy-cli does not gate this verb at all, so unlike ``partner_generate``'s
     spend gate there is no engine interlock to forward a flag to and no durable

--- a/tests/test_install_node.py
+++ b/tests/test_install_node.py
@@ -23,6 +23,12 @@ third-party code by accident:
 5. The result contract, including ``restart_required: True`` — this tool never
    restarts anything, which is what lets a user say "install it, I'll restart the
    server myself".
+6. The async plumbing that posture required, mirroring ``test_update_consent``'s:
+   the install keeps its OWN worker thread rather than asyncio's shared pool, it
+   forwards the 30-minute timeout, and the lock it holds belongs to the SUBPROCESS
+   rather than to the request. Without those three, replacing the done-callback
+   release with a ``try/finally`` around the await passes every other test in this
+   file while handing the lock to a retry that then runs a second concurrent pip.
 
 comfy-cli is mocked throughout: no real ComfyUI and nothing is ever installed.
 """
@@ -30,6 +36,8 @@ comfy-cli is mocked throughout: no real ComfyUI and nothing is ever installed.
 from __future__ import annotations
 
 import asyncio
+import threading
+from unittest import mock
 
 import pytest
 from mcp.server.elicitation import (
@@ -156,6 +164,69 @@ def test_an_oversized_name_is_reported_by_length_not_echoed(patched_plain_run):
     message = str(excinfo.value)
     assert "5000 characters" in message
     assert huge not in message
+
+
+def test_an_oversized_invalid_name_is_still_reported_by_length(patched_plain_run):
+    """The ordering the guard documents, pinned: length is checked before shape.
+
+    The test above cannot see that ordering — ``"a" * 5000`` MATCHES the registry
+    pattern, so it reaches the length error whichever check runs first. A value
+    that is both oversized and malformed is the case that separates them: with the
+    checks reversed it takes the id-shape branch, which echoes the value, and a
+    5000-character echo is exactly what the length branch exists to avoid.
+    """
+    patched_plain_run(0, stderr="installed")
+    junk = "/" * 5000
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        _install([junk], ctx=_FakeCtx())
+
+    message = str(excinfo.value)
+    assert "5000 characters" in message
+    assert "not a registry pack id" not in message  # took the length branch
+    assert junk not in message
+    assert "/" * 100 not in message  # nor any long slice of it
+
+
+def test_a_batch_that_joins_too_long_is_refused(patched_plain_run):
+    """The count cap and the per-id cap leave their PRODUCT unbounded.
+
+    32 ids of 128 characters each is a legal list by both other bounds and a
+    4,698-character confirmation prompt — the "scrolls past rather than reads"
+    failure the count cap exists to prevent, reached by padding instead of by
+    counting. Refused rather than shown truncated: the prompt naming every pack IS
+    the consent, so a batch padded with look-alike slugs must not be able to hide
+    the real pack past a truncation marker.
+    """
+    calls = patched_plain_run(0, stderr="installed")
+    names = [f"pack-{n}-" + "x" * 120 for n in range(server._MAX_NODE_PACK_NAMES)]
+    ctx = _FakeCtx()
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        _install(names, ctx=ctx)
+
+    message = str(excinfo.value)
+    assert "smaller batches" in message
+    assert str(server._MAX_NODE_PACK_NAMES_CHARS) in message
+    assert calls == []
+    assert ctx.elicitations == []  # nobody was asked to approve an unreadable list
+
+
+def test_a_full_size_batch_of_real_looking_ids_still_installs(patched_plain_run):
+    """The joined cap must not refuse a batch anyone would actually send.
+
+    Registry slugs run ~15-30 characters, so a full 32-pack call of realistic ids
+    lands under the bound; a cap that refused this would be the wrapper inventing
+    a limitation rather than keeping its own prompt readable.
+    """
+    calls = patched_plain_run(0, stderr="installed")
+    names = [f"comfyui-node-pack-{n:02d}" for n in range(server._MAX_NODE_PACK_NAMES)]
+
+    result = _install(names, ctx=(ctx := _FakeCtx()))
+
+    assert len(calls) == 1
+    assert result["installed"] == names
+    assert names[-1] in ctx.elicitations[0]  # every pack was named in the prompt
 
 
 def test_too_many_packs_is_refused_so_the_prompt_stays_readable(patched_plain_run):
@@ -456,3 +527,131 @@ def test_a_refused_install_never_took_the_lock(patched_plain_run):
 
     assert server._UPDATE_LOCK.acquire(blocking=False)
     server._UPDATE_LOCK.release()
+
+
+def test_the_busy_refusal_names_every_lock_sharer(patched_plain_run):
+    """The holder may be an update OR a version switch; say both.
+
+    A caller told only about "an update" goes hunting for an in-flight call that
+    may not exist. `update_comfyui` and `switch_comfyui_version` name a node
+    install in their own refusals for the same reason.
+    """
+    patched_plain_run(0, stderr="done")
+
+    assert server._UPDATE_LOCK.acquire(blocking=False)
+    try:
+        with pytest.raises(server.ComfyCliError) as excinfo:
+            _install(["comfyui-impact-pack"], ctx=_FakeCtx())
+    finally:
+        server._UPDATE_LOCK.release()
+
+    message = str(excinfo.value)
+    assert "version switch" in message
+    assert "Nothing was installed." in message
+
+
+# --- discoverability --------------------------------------------------------
+
+
+def test_the_handshake_instructions_teach_the_install_flow():
+    """An agent reads `INSTRUCTIONS` once, at handshake — it must find the door.
+
+    Before this, the missing-node guidance ended at "tell the USER what is
+    missing", which is precisely the dead end this tool removes: an agent that
+    learned the wall at handshake never discovers the tool that resolves it. The
+    restart is part of the same clause because installing without restarting looks
+    like a no-op from `search_nodes`.
+    """
+    flat = " ".join(server.INSTRUCTIONS.split())
+
+    assert "install_node" in flat
+    assert "`install_node` -> `restart_comfyui`" in flat
+
+
+def test_the_module_docstring_lists_the_tool():
+    """The inventory at the top of `server.py` is the other place a reader looks."""
+    assert "install_node" in server.__doc__
+
+
+# --- the async plumbing the gate required -----------------------------------
+
+
+def test_the_install_stays_off_the_default_executor(patched_plain_run):
+    """A 30-minute blocking call on asyncio's shared pool starves everything else.
+
+    `_UPDATE_EXECUTOR` and `_SWITCH_EXECUTOR` exist for exactly this reason, and an
+    install runs as long as either: on the default pool it would park the only
+    worker every other `to_thread` caller in the process shares.
+    """
+    patched_plain_run(0, stderr="done")
+    threads: list[str] = []
+
+    def _capture(*args, **kwargs):
+        threads.append(threading.current_thread().name)
+        return {"ok": True}
+
+    with mock.patch.object(server, "_run_comfy", _capture):
+        _install(
+            ["comfyui-impact-pack"],
+            confirm_install=True,
+            ctx=_FakeCtx(supports_elicitation=False),
+        )
+
+    assert threads and all(name.startswith("comfy-node-install") for name in threads)
+
+
+def test_the_timeout_is_generous(patched_plain_run):
+    """Resolving and installing a pack's dependencies is minutes, not seconds."""
+    calls = patched_plain_run(0, stderr="done")
+
+    _install(["comfyui-impact-pack"], ctx=_FakeCtx())
+
+    assert calls[0]["timeout"] == server._INSTALL_TIMEOUT
+    assert calls[0]["timeout"] >= 1800.0
+
+
+def test_the_lock_is_held_until_the_subprocess_finishes(patched_plain_run):
+    """Cancelling the REQUEST must not hand the lock to a second concurrent pip.
+
+    Cancellation raises `CancelledError` at the await but neither interrupts the
+    worker thread nor kills the `comfy node install` it spawned, so pip keeps
+    resolving. If the lock were released in a `finally` here, a retry, an
+    `update_comfyui` or a `switch_comfyui_version` would acquire it and run a
+    second install against the same venv — the corrupted environment the lock
+    exists to prevent. The done-callback ties the release to the JOB's lifetime
+    instead, so this is what fails if anyone "simplifies" it back to a `finally`.
+    """
+    started = threading.Event()
+    finish = threading.Event()
+
+    def _slow(*_args, **_kwargs):
+        started.set()
+        finish.wait(5)
+        return {"ok": True}
+
+    patched_plain_run(0, stderr="done")
+
+    async def _drive():
+        task = asyncio.ensure_future(
+            server.install_node(["comfyui-impact-pack"], confirm_install=True, ctx=None)
+        )
+        await asyncio.to_thread(started.wait, 5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # The abandoned install is still running, so the lock must still be taken.
+        assert not server._UPDATE_LOCK.acquire(blocking=False)
+        finish.set()
+        # ...and released once it actually ends, rather than leaked forever.
+        for _ in range(500):
+            if server._UPDATE_LOCK.acquire(blocking=False):
+                server._UPDATE_LOCK.release()
+                return
+            await asyncio.sleep(0.01)
+        raise AssertionError("the lock was never released")
+
+    with mock.patch.object(server, "_run_comfy", _slow):
+        try:
+            asyncio.run(_drive())
+        finally:
+            finish.set()

--- a/tests/test_switch_version.py
+++ b/tests/test_switch_version.py
@@ -518,6 +518,25 @@ def test_refuses_while_an_update_holds_the_shared_lock(patched_plain_run):
     assert calls == []
 
 
+def test_the_busy_refusal_names_every_lock_sharer(patched_plain_run):
+    """`install_node` holds the same lock, so the refusal has to name it too.
+
+    Otherwise a caller blocked by a 25-minute pack install is told "an update is
+    already running" and goes hunting for an update nobody started.
+    """
+    patched_plain_run(0, stderr="done")
+    assert server._UPDATE_LOCK.acquire(blocking=False)
+    try:
+        with pytest.raises(server.ComfyCliError) as excinfo:
+            _switch("0.24.0", ctx=_FakeCtx())
+    finally:
+        server._UPDATE_LOCK.release()
+
+    message = str(excinfo.value)
+    assert "node install" in message
+    assert "Nothing was changed." in message
+
+
 def test_a_declined_switch_leaves_the_lock_free(patched_plain_run):
     """A refusal must not park the lock an in-flight update legitimately needs."""
     patched_plain_run(0, stderr="done")

--- a/tests/test_update_consent.py
+++ b/tests/test_update_consent.py
@@ -334,6 +334,27 @@ def test_an_in_flight_update_refuses_before_the_prompt(patched_plain_run):
     assert calls == []
 
 
+def test_the_busy_refusal_names_every_lock_sharer(patched_plain_run):
+    """`_UPDATE_LOCK` is shared three ways, so "an update" is not the whole story.
+
+    A 25-minute `install_node` (or a `switch_comfyui_version`) is enough to refuse
+    this call, and a caller told only about "an update" goes looking for an
+    in-flight call that does not exist.
+    """
+    patched_plain_run(0, stderr="done")
+    assert server._UPDATE_LOCK.acquire(blocking=False)
+    try:
+        with pytest.raises(server.ComfyCliError) as excinfo:
+            _update("comfy", ctx=_FakeCtx())
+    finally:
+        server._UPDATE_LOCK.release()
+
+    message = str(excinfo.value)
+    assert "version switch" in message
+    assert "node install" in message
+    assert "Nothing was updated." in message
+
+
 def test_a_declined_update_leaves_the_lock_free(patched_plain_run):
     """A refusal must not park the lock a legitimate update (or switch) needs.
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -2263,6 +2263,26 @@ def test_tool_arguments_follow_the_naming_convention():
         assert not banned & set(properties), name
 
 
+def test_the_readme_tool_count_matches_the_live_tool_set():
+    """The README states the count twice; both have to be the real one.
+
+    Pure prose, so nothing else notices it going stale — and it went stale exactly
+    that way when a tool was added without recounting. A wrong count is the first
+    thing a reader can check and the first thing that costs the rest of the
+    document its credibility, so it gets a tripwire rather than a convention.
+    """
+    count = len(server.mcp._tool_manager.list_tools())
+    readme = (pathlib.Path(__file__).resolve().parent.parent / "README.md").read_text(
+        encoding="utf-8"
+    )
+
+    stated = re.findall(r"\b(\d+) tools\b", readme)
+    assert stated, "the README no longer states a tool count"
+    assert set(stated) == {str(count)}, (
+        f"the README says {sorted(set(stated))} tools; the server exposes {count}"
+    )
+
+
 def test_auth_status_maps_command_and_passes_payload_through(patched_run, monkeypatch):
     """auth_status wraps `comfy --json --where local cloud whoami`, payload unchanged."""
     whoami = {


### PR DESCRIPTION
## ELI5

Two consent gates shipped recently: one asks before installing custom node packs, one asks before rebuilding every third-party pack. Both hold up under attack. This PR fixes twelve things *around* them that an adversarial re-read found — a prompt that could be padded until nobody reads it, a docstring that promised something false in the dangerous direction, a tool nobody could discover, and a set of invariants the tests were not actually checking.

No gate's control flow changes. The additions are one input bound, one `re.fullmatch`, one clipped error echo, and otherwise documentation, error wording, and tests.

## What changed

### The prompt could be padded past readability

`install_node` caps the pack count at 32 and each id at 128 characters, but nothing capped their **product**: 32 long look-alike slugs render a **4,698-character** confirmation prompt, and it was accepted. Pad 31 slots, hide the real pack at position 17, and the user scrolls and clicks yes.

Now refused, not truncated. Truncating would collect an approval for names the prompt never showed, which is the same hole with a nicer error message — the enumeration *is* the consent here. (This is where `install_node` deliberately parts company with `_display_extra_args`, which does elide: showing a partial argument list still shows the user the flags that make it dangerous.) A full 32-pack call of realistic registry ids lands near 900 characters and still goes through.

### A docstring was false in the dangerous direction

`update_comfyui`'s docstring said every failed update raises. That holds for `target="comfy"` and `target="cli"`. It does **not** hold for `"all"`: comfy-cli routes that target through the node manager without `raise_on_error`, whose handler swallows a failed exit — prints to stderr, returns — so the command exits 0 and this server's synthesized `{"ok": True}` is not evidence of anything. Same swallow `--exit-on-fail` fixes for `node install`; `update all` has no such flag.

The docstring now scopes the claim and says how to verify (`message`, `server_info`'s `freshness.packs`). It also names the part that makes this more than a doc nit: the false success rides on the approval the user just gave, so an agent reporting "updated" from `ok` alone tells them their consent achieved something it did not. The engine fix belongs in comfy-cli per the thin-wrapper rule and is filed there — nothing is synthesized here.

### The tool was invisible where it matters

`install_node` appeared in `server.py` only inside its own implementation. It was missing from the module docstring's tool inventory and from the handshake `instructions`, which still taught the wall — "on `runnable: false` tell the user what is missing", "pre-flight with `validate_workflow`" — and never the door. An agent reads `instructions` once, at handshake.

The missing-node bullet now carries `install_node` -> `restart_comfyui` -> `validate_workflow`, the inventory lists the tool, and the README's tool count (stale at **50**; recounted **51** by decorator and by live `mcp.list_tools()`) is corrected in both places, with a tripwire test so it cannot drift silently a third time. `install_node` also joins the README's "not remoted" lifecycle list — `node` is not a target-aware subcommand, so no `--host`/`--port` is ever forwarded and its omission implied it honors `COMFYUI_URL`.

### Eight smaller accuracy fixes

- **All three busy refusals name all three lock sharers.** A 25-minute install blocking `update_comfyui` produced "an update is already running" when no update existed. `_UPDATE_BUSY` also gains the "Nothing was updated." reassurance the other two had.
- **`_REGISTRY_ID_RE` now uses `fullmatch`.** Its comment credited the `^…$` anchors with excluding whitespace, but Python's `$` matches before a trailing newline too — `_REGISTRY_ID_RE.match("pack\n")` was `True`. Safe today only because of the `strip()` upstream, so the invariant was attributed to the wrong line.
- **The id-shape error echo goes through `_clip_for_error`**, like every other caller-value echo in the module.
- **The guard's length-before-shape ordering is now pinned.** It was correct but untested: the existing oversized-name case uses `"a" * 5000`, which *matches* the pattern, so it hits the length error either way — vacuous with respect to the ordering it documented. A long *invalid* value (`"/" * 5000`) now separates them.
- **The `--exit-on-fail` floor argument says what the pin actually establishes.** comfy-cli's parser accepts the flag and acts on it (it is what sets `raise_on_error`, which is what makes a failure reach this wrapper), but the flag is also forwarded to ComfyUI-Manager's cm-cli, whose version travels with the user's ComfyUI rather than with comfy-cli — and an old one fails with an opaque usage error, unremapped.
- **Excluding `@` also removes cm-cli's `<pack>@<version>` pin.** Correct exclusion (it is what keeps `git@github.com:…` off argv), but the collateral was undocumented; the error and docstring now say a version pin is terminal-only, the way a URL already did.
- **`install_node` does not refuse while ComfyUI is running, and now says why.** `switch_comfyui_version` does refuse, for a hazard `install_node` describes itself as sharing ("same venv, same pip"). Two docstrings 300 lines apart made opposite calls with no explanation. The difference: a switch *replaces* the dependency set the live process already imported; an install *adds* a pack it has never loaded, which is ComfyUI-Manager's normal mode.
- **AGENTS.md's classification is corrected.** It listed `install_node` as argument-scoped alongside the launch pair and `update_comfyui`. It is not — it prompts on **every** call; what its argument carries is a *restriction*, not an argument-scoped *prompt*. AGENTS.md is the spec the next gate gets written against. Edit is line-neutral (200 lines before and after, 6 lines replacing 6); no content dropped.

### The tests that were not testing

`install_node`'s async plumbing was entirely unpinned. Replacing

```python
job.add_done_callback(lambda _job: _UPDATE_LOCK.release())
result = await asyncio.wrap_future(job)
```

with a `try/finally` release around the await — the exact regression the 8-line comment above it exists to prevent — **passed all 1690 tests.** The same mutation on `update_comfyui` is killed. Three tests ported from `test_update_consent` / `test_switch_version` now cover the lock's subprocess lifetime under request cancellation, the dedicated `comfy-node-install` executor thread, and the forwarded 30-minute timeout.

Each new invariant was verified by mutation, not by assumption:

| Mutation applied | Killed by |
|---|---|
| done-callback release -> `try/finally` | `test_the_lock_is_held_until_the_subprocess_finishes` |
| `_INSTALL_EXECUTOR` -> `_UPDATE_EXECUTOR` | `test_the_install_stays_off_the_default_executor` |
| `timeout=_INSTALL_TIMEOUT` dropped | `test_the_timeout_is_generous` |
| id-shape check hoisted above length check | `test_an_oversized_INVALID_name_is_still_reported_by_length` |

All four reverted after verification.

## Verification

```
1702 passed, 1 skipped, 3 deselected     (baseline on main: 1690 passed, 1 skipped, 3 deselected)
ruff 0.16.0 check .          All checks passed!
ruff 0.16.0 format --check . 42 files already formatted
wc -l AGENTS.md              200
```

## Provenance

Findings from an adversarial re-read of #188 and #190 after merge; 12 of them verified against the source before editing. Two premises were narrowed in the process rather than repeated: comfy-cli *does* consume `--exit-on-fail` as `raise_on_error` (it forwards the string to cm-cli **as well**), and `_REGISTRY_ID_RE`'s newline gap was reachable only in principle — a sweep of the code points surviving `str.strip()` found nothing else that both survives and matches. Both are reflected in the comments as written, not as reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
