### PR TITLE
ci: add a PyPI release workflow with trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,160 @@
+name: Publish to PyPI
+
+# Publishing is driven by a GitHub Release, not by a push to a branch: the
+# release is the human act, and the tag it carries is the only input. There is
+# deliberately no `workflow_dispatch` — a hand-triggered publish could ship a
+# version no tag points at, and a PyPI version number can never be reused.
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  # The version lives in TWO places in this repo — `pyproject.toml` and
+  # `src/comfy_mcp/__init__.py` — so a release can disagree with the package it
+  # would publish in two different ways. Check both against the tag BEFORE
+  # building, in a job that needs no credentials: an unpublishable release
+  # should fail here, cheaply, rather than after the OIDC exchange.
+  #
+  # (comfy-cli needs no equivalent check because it keeps `version = "0.0.0"` in
+  # the repo and its workflow rewrites it from the tag. This repo carries a real
+  # version instead, which is friendlier to `pip install -e .` and to
+  # `__version__` at runtime, and the cost is exactly this guard.)
+  check-version:
+    name: Tag matches the packaged version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      # The whole check is one Python program fed through a QUOTED heredoc, so
+      # the shell performs no expansion on it at all. Both version strings need
+      # quote characters to parse, and nesting those inside `python -c "…"` is a
+      # quoting puzzle whose failure mode is a workflow that breaks at release
+      # time — the worst possible moment to debug escaping. The tag arrives via
+      # the environment instead of being interpolated into the source.
+      - name: Compare the tag against pyproject.toml and __init__.py
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os, pathlib, re, sys, tomllib
+
+          tag = os.environ["TAG"]
+          version = tag[1:] if tag.startswith("v") else tag
+          print(f"tag={tag} -> version={version}")
+
+          # Read the authoritative value rather than grepping for it. tomllib is
+          # stdlib from 3.11, so this needs no dependency.
+          with open("pyproject.toml", "rb") as fh:
+              project = tomllib.load(fh)["project"]["version"]
+
+          # Parse `__version__` instead of importing the package: an import
+          # would pull in `mcp` and every runtime dependency to read a string.
+          src = pathlib.Path("src/comfy_mcp/__init__.py").read_text()
+          match = re.search(r"""^__version__\s*=\s*["']([^"']+)""", src, re.M)
+          dunder = match.group(1) if match else None
+          print(f"pyproject.toml={project} __init__.py={dunder}")
+
+          problems = []
+          if project != version:
+              problems.append(f"pyproject.toml version {project!r} != tag {tag!r}")
+          if dunder != version:
+              problems.append(
+                  f"src/comfy_mcp/__init__.py __version__ {dunder!r} != tag {tag!r}"
+              )
+          for problem in problems:
+              print(f"::error::{problem}")
+          if problems:
+              print(
+                  f"::error::Set the version to {version} in BOTH files, then "
+                  "re-cut the release. Nothing was published."
+              )
+              sys.exit(1)
+          print("Versions agree.")
+          PY
+
+  build-and-publish:
+    name: Build and publish to PyPI
+    needs: check-version
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      # Mandatory for PyPI trusted publishing (OIDC). No API token is stored:
+      # PyPI is configured to trust this repository + this workflow filename,
+      # so there is no long-lived credential to leak or rotate.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install build
+        run: python -m pip install --upgrade pip build
+
+      - name: Build sdist and wheel
+        run: python -m build --sdist --wheel --outdir dist/
+
+      - name: Check the built metadata
+        run: |
+          python -m pip install --upgrade twine
+          # Catches a README that renders on GitHub but breaks PyPI's stricter
+          # parser — worth knowing before the upload, since the version cannot
+          # be republished afterwards.
+          python -m twine check dist/*
+
+      # Pinned to the same commit comfy-cli's publish workflow already trusts,
+      # rather than a floating tag: a mutable ref on the action that uploads
+      # your package is the supply-chain edge worth nailing down, and matching
+      # the sibling repo means one SHA to review when it is bumped.
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+
+  verify-install:
+    name: Install from PyPI and smoke-test
+    needs: build-and-publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          # The floor this package declares, so the published wheel is proven
+          # installable on the oldest interpreter it claims to support.
+          python-version: '3.10'
+
+      - name: Install the published version
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          # PyPI's index can lag a successful upload by a minute or two, so
+          # retry rather than fail the job on propagation delay.
+          for i in 1 2 3 4 5 6 7 8; do
+            pip install --no-cache-dir "comfy-mcp==${VERSION}" && exit 0
+            echo "Attempt ${i}: not on the index yet, waiting 15s..."
+            sleep 15
+          done
+          echo "::error::comfy-mcp==${VERSION} did not install after 8 attempts."
+          exit 1
+
+      - name: Import the package and confirm the version
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          # Import rather than run the server: starting it would look for
+          # comfy-cli, which is the USER's dependency and deliberately not
+          # bundled (see AGENTS.md), so its absence is not a packaging failure.
+          INSTALLED=$(python -c "import comfy_mcp; print(comfy_mcp.__version__)")
+          echo "imported comfy_mcp ${INSTALLED}"
+          test "${INSTALLED}" = "${VERSION}"


### PR DESCRIPTION
## ELI5

Right now there's no way to actually ship this package — you can only install it from a git checkout. This adds the button. It also refuses to press itself if the tag and the code disagree about what version this is.

## Why now

`comfy-mcp` is not on PyPI and this repo has no publish workflow (`.github/workflows/` has ci, cla, groom, secret-scanning, agents-md, cursor-review — nothing that releases). That makes distribution a launch blocker independent of any code fix.

## Three jobs, ordered on purpose

**1. `check-version` — runs first, needs no credentials.**

The version lives in **two** places here: `pyproject.toml` and `src/comfy_mcp/__init__.py`. So a release can disagree with the package it would publish in two different ways, and **a PyPI version number can never be reused once taken.** Both are compared against the tag *before* anything is built, so an inconsistent release fails cheaply rather than after the OIDC exchange.

comfy-cli needs no equivalent guard because it keeps `version = "0.0.0"` in-repo and its workflow rewrites it from the tag. This repo carries a real version instead — friendlier to `pip install -e .` and to `__version__` at runtime — and this check is the price of that choice.

The check is **one Python program in a quoted heredoc**, not `python -c "…"`. Both version strings need quote characters to parse, and nesting those inside a double-quoted shell argument is a quoting puzzle whose failure mode is a workflow that breaks at release time — the worst possible moment to debug escaping. The tag arrives via `env:` rather than being interpolated into the source.

**2. `build-and-publish` — OIDC, no stored token.**

Builds sdist + wheel, then runs `twine check` *before* uploading: it catches a README that renders fine on GitHub but breaks PyPI's stricter parser, which is worth learning while the version can still be changed.

The publish action is pinned to `cef221092ed1bacb1cc03d23a2d87d1d172e277b` — the same commit comfy-cli's workflow already trusts, verified to resolve upstream. A mutable ref on the action that uploads your package is the supply-chain edge most worth nailing down, and matching the sibling repo means one SHA to review when it's bumped rather than two.

**3. `verify-install` — proves the artifact is real.**

Installs the published version from PyPI on the **3.10 floor this package declares**, then imports it and asserts the version round-tripped. It *imports* rather than starting the server, because starting it looks for comfy-cli — the user's dependency, deliberately never bundled (see `AGENTS.md`) — so its absence is not a packaging failure. PyPI's index can lag a successful upload, so the install retries instead of failing on propagation delay.

No `workflow_dispatch`: a hand-triggered publish could ship a version no tag points at.

## Verification

Not just "the YAML parses" — I extracted the actual step body and ran it:

| Input | Result |
|---|---|
| `TAG=v0.5.0` | `Versions agree.` exit 0 |
| `TAG=0.5.0` (no `v`) | `Versions agree.` exit 0 |
| `TAG=v9.9.9` | two `::error::` lines naming both files, exit 1 |

```
python -m build --sdist --wheel   → comfy_mcp-0.5.0.tar.gz + comfy_mcp-0.5.0-py3-none-any.whl
twine check dist/*                → both PASSED
```

## Two prerequisites this workflow cannot do for itself

Both are needed before the first release and neither is code:

1. **Register the project name on PyPI.** `https://pypi.org/pypi/comfy-mcp/json` currently returns **404**.
2. **Configure PyPI to trust this publisher** — owner `Comfy-Org`, repo `comfy-mcp`, workflow `publish.yml`, environment `pypi`. Trusted publishing has no fallback: without it the upload step fails with no token to substitute.

Worth doing in that order, and worth doing before the repo goes public so the name can't be taken in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)