### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfy-mcp"
-version = "0.5.0"
+version = "0.6.0"
 description = "MCP server for ComfyUI — a thin wrapper over comfy-cli."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/comfy_mcp/__init__.py
+++ b/src/comfy_mcp/__init__.py
@@ -1,3 +1,3 @@
 """comfy-mcp: a thin MCP wrapper over comfy-cli."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"


### PR DESCRIPTION
## ELI-5

Every build off `main` currently reports `0.5.0`, the last release — 33 commits ago. So when QA tests a build and files a result, there is no version in it that distinguishes the build carrying the comfy-cli 1.14.0 floor from one that predates it. This bumps the two version fields to `0.6.0` so a test build identifies itself.

## What changed

- `pyproject.toml` `version` → `0.6.0`
- `src/comfy_mcp/__init__.py` `__version__` → `0.6.0`

Nothing else. Verified both agree at runtime (`comfy_mcp.__version__` and `importlib.metadata.version("comfy-mcp")` both report `0.6.0`), which is what `publish.yml`'s `check-version` job compares against a tag.

## This does not publish anything

`publish.yml` triggers on `release: created` only — no `push:`, no `tags:`, and deliberately no `workflow_dispatch`. Merging this fires nothing, and the follow-up `v0.6.0` **git tag** fires nothing either; a tag is a ref, not a Release. The GitHub Release stays held for the public flip, which will also be the first time that workflow ever runs (it landed on `main` after v0.5.0 was cut, so it has zero runs to date).

Note this is a small, deliberate deviation from convention: every prior bump merged in the same second as its Release, so `main` has always carried the last *released* version. Here `main` carries `0.6.0` with no Release pointing at it until the flip. `check-version` simply has nothing to compare until then, and the version should still read `0.6.0` when the Release is cut.

## Provenance

Follows the comfy-cli v1.14.0 release and comfy-mcp#195 (floor raised to `>=1.14.0`). Asked for so Ali has a fixed, self-identifying build for the pre-public-release retest.

## Verification

- `pytest -m 'not e2e'` — 1732 passed, 1 skipped, 3 deselected
- `ruff check .` — clean