### PR TITLE
fix: pre-flight install_node's cm-cli requirement before the consent prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,16 @@ MCP request open. That stays inside the rule: every call still goes through
 behavior of its own. What would breach it is deriving the answer here (parsing
 the graph, keeping a table of what is "supported") instead of asking the engine
 — for `download_model` that would mean sizing the file on disk to decide whether
-it finished, rather than reading comfy-cli's `status`. `workflow_deps` reads its
+it finished, rather than reading comfy-cli's `status`. `install_node` composes
+the same way for a different reason: it reads `comfy env`'s
+`workspace.manager_detected` / `manager_mode` BEFORE its consent prompt, because
+`comfy node install` runs Manager's `cm-cli` and an install that has Manager only
+as a legacy clone under `custom_nodes/` cannot run it — so the user would be
+asked to authorize third-party code on a call guaranteed to fail. The verdict is
+comfy-cli's own field, not a scan this repo performs, and the check fails OPEN:
+an unreadable answer installs anyway and lets the engine's error stand.
+`workflow_deps` describes that same environment through the same two helpers
+(`_manager_state_clause` / `_MANAGER_VENV_REMEDY`) so the two cannot drift. `workflow_deps` reads its
 answer off DISK because the engine leaves no choice — `comfy node
 deps-in-workflow` emits no envelope and REQUIRES an `--output` path — so the
 temp-file round trip is that contract, and Manager's manifest goes back as

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,6 @@
 
 A short guide for AI agents (and humans) here. **Keep it in sync:** a PR that
 changes the architecture rule, the toolchain or the tool set updates it too.
-
-## What this repo is
-
 `comfy-mcp` is a small, standalone [MCP](https://modelcontextprotocol.io) server
 that lets an agent drive a user's **local** ComfyUI: a **thin wrapper over
 [`comfy-cli`](https://github.com/Comfy-Org/comfy-cli)**, which is the engine.
@@ -34,47 +31,42 @@ Hard guardrails — a PR that breaks any of these should be rejected:
   filesystem/multi-tenancy concerns to design around.
 
 A tool may COMPOSE more than one passthrough when the value is in the sequence
-rather than in new logic — `fetch_template` runs `templates fetch` and then
-`validate` to tell the caller whether the template it just wrote can actually
-run on this install, and `download_model` submits `model download --background`
-and then polls `model download-status` so a multi-GB transfer does not hold the
-MCP request open. That stays inside the rule: every call still goes through
-`_run_comfy`, the verdict is comfy-cli's own, and this repo adds no product
-behavior of its own. What would breach it is deriving the answer here (parsing
-the graph, keeping a table of what is "supported") instead of asking the engine
-— for `download_model` that would mean sizing the file on disk to decide whether
-it finished, rather than reading comfy-cli's `status`. `install_node` composes
-the same way for a different reason: it reads `comfy env`'s
-`workspace.manager_detected` / `manager_mode` BEFORE its consent prompt, because
-`comfy node install` runs Manager's `cm-cli` and an install that has Manager only
-as a legacy clone under `custom_nodes/` cannot run it — so the user would be
-asked to authorize third-party code on a call guaranteed to fail. The verdict is
-comfy-cli's own field, not a scan this repo performs, and the check fails OPEN:
-an unreadable answer installs anyway and lets the engine's error stand.
-`workflow_deps` describes that same environment through the same two helpers
-(`_manager_state_clause` / `_MANAGER_VENV_REMEDY`) so the two cannot drift. `workflow_deps` reads its
-answer off DISK because the engine leaves no choice — `comfy node
+rather than in new logic — `fetch_template` runs `templates fetch` then
+`validate`, telling the caller whether the template it just wrote can actually
+run here, and `download_model` submits `model download --background` then polls
+`model download-status` so a multi-GB transfer does not hold the MCP request
+open. That stays inside the rule: every call still goes through `_run_comfy`,
+the verdict is comfy-cli's own, and this repo adds no product behavior of its
+own. What would breach it is deriving the answer here (parsing the graph,
+keeping a table of what is "supported") instead of asking the engine — for
+`download_model` that would mean sizing the file on disk to decide whether it
+finished, rather than reading comfy-cli's `status`. `install_node` composes
+for a different reason: `comfy node install` runs Manager's `cm-cli`, which a
+legacy clone under `custom_nodes/` cannot provide, so it reads `comfy env`'s
+manager fields BEFORE the consent prompt rather than ask a user to authorize
+third-party code on a call that cannot succeed. It fails OPEN, and shares
+`workflow_deps`' two helpers so the two cannot drift. `workflow_deps` reads
+its answer off DISK because the engine leaves no choice — `comfy node
 deps-in-workflow` emits no envelope and REQUIRES an `--output` path — so the
 temp-file round trip is that contract, and Manager's manifest goes back as
 written bar `failure_log._scrub_text` masking credentials in its repo-URL keys.
 
 The one thing that legitimately lives here rather than in comfy-cli is **MCP
-protocol surface** — capabilities that only exist between this server and its
-client, and that comfy-cli has no way to express. Today that is the per-call
+protocol surface** — capabilities that exist only between this server and its
+client, which comfy-cli has no way to express. Today that is the per-call
 confirmation on the tools that can spend money, destroy local state, run
 third-party code, or expose the machine: `partner_generate`, `run_template`,
 `run_workflow`, `switch_comfyui_version`, `install_node`, `update_comfyui` when
 `target="all"`, and the `launch_comfyui` / `restart_comfyui` pair when
 `extra_args` would publish ComfyUI to the network. comfy-cli owns the
 credit-spend interlock and the durable "always proceed" (`comfy generate consent
-always`), and this server only raises the confirmation over MCP **elicitation**
-— the protocol's equivalent of the CLI's y/N prompt — then forwards the answer
-as `--yes` / `--allow-spend`, or (for the four the CLI does not gate at all)
-simply refuses to run the command. It stores no consent of its own. All of them
-share one fail-closed body, `_elicit_approval`; give a new gate its own
-`_ApprovalWording` rather than a second copy of that handling. Adding *product*
-behavior here is still a guardrail breach; adapting comfy-cli's contract to an
-MCP primitive is this repo's job.
+always`); this server only raises the confirmation over MCP **elicitation** —
+the protocol's y/N prompt — then forwards the answer as `--yes` /
+`--allow-spend`, or (for the four the CLI does not gate at all) refuses to run
+the command. It stores no consent of its own, and all share one fail-closed body,
+`_elicit_approval`; give a new gate its own `_ApprovalWording` rather than a
+second copy. Adding *product* behavior here is still a guardrail breach;
+adapting comfy-cli's contract to an MCP primitive is this repo's job.
 
 The three *spend* gates — `partner_generate`, `run_template`, `run_workflow` —
 differ where the engine's own shape differs, and those differences are
@@ -88,15 +80,15 @@ always-proceed as granting nothing. That shared opt-in policy is one body,
 SIGNAL: `run_template` can trust the verb, `run_workflow` must PROBE `comfy run
 --help` for the flag — its docstring says why, and what an engine without it
 means. `switch_comfyui_version`, `install_node` and `update_comfyui` sit outside
-that axis: none spends credits, the CLI gates none of them, so their prompt is
-this server's only gate, with no always-proceed to read. TWO gates are
-ARGUMENT-scoped, the danger being the argument and not the verb: the launch pair
-prompts only for `extra_args` that would publish an unauthenticated ComfyUI
-(`_network_exposing_args`), `update_comfyui` only for `target="all"`, which
-pip-installs every third-party pack (`comfy`/`cli` never prompt). `install_node`
-is NOT one: it prompts on EVERY call, and its argument is a RESTRICTION — `names`
-pinned to registry slugs, refusing a URL, as the prompt promises a REGISTRY pack.
-Mirror the engine's contract per tool; never generalize one gate onto another.
+that axis: none spends credits and the CLI gates none, so their prompt is this
+server's only gate, with no always-proceed to read. TWO are ARGUMENT-scoped, the
+danger being the argument and not the verb: the launch pair prompts only for
+`extra_args` publishing an unauthenticated ComfyUI (`_network_exposing_args`),
+`update_comfyui` only for `target="all"`, which pip-installs every third-party
+pack (`comfy`/`cli` never prompt). `install_node` is NOT one — it prompts on
+EVERY call, its `names` argument being a RESTRICTION to registry slugs refusing a
+URL, as the prompt promises a REGISTRY pack. Mirror the engine's contract per
+tool; never generalize one gate onto another.
 
 The local differentiator: discovery (`search_nodes`, `get_node`, `search_models`)
 reads the **user's live install** — custom nodes included — not a static catalog.
@@ -105,8 +97,8 @@ reads the **user's live install** — custom nodes included — not a static cat
 
 `server.py` holds the wrapper core (`_run_comfy`, the envelope parser, the
 `--json-stream` machinery, the spend-consent plumbing) and every `@mcp.tool()`.
-Three **leaf** modules sit under it — nothing in them imports `server`, so the
-dependency edges only ever point one way:
+Three **leaf** modules sit under it — none imports `server`, so the dependency
+edges only ever point one way:
 
 | Module | Owns |
 |---|---|
@@ -115,11 +107,11 @@ dependency edges only ever point one way:
 | `failure_log.py` | the opt-in `COMFY_MCP_DEBUG_LOG` failure log (its config, its module state, and `_log_failure`) **and the URL scrubbers** — `_scrub_text` / `_scrubbed_stream_tail` also mask credentials on the way to the MCP CLIENT, not just to disk |
 
 `server` reaches them **module-qualified** (`tcc._tcc_guidance(...)`,
-`failure_log._log_failure(...)`) and re-exports nothing. That is deliberate: a
-test that patches a moved name on `server` would otherwise silently patch a name
-nothing reads. **Patch the owning module** — `monkeypatch.setattr(failure_log,
-"_FAILURE_LOG_PATH", …)`, not `server`. Patching the wrong one now raises
-`AttributeError` instead of passing while testing nothing.
+`failure_log._log_failure(...)`) and re-exports nothing — deliberately: a test
+patching a moved name on `server` would otherwise silently patch a name nothing
+reads. **Patch the owning module** — `monkeypatch.setattr(failure_log,
+"_FAILURE_LOG_PATH", …)`, not `server`; the wrong one now raises `AttributeError`
+rather than passing while testing nothing.
 
 ## Toolchain
 
@@ -144,8 +136,7 @@ report on every PR, and the workflow already no-ops on Markdown-only changes.
 Tests live in `tests/` and mock comfy-cli — they never require a real ComfyUI or
 the `comfy` binary. `_run_comfy` and the envelope parser are exercised directly
 (`test_wrapper.py`, `test_parser.py`); each tool group has its own file
-(`test_discovery.py`, `test_templates.py`). When you add or change a tool, add or
-update its test in the same PR.
+(`test_discovery.py`, `test_templates.py`). Add or update a tool's test with it.
 
 **Mock comfy-cli through the shared fixtures in `tests/conftest.py`, never a
 hand-rolled stub.** They are the single place that mirrors how `server` spawns

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -9360,14 +9360,25 @@ _MANAGER_DETECTED_LEGACY_CLONE = "legacy-clone"
 _MANAGER_DETECTED_NONE = "none"
 
 # `workspace.manager_mode`'s two cm-cli-less values — the FALLBACK signal only,
-# for an engine that reports a mode but no `manager_detected`. The mode is a
-# per-user CONFIG key that comfy-cli reconciles against what is on disk, and the
-# reconciliation deliberately leaves `"disable"` and any unrecognised string
+# for an engine that reports a mode but no `manager_detected` at all. The mode is
+# a per-user CONFIG key that comfy-cli reconciles against what is on disk, and
+# the reconciliation deliberately leaves `"disable"` and any unrecognised string
 # ALONE as user intent — so a mode can be silent about a Manager that is missing.
 # `manager_detected` is that reconciliation's INPUT rather than its output, which
-# is why it is read first and why it wins where the two disagree.
+# is why it is read first and why its answer is taken WHOLE: an engine that
+# reports the field has already decided, and the mode gets no vote (see
+# `_cm_cli_unavailable_reason`).
 _MANAGER_MODE_NOT_INSTALLED = "not-installed"
 _MANAGER_MODE_LEGACY = "legacy"
+
+# What the MODE fallback can honestly conclude, and no more. Neither mode value
+# identifies the SHAPE of the gap: `server_info`'s own docstring records that a
+# legacy clone under `custom_nodes/` also reports `"not-installed"` here, and
+# `"legacy"` is a config string a user can set. So both map to this — cm-cli
+# cannot run, which of the two shapes it is unknown — and `_manager_state_clause`
+# gives it the same both-shapes wording it gives a caller holding no reason at
+# all. Refusing on this signal is right; naming the cause on it is not.
+_MANAGER_UNUSABLE_UNSPECIFIED = "unspecified"
 
 
 def _workspace_report() -> dict | None:
@@ -9388,9 +9399,12 @@ def _workspace_report() -> dict | None:
     """
     try:
         info = _run_comfy("env", timeout=60.0)
-    # `ComfyCliError` for a failed or unparseable `comfy env`; `OSError` for a
-    # spawn failure; `UnicodeDecodeError` for a workspace path that is not UTF-8
-    # (`_run_comfy` decodes strictly). None is grounds to refuse an install.
+    # `ComfyCliError` for a failed or unparseable `comfy env` — a TIMEOUT is one
+    # of these, because `_run_comfy_raw` kills the tree and re-raises
+    # `subprocess.TimeoutExpired` as `ComfyCliError(timed_out=True)`, so it never
+    # reaches this frame as itself; `OSError` for a spawn failure;
+    # `UnicodeDecodeError` for a workspace path that is not UTF-8 (`_run_comfy`
+    # decodes strictly). NONE OF THESE is grounds to refuse an install.
     except (ComfyCliError, OSError, UnicodeDecodeError):
         return None
     workspace = info.get("workspace") if isinstance(info, dict) else None
@@ -9400,12 +9414,17 @@ def _workspace_report() -> dict | None:
 def _cm_cli_unavailable_reason() -> str | None:
     """Why cm-cli cannot run on this install per ``comfy env``, or ``None``.
 
-    Returns :data:`_MANAGER_DETECTED_LEGACY_CLONE` or
-    :data:`_MANAGER_DETECTED_NONE` when comfy-cli's own environment report says
-    Manager's ``cm_cli`` is not importable from the workspace venv, and ``None``
-    when it is — or when the answer cannot be read. No new detection logic lives
-    here: both fields are comfy-cli's, computed by comfy-cli, and this only maps
-    them onto "would a cm-cli verb run".
+    Returns :data:`_MANAGER_DETECTED_LEGACY_CLONE`,
+    :data:`_MANAGER_DETECTED_NONE`, or :data:`_MANAGER_UNUSABLE_UNSPECIFIED` when
+    comfy-cli's own environment report says Manager's ``cm_cli`` is not
+    importable from the workspace venv, and ``None`` when it is — or when the
+    answer cannot be read. No new detection logic lives here: both fields are
+    comfy-cli's, computed by comfy-cli, and this only maps them onto "would a
+    cm-cli verb run".
+
+    The three refusals differ only in how much of the CAUSE is known, and that is
+    a property of which field answered: ``manager_detected`` names the shape, the
+    ``manager_mode`` fallback cannot and says so with the unspecified value.
 
     **Fails OPEN**, which is deliberately the OPPOSITE of
     :func:`_local_comfyui_running` and worth stating because the two sit in the
@@ -9414,9 +9433,9 @@ def _cm_cli_unavailable_reason() -> str | None:
     This one only improves an error message: the install still has comfy-cli's
     own refusal behind it, so an unreadable answer must NOT invent a refusal of
     its own and block an install that would have worked. Every uncertain path —
-    the probe failing, a missing ``workspace`` block, an unrecognised value, an
-    old engine reporting neither field — returns ``None`` and lets the engine
-    answer.
+    the probe failing, a missing ``workspace`` block, an unrecognised
+    ``manager_detected``, an old engine reporting neither field — returns
+    ``None`` and lets the engine answer.
 
     Advisory in TIME as well, like the ``_UPDATE_LOCK`` peek above it: a user who
     pip-installs Manager between this probe and the install simply gets an
@@ -9425,20 +9444,37 @@ def _cm_cli_unavailable_reason() -> str | None:
     workspace = _workspace_report()
     if workspace is None:
         return None
-    detected = workspace.get("manager_detected")
-    if detected == _MANAGER_DETECTED_VENV_PACKAGE:
+    if "manager_detected" in workspace:
+        # The authoritative field ANSWERED, so it is the whole answer — the
+        # membership test rather than a truthiness or `!= None` one, because a
+        # present `null` is still the engine having reported. Its two cm-cli-less
+        # values refuse; anything else, INCLUDING a value this server does not
+        # know or a non-string the engine should never emit, is unreadable, and
+        # the fail-open contract answers `None`. Falling through to
+        # `manager_mode` here is what the contract forbids: the mode is stale
+        # per-user config, so a future vocabulary for a perfectly USABLE Manager
+        # would be overruled by a `"legacy"` string nobody has corrected, and the
+        # install refused for a reason that is not true of this workspace.
+        detected = workspace["manager_detected"]
+        # The two `return None`s below are different answers that happen to
+        # coincide: "cm-cli runs" and "this value means nothing to us". Both let
+        # the install proceed, and keeping them apart is what makes the
+        # trichotomy — and which branch a future value lands in — legible.
+        if detected == _MANAGER_DETECTED_VENV_PACKAGE:
+            return None
+        if detected in (_MANAGER_DETECTED_LEGACY_CLONE, _MANAGER_DETECTED_NONE):
+            return detected
         return None
-    if detected in (_MANAGER_DETECTED_LEGACY_CLONE, _MANAGER_DETECTED_NONE):
-        return detected
-    # No `manager_detected` (or a value this server does not know): fall back to
+    # No `manager_detected` field at all — an engine older than it. Fall back to
     # the mode, whose two cm-cli-less values comfy-cli derives from the very same
     # probe. Only those two refuse — every other mode, including `"disable"`,
-    # says nothing about whether `cm_cli` imports.
-    mode = workspace.get("manager_mode")
-    if mode == _MANAGER_MODE_LEGACY:
-        return _MANAGER_DETECTED_LEGACY_CLONE
-    if mode == _MANAGER_MODE_NOT_INSTALLED:
-        return _MANAGER_DETECTED_NONE
+    # says nothing about whether `cm_cli` imports — and they refuse WITHOUT
+    # naming a shape, for the reason `_MANAGER_UNUSABLE_UNSPECIFIED` records.
+    if workspace.get("manager_mode") in (
+        _MANAGER_MODE_LEGACY,
+        _MANAGER_MODE_NOT_INSTALLED,
+    ):
+        return _MANAGER_UNUSABLE_UNSPECIFIED
     return None
 
 
@@ -9464,6 +9500,10 @@ def _manager_state_clause(reason: str | None) -> str:
     hand — ``ComfyUI-Manager not found. 'cm-cli' command is not available.`` is
     printed identically for both shapes, so a caller reacting to it after the
     fact genuinely cannot tell which it hit and must not claim to.
+
+    :data:`_MANAGER_UNUSABLE_UNSPECIFIED` lands on that same both-shapes clause
+    by falling through, and deliberately: a mode-fallback refusal knows no more
+    about the cause than an after-the-fact one does.
     """
     if reason == _MANAGER_DETECTED_LEGACY_CLONE:
         return (
@@ -9480,7 +9520,15 @@ def _manager_state_clause(reason: str | None) -> str:
         "either it is not installed at all, or it is a legacy clone under "
         "`custom_nodes/`, which is fully functional for ComfyUI itself but "
         "leaves `cm_cli` unimportable in the workspace venv. `server_info`'s "
-        "`workspace.manager_detected` reports which of the two this is."
+        # Named as a `workspace` block rather than as one field: this clause is
+        # emitted exactly where `manager_detected` may be ABSENT (an engine old
+        # enough to report only `manager_mode` is one of the two ways to reach
+        # it), so pointing at that field alone would send the user to a key that
+        # is not there. `manager_mode` is the older, weaker answer — hence the
+        # hedge, which is the honest one for a clause that means "unknown".
+        "`workspace` block distinguishes the two where it can: "
+        "`manager_detected` says which outright, and on an engine that predates "
+        "it `manager_mode` is the only, weaker hint."
     )
 
 
@@ -9499,13 +9547,27 @@ def _install_node_unavailable(reason: str | None) -> dict[str, Any]:
     terminal: it is the identical command through the identical ``cm-cli``, so
     sending the user there would be a second guaranteed failure, exactly the
     dead-end ``workflow_deps`` refuses to send them into in the other direction.
+
+    A refusal that does NOT know the shape — :data:`_MANAGER_UNUSABLE_UNSPECIFIED`
+    or ``None`` — still offers that route, CONDITIONALLY. It is the only working
+    route out of one of the two environments this refusal covers, and withholding
+    it because the probe could not tell them apart would hand a legacy-clone user
+    a dead end on a path that works. The conditional phrasing is what keeps that
+    from becoming a claim about which environment this is.
     """
-    routes = (
-        "Manager's own UI in the running ComfyUI can still install packs — that "
-        "half of a legacy clone works. "
-        if reason == _MANAGER_DETECTED_LEGACY_CLONE
-        else ""
-    )
+    if reason == _MANAGER_DETECTED_LEGACY_CLONE:
+        routes = (
+            "Manager's own UI in the running ComfyUI can still install packs — "
+            "that half of a legacy clone works. "
+        )
+    elif reason == _MANAGER_DETECTED_NONE:
+        routes = ""
+    else:
+        routes = (
+            "If this install is a legacy clone rather than no Manager at all, "
+            "Manager's own UI in the running ComfyUI can still install packs — "
+            "that half of a clone works. "
+        )
     return {
         "error": (
             f"install_node unavailable: {_manager_state_clause(reason)} "
@@ -9657,12 +9719,14 @@ async def install_node(
     degrades on the same environment, and with the same description of it. No
     prompt is raised and no install is spawned: a user must not be asked to
     approve running third-party code on a call that cannot succeed. The check
-    fails OPEN, so an engine that cannot answer simply installs and lets
-    comfy-cli's own error stand.
+    fails OPEN, so an engine that cannot answer simply installs — and if that
+    install then hits the same gap, comfy-cli's own refusal is mapped to the SAME
+    ``unsupported`` degrade rather than raising. One environment therefore always
+    answers in one shape, whether or not the probe could read it.
 
-    A pack id that does not exist, an unreachable registry, a dependency
-    conflict, or any cm-cli failure the pre-flight could not predict fails inside
-    comfy-cli and raises :class:`ComfyCliError` carrying its message.
+    A pack id that does not exist, an unreachable registry, or a dependency
+    conflict fails inside comfy-cli and raises :class:`ComfyCliError` carrying
+    its message.
 
     Returns ``{"installed", "result", "restart_required"}`` —
     ``restart_required`` is always ``True``, because a running ComfyUI will not
@@ -9684,10 +9748,18 @@ async def install_node(
     # worse than the failure it precedes. `switch_comfyui_version` orders its
     # running-server check ahead of its prompt for the same reason. Fails OPEN —
     # an unreadable answer proceeds and lets comfy-cli's own error stand.
-    # `server_info` is sync and spawns children, so it runs off the event loop.
+    # `_cm_cli_unavailable_reason` is sync and spawns a `comfy env` child (it
+    # bypasses `server_info` — see `_workspace_report`), so it runs off the loop.
     cm_cli_gap = await asyncio.to_thread(_cm_cli_unavailable_reason)
     if cm_cli_gap is not None:
         return _install_node_unavailable(cm_cli_gap)
+    # Re-peek: the probe above is a subprocess that can take up to a minute, and
+    # an update that starts DURING it would otherwise be discovered only by the
+    # authoritative acquire below — i.e. after the user has already approved
+    # running third-party code. Re-checking here restores the window the first
+    # peek was written to give, which is the whole point of peeking at all.
+    if _UPDATE_LOCK.locked():
+        raise ComfyCliError(_INSTALL_UPDATE_BUSY)
     await _resolve_install_consent(names_display, confirm_install, ctx)
     # Refuse rather than queue, exactly as `update_comfyui` does and for the same
     # reason — see its comment. Acquired AFTER consent so a declined call never
@@ -9707,7 +9779,28 @@ async def install_node(
     # against the same venv. A done-callback ties the release to the job's own
     # lifetime, and still fires if the job is cancelled before it ever starts.
     job.add_done_callback(lambda _job: _UPDATE_LOCK.release())
-    result = await asyncio.wrap_future(job)
+    try:
+        result = await asyncio.wrap_future(job)
+    except ComfyCliError as exc:
+        # The pre-flight failed OPEN and the install then hit the very gap it
+        # could not read — the probe timed out, or the engine reported no
+        # `manager_detected` and a mode that says nothing. Without this, ONE
+        # environment answers in two shapes depending on whether a subprocess
+        # happened to succeed: the degrade dict when the probe read it, a raw
+        # `ComfyCliError` when it did not. Callers are told to check
+        # `unsupported` before indexing `["installed"]`; that contract has to
+        # hold on every path to the same install, so map it here too.
+        #
+        # `reason=None` is the honest argument: this is comfy-cli's own refusal,
+        # which prints identically for a missing Manager and for a legacy clone,
+        # so the shape is genuinely unknown here — exactly `workflow_deps`'
+        # position. `guarded` is passed for the echoed-argument check even though
+        # `_guard_node_names` already makes a name that carries the sentence
+        # unreachable: the door stays shut from both sides rather than one tool's
+        # guard being the other's precondition.
+        if _is_manager_missing_error(exc, *guarded):
+            return _install_node_unavailable(None)
+        raise
     return {"installed": guarded, "result": result, "restart_required": True}
 
 

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -9348,6 +9348,178 @@ def _guard_node_names(names: Any) -> list[str]:
     return guarded
 
 
+# How `comfy env` reports the ComfyUI-Manager install it found
+# (`detect_manager_installation`, comfy-cli 1.14.0 — this server's floor, so a
+# compliant install always reports it). Exactly ONE of the three means cm-cli
+# works, and the equivalence is tight rather than inferred: `"venv-package"` IS
+# `find_cm_cli()` returning True, and `find_cm_cli()` is the same call
+# `execute_cm_cli` gates EVERY cm-cli-backed verb on — `node install` included.
+# So anything else here is the same False the install would hit for itself.
+_MANAGER_DETECTED_VENV_PACKAGE = "venv-package"
+_MANAGER_DETECTED_LEGACY_CLONE = "legacy-clone"
+_MANAGER_DETECTED_NONE = "none"
+
+# `workspace.manager_mode`'s two cm-cli-less values — the FALLBACK signal only,
+# for an engine that reports a mode but no `manager_detected`. The mode is a
+# per-user CONFIG key that comfy-cli reconciles against what is on disk, and the
+# reconciliation deliberately leaves `"disable"` and any unrecognised string
+# ALONE as user intent — so a mode can be silent about a Manager that is missing.
+# `manager_detected` is that reconciliation's INPUT rather than its output, which
+# is why it is read first and why it wins where the two disagree.
+_MANAGER_MODE_NOT_INSTALLED = "not-installed"
+_MANAGER_MODE_LEGACY = "legacy"
+
+
+def _workspace_report() -> dict | None:
+    """``comfy env``'s ``workspace`` block, or ``None`` if it cannot be read.
+
+    Shells out to ``comfy env`` DIRECTLY rather than composing
+    :func:`server_info` the way :func:`_local_comfyui_running` does, and the
+    difference is worth stating because that sibling is the obvious model. Its
+    reason for going through the tool is the compatibility gate ``server_info``
+    carries — which matters when the answer decides whether to do something
+    destructive. This probe only decides how to WORD a failure and fails open, so
+    it would swallow that gate's verdict rather than act on it, while paying for
+    ``server_info``'s other half: a ``comfy outdated`` freshness probe that
+    reaches the NETWORK and whose answer is then discarded. One local subprocess
+    is the whole cost this check should have.
+
+    Every failure is ``None``: this exists to improve a message, never to block.
+    """
+    try:
+        info = _run_comfy("env", timeout=60.0)
+    # `ComfyCliError` for a failed or unparseable `comfy env`; `OSError` for a
+    # spawn failure; `UnicodeDecodeError` for a workspace path that is not UTF-8
+    # (`_run_comfy` decodes strictly). None is grounds to refuse an install.
+    except (ComfyCliError, OSError, UnicodeDecodeError):
+        return None
+    workspace = info.get("workspace") if isinstance(info, dict) else None
+    return workspace if isinstance(workspace, dict) else None
+
+
+def _cm_cli_unavailable_reason() -> str | None:
+    """Why cm-cli cannot run on this install per ``comfy env``, or ``None``.
+
+    Returns :data:`_MANAGER_DETECTED_LEGACY_CLONE` or
+    :data:`_MANAGER_DETECTED_NONE` when comfy-cli's own environment report says
+    Manager's ``cm_cli`` is not importable from the workspace venv, and ``None``
+    when it is — or when the answer cannot be read. No new detection logic lives
+    here: both fields are comfy-cli's, computed by comfy-cli, and this only maps
+    them onto "would a cm-cli verb run".
+
+    **Fails OPEN**, which is deliberately the OPPOSITE of
+    :func:`_local_comfyui_running` and worth stating because the two sit in the
+    same position — a pre-flight ahead of a consent prompt. That one guards
+    against DOING something destructive, so an unreadable answer must refuse.
+    This one only improves an error message: the install still has comfy-cli's
+    own refusal behind it, so an unreadable answer must NOT invent a refusal of
+    its own and block an install that would have worked. Every uncertain path —
+    the probe failing, a missing ``workspace`` block, an unrecognised value, an
+    old engine reporting neither field — returns ``None`` and lets the engine
+    answer.
+
+    Advisory in TIME as well, like the ``_UPDATE_LOCK`` peek above it: a user who
+    pip-installs Manager between this probe and the install simply gets an
+    install that works. The window costs nothing in either direction.
+    """
+    workspace = _workspace_report()
+    if workspace is None:
+        return None
+    detected = workspace.get("manager_detected")
+    if detected == _MANAGER_DETECTED_VENV_PACKAGE:
+        return None
+    if detected in (_MANAGER_DETECTED_LEGACY_CLONE, _MANAGER_DETECTED_NONE):
+        return detected
+    # No `manager_detected` (or a value this server does not know): fall back to
+    # the mode, whose two cm-cli-less values comfy-cli derives from the very same
+    # probe. Only those two refuse — every other mode, including `"disable"`,
+    # says nothing about whether `cm_cli` imports.
+    mode = workspace.get("manager_mode")
+    if mode == _MANAGER_MODE_LEGACY:
+        return _MANAGER_DETECTED_LEGACY_CLONE
+    if mode == _MANAGER_MODE_NOT_INSTALLED:
+        return _MANAGER_DETECTED_NONE
+    return None
+
+
+# The remedy, written ONCE and shared by both cm-cli-backed tools. `install_node`
+# and `workflow_deps` fail on the same install for the same reason, so the two
+# must not describe that environment — or the way out of it — differently; this
+# constant and `_manager_state_clause` below are what make that structural rather
+# than a matter of keeping two message literals in step.
+_MANAGER_VENV_REMEDY = (
+    "Installing ComfyUI-Manager into the workspace VENV — the `comfyui_manager` "
+    "package, importable by the workspace Python — is what restores this tool; "
+    "that is the install `comfy install` performs, and in a terminal it is "
+    "`<workspace-python> -m pip install -r manager_requirements.txt` from the "
+    "ComfyUI directory."
+)
+
+
+def _manager_state_clause(reason: str | None) -> str:
+    """Describe the Manager install cm-cli cannot use, per what is KNOWN of it.
+
+    ``reason`` is a :func:`_cm_cli_unavailable_reason` value for a caller that
+    pre-flighted, or ``None`` for one that only has comfy-cli's own refusal in
+    hand — ``ComfyUI-Manager not found. 'cm-cli' command is not available.`` is
+    printed identically for both shapes, so a caller reacting to it after the
+    fact genuinely cannot tell which it hit and must not claim to.
+    """
+    if reason == _MANAGER_DETECTED_LEGACY_CLONE:
+        return (
+            "this workspace has ComfyUI-Manager only as a LEGACY CLONE under "
+            "`custom_nodes/` — which is fully functional for ComfyUI itself, so "
+            "Manager's own UI keeps working in the running server, but leaves "
+            "`cm_cli` unimportable in the workspace venv, and every cm-cli-backed "
+            "comfy-cli verb fails here."
+        )
+    if reason == _MANAGER_DETECTED_NONE:
+        return "this ComfyUI install does not have ComfyUI-Manager at all."
+    return (
+        "this ComfyUI install has no ComfyUI-Manager that comfy-cli can drive — "
+        "either it is not installed at all, or it is a legacy clone under "
+        "`custom_nodes/`, which is fully functional for ComfyUI itself but "
+        "leaves `cm_cli` unimportable in the workspace venv. `server_info`'s "
+        "`workspace.manager_detected` reports which of the two this is."
+    )
+
+
+def _install_node_unavailable(reason: str | None) -> dict[str, Any]:
+    """``install_node``'s degrade for an install whose cm-cli cannot run.
+
+    Same shape and same environment description as ``workflow_deps``' — see
+    :func:`_manager_state_clause`. What differs is only the ROUTING, because the
+    two tools have different ways out: a class this install already has is still
+    described by ``get_node``, whereas a pack it does not have cannot be
+    installed by any tool on this server.
+
+    The route named for a legacy clone is ComfyUI-Manager's own UI, which is a
+    path that genuinely still WORKS there — the clone serves it from the running
+    ComfyUI. What is deliberately NOT offered is ``comfy node install`` in a
+    terminal: it is the identical command through the identical ``cm-cli``, so
+    sending the user there would be a second guaranteed failure, exactly the
+    dead-end ``workflow_deps`` refuses to send them into in the other direction.
+    """
+    routes = (
+        "Manager's own UI in the running ComfyUI can still install packs — that "
+        "half of a legacy clone works. "
+        if reason == _MANAGER_DETECTED_LEGACY_CLONE
+        else ""
+    )
+    return {
+        "error": (
+            f"install_node unavailable: {_manager_state_clause(reason)} "
+            "`comfy node install` runs Manager's `cm-cli`, so it refuses here "
+            "before it downloads anything. Nothing was installed and nothing on "
+            f"this install was changed. {_MANAGER_VENV_REMEDY} {routes}"
+            "Running `comfy node install` in a terminal is NOT a way around "
+            "this — it is the same command through the same `cm-cli`, and it "
+            "fails identically."
+        ),
+        "unsupported": True,
+    }
+
+
 def _run_node_install(names: list[str]) -> Any:
     """Run the install. ``--exit-on-fail`` is NOT optional.
 
@@ -9473,9 +9645,24 @@ async def install_node(
     them is in flight is refused immediately rather than queued behind a job that
     may run for half an hour.
 
-    A pack id that does not exist, an unreachable registry, a dependency conflict,
-    or a missing ComfyUI-Manager all fail inside comfy-cli and raise
-    :class:`ComfyCliError` carrying its message.
+    **Requires a ComfyUI-Manager comfy-cli can drive**, and says so BEFORE
+    prompting: ``comfy node install`` runs Manager's ``cm-cli``, which needs the
+    ``comfyui_manager`` package importable in the workspace venv. An install that
+    has Manager only as a LEGACY CLONE under ``custom_nodes/`` — functional for
+    ComfyUI itself, and a common shape — cannot run it, and neither can one
+    without Manager at all. ``comfy env`` already reports both
+    (``workspace.manager_detected`` / ``manager_mode``), so that case returns
+    ``{"error": ..., "unsupported": True}`` INSTEAD of installing — check for
+    that key before indexing ``["installed"]``, exactly as ``workflow_deps``
+    degrades on the same environment, and with the same description of it. No
+    prompt is raised and no install is spawned: a user must not be asked to
+    approve running third-party code on a call that cannot succeed. The check
+    fails OPEN, so an engine that cannot answer simply installs and lets
+    comfy-cli's own error stand.
+
+    A pack id that does not exist, an unreachable registry, a dependency
+    conflict, or any cm-cli failure the pre-flight could not predict fails inside
+    comfy-cli and raises :class:`ComfyCliError` carrying its message.
 
     Returns ``{"installed", "result", "restart_required"}`` —
     ``restart_required`` is always ``True``, because a running ComfyUI will not
@@ -9490,6 +9677,17 @@ async def install_node(
     # prompt the user answered.
     if _UPDATE_LOCK.locked():
         raise ComfyCliError(_INSTALL_UPDATE_BUSY)
+    # The other half of that question, and the reason it runs HERE rather than
+    # after the prompt: on an install whose `cm_cli` does not import, this call
+    # cannot succeed no matter what the user answers, and being asked to
+    # authorize downloading and running third-party code that will not happen is
+    # worse than the failure it precedes. `switch_comfyui_version` orders its
+    # running-server check ahead of its prompt for the same reason. Fails OPEN —
+    # an unreadable answer proceeds and lets comfy-cli's own error stand.
+    # `server_info` is sync and spawns children, so it runs off the event loop.
+    cm_cli_gap = await asyncio.to_thread(_cm_cli_unavailable_reason)
+    if cm_cli_gap is not None:
+        return _install_node_unavailable(cm_cli_gap)
     await _resolve_install_consent(names_display, confirm_install, ctx)
     # Refuse rather than queue, exactly as `update_comfyui` does and for the same
     # reason — see its comment. Acquired AFTER consent so a declined call never
@@ -10952,8 +11150,12 @@ def workflow_deps(workflow_path: str) -> Any:
     userinfo in it, and this payload reaches the model's transcript (see
     :func:`_scrub_deps_manifest`); nothing else is rewritten.
 
-    Requires ComfyUI-Manager: the verb runs Manager's ``cm-cli``, and without it
-    comfy-cli refuses. That case returns ``{"error": ..., "unsupported": True}``
+    Requires a ComfyUI-Manager comfy-cli can drive: the verb runs Manager's
+    ``cm-cli``, which needs the ``comfyui_manager`` package importable in the
+    workspace venv — so a Manager present only as a legacy clone under
+    ``custom_nodes/`` refuses here exactly as an absent one does, and
+    ``install_node`` is unavailable on that same install for the same reason.
+    That case returns ``{"error": ..., "unsupported": True}``
     INSTEAD of the manifest — check for that key before indexing
     ``["custom_nodes"]`` — rather than the raw usage dump, the same way
     ``node_dependencies`` degrades on a comfy-cli that predates its verb. Any
@@ -11030,14 +11232,21 @@ def workflow_deps(workflow_path: str) -> Any:
             if _is_manager_missing_error(exc, workflow_path):
                 return {
                     "error": (
-                        "workflow_deps unavailable: this ComfyUI install does not "
-                        "have ComfyUI-Manager, and 'comfy node deps-in-workflow' "
-                        "resolves node classes to packs through Manager's map. "
-                        "Installing ComfyUI-Manager into the workspace is what "
-                        "restores this tool. Until then a class this install "
-                        "already has is still described by "
-                        "`get_node`/`search_nodes`, which read the running "
-                        "ComfyUI directly and never touch Manager. "
+                        # `reason=None`: this tool learns of the gap from
+                        # comfy-cli's refusal, which reads the same for a missing
+                        # Manager and for a legacy clone, so the shared clause
+                        # names both rather than asserting the one that used to
+                        # be claimed here. `install_node` pre-flights `comfy env`
+                        # and passes what it actually found; the environment and
+                        # the remedy are described by the same two helpers either
+                        # way, so the two tools cannot drift.
+                        "workflow_deps unavailable: "
+                        f"{_manager_state_clause(None)} 'comfy node "
+                        "deps-in-workflow' resolves node classes to packs "
+                        f"through Manager's map. {_MANAGER_VENV_REMEDY} Until "
+                        "then a class this install already has is still "
+                        "described by `get_node`/`search_nodes`, which read the "
+                        "running ComfyUI directly and never touch Manager. "
                         "`install_node` is NOT a way around this, though: "
                         "`comfy node install` goes through the same `cm-cli`, "
                         "so it fails on this install too — installing Manager "

--- a/tests/test_install_node.py
+++ b/tests/test_install_node.py
@@ -23,7 +23,13 @@ third-party code by accident:
 5. The result contract, including ``restart_required: True`` — this tool never
    restarts anything, which is what lets a user say "install it, I'll restart the
    server myself".
-6. The async plumbing that posture required, mirroring ``test_update_consent``'s:
+6. The cm-cli PRE-FLIGHT, which is the second half of that consent posture: on an
+   install whose ``cm_cli`` does not import — an absent ComfyUI-Manager, or one
+   present only as a legacy clone under ``custom_nodes/`` — the call is refused
+   BEFORE the prompt, because being asked to authorize third-party code that
+   cannot be downloaded is worse than the failure it precedes. It fails OPEN, so
+   an unreadable ``comfy env`` still installs and lets comfy-cli answer.
+7. The async plumbing that posture required, mirroring ``test_update_consent``'s:
    the install keeps its OWN worker thread rather than asyncio's shared pool, it
    forwards the 30-minute timeout, and the lock it holds belongs to the SUBPROCESS
    rather than to the request. Without those three, replacing the done-callback
@@ -40,6 +46,7 @@ import threading
 from unittest import mock
 
 import pytest
+from conftest import envelope
 from mcp.server.elicitation import (
     AcceptedElicitation,
     CancelledElicitation,
@@ -48,10 +55,41 @@ from mcp.server.elicitation import (
 
 from comfy_mcp import server
 
+# Captured before any test patches it, so the one test that wants the REAL
+# `comfy env` pre-flight can put it back and drive the probe end to end through
+# `patched_run`. Every other test runs with the stub the fixture below installs.
+_REAL_WORKSPACE_REPORT = server._workspace_report
+
 
 def _install(*args, **kwargs):
     """Drive the async ``install_node`` tool from a sync test."""
     return asyncio.run(server.install_node(*args, **kwargs))
+
+
+def _env(**workspace):
+    """A ``_workspace_report`` stand-in — the pre-flight's whole input."""
+    return lambda: dict(workspace)
+
+
+@pytest.fixture(autouse=True)
+def manager_is_usable(monkeypatch):
+    """Every test in this file runs on an install whose ``cm-cli`` works.
+
+    `install_node` pre-flights `comfy env` before its prompt, so without this
+    every test here would spawn a second child and read whatever the CLI fake was
+    canned with. Stubbing the `comfy env` READ (rather than the classification
+    that consumes it) keeps the real decision in the path — a test that expects an
+    install to proceed is still asserting that a `venv-package` install is allowed
+    to — while leaving `calls` to hold only the argv each test is actually about.
+
+    Individual tests below re-patch `_workspace_report` to describe a different
+    install; the last `setattr` wins, so overriding is just doing it again.
+    """
+    monkeypatch.setattr(
+        server,
+        "_workspace_report",
+        _env(manager_mode="enable-gui", manager_detected="venv-package"),
+    )
 
 
 class _FakeSession:
@@ -548,6 +586,268 @@ def test_the_busy_refusal_names_every_lock_sharer(patched_plain_run):
     message = str(excinfo.value)
     assert "version switch" in message
     assert "Nothing was installed." in message
+
+
+# --- the cm-cli pre-flight --------------------------------------------------
+#
+# `comfy node install` shells out to ComfyUI-Manager's `cm-cli`, and comfy-cli's
+# `execute_cm_cli` refuses outright — before it downloads anything — when
+# `cm_cli` does not import from the workspace Python. A LEGACY CLONE of Manager
+# under `custom_nodes/` is exactly that install: fully functional for ComfyUI
+# itself, and unusable by every cm-cli-backed verb. Verified against comfy-cli
+# 1.14.0 (this server's floor) on a workspace of that shape: `comfy env` reports
+# `manager_detected: "legacy-clone"`, and `comfy node install <pack>
+# --exit-on-fail` exits 1 with "ComfyUI-Manager not found. 'cm-cli' command is
+# not available." having installed nothing.
+#
+# What these lock in is the ORDER: the refusal happens before the elicitation, so
+# a user is never asked to approve downloading and running third-party code on a
+# call that cannot succeed.
+
+
+def test_a_legacy_clone_refuses_before_the_prompt(patched_plain_run, monkeypatch):
+    """The ticket case: Manager on disk, `cm_cli` not importable in the venv."""
+    calls = patched_plain_run(0, stderr="installed")
+    monkeypatch.setattr(
+        server,
+        "_workspace_report",
+        _env(manager_mode="legacy", manager_detected="legacy-clone"),
+    )
+    ctx = _FakeCtx()
+
+    result = _install(["comfyui-impact-pack"], ctx=ctx)
+
+    # No prompt, and no `comfy node install`: the two halves of "never authorize
+    # an impossible operation".
+    assert ctx.elicitations == []
+    assert calls == []
+    assert result["unsupported"] is True
+    message = result["error"]
+    assert "LEGACY CLONE" in message
+    assert "Nothing was installed" in message
+    # The remedy is the venv package, not "install ComfyUI-Manager" unqualified —
+    # the user demonstrably HAS Manager, which is why the old raw cm-cli error
+    # read as nonsense on this install.
+    assert "workspace VENV" in message
+    assert "comfyui_manager" in message
+
+
+def test_no_manager_at_all_refuses_and_says_so(patched_plain_run, monkeypatch):
+    """The other cm-cli-less shape, described as itself rather than as a clone."""
+    calls = patched_plain_run(0, stderr="installed")
+    monkeypatch.setattr(
+        server,
+        "_workspace_report",
+        _env(manager_mode="not-installed", manager_detected="none"),
+    )
+    ctx = _FakeCtx()
+
+    result = _install(["comfyui-impact-pack"], ctx=ctx)
+
+    assert ctx.elicitations == []
+    assert calls == []
+    assert result["unsupported"] is True
+    assert "does not have ComfyUI-Manager at all" in result["error"]
+    assert "LEGACY CLONE" not in result["error"]
+
+
+def test_the_refusal_routes_instead_of_dead_ending(patched_plain_run, monkeypatch):
+    """A denial must send the user somewhere that WORKS, and nowhere that does not.
+
+    Manager's own UI keeps serving from a legacy clone, so it is named. A terminal
+    `comfy node install` is the identical command through the identical `cm-cli`,
+    so it is named as NOT a way around this rather than offered as the escape
+    hatch — sending the user there would be a second guaranteed failure.
+    """
+    patched_plain_run(0, stderr="installed")
+    monkeypatch.setattr(
+        server, "_workspace_report", _env(manager_detected="legacy-clone")
+    )
+
+    message = _install(["comfyui-impact-pack"], ctx=_FakeCtx())["error"]
+
+    assert "Manager's own UI in the running ComfyUI can still install packs" in message
+    assert "is NOT a way around this" in message
+
+
+@pytest.mark.parametrize(
+    "workspace",
+    [
+        # No `manager_detected` at all — an engine that reports only the mode.
+        {"manager_mode": "legacy"},
+        {"manager_mode": "not-installed"},
+        # `manager_detected` wins where the two disagree: the mode is a per-user
+        # CONFIG key comfy-cli leaves alone when it reads `disable` or anything
+        # it does not recognise, so it can stay silent about a Manager that is
+        # missing. The detection is the reconciliation's input, not its output.
+        {"manager_mode": "disable", "manager_detected": "legacy-clone"},
+        {"manager_mode": "enable-gui", "manager_detected": "none"},
+    ],
+)
+def test_every_cm_cli_less_report_refuses(patched_plain_run, monkeypatch, workspace):
+    """Both fields are read, and the authoritative one is read first."""
+    calls = patched_plain_run(0, stderr="installed")
+    monkeypatch.setattr(server, "_workspace_report", _env(**workspace))
+    ctx = _FakeCtx()
+
+    assert _install(["comfyui-impact-pack"], ctx=ctx)["unsupported"] is True
+    assert ctx.elicitations == []
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "workspace",
+    [
+        # cm-cli is usable — the ordinary case, and the one `manager_detected`
+        # answers outright whatever the stale config mode says.
+        {"manager_detected": "venv-package"},
+        {"manager_detected": "venv-package", "manager_mode": "not-installed"},
+        # …and every report that is merely UNINFORMATIVE. None of these is
+        # evidence the install would fail, so none may block it.
+        {"manager_mode": "enable-gui"},
+        {"manager_mode": "disable"},
+        {"manager_mode": "disable-gui"},
+        {"manager_detected": "a-shape-from-a-later-comfy-cli"},
+        {},
+    ],
+)
+def test_an_uninformative_or_healthy_report_installs_anyway(
+    patched_plain_run, monkeypatch, workspace
+):
+    """The pre-flight FAILS OPEN — the opposite of the version switch's check.
+
+    That check guards against DOING something destructive, so it refuses when it
+    cannot tell. This one only improves an error message, and comfy-cli's own
+    refusal is still behind it, so inventing a refusal here would block installs
+    that work. Every uncertain answer proceeds.
+    """
+    calls = patched_plain_run(0, stderr="installed")
+    monkeypatch.setattr(server, "_workspace_report", _env(**workspace))
+
+    result = _install(["comfyui-impact-pack"], ctx=_FakeCtx())
+
+    assert result["installed"] == ["comfyui-impact-pack"]
+    assert len(calls) == 1
+    assert calls[0]["cmd"][-3:] == ["install", "comfyui-impact-pack", "--exit-on-fail"]
+
+
+@pytest.mark.parametrize(
+    "run_kwargs",
+    [
+        # `comfy env` failed outright, or answered something that is not an
+        # envelope. Both raise `ComfyCliError` out of `_run_comfy`.
+        {"stdout": "not json at all", "returncode": 1},
+        {"stdout": envelope(ok=False, error={"code": "boom", "message": "no"})},
+        # It succeeded, but said nothing this probe can use.
+        {"stdout": envelope(data={"server": {"running": False}})},
+        {"stdout": envelope(data={"workspace": None})},
+        {"stdout": envelope(data=["not a mapping at all"])},
+        # The spawn itself failed.
+        {"raises": OSError("no such binary")},
+    ],
+)
+def test_a_probe_that_cannot_answer_reads_as_no_gap(
+    patched_run, monkeypatch, run_kwargs
+):
+    """`_workspace_report` swallows every failure — it exists to word an error.
+
+    Driven at the probe rather than through the tool because these are the shapes
+    the tool's stub short-circuits: an unparseable body, an error envelope, a
+    payload with no `workspace`, a spawn that never started.
+    """
+    patched_run(**run_kwargs)
+    monkeypatch.setattr(server, "_workspace_report", _REAL_WORKSPACE_REPORT)
+
+    assert server._workspace_report() is None
+    assert server._cm_cli_unavailable_reason() is None
+
+
+def test_the_preflight_reads_comfy_env_and_never_spawns_the_install(
+    patched_run, monkeypatch
+):
+    """End to end through the real probe: comfy-cli's own `env` payload refuses.
+
+    The stub above short-circuits the `comfy env` read, which is what keeps the
+    rest of this file about the install. This one puts the real one back, so
+    `workspace.manager_detected` is read off an actual `envelope/1` body the way
+    it arrives from `comfy env` — and asserts the thing the ordering exists for:
+    `node install` is never spawned.
+    """
+    calls = patched_run(
+        envelope(
+            data={
+                "server": {"running": False, "url": None},
+                "workspace": {
+                    "path": "/ws",
+                    "manager_mode": "legacy",
+                    "manager_detected": "legacy-clone",
+                },
+            }
+        )
+    )
+    monkeypatch.setattr(server, "_workspace_report", _REAL_WORKSPACE_REPORT)
+    ctx = _FakeCtx()
+
+    assert _install(["comfyui-impact-pack"], ctx=ctx)["unsupported"] is True
+
+    assert ctx.elicitations == []
+    assert calls, "the pre-flight must actually ask comfy-cli"
+    assert calls[0]["cmd"][:5] == [
+        server.COMFY_BIN,
+        "--json",
+        "--where",
+        "local",
+        "env",
+    ]
+    # The probe may run more than one child (`comfy env` plus `server_info`'s own
+    # freshness probe); what must never appear is the install.
+    assert not any("install" in call["cmd"] for call in calls)
+
+
+def test_a_cm_cli_failure_the_preflight_missed_is_still_relayed_raw(patched_plain_run):
+    """The pre-flight is an addition, not a replacement, for comfy-cli's error.
+
+    An install can still fail inside `cm-cli` for reasons `comfy env` cannot
+    predict — a Manager removed between the probe and the install, an unreachable
+    channel, a broken pack. comfy-cli's own message is what the caller gets.
+    """
+    patched_plain_run(
+        1, stderr="\nComfyUI-Manager not found. 'cm-cli' command is not available.\n"
+    )
+
+    with pytest.raises(server.ComfyCliError, match="cm-cli"):
+        _install(["comfyui-impact-pack"], ctx=_FakeCtx())
+
+
+def test_both_cm_cli_tools_describe_the_same_install_the_same_way(
+    patched_run, monkeypatch
+):
+    """`install_node` and `workflow_deps` fail on ONE environment — one story.
+
+    They reach the verdict differently — this tool pre-flights `comfy env`, that
+    one reads comfy-cli's refusal after the fact — which is exactly how two
+    messages drift into describing the same machine as two different machines.
+    Sharing the remedy makes that structural rather than a matter of keeping two
+    literals in step.
+    """
+    monkeypatch.setattr(
+        server, "_workspace_report", _env(manager_detected="legacy-clone")
+    )
+    install_message = _install(["comfyui-impact-pack"], ctx=_FakeCtx())["error"]
+
+    patched_run(
+        "",
+        returncode=1,
+        stderr="\nComfyUI-Manager not found. 'cm-cli' command is not available.\n",
+    )
+    deps_message = server.workflow_deps("/tmp/flux.json")["error"]
+
+    assert server._MANAGER_VENV_REMEDY in install_message
+    assert server._MANAGER_VENV_REMEDY in deps_message
+    # And neither claims more than it knows: the pre-flight saw the clone, the
+    # post-hoc read cannot tell a clone from an absent Manager and says so.
+    assert "LEGACY CLONE" in install_message
+    assert "either it is not installed at all, or it is a legacy clone" in deps_message
 
 
 # --- discoverability --------------------------------------------------------

--- a/tests/test_install_node.py
+++ b/tests/test_install_node.py
@@ -695,6 +695,31 @@ def test_every_cm_cli_less_report_refuses(patched_plain_run, monkeypatch, worksp
     assert calls == []
 
 
+@pytest.mark.parametrize("mode", ["legacy", "not-installed"])
+def test_the_mode_fallback_refuses_without_naming_a_shape(
+    patched_plain_run, monkeypatch, mode
+):
+    """Neither mode value identifies WHICH cm-cli-less shape this install is.
+
+    `server_info`'s own docstring records that a legacy clone under
+    `custom_nodes/` also reports `manager_mode: "not-installed"` — and this
+    fallback runs only on engines old enough to lack `manager_detected`, which is
+    exactly where that conflation is likeliest. So a clone user must not be told
+    they have no Manager and denied the Manager-UI route that still works for
+    them. The refusal is right; naming the cause on this signal is not.
+    """
+    patched_plain_run(0, stderr="installed")
+    monkeypatch.setattr(server, "_workspace_report", _env(manager_mode=mode))
+
+    message = _install(["comfyui-impact-pack"], ctx=_FakeCtx())["error"]
+
+    assert "either it is not installed at all, or it is a legacy clone" in message
+    assert "does not have ComfyUI-Manager at all" not in message
+    # …and the route out of the shape it MIGHT be is still offered, conditionally.
+    assert "If this install is a legacy clone" in message
+    assert "Manager's own UI in the running ComfyUI can still install packs" in message
+
+
 @pytest.mark.parametrize(
     "workspace",
     [
@@ -708,6 +733,22 @@ def test_every_cm_cli_less_report_refuses(patched_plain_run, monkeypatch, worksp
         {"manager_mode": "disable"},
         {"manager_mode": "disable-gui"},
         {"manager_detected": "a-shape-from-a-later-comfy-cli"},
+        # The combination that made the fail-open contract a lie: a vocabulary
+        # from a LATER comfy-cli — which may well name a perfectly usable Manager
+        # — alongside a stale config mode. An unrecognised detection must not
+        # fall through to the mode; the field ANSWERED, and a `"legacy"` string
+        # nobody has corrected does not get to overrule it and refuse an install
+        # that works. Non-string shapes fail open by the same rule.
+        {
+            "manager_detected": "a-shape-from-a-later-comfy-cli",
+            "manager_mode": "legacy",
+        },
+        {
+            "manager_detected": "a-shape-from-a-later-comfy-cli",
+            "manager_mode": "not-installed",
+        },
+        {"manager_detected": ["not", "a", "string"], "manager_mode": "not-installed"},
+        {"manager_detected": None, "manager_mode": "legacy"},
         {},
     ],
 )
@@ -804,19 +845,84 @@ def test_the_preflight_reads_comfy_env_and_never_spawns_the_install(
     assert not any("install" in call["cmd"] for call in calls)
 
 
-def test_a_cm_cli_failure_the_preflight_missed_is_still_relayed_raw(patched_plain_run):
+def test_a_failure_the_preflight_cannot_predict_is_still_relayed_raw(
+    patched_plain_run,
+):
     """The pre-flight is an addition, not a replacement, for comfy-cli's error.
 
     An install can still fail inside `cm-cli` for reasons `comfy env` cannot
-    predict — a Manager removed between the probe and the install, an unreachable
-    channel, a broken pack. comfy-cli's own message is what the caller gets.
+    predict — an unreachable channel, a broken pack, a dependency conflict.
+    comfy-cli's own message is what the caller gets.
     """
-    patched_plain_run(
+    patched_plain_run(1, stderr="\nFailed to install: dependency conflict.\n")
+
+    with pytest.raises(server.ComfyCliError, match="dependency conflict"):
+        _install(["comfyui-impact-pack"], ctx=_FakeCtx())
+
+
+def test_a_cm_cli_gap_the_preflight_failed_open_on_degrades_the_same_way(
+    patched_plain_run, monkeypatch
+):
+    """ONE environment must not answer in TWO shapes.
+
+    The pre-flight fails open, so an unreadable `comfy env` — a probe that timed
+    out, an engine reporting neither field — lets the install run and hit the very
+    gap the probe could not see. Callers are told to check `unsupported` before
+    indexing `["installed"]`; if that path raised a raw `ComfyCliError` instead,
+    the contract would hold only when a subprocess happened to succeed. So
+    comfy-cli's own refusal maps to the same degrade, and — since that message
+    reads identically for a missing Manager and for a clone — claims no shape.
+    """
+    calls = patched_plain_run(
         1, stderr="\nComfyUI-Manager not found. 'cm-cli' command is not available.\n"
     )
+    monkeypatch.setattr(server, "_workspace_report", lambda: None)
+    ctx = _FakeCtx()
 
-    with pytest.raises(server.ComfyCliError, match="cm-cli"):
-        _install(["comfyui-impact-pack"], ctx=_FakeCtx())
+    result = _install(["comfyui-impact-pack"], ctx=ctx)
+
+    assert result["unsupported"] is True
+    assert "installed" not in result
+    assert server._MANAGER_VENV_REMEDY in result["error"]
+    assert (
+        "either it is not installed at all, or it is a legacy clone" in result["error"]
+    )
+    # It failed open, so the user WAS prompted and the install WAS spawned — this
+    # degrade is after the fact, not instead of the attempt.
+    assert len(ctx.elicitations) == 1
+    assert len(calls) == 1
+
+
+def test_an_update_that_starts_during_the_probe_refuses_before_the_prompt(
+    patched_plain_run, monkeypatch
+):
+    """The peek is re-taken after the probe, because the probe is SLOW.
+
+    The pre-flight is a subprocess with a 60-second ceiling, sitting between the
+    first `_UPDATE_LOCK` peek and the prompt. An update that starts inside that
+    window would otherwise be discovered only by the authoritative acquire — i.e.
+    after the user had already approved running third-party code, which is the
+    outcome the peek exists to prevent.
+    """
+    calls = patched_plain_run(0, stderr="installed")
+
+    def _probe_during_which_an_update_starts():
+        server._UPDATE_LOCK.acquire()
+        return {"manager_detected": "venv-package"}
+
+    monkeypatch.setattr(
+        server, "_workspace_report", _probe_during_which_an_update_starts
+    )
+    ctx = _FakeCtx()
+
+    try:
+        with pytest.raises(server.ComfyCliError, match="already running"):
+            _install(["comfyui-impact-pack"], ctx=ctx)
+    finally:
+        server._UPDATE_LOCK.release()
+
+    assert ctx.elicitations == []
+    assert calls == []
 
 
 def test_both_cm_cli_tools_describe_the_same_install_the_same_way(


### PR DESCRIPTION
## ELI-5

Installing a node pack goes through ComfyUI-Manager's `cm-cli`. If your ComfyUI has Manager the old way — cloned into `custom_nodes/` instead of installed into the venv — `cm-cli` isn't there, so that install can never work. Before this, `install_node` asked you to approve downloading and running third-party code, *then* failed with a confusing error and installed nothing. Now it checks first and tells you what's actually wrong, without asking you to approve something impossible.

## Summary

`install_node` forwards to `comfy node install --exit-on-fail`, which comfy-cli runs through `execute_cm_cli`. That function refuses outright — exit 1, no envelope — when `cm_cli` does not import from the workspace Python. A ComfyUI-Manager present only as a **legacy clone** under `custom_nodes/` is exactly that install: fully functional for ComfyUI itself (Manager's UI keeps serving), and unusable by every cm-cli-backed comfy-cli verb. That is the default state of a legacy-clone install, not an exotic edge.

The result was the worst ordering available: raise the consent prompt that says third-party code will be downloaded and run, collect the user's approval, then relay a raw cm-cli error having installed nothing. `workflow_deps` already handled this environment with a structured degrade; `install_node` had no equivalent, even though `workflow_deps`' own message says it shares the failure.

This adds the pre-flight **before** the elicitation — the ordering `switch_comfyui_version` uses for its running-server check, and for the same stated reason — reading fields comfy-cli already computes.

## Changes

- **`_workspace_report()`** — one `comfy env` passthrough returning its `workspace` block, or `None` on any failure. It shells out directly rather than composing `server_info()` the way `_local_comfyui_running()` does: that sibling goes through the tool for the compatibility gate it carries, which matters when the answer decides whether to do something destructive. This probe only decides how to *word* a failure and fails open, so it would swallow that gate's verdict while paying for `server_info`'s other half — a `comfy outdated` freshness probe that reaches the network and whose answer is discarded.
- **`_cm_cli_unavailable_reason()`** — maps `workspace.manager_detected` (`venv-package` / `legacy-clone` / `none`) onto "would a cm-cli verb run", falling back to `manager_mode` (`legacy` / `not-installed`) for an engine that reports only the mode. `manager_detected` is read **first** because it is the input to comfy-cli's own reconciliation rather than its output: the mode is a per-user config key that comfy-cli deliberately leaves alone when it reads `disable` or anything it does not recognise, so a mode can be silent about a Manager that is missing.
- **`install_node`** returns `{"error": ..., "unsupported": True}` — `workflow_deps`' shape — when the probe reports a gap, before the elicitation and before any install is spawned.
- **Shared wording.** `_manager_state_clause()` + `_MANAGER_VENV_REMEDY` describe the environment and its remedy once, for both tools. `workflow_deps` passes `reason=None` because it only sees comfy-cli's refusal, which reads identically for an absent Manager and for a legacy clone — so it now names both possibilities and points at `server_info`'s `manager_detected`, instead of asserting "this ComfyUI install does not have ComfyUI-Manager", which is simply false on a legacy-clone box.
- `AGENTS.md`: the composition rule now covers this pre-flight, per the keep-in-sync rule.

**Fails OPEN, deliberately.** `_local_comfyui_running` fails *closed* because it guards against doing something destructive. This one only improves an error message, and comfy-cli's own refusal is still behind it, so inventing a refusal here would block installs that work. `comfy env` failing, a missing `workspace` block, an unrecognised value, an engine reporting neither field — all proceed and let the engine answer. It is advisory in time as well: a user who installs Manager between the probe and the install just gets an install that works.

## Motivation

Being asked to authorize something that cannot succeed is the part worth fixing. The raw cm-cli error is also actively misleading on this configuration — the user demonstrably *has* ComfyUI-Manager, so "ComfyUI-Manager not found" reads as nonsense. Compare `_run_version_switch`, which remaps a missing `--version` into an actionable upgrade instruction rather than passing through a usage dump.

## Testing

- [x] Existing tests pass (`pytest` — 1756 passed, 3 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — see the falsification below

New coverage in `tests/test_install_node.py`: a legacy clone and a no-Manager install each refuse with **zero elicitations** and **zero `node install` spawns**; both fields are read and the authoritative one wins where they disagree; seven uninformative/healthy reports install normally; six unreadable `comfy env` answers (unparseable body, error envelope, no `workspace`, `workspace: null`, non-mapping payload, spawn failure) read as "no gap"; one end-to-end test drives the real probe through an actual `envelope/1` body and asserts exactly one child ran and it was `env`; a cm-cli failure that survives the pre-flight still relays comfy-cli's own message; and a cross-tool test asserts both tools carry the identical remedy text.

An autouse fixture stubs the `comfy env` READ (not the classification that consumes it) for the rest of the file, so the pre-existing exact-argv assertions still hold and every test that expects an install to proceed is still asserting that a `venv-package` install is allowed to.

### Negative-claim falsification

This diff denies a capability, so the denial was tested empirically rather than asserted. On this machine, against comfy-cli **1.14.0** (this server's floor), on a workspace built into the legacy-clone shape (`custom_nodes/<pack>/cm-cli.py` present, `comfyui_manager` absent from the venv):

```
$ comfy --json --where local --workspace $WS env
... "workspace": {..., "manager_mode": "legacy", "manager_detected": "legacy-clone", ...}

$ comfy --json --where local --workspace $WS node install comfyui-impact-pack --exit-on-fail
ComfyUI-Manager not found. 'cm-cli' command is not available.
exit=1

$ comfy --json --where local --workspace $WS node deps-in-workflow --workflow wf.json --output deps.json
ComfyUI-Manager not found. 'cm-cli' command is not available.
exit=1
```

So the ticket's configuration reproduces exactly, and the denied capability genuinely fails — nothing is installed. Every other path was checked before shipping the refusal:

- **Other tools on this server**: `install_node` is the only one that installs a pack. `node_dependencies` (`comfy node deps`) does **not** need cm-cli and is unaffected.
- **Other comfy-cli verbs**: every `comfy node` install/reinstall/install-deps route goes through the same `execute_cm_cli`, so there is no non-cm-cli install path to redirect to — which is why the message does **not** send the user to `comfy node install` in a terminal.
- **A path that does work**: Manager's own UI in the running ComfyUI still installs packs from a legacy clone, and the refusal names it. The remedy — the `comfyui_manager` package in the workspace venv — is also named, with the terminal command comfy-cli itself runs (`<workspace-python> -m pip install -r manager_requirements.txt`).

The equivalence behind the check is exact rather than inferred: `manager_detected == "venv-package"` **is** comfy-cli's `find_cm_cli()` returning True, and `find_cm_cli()` is the same call `execute_cm_cli` gates every cm-cli-backed verb on.

## Additional Notes

Judgment calls, stated rather than buried:

1. **"Point at the terminal command as the escape hatch"** — the terminal command named is the one that installs Manager into the venv, not `comfy node install`. Pointing at `comfy node install` would be a second guaranteed failure through the identical `cm-cli` (verified above), i.e. exactly the dead-end redirect `workflow_deps` already refuses to make in the other direction.
2. **"Zero subprocesses spawned"** — the pre-flight itself is a `comfy env` passthrough, so it necessarily spawns one child. The tests assert the thing the ordering exists for: `node install` is never spawned, and no prompt is raised. The end-to-end test asserts exactly one child ran and it was `env`.
3. **Degrade shape over an exception** — `{"error", "unsupported": True}` follows the "workflow_deps' shape" instruction. The docstring tells callers to check for `unsupported` before indexing `["installed"]`, mirroring `workflow_deps`' own note.
4. **Sibling gap, deliberately NOT fixed here**: `update_comfyui(target="all")` runs `execute_cm_cli(["update", "all"])` and is consent-gated, so it has the identical approve-then-fail-opaquely problem on the same install. Fixing it is ~3 lines now that the helpers exist, but it is outside this change's scope and its return contract needs its own call — worth a follow-up.
