### PR TITLE
fix: convert spawn-time failures at the four subprocess sites into ComfyCliError (BE-6487)

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -60,6 +60,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import functools
 import ipaddress
 import json
@@ -1970,6 +1971,92 @@ def _timeout_failure(
     return ComfyCliError(message, timed_out=True)
 
 
+def _spawn_failure(
+    cmd: list[str],
+    args: tuple[str, ...],
+    exc: BaseException,
+) -> ComfyCliError:
+    """Format + log a failure to START comfy-cli, and RETURN it for the caller to raise.
+
+    The BACKSTOP under every pre-spawn guard, shared by all four spawn sites
+    (:func:`_run_comfy_raw`, :func:`_run_comfy_async`,
+    :func:`_run_comfy_streaming`, :func:`_start_login`) so a spawn that never
+    happened reports identically wherever it was attempted. Returning rather than
+    raising is :func:`_timeout_failure`'s rationale verbatim: the
+    ``raise ... from exc`` stays at the call site, so each runner remains visibly
+    the thing that failed and the chaining sits where the originating exception is
+    bound.
+
+    It exists because the spawn call sits OUTSIDE the ``try`` that each runner
+    opens around ``communicate()`` / the drain — everything after a successful
+    spawn already has a handler, and a spawn that raised has no child to reap. An
+    exception from the constructor therefore escaped as an unconverted internal
+    error: no :class:`ComfyCliError`, no failure-log line. Reachable in practice
+    because MCP tool arguments cross the wire uncapped for the free-form values
+    (``search_models``'s ``query``, a ``partner_generate`` param), and a big
+    enough one trips the OS limit on ``execve`` — measured on macOS, a ~2 MiB
+    argument raises ``OSError: [Errno 7] Argument list too long``.
+
+    The message names the failure CLASS and the rendered command, and adds
+    nothing else — in particular no separate echo of the offending value, which
+    is by definition the oversized or unencodable one. The rendering is
+    :func:`_cmd_for_message`, the same one :func:`_timeout_failure` uses, so the
+    argv is credential-scrubbed and head-clipped to
+    :data:`_MAX_ERROR_FIELD_CHARS`: a megabyte-long "query" cannot come back
+    whole, while the identifying ``comfy --json --where local <subcommand>``
+    prefix still tells a reader WHICH call could not be started. A value short
+    enough to fit inside that clip does appear, exactly as it does in the timeout
+    and error-envelope messages — the bound is the contract, not omission.
+
+    Four classes, and the isinstance order is load-bearing:
+    :class:`UnicodeEncodeError` is a :class:`ValueError` SUBCLASS, so it has to be
+    tested before the bare-``ValueError`` case that names an embedded NUL, or an
+    unencodable argument would be reported as the wrong mistake.
+
+    This does NOT replace :func:`_reject_nul` / :func:`_guard_arg_len`, which
+    still run first and still produce the better, argument-NAMING error. What
+    lands here is what those cannot see: a value shape they do not cover, an
+    environment that pushes the total over ``ARG_MAX``, or the binary vanishing
+    between :func:`_require_comfy_bin` and the spawn.
+    """
+    rendered = _cmd_for_message(cmd)
+    if isinstance(exc, OSError) and exc.errno == errno.E2BIG:
+        message = (
+            "could not start comfy-cli: the argument list and environment exceed "
+            "this system's limit — shorten the oversized argument and retry: "
+            f"{rendered}"
+        )
+    elif isinstance(exc, UnicodeEncodeError):
+        # Same wording as `_encode_argv`'s refusal, for the same reason it gives:
+        # `os.fsencode` uses the interpreter's filesystem encoding, so under a
+        # non-UTF-8 locale an ordinary multibyte value raises this too. Name the
+        # encoding and offer the usual cause rather than asserting one.
+        message = (
+            "could not start comfy-cli: an argument cannot be encoded with this "
+            f"system's filesystem encoding ({sys.getfilesystemencoding()}), so it "
+            "cannot be passed to comfy-cli as a command-line argument — usually an "
+            "unpaired surrogate, or a character the current locale cannot "
+            f"represent: {rendered}"
+        )
+    elif isinstance(exc, OSError):
+        # `FileNotFoundError` if the binary vanished between `_require_comfy_bin`
+        # and here, `EACCES` if it lost its exec bit, and whatever else the OS
+        # reports. `strerror` is None for an `OSError` raised without one, hence
+        # the fallbacks — an empty diagnosis is worse than a class name.
+        detail = exc.strerror or str(exc) or type(exc).__name__
+        message = f"could not start comfy-cli: {detail}: {rendered}"
+    else:
+        message = (
+            "could not start comfy-cli: an argument contains an embedded NUL: "
+            f"{rendered}"
+        )
+    # No streams and no exit code: there is no child. `args` is still logged (the
+    # subcommand and its flags, scrubbed by `_log_failure`) so a reader can tell
+    # WHICH call could not be started.
+    failure_log._log_failure("spawn_failed", args, message=message)
+    return ComfyCliError(message)
+
+
 def _run_comfy_raw(
     *args: str, timeout: float | None = None
 ) -> tuple[dict | None, str, tuple[str, ...], int, str]:
@@ -1993,38 +2080,44 @@ def _run_comfy_raw(
     # a trailing --json errors with "No such option". (Verified against comfy-cli.)
     cmd = [COMFY_BIN, "--json", "--where", "local", *args]
     env = _comfy_env()
-    proc = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        # This process speaks JSON-RPC over stdio, so the parent's stdin IS
-        # the protocol channel. A child that inherits it (the subprocess
-        # default) can consume request bytes the client sent us — silently
-        # corrupting the session — or block on a prompt nobody can answer.
-        # No comfy-cli invocation here is interactive, so close it outright;
-        # `_comfy_env` also sets GIT_TERMINAL_PROMPT=0 / PIP_NO_INPUT=1 so a
-        # child that WOULD have prompted fails fast instead of hanging.
-        stdin=subprocess.DEVNULL,
-        text=True,
-        # Pin the parent-side decode to UTF-8 so it matches what the child
-        # is forced to emit (_comfy_env). Without this, text=True decodes
-        # the pipe with the system locale (cp1252 on a default Windows
-        # console) and the non-ASCII catalog output raises UnicodeDecodeError
-        # or yields mojibake before _unwrap_envelope — the exact crash this
-        # fix targets, just moved to the reader.
-        encoding="utf-8",
-        env=env,
-        # Own process group so a timeout can kill the whole TREE, exactly as the
-        # streaming path has since BE-3343. comfy-cli's long verbs fork real
-        # work — `update` runs `git pull` and then a multi-GB
-        # `pip install -r requirements.txt`, `model download` streams a large
-        # file — and `subprocess.run` (which this used to be) kills only the
-        # direct `comfy` child on a timeout, so those grandchildren kept
-        # mutating the ComfyUI workspace and Python environment long after the
-        # tool reported failure. `Popen` is what exposes the pid the group kill
-        # needs. See `_kill_proc_tree`.
-        start_new_session=True,
-    )
+    # ONLY the spawn is wrapped: `communicate()` and everything after it already
+    # has the timeout and BaseException handlers below, and a spawn that raised
+    # has no child to reap. See `_spawn_failure`.
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            # This process speaks JSON-RPC over stdio, so the parent's stdin IS
+            # the protocol channel. A child that inherits it (the subprocess
+            # default) can consume request bytes the client sent us — silently
+            # corrupting the session — or block on a prompt nobody can answer.
+            # No comfy-cli invocation here is interactive, so close it outright;
+            # `_comfy_env` also sets GIT_TERMINAL_PROMPT=0 / PIP_NO_INPUT=1 so a
+            # child that WOULD have prompted fails fast instead of hanging.
+            stdin=subprocess.DEVNULL,
+            text=True,
+            # Pin the parent-side decode to UTF-8 so it matches what the child
+            # is forced to emit (_comfy_env). Without this, text=True decodes
+            # the pipe with the system locale (cp1252 on a default Windows
+            # console) and the non-ASCII catalog output raises UnicodeDecodeError
+            # or yields mojibake before _unwrap_envelope — the exact crash this
+            # fix targets, just moved to the reader.
+            encoding="utf-8",
+            env=env,
+            # Own process group so a timeout can kill the whole TREE, exactly as
+            # the streaming path has since BE-3343. comfy-cli's long verbs fork
+            # real work — `update` runs `git pull` and then a multi-GB
+            # `pip install -r requirements.txt`, `model download` streams a large
+            # file — and `subprocess.run` (which this used to be) kills only the
+            # direct `comfy` child on a timeout, so those grandchildren kept
+            # mutating the ComfyUI workspace and Python environment long after the
+            # tool reported failure. `Popen` is what exposes the pid the group
+            # kill needs. See `_kill_proc_tree`.
+            start_new_session=True,
+        )
+    except (OSError, ValueError) as exc:
+        raise _spawn_failure(cmd, args, exc) from exc
     try:
         stdout, stderr = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired as exc:
@@ -3187,21 +3280,27 @@ async def _run_comfy_async(
     # a trailing --json errors with "No such option".
     cmd = [COMFY_BIN, "--json", "--where", "local", *args]
     env = _comfy_env()
-    proc = await asyncio.create_subprocess_exec(
-        *cmd,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        # Same reason as both other spawn sites: this process speaks JSON-RPC
-        # over stdio, so a child that inherits the parent's stdin can eat request
-        # bytes the client sent us. See _run_comfy_raw.
-        stdin=asyncio.subprocess.DEVNULL,
-        env=env,
-        # Own process group so one kill reaps the whole TREE (child +
-        # grandchildren) and closes every inherited copy of the pipes — otherwise
-        # a grandchild holding an fd keeps the drain from ever seeing EOF. See
-        # _kill_proc_tree_async. (BE-3343)
-        start_new_session=True,
-    )
+    # Only the spawn, for the reason `_run_comfy_raw` gives: the `finally` below
+    # already reaps everything a STARTED child needs reaped, and a spawn that
+    # raised produced none. See `_spawn_failure`.
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            # Same reason as both other spawn sites: this process speaks JSON-RPC
+            # over stdio, so a child that inherits the parent's stdin can eat
+            # request bytes the client sent us. See _run_comfy_raw.
+            stdin=asyncio.subprocess.DEVNULL,
+            env=env,
+            # Own process group so one kill reaps the whole TREE (child +
+            # grandchildren) and closes every inherited copy of the pipes —
+            # otherwise a grandchild holding an fd keeps the drain from ever
+            # seeing EOF. See _kill_proc_tree_async. (BE-3343)
+            start_new_session=True,
+        )
+    except (OSError, ValueError) as exc:
+        raise _spawn_failure(cmd, args, exc) from exc
     # Owned by THIS frame, not by the reader coroutines, so a bound that fires
     # mid-transfer still leaves the tail each stream had reached — see
     # `_drain_capped_into`.
@@ -3307,23 +3406,29 @@ async def _run_comfy_streaming(
     # subcommand; a trailing form errors with "No such option".
     cmd = [COMFY_BIN, "--json-stream", "--where", "local", *args]
     env = _comfy_env()
-    proc = await asyncio.create_subprocess_exec(
-        *cmd,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        # Same reason as the plain path: never let a child inherit the stdio
-        # transport's stdin and eat JSON-RPC request bytes. See _run_comfy_raw.
-        stdin=asyncio.subprocess.DEVNULL,
-        env=env,
-        # Own process group so a timeout can kill the whole tree (child +
-        # grandchildren) and close every copy of the stderr pipe — otherwise a
-        # grandchild that inherited the fd keeps the stderr drain from ever
-        # seeing EOF. See _kill_proc_tree_async. (BE-3343)
-        start_new_session=True,
-        # Read granularity, not a maximum line length: `_readline_unbounded`
-        # stitches an over-long line back together rather than raising.
-        limit=_STREAM_LINE_LIMIT,
-    )
+    # Only the spawn — the pump, the drain and the timeout below all belong to a
+    # child that actually started. See `_spawn_failure`.
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            # Same reason as the plain path: never let a child inherit the stdio
+            # transport's stdin and eat JSON-RPC request bytes. See
+            # _run_comfy_raw.
+            stdin=asyncio.subprocess.DEVNULL,
+            env=env,
+            # Own process group so a timeout can kill the whole tree (child +
+            # grandchildren) and close every copy of the stderr pipe — otherwise
+            # a grandchild that inherited the fd keeps the stderr drain from ever
+            # seeing EOF. See _kill_proc_tree_async. (BE-3343)
+            start_new_session=True,
+            # Read granularity, not a maximum line length: `_readline_unbounded`
+            # stitches an over-long line back together rather than raising.
+            limit=_STREAM_LINE_LIMIT,
+        )
+    except (OSError, ValueError) as exc:
+        raise _spawn_failure(cmd, args, exc) from exc
     lines: list[str] = []
     tracker = _StreamProgress()
 
@@ -4242,25 +4347,33 @@ async def _start_login() -> tuple[_LoginChild | None, dict]:
     # block the event loop.
     await asyncio.to_thread(_check_comfy_version)
     args = ("cloud", "login", "--no-browser", "--timeout", str(_LOGIN_TIMEOUT_S))
-    proc = await asyncio.create_subprocess_exec(
-        COMFY_BIN,
-        # Global flags precede the subcommand, as everywhere else. `--json` is
-        # what makes comfy-cli emit the machine `login_url` event (it upgrades
-        # itself to the NDJSON stream to do so); `--where` is deliberately not
-        # forwarded — this verb targets the cloud by definition.
-        "--json",
-        *args,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        # Never let a child inherit the stdio transport's stdin and eat JSON-RPC
-        # request bytes. Same reason as both synchronous spawn sites.
-        stdin=asyncio.subprocess.DEVNULL,
-        env=_comfy_env(),
-        # Own process group so `_kill_proc_tree_async` can take the whole tree
-        # and close every copy of the stderr pipe.
-        start_new_session=True,
-        limit=_LOGIN_LINE_LIMIT,
-    )
+    # Materialized rather than spelled inline at the spawn so `_spawn_failure`
+    # can render the same argv the other three sites hand it. Global flags
+    # precede the subcommand, as everywhere else. `--json` is what makes
+    # comfy-cli emit the machine `login_url` event (it upgrades itself to the
+    # NDJSON stream to do so); `--where` is deliberately not forwarded — this
+    # verb targets the cloud by definition.
+    cmd = [COMFY_BIN, "--json", *args]
+    # Nothing here is caller-supplied — the argv is constants only — so this wrap
+    # is for uniformity plus the two failures that reach a constant argv anyway:
+    # an environment that pushes the total over `ARG_MAX`, and the binary
+    # vanishing between `_require_comfy_bin` and the spawn. See `_spawn_failure`.
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            # Never let a child inherit the stdio transport's stdin and eat
+            # JSON-RPC request bytes. Same reason as both synchronous spawn sites.
+            stdin=asyncio.subprocess.DEVNULL,
+            env=_comfy_env(),
+            # Own process group so `_kill_proc_tree_async` can take the whole tree
+            # and close every copy of the stderr pipe.
+            start_new_session=True,
+            limit=_LOGIN_LINE_LIMIT,
+        )
+    except (OSError, ValueError) as exc:
+        raise _spawn_failure(cmd, tuple(args), exc) from exc
     prefix: list[str] = []
     stderr_task = asyncio.ensure_future(
         _drain_capped_async(proc.stderr, _LOGIN_STREAM_MAX_CHARS)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 
 import pytest
 
@@ -227,6 +228,27 @@ def _raises_at_spawn(exc: BaseException) -> bool:
     )
 
 
+def _encode_argv_like_posix(cmd) -> None:
+    """Raise what a real POSIX spawn would for an argv entry it cannot encode.
+
+    ``subprocess.Popen`` and ``asyncio.create_subprocess_exec`` both render POSIX
+    argv with :func:`os.fsencode`, so an unencodable entry — a lone surrogate, or
+    under a non-UTF-8 locale ordinary multibyte text — raises
+    :class:`UnicodeEncodeError` from the spawn CALL, before any child exists.
+    Every fake below reproduces that instead of accepting any ``str``, so a test
+    can drive that refusal end-to-end rather than injecting the exception and
+    then asserting its own premise.
+
+    A no-op off POSIX, where ``subprocess`` builds a UTF-16 command line for
+    ``CreateProcessW`` and never calls :func:`os.fsencode` at all — the same
+    platform split ``server._encode_argv`` documents.
+    """
+    if os.name != "posix":
+        return
+    for arg in cmd:
+        os.fsencode(arg)
+
+
 class _FakeRunProc:
     """A ``Popen`` stand-in for the plain path: one canned result, no real pipes.
 
@@ -322,6 +344,7 @@ def _canonical_run(calls: list[dict], *, stdout, returncode, stderr, raises, on_
         calls.append(record)
         if raises is not None and _raises_at_spawn(raises):
             raise raises
+        _encode_argv_like_posix(cmd)
         if on_spawn is not None:
             on_spawn(cmd)
         return _FakeRunProc(
@@ -494,16 +517,26 @@ class _RecordingCtx:
 def patched_stream(monkeypatch):
     """Patch ``shutil.which`` + ``asyncio.create_subprocess_exec`` for streaming.
 
-    Returns ``setup(stdout_text) -> procs`` — the list capturing each spawned
-    ``_FakeProc`` (so the test can assert the command line that was run).
+    Returns ``setup(stdout_text, raises=…) -> procs`` — the list capturing each
+    spawned ``_FakeProc`` (so the test can assert the command line that was run).
+
+    ``raises`` is an exception instance the fake raises INSTEAD of returning a
+    child, for the spawn-failure cases (``OSError``, the bare ``ValueError`` an
+    embedded NUL produces) — the streaming counterpart of :func:`patched_run`'s
+    same-named argument. It fires from the spawn call because that is where the
+    real constructor fails; there is no wait-side half here, since a child that
+    started is modelled by the canned stream instead.
     """
 
-    def setup(stdout_text: str) -> list[_FakeProc]:
+    def setup(stdout_text: str, *, raises=None) -> list[_FakeProc]:
         procs: list[_FakeProc] = []
 
         async def fake_exec(
             *cmd, stdout, stderr, env, stdin=None, limit=None, **kwargs
         ):
+            if raises is not None:
+                raise raises
+            _encode_argv_like_posix(cmd)
             proc = _FakeProc(list(cmd), stdout_text, env=env, stdin=stdin, limit=limit)
             procs.append(proc)
             return proc
@@ -591,12 +624,14 @@ def patched_async_run(monkeypatch):
 
     The plain-JSON counterpart to :func:`patched_stream`, for
     ``server._run_comfy_async``. Returns
-    ``setup(stdout=…, returncode=…, stderr=…, hang=…) -> procs`` — the live list of
-    spawned :class:`_FakeAsyncRunProc` objects, so a test can assert the argv, the
-    spawn kwargs, and (on the timeout / cancellation cases) that ``killed`` fired.
+    ``setup(stdout=…, returncode=…, stderr=…, hang=…, raises=…) -> procs`` — the
+    live list of spawned :class:`_FakeAsyncRunProc` objects, so a test can assert
+    the argv, the spawn kwargs, and (on the timeout / cancellation cases) that
+    ``killed`` fired.
 
     ``stdout`` accepts a dict (JSON-encoded for you — pass an :func:`envelope`), a
-    string, or bytes, matching :func:`patched_run`'s ergonomics.
+    string, or bytes, matching :func:`patched_run`'s ergonomics. ``raises`` is the
+    same spawn-failure injection :func:`patched_stream` documents.
     """
 
     def setup(
@@ -605,6 +640,7 @@ def patched_async_run(monkeypatch):
         returncode: int = 0,
         stderr: str = "",
         hang: bool = False,
+        raises=None,
     ) -> list[_FakeAsyncRunProc]:
         if stdout is None:
             stdout = ""
@@ -619,6 +655,9 @@ def patched_async_run(monkeypatch):
         async def fake_exec(
             *cmd, stdout, stderr, env, stdin=None, start_new_session=None
         ):
+            if raises is not None:
+                raise raises
+            _encode_argv_like_posix(cmd)
             proc = _FakeAsyncRunProc(
                 list(cmd),
                 stdout=canned_stdout,

--- a/tests/test_spawn_failure.py
+++ b/tests/test_spawn_failure.py
@@ -1,0 +1,250 @@
+"""A comfy-cli child that never STARTS still fails as a ``ComfyCliError``.
+
+Each of the four spawn sites (``_run_comfy_raw``, ``_run_comfy_async``,
+``_run_comfy_streaming``, ``_start_login``) calls its constructor OUTSIDE the
+``try`` that guards the rest of the run — everything after a successful spawn
+already has a handler, and a spawn that raised has no child to reap. An
+exception from the constructor itself therefore used to escape unconverted: no
+``ComfyCliError``, no failure-log line, just an ``OSError`` surfacing as an
+internal error.
+
+Reachable because MCP tool arguments cross the wire uncapped for the free-form
+values — ``search_models``'s ``query``, a ``run_template`` param — and a big
+enough one trips the OS limit on ``execve`` (measured on macOS: a ~2 MiB
+argument raises ``OSError: [Errno 7] Argument list too long``). The
+pre-spawn guards (``_reject_nul``, ``_guard_arg_len``) still produce the better,
+argument-NAMING error first; ``_spawn_failure`` is the backstop underneath them,
+so what lands here is what those cannot see.
+
+The unencodable-argument tests drive the REAL refusal rather than injecting the
+exception: the conftest fakes render argv with :func:`os.fsencode` exactly as a
+POSIX spawn does (``_encode_argv_like_posix``), so a lone surrogate raises
+``UnicodeEncodeError`` from the fake spawn where the real one would. A test that
+injected the exception would only assert its own premise. Those calls are made
+in-process on purpose: the MCP SDK's wire parser rejects a ``\\ud800`` escape as
+invalid JSON before a tool ever runs, so a direct call is exactly the layer
+these exercise — and the same branch is genuinely reachable over the wire on a
+host whose filesystem encoding is not UTF-8, where ordinary non-ASCII in a
+free-form value fails ``os.fsencode`` too.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import errno
+import json
+
+import pytest
+from conftest import _OK_STREAM, _RecordingCtx
+
+from comfy_mcp import failure_log, server
+
+# Long enough that `_cmd_for_message`'s `_MAX_ERROR_FIELD_CHARS` head slice
+# cannot carry the whole thing into the message — which is the property the
+# oversized-argument tests assert. The marker is distinctive so `in` is a real
+# check rather than an accident of common substrings.
+_OVERSIZED = "SPAWN-FAILURE-MARKER-" * 200
+
+# A lone high surrogate: valid in a Python `str`, and NOT in the DC80..DCFF
+# range `surrogateescape` round-trips, so `os.fsencode` refuses it on any
+# UTF-8 POSIX host.
+_UNENCODABLE = "\ud800abc"
+
+_E2BIG = OSError(errno.E2BIG, "Argument list too long")
+
+
+@pytest.fixture
+def log_path(monkeypatch, tmp_path):
+    """Enable the opt-in failure log at a path under ``tmp_path``.
+
+    Patched on the OWNING module (``failure_log``), per AGENTS.md — patching the
+    re-export-free ``server`` name would raise instead of silently testing
+    nothing.
+    """
+    path = tmp_path / "state" / "failures.jsonl"
+    monkeypatch.setattr(failure_log, "_FAILURE_LOG_PATH", str(path))
+    return path
+
+
+@pytest.fixture
+def fresh_login(monkeypatch):
+    """Reset ``auth_login``'s parked-child globals, as ``test_auth_login`` does.
+
+    The tool caches a live child in module state; a spawn-failure test must not
+    inherit (or leave behind) one from another test.
+    """
+    monkeypatch.setattr(server, "_login_child", None, raising=False)
+    monkeypatch.setattr(server, "_login_lock", None, raising=False)
+    monkeypatch.setattr(server, "_login_lock_loop", None, raising=False)
+
+
+# --- the plain `--json` path (`_run_comfy_raw` / `subprocess.Popen`) ---------
+
+
+def test_oversized_argv_is_a_comfy_cli_error_not_an_oserror(patched_run):
+    """E2BIG from the spawn comes back as the tool error, naming the OS limit."""
+    patched_run(raises=_E2BIG)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.search_models(query=_OVERSIZED)
+
+    message = str(excinfo.value)
+    assert "could not start comfy-cli" in message
+    assert "argument list and environment exceed" in message
+    # The rendered argv is clipped, so the oversized value cannot come back whole
+    # — echoing a megabyte-long "query" is the same denial-of-legibility the
+    # length guards refuse to commit.
+    assert _OVERSIZED not in message
+    assert "models search" in message  # ...but WHICH call still reads clearly
+
+
+def test_oversized_argv_records_a_spawn_failed_entry(patched_run, log_path):
+    """The failure log gets one ``spawn_failed`` line with no exit code."""
+    patched_run(raises=_E2BIG)
+
+    with pytest.raises(server.ComfyCliError):
+        server.search_models(query=_OVERSIZED)
+
+    (entry,) = [
+        json.loads(line) for line in log_path.read_text().splitlines() if line.strip()
+    ]
+    assert entry["kind"] == "spawn_failed"
+    assert entry["exit_code"] is None  # there is no child to have reported one
+    assert entry["args"][:2] == ["models", "search"]
+    assert "argument list and environment exceed" in entry["message"]
+
+
+def test_embedded_nul_valueerror_is_converted(patched_run):
+    """``subprocess``'s bare ``ValueError`` is named as the embedded NUL it is.
+
+    The backstop under :func:`server._reject_nul`, which normally refuses a NUL
+    first and names the argument — this covers a value shape it does not reach.
+    """
+    patched_run(raises=ValueError("embedded null byte"))
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.search_models(query="whatever")
+
+    assert "embedded NUL" in str(excinfo.value)
+
+
+def test_vanished_binary_is_converted_with_its_strerror(patched_run):
+    """A binary that disappears after ``_require_comfy_bin`` reports generically."""
+    patched_run(raises=FileNotFoundError(errno.ENOENT, "No such file or directory"))
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.search_models(query="whatever")
+
+    message = str(excinfo.value)
+    assert "could not start comfy-cli: No such file or directory" in message
+    # NOT diagnosed as the argument-list limit: only E2BIG earns that wording.
+    assert "argument list" not in message
+
+
+def test_unencodable_argument_is_converted_not_raised(patched_run):
+    """A lone surrogate fails as a tool error, naming the filesystem encoding.
+
+    ``UnicodeEncodeError`` is a ``ValueError`` SUBCLASS, so this also pins the
+    isinstance ORDER inside ``_spawn_failure``: tested after it, the same input
+    would come back described as an embedded NUL.
+    """
+    patched_run()
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.search_models(query=_UNENCODABLE)
+
+    message = str(excinfo.value)
+    assert "cannot be encoded with this system's filesystem encoding" in message
+    assert "embedded NUL" not in message
+
+
+def test_unencodable_argument_message_stays_bounded(patched_run):
+    """A long unencodable value is clipped out of the message like any other."""
+    patched_run()
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.search_models(query=_OVERSIZED + _UNENCODABLE)
+
+    assert _OVERSIZED not in str(excinfo.value)
+
+
+# --- the plain-JSON async path (`_run_comfy_async`) --------------------------
+
+
+def test_async_runner_converts_a_spawn_failure(patched_async_run):
+    """The cancellable twin converts identically — same helper, same wording."""
+    patched_async_run(raises=_E2BIG)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        asyncio.run(server._run_comfy_async("model", "download", "--url", "u"))
+
+    assert "argument list and environment exceed" in str(excinfo.value)
+
+
+def test_async_runner_converts_an_unencodable_argument(patched_async_run):
+    """Same real ``os.fsencode`` refusal as the sync path, on the async spawn."""
+    patched_async_run()
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        asyncio.run(server._run_comfy_async("model", "download", "--url", _UNENCODABLE))
+
+    assert "cannot be encoded with this system's filesystem encoding" in str(
+        excinfo.value
+    )
+
+
+# --- the streaming path (`_run_comfy_streaming`) -----------------------------
+
+
+def test_streaming_runner_converts_a_spawn_failure(patched_stream):
+    """``run_workflow(wait=True)`` reports a failed spawn as the tool error."""
+    patched_stream(_OK_STREAM, raises=_E2BIG)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        asyncio.run(server.run_workflow("wf.json", wait=True, ctx=_RecordingCtx()))
+
+    assert "argument list and environment exceed" in str(excinfo.value)
+
+
+def test_streaming_runner_converts_an_unencodable_argument(patched_stream):
+    """The unencodable branch on the streaming spawn, driven at the runner.
+
+    Deliberately NOT through a tool: no streaming tool forwards a raw free-form
+    string to argv today. ``run_workflow`` / ``watch_job`` take only path- and
+    id-shaped values, which ``_guard_arg_len`` / ``_guard_prompt_id`` already
+    refuse first and name; ``run_template``'s params are ``json.dumps``-encoded
+    with the default ``ensure_ascii=True``, which escapes an unencodable
+    character to a pure-ASCII ``\\uXXXX`` before it ever reaches the spawn. The
+    wrap still has to hold for whatever a later tool forwards, so the runner is
+    the honest place to pin it.
+    """
+    patched_stream(_OK_STREAM)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        asyncio.run(server._run_comfy_streaming("jobs", "watch", _UNENCODABLE))
+
+    assert "cannot be encoded with this system's filesystem encoding" in str(
+        excinfo.value
+    )
+
+
+# --- the login path (`_start_login`) ----------------------------------------
+
+
+def test_login_spawn_failure_is_converted(patched_stream, fresh_login):
+    """Constants-only argv, but the environment budget and the binary can still fail.
+
+    ``auth_login`` passes no caller value at all, so this covers the two ways a
+    constant argv still refuses to start: an environment that pushes the total
+    over ``ARG_MAX``, and the binary vanishing between ``_require_comfy_bin`` and
+    the spawn.
+    """
+    patched_stream("", raises=_E2BIG)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        asyncio.run(server.auth_login())
+
+    message = str(excinfo.value)
+    assert "argument list and environment exceed" in message
+    assert "cloud login" in message  # the rendered argv names the verb
+    assert server._login_child is None  # nothing parked: there is no child


### PR DESCRIPTION
## ELI-5

When this server runs a `comfy` command it starts a child process. If the OS refuses to *start* that child at all — because the arguments were too big for `execve`, or one of them couldn't be turned into bytes — the failure came back as a raw Python error instead of the tidy "comfy-cli failed because X" message every other failure produces, and nothing was written to the debug log. This teaches all four places that start a child to say what went wrong in the normal way.

## Summary

The four spawn sites (`_run_comfy_raw`, `_run_comfy_async`, `_run_comfy_streaming`, `_start_login`) each call their process constructor OUTSIDE the `try` that guards the rest of the run. That is correct — everything after a successful spawn already has a timeout / `BaseException` handler, and a spawn that raised has no child to reap — but it left the constructor itself unhandled, so an exception from it escaped as an unconverted internal error: no `ComfyCliError`, no `failure_log` entry.

Reachable in practice: MCP tool arguments cross the stdio wire uncapped for the free-form values (`search_models`'s `query`, a `partner_generate` param, `vary_workflow`'s `--slot` entries), and a big enough one trips the OS limit. Measured on macOS, `Popen(["/bin/echo", "x"*2097152])` raises `OSError: [Errno 7] Argument list too long` from the spawn call.

## Changes

- **`_spawn_failure(cmd, args, exc) -> ComfyCliError`**, next to `_timeout_failure` and mirroring its shape exactly: it builds the message, calls `failure_log._log_failure("spawn_failed", args, message=…)`, and RETURNS the error so each site keeps `raise _spawn_failure(...) from exc` — the same return-not-raise rationale `_timeout_failure`'s docstring gives (the traceback starts at the runner, and the `from exc` chaining stays where the originating exception is bound).
- Four failure classes, with the isinstance order load-bearing because `UnicodeEncodeError` is a `ValueError` subclass: `OSError` with `errno == errno.E2BIG` → the argument-list/environment limit plus "shorten the oversized argument"; `UnicodeEncodeError` → the wording from #184's `_encode_argv` (names `sys.getfilesystemencoding()`, offers the usual causes); any other `OSError` → generic "could not start comfy-cli: `<strerror>`"; the bare `ValueError` → named as an embedded NUL.
- **Only the spawn call is wrapped** at each of the four sites, with `except (OSError, ValueError)`. The wrap was not widened to `communicate()` / `wait()` / the drains.
- `_start_login` had no `cmd` in scope, so its argv is now materialized into one (`[COMFY_BIN, "--json", *args]`) and splatted at the spawn — byte-identical argv, and the helper gets the same rendering the other three hand it.
- **No pre-spawn guard removed or weakened.** `_reject_nul` and `_guard_arg_len` still run first and still produce the better, argument-NAMING error; this is the backstop underneath them.
- **Shared fixtures (`tests/conftest.py`)**: the fakes now render argv with `os.fsencode` exactly as a POSIX spawn does (`_encode_argv_like_posix`), and `patched_stream` / `patched_async_run` gained the `raises=` spawn injection `patched_run` already had.

## Motivation

Ticket BE-6487. This is the last unconverted internal-error path in the wrapper core: #184 capped the path-shaped argv strings, and this is the backstop under everything that guard cannot see — a free-form value it does not cover, an environment that pushes the total over `ARG_MAX`, or the binary vanishing between `_require_comfy_bin` and the spawn.

## Testing

- [x] Existing tests pass (`pytest`) — **1743 passed, 4 skipped**
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [ ] Tested manually

New `tests/test_spawn_failure.py` (11 tests): E2BIG conversion + the `spawn_failed` log entry on the sync path; the bare-`ValueError` NUL backstop; a vanished binary reporting its `strerror` and NOT the argument-list wording; unencodable-argument conversion on the sync, async and streaming spawns; a spawn failure through `run_workflow` (streaming) and `auth_login` (`_start_login`, which also asserts no child is parked).

The unencodable-argument tests drive the REAL refusal rather than injecting the exception — the conftest fakes `os.fsencode` argv the way a POSIX spawn does, so a lone surrogate raises `UnicodeEncodeError` from the fake spawn where the real one would. Injecting it would only assert the test's own premise. Those calls are made in-process on purpose: the SDK wire parser rejects a `\ud800` escape as invalid JSON before a tool ever runs, so a direct call is exactly the layer they exercise — and the branch is genuinely reachable over the wire on a host whose filesystem encoding is not UTF-8, where ordinary non-ASCII in a free-form value fails `os.fsencode` too.

## Additional Notes — judgment calls

**#184 landed first**, so this is rebased on it and reuses its `_encode_argv` message wording verbatim rather than duplicating it, exactly as the coordination note asked.

**The lone-surrogate test on the login path is an OSError case instead.** `_start_login`'s argv is constants-only (the ticket says so), so no caller value can make it unencodable — there is nothing to pass. The login coverage is the `raises=` spawn case the ticket also asks for, plus an assertion that no child is parked afterwards.

**The streaming unencodable test is driven at the runner, not through a tool.** No streaming tool forwards a raw free-form string to argv today: `run_workflow` / `watch_job` take only path- and id-shaped values that `_guard_arg_len` / `_guard_prompt_id` refuse first and name, and `run_template`'s params are `json.dumps`-encoded with the default `ensure_ascii=True`, which escapes an unencodable character to a pure-ASCII `\uXXXX` before it reaches the spawn. That is worth knowing on its own; the wrap still has to hold for whatever a later tool forwards, so the runner is the honest place to pin it. The sync path's test IS tool-level (`search_models`'s `query`), which is the reachable case the ticket describes.

**"Never the offending value's content" is bounded, not absolute.** The message uses `_cmd_for_message(cmd)` as specified, which renders the whole argv scrubbed and head-clipped to `_MAX_ERROR_FIELD_CHARS` (500). So an *oversized* value provably cannot come back whole — that is what the tests assert — but a short value does appear inside the rendered argv, exactly as it already does in the timeout and error-envelope messages. The docstring says this plainly rather than overclaiming omission; adding a second, redacting renderer just for this path would diverge from `_timeout_failure` for no gain.

**A fifth spawn site exists and is deliberately untouched:** `_spawn_comfy_version` (`subprocess.run([COMFY_BIN, "--version"])`). Its argv is constants-only and both callers already wrap it with their own load-bearing failure policies — `_check_comfy_version` catches `PermissionError` (the macOS TCC translation) then `(OSError, SubprocessError)` fail-open, and `_detect_comfy_cli_version` catches `(SubprocessError, OSError)` → `None`. Converting it here would break those policies. Verified, not overlooked.

**Negative-claim falsification (regression case comfy-cloud-mcp-server#581): the trigger does not fire.** The diff adds no "not supported" / "unavailable" / "STOP" string, no throw/deny dead-end, and flips no test to assert a dead-end. Nothing that previously succeeded now fails: every added `except` runs only on a spawn that had ALREADY raised, and the call it converts had already failed with no child started. This change strictly *improves* an existing failure's reporting — it denies no capability, so there is nothing to attempt-and-falsify.
