### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfy-mcp"
-version = "0.6.0"
+version = "0.7.0"
 description = "MCP server for ComfyUI — a thin wrapper over comfy-cli."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/comfy_mcp/__init__.py
+++ b/src/comfy_mcp/__init__.py
@@ -1,3 +1,3 @@
 """comfy-mcp: a thin MCP wrapper over comfy-cli."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"


### PR DESCRIPTION
## ELI-5

The package says what version it is in two places. Both now say `0.7.0` instead of `0.6.0`, so QA has a named build to pull and test against the comfy-cli release that just went out.

Nothing else changes. No behavior, no dependencies, no floor.

## Why now

comfy-cli 1.15.0 shipped a validation fix worth retesting against
([Comfy-Org/comfy-cli#680](https://github.com/Comfy-Org/comfy-cli/pull/680)): a
loader whose option list is empty — `UNETLoader` and `CLIPLoader` on an install
with no models — used to be treated as *unconstrained*, so its missing model was
never reported at all. Detection got worse the emptier the install, which is
backwards for the fresh-install case the pre-flight exists to serve, and the two
silently-skipped loaders are the large downloads.

This server's `validate_workflow` relays comfy-cli's findings, so that fix is
what turns its pre-flight from a confident half-answer into a complete one. QA
needs a version number to pull and report against; `0.6.0` was already tagged on
2026-08-04 as the reference build for the *previous* retest, against 1.14.0.

## What is in the build

The eight commits merged since the `v0.6.0` tag, unchanged by this PR:

1. `#204` — route `upload_file` through the cancellable async runner
2. `#203` — route `workflow_deps` through the cancellable async runner
3. `#202` — `restart_comfyui`: gated kill of a verified untracked server
4. `#201` — bound the validate relay in every direction, not just list length
5. `#200` — read `install_node`'s verdict from the engine's output, not its exit status
6. `#199` — return `comfy validate`'s findings instead of raising an empty error
7. `#198` — convert spawn-time failures at the four subprocess sites into `ComfyCliError`
8. `#197` — pre-flight `install_node`'s cm-cli requirement before the consent prompt

`#199` is the server-side half of the missing-model pre-flight, and pairs with
comfy-cli#680 above: this side stopped discarding the findings, that side stopped
failing to produce two of them. Both are in a tester's hands for the first time
with this build.

## The comfy-cli floor is deliberately NOT raised

`_MIN_COMFY_CLI` stays at `(1, 14, 0)`. Three reasons:

1. **A floor is a minimum, not a pin.** 1.15.0 already satisfies a 1.14.0 floor,
   so a tester running 1.15.0 is unblocked either way. Raising it grants nothing.
2. **It is not a one-line change.** `server.py` mentions `1.14.0` in 39 places
   and only ~8 are floor assertions. The rest are correct history — *"the verdict
   landed in comfy-cli 1.14.0"*, *"the TTL shipped in v1.14.0"* — which a sweep
   would turn into false claims. That deserves its own reviewable PR, not a
   ride-along in a version bump.
3. **The guarantee is already available without code.** Setting
   `COMFY_CLI_MIN_VERSION=1.15.0` makes `server_info` refuse an older comfy-cli
   outright, which is the enforcement a tester actually wants, and it warns
   loudly rather than silently no-opping if the value is unparseable.

## Both version files move together, on purpose

`publish.yml`'s `check-version` job compares the release tag against
`pyproject.toml` **and** `src/comfy_mcp/__init__.py` before any credential is
touched. Bumping one and not the other fails a release at its cheapest gate,
which is the entire point of that job — so they move in one commit.

## Provenance

**Authored by:** Claude Code (Opus 5), interactive session, driven by the
maintainer.

**From:** a request to give QA a tagged build to test against the comfy-cli
release cut earlier today, rather than a PyPI publish. Publishing is explicitly
out of scope here — see Deviations.

**Verified:**

1. `pytest -q` — 1872 passed, 1 skipped, 1 failed. The failure is
   `tests/e2e/test_smoke.py::test_generate_image_round_trip`, the live e2e smoke
   test, which fails on this workstation for lack of an SD1.5 checkpoint
   (`'v1-5-pruned-emaonly-fp16.safetensors' not in 1 known options for
   ckpt_name`). It skips in CI, which has no local ComfyUI, and a version-string
   change cannot affect which models are on disk.
2. `ruff check .` — all checks passed.
3. `ruff format --check .` — 44 files already formatted.
4. Both checks were re-run with the venv's ruff 0.16.0 after a first pass with a
   stray PATH ruff 0.15.15 reported 8 phantom `BLE001` errors. The repo pins
   `ruff>=0.16,<0.17` precisely because 0.16 expanded its default rule set, so
   the older binary does not evaluate this repo's explicit `select`.

**Deviations:** the tag that follows this merge is intended to be **tag-only,
with no GitHub Release** — mirroring `v0.6.0`. `publish.yml` fires on
`release: created`, so a Release would attempt a PyPI publish, and the
`comfy-mcp` name is still unclaimed on PyPI with no trusted publisher
configured. A tag alone gives QA something to check out and publishes nothing.
