### PR TITLE
fix(failure_log): mask every credential URL in a token, not just the first

### DIFF
--- a/src/comfy_mcp/failure_log.py
+++ b/src/comfy_mcp/failure_log.py
@@ -124,14 +124,33 @@ def _scrub_url(url: str) -> str:
 
 
 # A URL ANYWHERE in a recorded string — deliberately not anchored to the start.
-# argv is not all bare URLs: `_render_param_args` emits combined-flag tokens
-# (`--image_url=https://<user>:<pass>@host/x?token=…`, `--param=k={"https://…"}`)
-# whose URL sits mid-token, so a start-anchored test would wave the credential
-# straight through into `args`. Anchoring on the literal scheme still lets the
-# engine skip ahead to a candidate rather than re-scan from every offset, and
-# `\S+` is a possessive-free single-pass match — no backtracking risk on a
-# multi-KB message.
-_URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+# argv is not all bare URLs: `_run_template_param_args` / `_generate_param_args`
+# emit combined-flag tokens (`--image_url=https://<user>:<pass>@host/x?token=…`,
+# `--param=k={"https://…"}`) whose URL sits mid-token, so a start-anchored test
+# would wave the credential straight through into `args`. Anchoring on the
+# literal scheme still lets the engine skip ahead to a candidate rather than
+# re-scan from every offset.
+#
+# The body is `\S`-equivalent but TEMPERED: a match ENDS where the next
+# `https?://` begins, so two URLs glued together with no whitespace between them
+# — a comma/semicolon-separated list inside one `--param=` token, a manifest
+# value, a validator hint — are scrubbed INDEPENDENTLY. A plain `\S+` swallowed
+# the pair as ONE match, and `_scrub_url_match` then masked only the first
+# URL's userinfo while the second's went to the client and to disk verbatim.
+# Tempering costs one bounded lookahead per character consumed and still
+# consumes each character exactly once, so the match stays single-pass and
+# linear — no backtracking risk on a multi-KB message.
+#
+# The tempering STOPS at the first `?`/`#`, after which the rest of the token is
+# taken untempered: past that delimiter `_scrub_url` deletes everything anyway,
+# so splitting there would REVIVE text the scrubber drops today. The case that
+# bites is a query whose value is itself an absolute URL
+# (`?next=https://h2/y&token=…`) — split there, the trailing `&token=…` lands in
+# a second match with no `?` of its own to cut on, and a secret this scrubber
+# masks today would start leaking. Over-redacting a second host out of a debug
+# tail is the right side to err on; the comma-separated list above is
+# unaffected, its delimiter not being `?`.
+_URL_RE = re.compile(r"https?://(?:(?!https?://)[^\s?#])*(?:[?#]\S*)?", re.IGNORECASE)
 
 # The first whitespace-delimited token of a clipped stream window — the one
 # place a URL can appear with its `https://` already sliced off, so the one
@@ -140,8 +159,8 @@ _URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
 _LEADING_TOKEN_RE = re.compile(r"\S*")
 
 # Closing punctuation, peeled off the END of a `_URL_RE` match before scrubbing
-# and re-attached after. `\S+` cannot tell a URL from the character that merely
-# FOLLOWS it, and `_scrub_url` deletes everything from the first `?` — so
+# and re-attached after. `_URL_RE` cannot tell a URL from the character that
+# merely FOLLOWS it, and `_scrub_url` deletes everything from the first `?` — so
 # without this, comfy-cli's `Invalid value for '--url': 'https://h/x?q=1'`
 # comes back having lost its closing quote and the rest of the sentence glued
 # to it, and `_render_error_details`' `", "`-joined entries merge into one

--- a/tests/test_failure_log.py
+++ b/tests/test_failure_log.py
@@ -433,8 +433,9 @@ def test_scrub_arg_cases(arg, expected):
 @pytest.mark.parametrize(
     ("arg", "expected"),
     [
-        # `_render_param_args` emits combined-flag tokens, so the URL is not at
-        # the token's start — a start-anchored test would log the credential.
+        # `_run_template_param_args` / `_generate_param_args` emit combined-flag
+        # tokens, so the URL is not at the token's start — a start-anchored test
+        # would log the credential.
         (
             "--image_url=https://<user>:<tok>@host/x?token=abc",
             "--image_url=https://***@host/x",
@@ -454,9 +455,9 @@ def test_scrub_arg_finds_a_url_anywhere_in_the_token(arg, expected):
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
-        # Click quotes the offending value; `\S+` swallows the closing quote and
-        # `_scrub_url` cuts from the `?`, so the rest of the sentence went with
-        # the query. These messages reach the MCP CLIENT now, not just the log.
+        # Click quotes the offending value; `_URL_RE` swallows the closing quote
+        # and `_scrub_url` cuts from the `?`, so the rest of the sentence went
+        # with the query. These messages reach the MCP CLIENT, not just the log.
         (
             "Invalid value for '--url': 'https://h/x?q=1' is not reachable.",
             "Invalid value for '--url': 'https://h/x' is not reachable.",
@@ -472,16 +473,81 @@ def test_scrub_arg_finds_a_url_anywhere_in_the_token(arg, expected):
         ("'https://<u>:<p>@h/p'", "'https://***@h/p'"),
         # Punctuation INSIDE the URL is still dropped with the rest of the query.
         ("https://h/x?a=1,2,3 next", "https://h/x next"),
+        # Userinfo, a query AND a closing quote at once — the shape the split
+        # below has to leave alone, since a quote is not a scheme boundary.
+        (
+            "quoted 'https://<u>:<p>@h/x?q=1' tail",
+            "quoted 'https://***@h/x' tail",
+        ),
     ],
 )
 def test_scrub_text_keeps_the_punctuation_glued_to_a_url(text, expected):
-    """`_URL_RE`'s `\\S+` cannot tell a URL from what merely FOLLOWS it.
+    """`_URL_RE` cannot tell a URL from what merely FOLLOWS it.
 
     None of the peeled characters is credential material, so restoring them
     gives nothing back — and without them a scrubbed message loses the quote,
     comma or full stop that made it a sentence.
     """
     assert failure_log._scrub_text(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # Two URLs glued by a comma are ONE whitespace-delimited token. Under a
+        # plain `\S+` they matched as one, and only the FIRST one's userinfo was
+        # masked — the second went to the client and to disk verbatim.
+        (
+            "opts: https://<u1>:<p1>@a.invalid/x,https://<u2>:<p2>@b.invalid/y",
+            "opts: https://***@a.invalid/x,https://***@b.invalid/y",
+        ),
+        # Three deep, semicolon-separated: every match ends at the next scheme,
+        # so the run is scrubbed pairwise rather than first-one-wins.
+        (
+            "https://<u1>:<p1>@a.invalid/x;https://<u2>:<p2>@b.invalid/y"
+            ";https://<u3>:<p3>@c.invalid/z",
+            "https://***@a.invalid/x;https://***@b.invalid/y;https://***@c.invalid/z",
+        ),
+        # The second URL keeps its own query cut — the delimiter it anchors on
+        # is inside its own match, not the first URL's.
+        (
+            "https://<u1>:<p1>@a.invalid/x,https://<u2>:<p2>@b.invalid/y?token=s3cret",
+            "https://***@a.invalid/x,https://***@b.invalid/y",
+        ),
+        # …and where the FIRST carries the query, its cut still takes the whole
+        # query with it, second URL included: tempering stops at the `?`.
+        ("https://h/a?token=1,https://h2/b?token=2", "https://h/a"),
+        # The case that keeps the tempering query-bounded: a query VALUE that is
+        # itself an absolute URL. Splitting there would strand `&token=…` in a
+        # second match with no `?` left to cut on, leaking a secret the plain
+        # `\S+` dropped. Over-redacting the nested host is the safe direction.
+        ("https://<u>:<p>@h/x?next=https://h2/y&token=s3cret", "https://***@h/x"),
+        # Regression: one URL with userinfo AND a query is unchanged, and a
+        # string with no URL at all comes back byte-for-byte.
+        ("https://<u>:<p>@h/x?token=s3cret", "https://***@h/x"),
+        (
+            "comfy run wf.json failed: node 3 has no input",
+            "comfy run wf.json failed: node 3 has no input",
+        ),
+    ],
+)
+def test_scrub_text_masks_every_url_in_a_token_not_just_the_first(text, expected):
+    """Adjacent URLs with no whitespace between them scrub independently."""
+    assert failure_log._scrub_text(text) == expected
+
+
+def test_scrub_arg_masks_both_urls_of_a_combined_flag_list():
+    """The argv shape the split exists for: a URL list inside one `--param=`.
+
+    `_run_template_param_args` renders the whole value into a single token, so a
+    caller passing two source images hands the scrubber one `\\S+` run holding
+    two credentials.
+    """
+    arg = '--param=src="https://<u1>:<p1>@a.invalid/x,https://<u2>:<p2>@b.invalid/y"'
+
+    assert failure_log._scrub_arg(arg) == (
+        '--param=src="https://***@a.invalid/x,https://***@b.invalid/y"'
+    )
 
 
 def test_message_is_scrubbed_before_it_is_capped(log_path):
@@ -607,6 +673,42 @@ def test_stream_tail_drops_a_head_fragment_clipped_past_its_query_marker(log_pat
     assert len(entry["stderr_tail"]) <= limit  # it DID take the early return
     assert "SECRETVALUE" not in log_path.read_text()
     assert entry["stderr_tail"].startswith("... https://h/a ")
+
+
+def test_stream_tail_masks_adjacent_urls_around_a_dropped_head_fragment(log_path):
+    """The URL-split and the head-fragment contract hold at the same time.
+
+    Two things share this window: a leading token that is a scheme-shorn URL
+    fragment with a SECOND, full-schemed URL glued to it, and — past the first
+    whitespace, where the head drop cannot reach — a comma-joined pair of full
+    URLs. The pair is what a plain ``\\S+`` matched as one token, masking only
+    the first credential; here both must come out masked. The head fragment
+    keeps today's contract regardless: dropped outright, second URL and all.
+    """
+    limit = failure_log._FAILURE_LOG_TAIL_CHARS
+    head = "user:tok@a.invalid/x,https://<u2>:<p2>@b.invalid/y "
+    pair = "https://<u3>:<p3>@c.invalid/x,https://<u4>:<p4>@d.invalid/y "
+    # Same shrink-to-under-`limit` packing as the tests above: it is the early
+    # return that carries the head fragment (and the pair) out to disk.
+    unit = "https://h/a?token=" + "A" * 100 + " "
+    filler = unit * ((limit * 2 - len(head) - len(pair)) // len(unit))
+    body = head + pair + filler
+    # Exactly `limit * 2` after the scheme, so the window's cut lands right
+    # after `https://` and `head` arrives scheme-shorn.
+    stderr = "Z" * 10_000 + "https://" + body.ljust(limit * 2, "B")
+
+    failure_log._log_failure("no_json", ("run",), stderr=stderr)
+
+    (entry,) = _entries(log_path)
+    assert len(entry["stderr_tail"]) <= limit  # it DID take the early return
+    written = log_path.read_text()
+    for secret in ("user:tok", "<p2>", "<p3>", "<p4>"):
+        assert secret not in written
+    # The head fragment is dropped whole; the pair behind it survives, masked on
+    # BOTH sides of the comma.
+    assert entry["stderr_tail"].startswith(
+        "... https://***@c.invalid/x,https://***@d.invalid/y "
+    )
 
 
 def test_stream_tail_keeps_a_whitespace_free_window_rather_than_emptying_it(log_path):


### PR DESCRIPTION
## ELI-5

The failure log has one function that hides passwords before an error string goes back to the agent or gets written to disk. It found URLs with a pattern that meant "`https://` followed by everything up to the next space" — so when two URLs were stuck together with only a comma between them (`https://a...,https://b...`), it saw them as ONE thing and only scrubbed the first one's password. The second one's password went out in the clear. Now a match stops as soon as the next `https://` starts, so each URL in a run gets scrubbed on its own.

## Summary

`_URL_RE` in `src/comfy_mcp/failure_log.py` was `https?://\S+`. Two URLs adjacent with no whitespace between them — a comma/semicolon-separated list inside a single `--param=KEY=VALUE` argv token from `_run_template_param_args` / `_generate_param_args`, a manifest value, a validator hint — matched as one token, so `_scrub_url_match` → `_scrub_url` → `_redact_url` only ever masked the first URL's userinfo.

Verified against the pre-fix code:

```python
>>> failure_log._scrub_text('opts: https://u1:p1@a.invalid/x,https://u2:p2@b.invalid/y')
'opts: https://***@a.invalid/x,https://u2:p2@b.invalid/y'   # second credential leaks
```

`_scrub_text` is this repo's one credential mask on the way to the MCP **client** as well as to the persisted `failures.jsonl`, so every caller inherited the gap — the argv scrub, the message, both stream tails, and the ~20 `server.py` call sites including `_scrub_deps_manifest` and the `validate_workflow` report relay.

## Changes

- `_URL_RE` is now `https?://(?:(?!https?://)[^\s?#])*(?:[?#]\S*)?` — a tempered body, so a match ends where the next `https?://` begins and `re.sub` scrubs each adjacent URL independently. Everything downstream is untouched: `_scrub_url_match`'s trailing-punctuation peel still sees the delimiter glued to each match's end, `_scrub_url`'s query/fragment cut is unchanged, and `_scrubbed_stream_tail`'s leading-fragment drop/mask contract is unchanged.
- Rewrote the comment block above `_URL_RE` for the new pattern (the old text praised `\S+` as a single-pass no-backtracking match), and refreshed the stale producer name `_render_param_args` → `_run_template_param_args` / `_generate_param_args` there and in its mirror comment in `tests/test_failure_log.py`.
- New tests in `tests/test_failure_log.py`, alongside the existing `test_scrub_*` cases: adjacent pairs and triples through `_scrub_text`, the combined-flag argv shape through `_scrub_arg`, the second-URL-with-a-query case, single-URL and no-URL regressions, the quoted trailing-punctuation shape, and a `_scrubbed_stream_tail` case where a clipped scheme-shorn head fragment and an adjacent URL pair share one window.

## Motivation

Deferred from a review thread on #199 — the defect is in `failure_log`, not the validate relay that PR touched.

## Judgment call — the pattern is also bounded at the query, which the filed plan did not ask for

The ticket specified `https?://(?:(?!https?://)\S)+` (temper everywhere). I shipped the same tempering **stopped at the first `?`/`#`**, because the unbounded form introduces a *new* credential leak in the middle of a change whose whole purpose is closing one:

| input | `main` today | ticket's regex | shipped |
|---|---|---|---|
| `https://<u>:<p>@h/x?next=https://h2/y&token=s3cret` | `https://***@h/x` | `https://***@h/xhttps://h2/y&token=s3cret` | `https://***@h/x` |

When a query *value* is itself an absolute URL, tempering splits there; the trailing `&token=…` then lands in a second match that has no `?` of its own for `_scrub_url` to cut on, so a secret the current code drops starts surviving. Bounding the temper at the delimiter keeps that case byte-identical to `main` — past a `?` the whole remainder is deleted anyway, so there is nothing there worth splitting.

The cost is one case of extra redaction: `https://h/a?token=1,https://h2/b?token=2` yields `https://h/a` rather than `https://h/a,https://h2/b`. Both drop both tokens; the shipped form additionally loses the second host from a debug tail. That is the direction this module already errs in (`_scrub_url` deletes whole query strings sight-unseen, and `_scrubbed_stream_tail` drops a head fragment rather than mask it), and it is a diagnostics loss rather than a disclosure. Both behaviours are pinned by tests, so the trade-off is explicit rather than incidental — reverting to the unbounded form is a one-line change plus deleting two parametrized cases if a reviewer disagrees.

Net effect on matching: the shipped pattern's extent is identical to `\S+`'s in every case *except* an adjacent `https?://` occurring before any `?`/`#` in the token — which is exactly the reported bug and nothing else.

Two smaller calls: credential fixtures use `https://<u1>:<p1>@host` rather than the ticket's literal `u1:p1@`, per AGENTS.md destined-public hygiene (a bare `user:pass@` fails the secret-scanning diff gate); and the ticket's trailing-punctuation case was added to the existing `test_scrub_text_keeps_the_punctuation_glued_to_a_url` table with userinfo added, rather than duplicated as a new test, since that table is where the peel behaviour already lives.

Negative-claim falsification (self-review clause (e)): not triggered. The diff adds no "not supported"/"unavailable"/deny path and denies no capability — it widens redaction inside an existing scrubber. No tests were flipped to assert a dead-end.

## Testing

- [x] Existing tests pass (`pytest`) — 1887 passed, 3 skipped
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — reproduced the leak against the pre-fix code in a REPL (output above), and confirmed each new test genuinely discriminates: reverting `_URL_RE` to `https?://\S+` fails 5 of them, and applying the ticket's unbounded temper fails the 2 that pin the query bound.

## Additional Notes

No behaviour change for any single URL, and no public surface changes — `_URL_RE` and `_scrub_text` are private to `failure_log`.
