### PR TITLE
ci: restore contents:read in the publish job's permissions block

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,6 +91,11 @@ jobs:
       # PyPI is configured to trust this repository + this workflow filename,
       # so there is no long-lived credential to leak or rotate.
       id-token: write
+      # A job-level permissions block zeroes every permission it does not name,
+      # including the workflow-level `contents: read` — without this line the
+      # job's own checkout fails on a private repo with "repository not found"
+      # (how v0.7.0's first publish attempt died).
+      contents: read
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
A job-level `permissions:` block zeroes every permission it does not name. `build-and-publish` declares only `id-token: write`, which dropped the workflow-level `contents: read` — so the job's own checkout failed on the private repo with `repository 'https://github.com/Comfy-Org/comfy-mcp/' not found` (run 31208939835, the first v0.7.0 publish attempt). One line restores it. `check-version` and `verify-install` are unaffected (no job-level permissions of their own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)