### PR TITLE
docs: routing bands are defaults, not a ban

### DIFF
--- a/src/comfy_mcp/instructions.py
+++ b/src/comfy_mcp/instructions.py
@@ -224,7 +224,11 @@ through these steps IN ORDER — a later step never overrides an earlier one:
   Apple-only `ram_bytes` substitution of step 2). A CONFIRMED absence of a
   GPU is the USER telling you there is none — no `hardware` payload states
   it, since a null or absent `gpu` is UNKNOWN by step 3 — and that answer
-  also means do NOT run local diffusion.
+  also means do NOT run local diffusion. These bands are defaults, not a ban
+  the user cannot override: when a model's own documentation — its template
+  notes, or knowledge your client provides — says a workload is slow but
+  feasible on this hardware, quote the time estimate and let the user choose
+  rather than refusing outright.
 - STEP 5, when the answer is "not on this machine", REDIRECT rather than
   dead-end: partner nodes (plain web calls, fine on any machine) or the
   Comfy Cloud MCP if their client has it connected.

--- a/tests/test_routing_instructions.py
+++ b/tests/test_routing_instructions.py
@@ -276,6 +276,21 @@ def test_routing_keeps_video_reachable_on_a_mac_via_a_filter_that_works(routing)
     assert "APPLE-GPU rule, not" in routing
 
 
+def test_routing_lets_the_user_override_a_slow_band_with_a_time_estimate(routing):
+    """The VRAM bands in STEP 4 are defaults an informed user can override.
+
+    The model team's guidance: for some current models, low VRAM means SLOW,
+    not infeasible. An agent that reads STEP 4's bands as a hard floor refuses
+    a run the user might knowingly want to wait for. This repo carries no model
+    knowledge to act on that guidance directly, so the block instead tells the
+    agent to defer to whatever the model's own documentation (template notes,
+    or knowledge the client provides) says, quote the time estimate, and let
+    the user decide — rather than treating the band as a ban.
+    """
+    assert "defaults, not a ban" in routing
+    assert "quote the time estimate" in routing
+
+
 def test_routing_steers_model_choice_to_discovery_not_a_hardcoded_default(routing):
     """No model registry lives in this repo — the agent searches for one.
 


### PR DESCRIPTION
## Summary

The STEP 4 routing block in `src/comfy_mcp/instructions.py` states hard VRAM bands (e.g. "under 8 GB, do NOT run local diffusion") as if they were absolute. The model team's current guidance conflicts with that: for some current models (dynamic-VRAM video models), low VRAM means the run is *slow*, not infeasible. An agent following the bands literally refuses runs a user might knowingly want to wait for.

This PR adds one generic sentence to the end of STEP 4 telling the agent: when a model's own documentation (its template notes, or knowledge the client provides) says a workload is slow-but-feasible on this hardware, quote the time estimate and let the user choose, rather than refusing outright — the bands are defaults, not a ban the user cannot override. No model is named; model knowledge intentionally does not live in this repo.

## Test plan
- [x] Read `tests/test_routing_instructions.py` first; all existing tripwire anchors still pass, block still ends with "current templates track current models."
- [x] Added `test_routing_lets_the_user_override_a_slow_band_with_a_time_estimate`, anchored on "defaults, not a ban" / "quote the time estimate"
- [x] `uv run --no-sync pytest -q` — 1983 passed, 6 deselected
- [x] `tests/test_payload_budget.py` stays green at `_BUDGET_TOKENS = 15_000`
- [x] `ruff check .` and `ruff format --check .` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)