### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfy-mcp"
-version = "0.7.0"
+version = "0.8.0"
 description = "MCP server for ComfyUI — a thin wrapper over comfy-cli."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/comfy_mcp/__init__.py
+++ b/src/comfy_mcp/__init__.py
@@ -1,3 +1,3 @@
 """comfy-mcp: a thin MCP wrapper over comfy-cli."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"


### PR DESCRIPTION
Version bump for the first release from the consolidated surface: the payload diet, six-module split, project anchoring, and the breaking 39-tool consolidation (grouped `job`/`download`/`nodes`) all ship in v0.8.0. The bump is minor-level because the tool surface changed incompatibly relative to 0.7.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)