### PR TITLE
fix: five P1s from the 0.8.0 QA pass (generate_image, search_templates, consent wording, discover size, slot mis-pairing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,37 @@ in the client registration `env` block (shown in every
 the `comfy auth set comfy-cloud-api-key --key …` fallback and the list of offending nodes; the
 server also retries a transient credential failure briefly before surfacing it.
 
+## Confirmation prompts on clients that can't show them
+
+Several tools ask you to confirm before they act: `install_node`,
+`update_comfyui(target="all")`, `switch_comfyui_version`, `restart_comfyui` when it must stop a
+server it did not start, and `launch_comfyui` with `--listen` (which exposes an unauthenticated
+ComfyUI to your network). Each raises an MCP *elicitation* and **fails closed** if it is not
+approved.
+
+Some MCP clients answer that request without ever showing you a prompt. When that happens the
+tool refuses and tells you so — nothing is changed, and the error names the equivalent terminal
+command you can run instead.
+
+If you would rather pre-authorize specific gates, set `COMFY_MCP_ASSUME_CONSENT` in the server's
+environment — the `env` block of your client registration, alongside `COMFY_BIN`:
+
+```jsonc
+"env": { "COMFY_MCP_ASSUME_CONSENT": "install_node,update_all" }
+```
+
+Accepted names: `install_node`, `update_all`, `version_switch`, `kill_untracked`,
+`network_exposure` — or `all` for every one of them. List only what you want; authorizing node
+installs should not silently also authorize binding ComfyUI to every network interface.
+
+This is a setting **you** write, in a file the model cannot edit. That is the point: an agent
+cannot grant itself permission by passing an argument, which is why no tool parameter does this.
+
+**Spending credits is deliberately excluded.** No value — including `all` — pre-authorizes
+`partner_generate`, `run_template` or `run_workflow`. Money keeps a single owner: comfy-cli's own
+durable consent (`comfy generate consent always`). See
+[Spending credits on partner models](#spending-credits-on-partner-models).
+
 ## Spending credits on partner models
 
 `partner_generate` is the one tool whose *whole purpose* is to spend: it wraps `comfy generate

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -2956,10 +2956,15 @@ async def run_workflow(
     accepts an API-format or UI-export file.
 
     Args:
-        wait: if True (default), block until the run finishes, streaming
-            progress as MCP notifications, and return the full result. If
-            False, submit and return with a ``prompt_id`` to poll via
-            ``job(action="status")``.
+        wait: if True (default), block until the run finishes and return the
+            full result. If False, submit and return with a ``prompt_id`` to
+            poll via ``job(action="status")``.
+
+            Progress notifications are EMITTED WHEN THE ENGINE REPORTS ANY —
+            do not rely on them. comfy-cli 1.15.0's stream carries no
+            per-step events for this verb, so in practice a run is silent
+            until it finishes. Poll ``job(action="status")`` from a second
+            call if you need progress.
         timeout_seconds: used only when ``wait=True``; default 110s sits under
             a typical client's ~120s budget. For a longer run, prefer
             ``wait=False`` + ``job(action="wait")``/``job(action="watch")``.
@@ -5104,9 +5109,9 @@ async def job(
     - "wait" -> poll until terminal (default 25.0s, ceiling 3600s); returns the
       final payload, or `{"timed_out": True, "status": <last>}` on expiry — a
       TIMEOUT, not a failure.
-    - "watch" -> stream live progress via MCP notifications (default 600.0s,
-      same ceiling); same `timed_out` (timeout, not failure) shape, but `status` is a live
-      `{progress, total, nodes_done}` snapshot, not a raw status dict.
+    - "watch" -> relay progress notifications while waiting (default 600.0s,
+      same ceiling); `status` is a `{progress, total, nodes_done}` snapshot.
+      comfy-cli 1.15.0 sends no per-step events: expect `progress: null`.
     - "cancel" -> stop a queued/running job.
     - "queue" -> list known jobs (Comfy Cloud-tracked rows filtered out).
 

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -3020,11 +3020,27 @@ async def run_workflow(
             await asyncio.sleep(backoff)
 
 
-# The gallery template `generate_image` runs: ComfyUI's own default graph — the
-# basic SD1.5 text-to-image workflow whose CheckpointLoaderSimple default is
-# `v1-5-pruned-emaonly-fp16.safetensors`. Free (core nodes only, no partner-API
-# node, no `API` gallery tag), so the run never trips comfy-cli's spend gate.
-_T2I_TEMPLATE = "default"
+# The gallery template `generate_image` runs. Free (core nodes only, no
+# partner-API node, no `API` gallery tag), so the run never trips comfy-cli's
+# spend gate.
+#
+# WAS `"default"`, which no longer exists in the gallery — `comfy run-template
+# default` failed with `no template named 'default' in the gallery` on EVERY
+# call, making the documented on-ramp dead. That was not a stale-cache problem:
+# it reproduces on a fresh install with the cache refreshed, and independently on
+# both macOS/MPS and Linux/CUDA hosts. The gallery moved on and this constant
+# rotted with it; the shipped package carries no `default` and no `get_started`.
+#
+# `image_z_image_turbo` is verified present and runnable end to end (a real
+# 512x512 PNG on an RTX 4070 Ti). NOTE it is a SUBGRAPH template: the positive
+# prompt is a promoted proxy widget on instance node 57, hence the `57.text`
+# address rather than a bare `text` — see _T2I_PROMPT_SLOT.
+#
+# Whatever this names must actually exist in the gallery. A hardcoded gallery
+# name is inherently rot-prone, which is exactly how this bug happened, so
+# `_t2i_missing_template_hint` is the durable half of the fix: it turns the next
+# rotation into one actionable error instead of a dead-end hint.
+_T2I_TEMPLATE = "image_z_image_turbo"
 
 # Slot keys for that template's prompt + checkpoint inputs. These VERSION WITH
 # `_T2I_TEMPLATE` — they are properties of that one graph, verified with
@@ -3039,8 +3055,73 @@ _T2I_TEMPLATE = "default"
 # (`workflow_slot_invalid`) rather than guessing which one is the positive
 # prompt. `ckpt_name` is unique in this graph, so the name form is used there —
 # it survives a template revision that renumbers nodes.
-_T2I_PROMPT_SLOT = "6.text"
-_T2I_CHECKPOINT_SLOT = "ckpt_name"
+#
+# The addresses above described the retired `default` graph. `image_z_image_turbo`
+# is a subgraph template and exposes its positive prompt as a promoted proxy
+# widget on instance node 57, so the address is `57.text`.
+_T2I_PROMPT_SLOT = "57.text"
+# EMPTY on purpose. `image_z_image_turbo` loads its weights through
+# UNETLoader/CLIPLoader/VAELoader, not CheckpointLoaderSimple, so there is no
+# `ckpt_name` slot to point `checkpoint=` at — and this is not peculiar to this
+# template: the split-loader layout is now the gallery norm, with NONE of the
+# current free `*_text_to_image` templates carrying a CheckpointLoaderSimple.
+# Left empty so `generate_image(checkpoint=...)` REFUSES by name (see the guard
+# in that tool) instead of addressing a slot the graph does not have, which
+# comfy-cli would reject as `workflow_slot_invalid` mid-run. Set
+# COMFY_T2I_CHECKPOINT_SLOT together with COMFY_T2I_TEMPLATE to re-enable it for
+# a checkpoint-style graph.
+_T2I_CHECKPOINT_SLOT = ""
+
+
+def _t2i_missing_template_hint(
+    exc: ComfyCliError, template: str
+) -> ComfyCliError | None:
+    """Turn comfy-cli's dead-end "no template named" into an actionable error.
+
+    Returns None when ``exc`` is some other failure, so the caller re-raises the
+    original untouched.
+
+    This is the durable half of the `default`-template regression. comfy-cli's own
+    text ends with ``try `comfy templates ls --name <substring>` to search``,
+    which is a dead end for an agent: it does not say WHICH name to search for,
+    and the failure is in a constant the caller never chose. Naming the free
+    text-to-image rows that actually exist turns a hard stop into a next step —
+    and, because the lookup only runs on the failure path, it costs nothing on
+    every healthy call.
+    """
+    if "no template named" not in str(exc).lower():
+        return None
+    try:
+        data = _run_comfy("templates", "ls", "--type", "image", timeout=60.0)
+        rows = data.get("rows", []) if isinstance(data, dict) else []
+        names = sorted(
+            str(r.get("name"))
+            for r in rows
+            if isinstance(r, dict)
+            and r.get("name")
+            and "API" not in (r.get("tags") or [])
+        )
+        suggestions = [n for n in names if "text_to_image" in n or "t2i" in n][
+            :8
+        ] or names[:8]
+    except (ComfyCliError, OSError, ValueError, TypeError, KeyError):
+        # A gallery lookup that itself fails must not mask the real error the
+        # caller came here with — fall back to naming only the broken constant.
+        # Narrow rather than bare `Exception` so a genuine bug in this hint path
+        # still surfaces instead of being swallowed into a vaguer message.
+        suggestions = []
+    tail = (
+        f" Free text-to-image templates currently in the gallery include: "
+        f"{', '.join(suggestions)}."
+        if suggestions
+        else ""
+    )
+    return ComfyCliError(
+        f"generate_image is configured to run template {template!r}, which is not in "
+        f"the gallery.{tail} Set COMFY_T2I_TEMPLATE (with COMFY_T2I_PROMPT_SLOT, and "
+        "COMFY_T2I_CHECKPOINT_SLOT if the graph has one) to a template that exists, "
+        "or use search_templates -> fetch_template -> run_workflow directly."
+    )
 
 
 def _t2i_config() -> tuple[str, str, str]:
@@ -3120,6 +3201,22 @@ async def generate_image(
     # `params` (see module docstring / imports), and a same-named local here
     # would shadow it for the rest of this function.
     template_params: dict[str, Any] = {prompt_slot: prompt}
+    if checkpoint and not checkpoint_slot:
+        # The configured template loads weights through split loaders and has no
+        # checkpoint slot. Refusing by name beats forwarding `checkpoint` to an
+        # empty address, which comfy-cli rejects mid-run as `workflow_slot_invalid`
+        # after the submit — an error about slot syntax for what is really an
+        # unsupported argument on this graph.
+        raise ComfyCliError(
+            f"generate_image(checkpoint=...) is not supported by template "
+            f"{template!r}: it loads weights through UNETLoader/CLIPLoader/"
+            "VAELoader, so there is no checkpoint slot to set. Omit `checkpoint` "
+            "to use the template's own weights, or point the on-ramp at a "
+            "CheckpointLoaderSimple graph by setting COMFY_T2I_TEMPLATE, "
+            "COMFY_T2I_PROMPT_SLOT and COMFY_T2I_CHECKPOINT_SLOT together "
+            "(list a candidate's slots with `comfy templates fetch <name> -o "
+            "wf.json && comfy workflow slots wf.json`)."
+        )
     if checkpoint:
         if checkpoint_slot == prompt_slot:
             # Same key for both slots would have the checkpoint overwrite the
@@ -3153,6 +3250,9 @@ async def generate_image(
         # same verb, so it spends the budget the same way.
         return await _run_template_exec(args, budget, wait=wait, ctx=ctx)
     except ComfyCliError as exc:
+        missing = _t2i_missing_template_hint(exc, template)
+        if missing is not None:
+            raise missing from exc
         hinted = _t2i_slot_hint(
             exc, template, prompt_slot, checkpoint_slot if checkpoint else None
         )

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -3164,7 +3164,13 @@ def _t2i_missing_template_hint(
             for r in rows
             if isinstance(r, dict)
             and r.get("name")
-            and "API" not in (r.get("tags") or [])
+            # Case-insensitive, matching `search_templates`' own
+            # `t.lower() == "api"`: an exact-case test would let a paid row slip
+            # into a list of FREE suggestions, which is the one thing this hint
+            # must not do.
+            and not any(
+                isinstance(t, str) and t.lower() == "api" for t in (r.get("tags") or [])
+            )
         )
         suggestions = [n for n in names if "text_to_image" in n or "t2i" in n][
             :8
@@ -8208,7 +8214,13 @@ def search_templates(
 
     Args:
         query: free-text match over name/title/description/tags/models.
-            Tokenized: EVERY word must prefix a word in the row, so
+            Two passes. A PHRASE pass first — the words must appear
+            consecutively — so ``image to image`` stays img2img rather than
+            matching every ``text to image`` row. Only if that finds nothing
+            does an all-words pass run, and the reply then carries
+            ``match: "all-words"`` so a widened result is never mistaken for an
+            exact one. In the all-words pass: EVERY word must prefix a word in
+            the row, so
             ``MiniMax Text to Video`` finds ``MiniMax H3: Text to Video``, and
             each extra word only narrows. Word-anchored, so ``flux`` finds
             ``flux2`` but ``ext`` does not match ``text``. When nothing matches,
@@ -10621,6 +10633,14 @@ def set_workflow_slot(
     # caught, and one extra `workflow slots` call is cheap next to a corrupted
     # workflow. Best-effort: a probe that cannot run must not block a write that
     # would otherwise be fine, so any failure to inspect falls through.
+    #
+    # COST, accepted deliberately: this doubles the child processes for every
+    # slot write, including the overwhelmingly common clean case. One extra
+    # `workflow slots` is cheap next to silently writing a user's value into the
+    # wrong field of their graph — a corruption that reports success, leaves
+    # `validate_workflow` reporting valid: true, and survives the obvious
+    # read-back check. If the probe ever shows up in a profile, cache it per
+    # (path, mtime) rather than dropping it.
     # The probe is suppressed; the REFUSAL is raised outside it. Raising inside
     # the `suppress` would have it swallow its own exception and write anyway —
     # turning the guard into a no-op that still costs a subprocess.

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -3635,6 +3635,10 @@ class _ApprovalWording(NamedTuple):
     #: Optional trailing sentence naming another route for a client that cannot
     #: be prompted. Begins with a space — it is concatenated, not joined.
     escape_hatch: str = ""
+    #: The name an OPERATOR types in ``COMFY_MCP_ASSUME_CONSENT`` to
+    #: pre-authorize this gate. EMPTY means the gate can never be pre-authorized
+    #: — which is how the spend gates are held out of the mechanism entirely.
+    consent_token: str = ""
 
 
 _SPEND_APPROVAL_WORDING = _ApprovalWording(
@@ -3668,6 +3672,63 @@ _OPTIN_SPEND_APPROVAL_WORDING = _ApprovalWording(
 )
 
 
+# Operator-set pre-authorization for the per-call consent gates.
+#
+# WHY THIS EXISTS. Every gate raises an MCP elicitation and fails closed when it
+# is not affirmatively approved — correct, and unchanged. But the clients agents
+# actually run under (Claude Code, Codex CLI, both verified) answer the
+# elicitation WITHOUT rendering a prompt, so in practice no human is ever asked
+# and five tools are unusable: install_node, update_comfyui(target="all"),
+# switch_comfyui_version, restart_comfyui's kill-untracked, and launch with
+# --listen. The terminal escape hatch each error names is a real answer, but it
+# is not one an agent can take.
+#
+# WHY AN ENVIRONMENT VARIABLE, and not a tool argument. A tool argument is set by
+# the AGENT, so honouring one would let the agent consent on the user's behalf —
+# exactly what these gates exist to prevent, and what the fallback comments
+# elsewhere in this file warn against. This variable lives in the SERVER's
+# environment, written by whoever configured the MCP server (mcp.json, a shell
+# profile, a container spec). The model cannot set it. So it is a human granting
+# consent out-of-band at configuration time, which is the property the
+# elicitation was reaching for in the first place.
+#
+# WHY SPEND IS EXCLUDED. The spend gates carry no `consent_token`, so no value of
+# this variable — including "all" — can pre-authorize them. Money already has a
+# durable, human-set route in comfy-cli itself (`comfy generate consent always`,
+# read via `_engine_auto_confirms`), and a second mechanism would split that
+# policy across two places. Keeping one owner for the spend decision matters more
+# than the symmetry.
+#
+# The value is a COMMA-SEPARATED LIST of gate tokens, or "all". A list rather than
+# a boolean so the operator states what they are authorizing: enabling node
+# installs should not silently also authorize binding ComfyUI to every interface.
+_ASSUME_CONSENT_ENV = "COMFY_MCP_ASSUME_CONSENT"
+
+
+def _preauthorized_gates() -> frozenset[str]:
+    """Gate tokens the operator pre-authorized, lowercased.
+
+    Read per call rather than latched at import, so a test (or a client that
+    re-execs with different env) sees the current value — the same convention
+    `_t2i_config` follows.
+    """
+    raw = os.environ.get(_ASSUME_CONSENT_ENV, "")
+    return frozenset(part.strip().lower() for part in raw.split(",") if part.strip())
+
+
+def _is_preauthorized(wording: _ApprovalWording) -> bool:
+    """Whether this gate was pre-authorized out-of-band by the operator.
+
+    A gate with no token is never pre-authorizable, which is what holds the spend
+    gates out of this mechanism no matter what the variable says.
+    """
+    token = wording.consent_token
+    if not token:
+        return False
+    granted = _preauthorized_gates()
+    return "all" in granted or token.lower() in granted
+
+
 async def _elicit_approval(
     ctx: Context, message: str, schema: type, wording: _ApprovalWording
 ) -> bool:
@@ -3688,6 +3749,17 @@ async def _elicit_approval(
       action, an auto-answer). Failing closed is the same; claiming a human
       refused is not, so that wording is not available to the caller at all.
     """
+    if _is_preauthorized(wording):
+        # Checked BEFORE contacting the client: the operator has already decided,
+        # so prompting would be theatre — and on a client that cannot render one,
+        # it would fail closed against a human who already said yes. Logged so the
+        # approval is auditable rather than invisible.
+        logging.getLogger(__name__).info(
+            "consent pre-authorized for gate %r via %s",
+            wording.consent_token,
+            _ASSUME_CONSENT_ENV,
+        )
+        return True
     try:
         result = await asyncio.wait_for(
             ctx.elicit(message=message, schema=schema),
@@ -5759,6 +5831,7 @@ _NETWORK_APPROVAL_WORDING = _ApprovalWording(
         " If this client cannot show prompts, run "
         "`comfy launch --background -- <flags>` in a terminal instead."
     ),
+    consent_token="network_exposure",
 )
 
 
@@ -6321,6 +6394,7 @@ _KILL_UNTRACKED_APPROVAL_WORDING = _ApprovalWording(
         " If this client cannot show prompts, run `comfy stop --port <PORT>` in a "
         "terminal instead."
     ),
+    consent_token="kill_untracked",
 )
 
 
@@ -6735,6 +6809,7 @@ _UPDATE_ALL_APPROVAL_WORDING = _ApprovalWording(
         " If this client cannot show prompts, run `comfy update all` in a "
         "terminal instead."
     ),
+    consent_token="update_all",
 )
 
 # Said in the prompt AND in the cannot-be-prompted refusal, because both have to
@@ -6931,6 +7006,7 @@ _SWITCH_APPROVAL_WORDING = _ApprovalWording(
         " If this client cannot show prompts, run "
         "`comfy update comfy --version <VERSION>` in a terminal instead."
     ),
+    consent_token="version_switch",
 )
 
 
@@ -7287,6 +7363,7 @@ _INSTALL_APPROVAL_WORDING = _ApprovalWording(
         " If this client cannot show prompts, run "
         "`comfy node install <name>` in a terminal instead."
     ),
+    consent_token="install_node",
 )
 
 

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -10147,6 +10147,78 @@ def validate_workflow(workflow_path: str) -> Any:
     return _relayed_validation_report(report)
 
 
+def _slot_pairing_is_broken(slot: Any) -> bool:
+    """True when a slot's declared TYPE contradicts the value sitting in it.
+
+    Detects `comfy workflow slots` mis-pairing names onto values. comfy-cli zips
+    a node's input names (from ``object_info``) positionally against its
+    ``widgets_values``, so a node whose ``object_info`` under-reports its inputs
+    shifts every later pairing. Observed on the dynamic-combo partner nodes as a
+    class — ``MinimaxHailuo03TextToVideoNode`` exposes 3 inputs against 8
+    ``widgets_values``, which lands ``"MiniMax H3"`` in the ``INT`` slot
+    ``23.seed`` and ``"768P"`` in the ``BOOLEAN`` slot ``23.watermark``.
+
+    That is comfy-cli's bug, not this server's — reproduced with `comfy workflow
+    slots` directly, no MCP involved — and it cannot be repaired here: the true
+    pairing is not recoverable from a payload that has already lost it. What CAN
+    be done is refuse to pass it off as fact, because the failure is otherwise
+    entirely silent: ``validate_workflow`` still reports ``valid: true``, and
+    ``set_workflow_slot`` would write the user's value into the WRONG field.
+
+    Deliberately CONSERVATIVE — only flat contradictions, so a legitimate slot is
+    never flagged. A numeric string in an ``INT`` (``"42"``) and any string in a
+    ``COMBO``/``STRING`` are normal and pass.
+    """
+    if not isinstance(slot, dict):
+        return False
+    declared = str(slot.get("type") or "").upper()
+    value = slot.get("current_value")
+    if not isinstance(value, str):
+        return False
+    if declared in ("INT", "FLOAT"):
+        try:
+            float(value)
+        except ValueError:
+            return True
+    elif declared == "BOOLEAN" and value.strip().lower() not in ("true", "false"):
+        return True
+    return False
+
+
+def _flag_mispaired_slots(data: Any) -> Any:
+    """Annotate a `workflow slots` payload with any mis-paired slots it carries.
+
+    Additive: every original slot is relayed untouched, so nothing an agent
+    already reads disappears. The flag is what turns a silent wrong answer into a
+    visible suspect one.
+    """
+    if not isinstance(data, dict):
+        return data
+    slots = data.get("slots")
+    if not isinstance(slots, list):
+        return data
+    suspect = [
+        str(s.get("address"))
+        for s in slots
+        if _slot_pairing_is_broken(s) and isinstance(s, dict)
+    ]
+    if not suspect:
+        return data
+    for slot in slots:
+        if isinstance(slot, dict) and _slot_pairing_is_broken(slot):
+            slot["pairing_suspect"] = True
+    data["suspect_slots"] = suspect
+    data["warning"] = (
+        f"{len(suspect)} slot(s) hold a value that contradicts their declared type: "
+        f"{', '.join(suspect)}. comfy-cli pairs slot names onto values positionally, "
+        "and a node whose object_info under-reports its inputs shifts every later "
+        "pairing — so these names and values do NOT belong together. Do not set them: "
+        "the write would land in a different field. Edit the workflow JSON directly, "
+        "or use a template without dynamic-combo partner nodes."
+    )
+    return data
+
+
 @mcp.tool()
 def list_workflow_slots(workflow_path: str) -> Any:
     """List the agent-tweakable slots a frontend-format workflow exposes.
@@ -10168,7 +10240,8 @@ def list_workflow_slots(workflow_path: str) -> Any:
     # Bare positional, same as `set_workflow_slot` — a leading-dash path is read
     # as a flag rather than the path comfy-cli is meant to read.
     argv._guard_workflow_path(workflow_path, frontend=True)
-    return _run_comfy("workflow", "slots", workflow_path, timeout=60.0)
+    data = _run_comfy("workflow", "slots", workflow_path, timeout=60.0)
+    return _flag_mispaired_slots(data)
 
 
 @mcp.tool()
@@ -10295,6 +10368,40 @@ def set_workflow_slot(
         )
         argv._reject_nul("override", o)
         rendered.append(o)
+    # REFUSE to write into a slot whose name and value were mis-paired upstream.
+    # This is the half of the mis-pairing bug that actually destroys data: the
+    # write itself "succeeds", `applied` names the address the caller asked for,
+    # and the value silently lands in a DIFFERENT field of the node — with
+    # `validate_workflow` still reporting `valid: true` afterwards. Reading the
+    # slots back (the obvious check) shows the address the caller named, so
+    # nothing looks wrong. Failing closed here is the only point where it can be
+    # caught, and one extra `workflow slots` call is cheap next to a corrupted
+    # workflow. Best-effort: a probe that cannot run must not block a write that
+    # would otherwise be fine, so any failure to inspect falls through.
+    # The probe is suppressed; the REFUSAL is raised outside it. Raising inside
+    # the `suppress` would have it swallow its own exception and write anyway —
+    # turning the guard into a no-op that still costs a subprocess.
+    targeted: list[str] = []
+    with contextlib.suppress(Exception):
+        probe = _flag_mispaired_slots(
+            _run_comfy("workflow", "slots", workflow_path, timeout=60.0)
+        )
+        if isinstance(probe, dict):
+            suspect = {str(a) for a in probe.get("suspect_slots") or []}
+            targeted = sorted(
+                a for a in suspect if any(r.startswith(f"{a}=") for r in rendered)
+            )
+    if targeted:
+        raise ComfyCliError(
+            f"refusing to set {', '.join(targeted)}: comfy-cli reports these "
+            "slots with a value that contradicts their declared type, which "
+            "means their names were paired onto the wrong values (positional "
+            "zip against a node whose object_info under-reports its inputs). "
+            "The write would land in a different field and validate_workflow "
+            "would still say valid: true. Edit the workflow JSON directly, or "
+            "use a template without dynamic-combo partner nodes. "
+            "list_workflow_slots names every affected slot."
+        )
     args = ["workflow", "set-slot", workflow_path, *rendered]
     if stdout:
         args.append("--stdout")

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -1474,8 +1474,10 @@ def _unwrap_envelope(
                 "<workspace> switch master`), then retry. To move between "
                 "releases instead, use `switch_comfyui_version`, which does not "
                 "need a branch. `server_info` reports the workspace path.\n\n"
-                "Original error: "
+                "Original error: stderr: "
                 f"{failure_log._scrubbed_stream_tail(stderr, errors._MAX_ERROR_FIELD_CHARS)}"
+                " | stdout: "
+                f"{failure_log._scrubbed_stream_tail(stdout, errors._MAX_ERROR_FIELD_CHARS)}"
             )
             failure_log._log_failure(
                 "no_json",
@@ -3183,7 +3185,11 @@ def _t2i_missing_template_hint(
         f"generate_image is configured to run template {template!r}, which is not in "
         f"the gallery.{tail} Set COMFY_T2I_TEMPLATE (with COMFY_T2I_PROMPT_SLOT, and "
         "COMFY_T2I_CHECKPOINT_SLOT if the graph has one) to a template that exists, "
-        "or use search_templates -> fetch_template -> run_workflow directly."
+        "or use search_templates -> fetch_template -> run_workflow directly.",
+        # Preserve comfy-cli's structured code, the way `_t2i_slot_hint` does:
+        # rewriting the prose must not silently drop the field a caller branches
+        # on (`template_not_found`).
+        code=getattr(exc, "code", None),
     )
 
 
@@ -3272,8 +3278,10 @@ async def generate_image(
         # unsupported argument on this graph.
         raise ComfyCliError(
             f"generate_image(checkpoint=...) is not supported by template "
-            f"{template!r}: it loads weights through UNETLoader/CLIPLoader/"
-            "VAELoader, so there is no checkpoint slot to set. Omit `checkpoint` "
+            f"{template!r}: no checkpoint slot is configured for it, so there is "
+            "nothing to set. (The built-in on-ramp template loads weights through "
+            "UNETLoader/CLIPLoader/VAELoader rather than CheckpointLoaderSimple, "
+            "which is now the gallery norm.) Omit `checkpoint` "
             "to use the template's own weights, or point the on-ramp at a "
             "CheckpointLoaderSimple graph by setting COMFY_T2I_TEMPLATE, "
             "COMFY_T2I_PROMPT_SLOT and COMFY_T2I_CHECKPOINT_SLOT together "
@@ -4331,10 +4339,24 @@ def _stamp_partner_provenance(out_path: str, model: str) -> dict[str, Any] | Non
             meta = {}
             node["_meta"] = meta
         meta[_PROVENANCE_KEY] = block
+    # ATOMIC, because the alternative destroys the caller's file. Opening
+    # `out_path` with "w" truncates the emitted workflow before `json.dump`
+    # finishes; a failure part-way (full disk, a serialization error) would
+    # leave a half-written or empty graph where a perfectly good one was, and
+    # the emit that produced it has already returned. Write a sibling temp file,
+    # fsync it, then `os.replace` — which is atomic on the same filesystem, so
+    # a reader sees either the original or the stamped version, never a stump.
+    tmp_path = f"{out_path}.comfy-mcp.tmp"
     try:
-        with open(out_path, "w", encoding="utf-8") as fh:
+        with open(tmp_path, "w", encoding="utf-8") as fh:
             json.dump(graph, fh, indent=2)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, out_path)
     except OSError:
+        # Best-effort cleanup; the original file is untouched either way.
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
         return None
     return block
 
@@ -10344,7 +10366,7 @@ def _flag_mispaired_slots(data: Any) -> Any:
     suspect = [
         str(s.get("address"))
         for s in slots
-        if _slot_pairing_is_broken(s) and isinstance(s, dict)
+        if isinstance(s, dict) and _slot_pairing_is_broken(s)
     ]
     if not suspect:
         return data

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -7769,23 +7769,100 @@ _TEMPLATE_LIST_FIELDS = (
 _TEMPLATE_LIST_MAX_LIMIT = 200
 
 
-def _template_matches(row: dict, query_lower: str) -> bool:
-    """True if ``query_lower`` (already lowercased) matches a template ``row``.
+# Words, for query tokenizing and row indexing. Splitting on anything that is not
+# alphanumeric is what lets `MiniMax H3: Text to Video` be found by
+# `MiniMax Text to Video` — the colon and the `H3` no longer have to be typed.
+_TEMPLATE_WORD_RE = re.compile(r"[a-z0-9]+")
 
-    Case-insensitive substring match over the free-text fields ``name`` /
-    ``title`` / ``description`` plus the string items inside the ``tags`` and
-    ``models`` list values — deliberately NOT every string value, so a query
-    like ``"image"`` does not hit ``output_type`` on hundreds of rows.
+
+def _template_words(row: dict) -> list[str]:
+    """Every searchable word in a template ``row``, lowercased.
+
+    ``name``/``title``/``description`` plus the string items inside ``tags`` and
+    ``models`` — deliberately NOT every string value, so a query like ``image``
+    does not hit ``output_type`` on hundreds of rows.
     """
+    words: list[str] = []
     for key in ("name", "title", "description"):
         value = row.get(key)
-        if isinstance(value, str) and query_lower in value.lower():
-            return True
+        if isinstance(value, str):
+            words += _TEMPLATE_WORD_RE.findall(value.lower())
     for key in ("tags", "models"):
         for item in row.get(key) or []:
-            if isinstance(item, str) and query_lower in item.lower():
-                return True
+            if isinstance(item, str):
+                words += _TEMPLATE_WORD_RE.findall(item.lower())
+    return words
+
+
+def _template_phrase_matches(row: dict, query_lower: str) -> bool:
+    """True if the query's words appear CONSECUTIVELY in ``row``.
+
+    The precise pass. Word-anchored rather than a raw substring test, so
+    ``image to image`` still means img2img and does not also match the
+    ``text to image`` rows, while the mid-word fragment ``ext to imag`` — which
+    the old substring test happily matched inside ``text to image`` — cannot
+    match anything.
+
+    The final token may be a PREFIX so that partial typing keeps working while
+    the phrase is still being typed (``image to ima`` finds img2img); every
+    earlier token must be a whole word, which is what preserves the ordering.
+    """
+    tokens = _TEMPLATE_WORD_RE.findall(query_lower)
+    if not tokens:
+        return True
+    words = _template_words(row)
+    last = len(tokens) - 1
+    for start in range(len(words) - len(tokens) + 1):
+        if all(
+            words[start + i].startswith(tok) if i == last else words[start + i] == tok
+            for i, tok in enumerate(tokens)
+        ):
+            return True
     return False
+
+
+def _template_matches(row: dict, query_lower: str) -> bool:
+    """True if every word of ``query_lower`` prefixes some word in ``row``.
+
+    WAS a raw substring test over the same fields, which failed in both
+    directions on the gallery's primary discovery path:
+
+    * FALSE NEGATIVES — the first phrasing anyone types. ``basic text to image``,
+      ``text image`` and ``MiniMax Text to Video`` all returned 0, the last one
+      despite ``MiniMax H3: Text to Video`` existing, because the stored title
+      has ``H3:`` in the middle and a substring test needs the phrase contiguous.
+      A clean ``total: 0`` is indistinguishable from "no such capability", so the
+      failure reads as absence rather than as a bad query.
+    * FALSE POSITIVES — mid-word fragments. ``ext to imag`` matched the same 91
+      rows as ``text to image``, and ``o Image`` matched 118 by landing inside
+      ``two images``.
+
+    Tokenized AND-matching fixes the first; anchoring each token at a WORD START
+    fixes the second while keeping the partial typing people rely on (``flux``
+    still finds ``flux2``, and ``t2v`` still finds ``t2v``). An all-tokens-must-
+    match rule means adding a word can only ever narrow, which is what makes
+    refining a search behave predictably.
+    """
+    tokens = _TEMPLATE_WORD_RE.findall(query_lower)
+    if not tokens:
+        return True
+    words = _template_words(row)
+    return all(any(word.startswith(token) for word in words) for token in tokens)
+
+
+def _unmatched_template_tokens(rows: list[dict], query_lower: str) -> list[str]:
+    """Query words that prefix NO word in any row — why a search came back empty.
+
+    A bare ``total: 0`` cannot distinguish "this capability does not exist" from
+    "one word of your query was wrong", and on a discovery tool that difference
+    decides whether an agent reports a feature missing. Naming the dead words
+    turns the retry into an obvious one.
+    """
+    tokens = _TEMPLATE_WORD_RE.findall(query_lower)
+    if not tokens:
+        return []
+    vocabulary = {word for row in rows for word in _template_words(row)}
+    return [t for t in tokens if not any(word.startswith(t) for word in vocabulary)]
 
 
 @mcp.tool()
@@ -7810,6 +7887,11 @@ def search_templates(
 
     Args:
         query: free-text match over name/title/description/tags/models.
+            Tokenized: EVERY word must prefix a word in the row, so
+            ``MiniMax Text to Video`` finds ``MiniMax H3: Text to Video``, and
+            each extra word only narrows. Word-anchored, so ``flux`` finds
+            ``flux2`` but ``ext`` does not match ``text``. When nothing matches,
+            the reply carries ``unmatched_query_words`` naming the dead words.
         tag/type/model/provider: forwarded filters (``tag``/``type`` exact,
             ``model``/``provider`` substring).
         exclude_api: drop ``API``-tagged rows.
@@ -7870,20 +7952,51 @@ def search_templates(
                 isinstance(t, str) and t.lower() == "api" for t in r.get("tags") or []
             )
         ]
+    unmatched: list[str] = []
+    relaxed = False
     if query:
         q = query.lower()
-        rows = [r for r in rows if _template_matches(r, q)]
+        candidates = rows
+        # TWO PASSES, precise first. The phrase pass keeps a multi-word query
+        # meaning what it says (`image to image` is img2img, not every
+        # `text to image` row); the token pass is what rescues the phrasings the
+        # old substring test dropped to a bare `total: 0` — a title with
+        # something in the middle (`MiniMax H3: Text to Video` for
+        # `MiniMax Text to Video`) or words the author never wrote contiguously.
+        # Falling back only when the precise pass finds NOTHING means recall is
+        # gained without ever diluting a query that already worked.
+        rows = [r for r in candidates if _template_phrase_matches(r, q)]
+        if not rows:
+            rows = [r for r in candidates if _template_matches(r, q)]
+            relaxed = bool(rows)
+        if not rows:
+            # Only computed on the empty path, where it is the whole value: a
+            # populated result needs no explanation.
+            unmatched = _unmatched_template_tokens(candidates, q)
 
     total = len(rows)
     offset = max(0, offset)
     page = rows[offset : offset + limit]
     projected = [{k: r.get(k) for k in _TEMPLATE_LIST_FIELDS} for r in page]
-    return {
+    result = {
         "total": total,
         "shown": len(projected),
         "offset": offset,
         "rows": projected,
     }
+    if relaxed:
+        # Say so rather than silently widening: these rows contain every query
+        # word but not as the phrase that was typed, which is worth knowing
+        # before picking one.
+        result["match"] = "all-words"
+    if unmatched:
+        result["unmatched_query_words"] = unmatched
+        result["hint"] = (
+            f"No template matched every word. These matched nothing in the gallery: "
+            f"{', '.join(unmatched)}. Drop or reword them and search again — all "
+            "query words must match, so each extra word only narrows the result."
+        )
+    return result
 
 
 # Cap on how many validator findings ride back in a template's `local_check` —

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -7716,19 +7716,29 @@ def get_logs(tail: int = 200, port: int | None = None) -> Any:
 
 
 @mcp.tool()
-def discover(schemas_only: bool = True) -> Any:
+def discover(schemas_only: bool = True, command: str = "") -> Any:
     """Return comfy-cli's self-describing command surface (its own contract).
 
     Wraps ``comfy discover`` so an agent can learn the CLI's contract at
     runtime instead of hard-coding it.
 
-    ``schemas_only`` (default True) forwards ``--schemas-only``: returns just
-    the schema bundle (~9k tokens) — argument/capability schemas, NOT the
-    ``commands`` tree or ``error_codes``. Pass ``schemas_only=False`` for
-    those too, in the full surface (~45k tokens, ~5x bigger — measured on
-    comfy-cli 1.13.0). Default is slim because MCP clients cap tool output
-    (e.g. Claude Code's ``MAX_MCP_OUTPUT_TOKENS``, default 25,000) by
-    TRUNCATING mid-JSON — the full tree can silently come back broken.
+    Args:
+        schemas_only: forwards ``--schemas-only`` to the CLI (default True).
+        command: return ONE schema body by name instead of the index.
+
+    Sizes matter here because MCP clients cap tool output (e.g. Claude Code's
+    ``MAX_MCP_OUTPUT_TOKENS``, default 25,000) by TRUNCATING mid-JSON, so an
+    oversized reply comes back broken rather than short:
+
+    - ``discover()`` — the default. Capabilities, version, command schemas, and
+      a ``schema_index`` of names. A couple of KB; always under the cap.
+    - ``discover(command="run")`` — one schema body (~1.6 KB).
+    - ``discover(schemas_only=False)`` — the entire surface, ``commands`` tree
+      and ``error_codes`` included. Big; only for a client with a raised cap.
+
+    The default USED to return all 35 schema bodies — ~63 KB from the CLI and
+    ~109 KB once pretty-printed, which exceeded a standard cap and made the tool
+    uncallable at its own default. Measured on comfy-cli 1.15.0.
     """
     args = ["discover"]
     if schemas_only:
@@ -7736,7 +7746,47 @@ def discover(schemas_only: bool = True) -> Any:
         # shipped in the same comfy-cli commit that introduced `discover`, so
         # any build carrying the command carries the flag.
         args.append("--schemas-only")
-    return _run_comfy(*args, timeout=60.0)
+    data = _run_comfy(*args, timeout=60.0)
+
+    # Everything below narrows what comes BACK; the child call is unchanged.
+    #
+    # Measured on comfy-cli 1.15.0: the default payload is ~63 KB of compact JSON
+    # from the CLI, and ~109 KB once a client pretty-prints it — over a standard
+    # 25,000-token cap, so the tool was rejected outright and could not be called
+    # AT ALL at its default setting. `schemas` is ~95% of that (35 entries,
+    # ~1.6 KB each) while `capabilities`/`version`/`command_schemas` together are
+    # ~2.7 KB.
+    #
+    # So the default now returns an INDEX of the schema names instead of every
+    # schema body. That is a deliberate response-shape change: a tool that
+    # exceeds the client cap returns nothing usable, and a truncated mid-JSON
+    # reply is worse than a small complete one. Any single schema is one more
+    # call away via `command=`, and `schemas_only=False` still returns the whole
+    # surface for a client that can take it.
+    if not isinstance(data, dict):
+        return data
+    schemas = data.get("schemas")
+    if not isinstance(schemas, dict):
+        return data
+    if command:
+        entry = schemas.get(command)
+        if entry is None:
+            raise ComfyCliError(
+                f"discover: no schema named {command!r}. Available: "
+                f"{', '.join(sorted(schemas))}."
+            )
+        return {"schema": entry, "version": data.get("version")}
+    if schemas_only:
+        slim = {k: v for k, v in data.items() if k != "schemas"}
+        slim["schema_index"] = sorted(schemas)
+        slim["hint"] = (
+            f"{len(schemas)} schema bodies omitted (~"
+            f"{len(json.dumps(schemas, separators=(',', ':'))) // 1024} KB, over a "
+            'typical MCP client\'s output cap). Call discover(command="<name>") '
+            "for one, or discover(schemas_only=False) for the whole surface."
+        )
+        return slim
+    return data
 
 
 @mcp.tool()

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -3607,6 +3607,15 @@ async def _elicit_approval(
     ``target="all"``), and the launch pair's network-exposure gate. Only the
     message, the answer schema, and ``wording`` differ; the fail-closed handling
     below must not. True = the user affirmatively approved.
+
+    Three outcomes, not two — the distinction the QA pass found missing:
+
+    * True — a person saw the prompt and approved.
+    * False — a person saw the prompt and DECLINED (``action == "decline"``).
+      Only here may a caller say "the user declined".
+    * raises — the client never got a decision to us (``"cancel"``, a missing
+      action, an auto-answer). Failing closed is the same; claiming a human
+      refused is not, so that wording is not available to the caller at all.
     """
     try:
         result = await asyncio.wait_for(
@@ -3630,8 +3639,27 @@ async def _elicit_approval(
     # Every read is a `getattr`: a non-conforming client can return an object
     # with no `.action`/`.data`, and an AttributeError here would escape as an
     # uncaught crash instead of the refusal this contract promises.
-    if getattr(result, "action", None) != "accept":
-        return False
+    action = getattr(result, "action", None)
+    if action != "accept":
+        # "DECLINE" is a person saying no. Anything else — "cancel", a missing
+        # action, a client that resolves the request without ever rendering it —
+        # is NOT a decision, and reporting it as one is a lie about a human.
+        #
+        # This is the bug behind "the user declined ..." appearing in sessions
+        # where no prompt was ever displayed, across four different gates: every
+        # non-accept answer collapsed into the same False, and each caller then
+        # raised its "the user declined" text. Failing closed was right; naming a
+        # refusal nobody made was not — it sends the reader to argue with a user
+        # who was never asked, and hides that the client is the thing that needs
+        # fixing.
+        if action == "decline":
+            return False
+        raise ComfyCliError(
+            f"{wording.subject} not confirmed: the client did not present the "
+            f"confirmation prompt (it answered {action!r} without a user "
+            f"decision), so nobody was asked. {wording.nothing_done}"
+            f"{wording.escape_hatch}"
+        )
     return getattr(getattr(result, "data", None), "approve", False) is True
 
 

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -1063,6 +1063,28 @@ def _run_comfy(*args: str, timeout: float | None = None, plain_ok: bool = False)
     return _unwrap_envelope(real_envelope, args, returncode, stderr, stdout=stdout)
 
 
+# git's own wording, and the state it describes. Matched on BOTH streams because
+# comfy-cli splits diagnostics unpredictably — the traceback lands on stderr
+# while a status line can land on stdout.
+_DETACHED_HEAD_MARKERS = (
+    "you are not currently on a branch",
+    "detached head",
+)
+
+
+def _looks_like_detached_head(stderr: str, stdout: str) -> bool:
+    """True when a failed comfy-cli run is really "this checkout has no branch".
+
+    Deliberately narrow: it must ALSO look like the git pull path, so an
+    unrelated failure that happens to quote the phrase (a log line, a node pack
+    README) cannot claim this branch and hide its own cause.
+    """
+    blob = f"{stderr}\n{stdout}".lower()
+    if not any(marker in blob for marker in _DETACHED_HEAD_MARKERS):
+        return False
+    return "git" in blob and ("pull" in blob or "branch" in blob)
+
+
 def _envelope_schema(envelope: dict) -> str | None:
     """The envelope's declared ``schema`` string (e.g. ``"envelope/1"``), or None."""
     value = envelope.get("schema")
@@ -1419,6 +1441,42 @@ def _unwrap_envelope(
             # envelope, not a different kind of failure. Unlike the message, the
             # record keeps the raw stdout too: a diagnostic trail is read after
             # the fact, when a curated guidance string is no longer enough.
+            failure_log._log_failure(
+                "no_json",
+                args,
+                exit_code=returncode,
+                message=message,
+                stdout=stdout,
+                stderr=stderr,
+                streaming=streaming,
+            )
+            raise ComfyCliError(message, no_envelope=True, returncode=returncode)
+        if _looks_like_detached_head(stderr, stdout):
+            # comfy-cli runs `git pull` and, on failure, raises
+            # CalledProcessError — discarding git's own stderr, which already
+            # said exactly what is wrong ("You are not currently on a branch").
+            # What reaches the client is a raw Python traceback in rich
+            # box-drawing frames wrapped as "returned no JSON (exit 1)": the one
+            # actionable sentence is buried, and may be clipped away entirely by
+            # the field cap below.
+            #
+            # A detached HEAD is a NORMAL state — it is what a tag-pinned install
+            # looks like, and `switch_comfyui_version` produces one — so this is
+            # a routine condition being reported as a crash. Named here for the
+            # same reason the TCC branch above is: the cause is identifiable, so
+            # the caller should get the fix rather than the stack.
+            message = (
+                f"update_comfyui cannot pull (exit {returncode}): this ComfyUI "
+                "checkout is on a DETACHED HEAD, so `git pull` has no branch to "
+                "pull into. That is the normal state of a version-pinned "
+                "install — `switch_comfyui_version` leaves one behind.\n\n"
+                "Fix: check out a branch before updating (e.g. `git -C "
+                "<workspace> switch master`), then retry. To move between "
+                "releases instead, use `switch_comfyui_version`, which does not "
+                "need a branch. `server_info` reports the workspace path.\n\n"
+                "Original error: "
+                f"{failure_log._scrubbed_stream_tail(stderr, errors._MAX_ERROR_FIELD_CHARS)}"
+            )
             failure_log._log_failure(
                 "no_json",
                 args,
@@ -4192,7 +4250,88 @@ async def emit_partner_workflow(
     # the 120s backstop fires. On the default executor a run of cancelled calls
     # would pin those workers and starve every other tool that off-loads through
     # `to_thread`. See `_GENERATE_EXECUTOR`.
-    return await _in_generate_pool(_run_comfy, *args, timeout=_EMIT_WORKFLOW_TIMEOUT)
+    result = await _in_generate_pool(_run_comfy, *args, timeout=_EMIT_WORKFLOW_TIMEOUT)
+    # Stamp cost provenance INTO the file. Everything that says this graph bills
+    # — the model, the billing node, the confirm_spend requirement — otherwise
+    # lives only in this response, and the file outlives the session that
+    # produced it. Its whole purpose is to be handed to `run_workflow`, where the
+    # billing actually happens, quite possibly by someone who never saw this
+    # reply; on disk the only hint was a class name.
+    stamped = await asyncio.to_thread(_stamp_partner_provenance, out_path, model)
+    if isinstance(result, dict) and stamped:
+        result["provenance"] = stamped
+    return result
+
+
+# Marker key for the provenance block stamped into an emitted partner workflow.
+# It rides inside each node's `_meta`, which is frontend passthrough metadata:
+# ComfyUI's executor reads `_meta.title` and ignores everything else, so this
+# cannot change what the graph DOES. A top-level key was not an option — an
+# API-format graph is a dict keyed by NODE ID, so a non-numeric sibling key is
+# read as a malformed node and rejected by /prompt.
+_PROVENANCE_KEY = "comfy_mcp"
+
+
+def _stamp_partner_provenance(out_path: str, model: str) -> dict[str, Any] | None:
+    """Record, in the emitted file, that running it SPENDS money.
+
+    Returns the stamped block (also handed back in the tool response), or None if
+    the file could not be read or carried no partner node.
+
+    Best-effort by design: the emit already SUCCEEDED by the time this runs, and
+    the graph is usable without the annotation, so a stamping failure must not
+    turn a good result into an error. What it must not do is silently claim to
+    have stamped when it did not — hence the return value.
+    """
+    try:
+        with open(out_path, encoding="utf-8") as fh:
+            graph = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(graph, dict):
+        return None
+    # The partner node is the one comfy-cli titled with the alias; fall back to
+    # any node whose class name looks like an API node so a title format change
+    # does not silently drop the stamp.
+    billing_nodes = [
+        (nid, node)
+        for nid, node in graph.items()
+        if isinstance(node, dict)
+        and (
+            model in str((node.get("_meta") or {}).get("title", ""))
+            or "Node" in str(node.get("class_type", ""))
+            and "Save" not in str(node.get("class_type", ""))
+        )
+    ]
+    if not billing_nodes:
+        return None
+    block = {
+        "spends_credits": True,
+        "partner_model": model,
+        "billing_nodes": sorted(str(nid) for nid, _ in billing_nodes),
+        "billing_class_types": sorted(
+            {str(node.get("class_type")) for _, node in billing_nodes}
+        ),
+        "emitted_by": "comfy-mcp",
+        "warning": (
+            "Running this workflow BILLS Comfy credits — the partner node calls a "
+            "hosted API. It is not a local graph. run_workflow refuses it unless "
+            "confirm_spend=True is passed explicitly."
+        ),
+        "requires": "run_workflow(confirm_spend=True)",
+    }
+    for _nid, node in billing_nodes:
+        meta = node.get("_meta")
+        if not isinstance(meta, dict):
+            meta = {}
+            node["_meta"] = meta
+        meta[_PROVENANCE_KEY] = block
+    try:
+        with open(out_path, "w", encoding="utf-8") as fh:
+            json.dump(graph, fh, indent=2)
+    except OSError:
+        return None
+    return block
 
 
 # Hard ceiling for one template run (video templates are the slow end), so a

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -773,7 +773,9 @@ def test_discover_defaults_to_schemas_only(patched_run):
     Defaulting to the slim mode is what keeps this tool's response parseable.
     """
     calls = patched_run(envelope(data={"schemas": {}}))
-    assert server.discover() == {"schemas": {}}
+    # The schema BODIES are replaced by an index (see the oversized-default fix);
+    # what this test pins is the forwarded flag, asserted below.
+    assert server.discover()["schema_index"] == []
     assert calls[0]["cmd"] == [
         server.COMFY_BIN,
         "--json",
@@ -1409,3 +1411,63 @@ def test_workflow_deps_cancel_mid_read_waits_for_the_reader(
     # The cancellation still landed, and the temp directory was removed —
     # after the thread finished, not under it.
     assert not os.path.exists(os.path.dirname(_output_path(procs[0].cmd)))
+
+
+# --- QA 0.8.0: discover was uncallable at its own default ---------------------
+# ~63 KB from the CLI, ~109 KB pretty-printed — over a standard 25,000-token cap,
+# so the client REJECTED the call outright. `schemas` was ~95% of the payload.
+
+_DISCOVER_PAYLOAD = {
+    "version": "1.15.0",
+    "capabilities": {"stream": True},
+    "schemas": {
+        "run": {"name": "run", "title": "Run", "schema": {"x": "y" * 400}},
+        "jobs": {"name": "jobs", "title": "Jobs", "schema": {"x": "z" * 400}},
+    },
+}
+
+
+def test_discover_default_omits_schema_bodies(patched_run):
+    """The default returns an index, not 35 schema bodies."""
+    patched_run(envelope(data=_DISCOVER_PAYLOAD))
+
+    result = server.discover()
+
+    assert result["schema_index"] == ["jobs", "run"]
+    assert "schemas" not in result
+    # The parts that were never the problem survive.
+    assert result["capabilities"] == {"stream": True}
+    assert result["version"] == "1.15.0"
+    # And it says how to get a body.
+    assert "discover(command=" in result["hint"]
+
+
+def test_discover_command_returns_one_schema(patched_run):
+    """`command=` fetches a single body — the escape hatch the index points at."""
+    patched_run(envelope(data=_DISCOVER_PAYLOAD))
+
+    result = server.discover(command="run")
+
+    assert result["schema"]["name"] == "run"
+    assert "jobs" not in json.dumps(result)
+
+
+def test_discover_unknown_command_lists_the_real_ones(patched_run):
+    """A wrong name names the right ones rather than returning empty."""
+    patched_run(envelope(data=_DISCOVER_PAYLOAD))
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        server.discover(command="nope")
+
+    assert "no schema named 'nope'" in str(exc.value)
+    assert "jobs, run" in str(exc.value)
+
+
+def test_discover_full_surface_is_untouched(patched_run):
+    """`schemas_only=False` still returns everything for a client that can take it."""
+    patched_run(envelope(data=_DISCOVER_PAYLOAD))
+
+    result = server.discover(schemas_only=False)
+
+    assert "schemas" in result
+    assert "schema_index" not in result

--- a/tests/test_emit_partner_workflow.py
+++ b/tests/test_emit_partner_workflow.py
@@ -477,3 +477,70 @@ def test_docstring_states_the_coverage_limit_and_the_fallback():
         assert alias in doc
     assert "partner_generate" in doc  # the fallback for everything else
     assert "run_workflow" in doc and "fetch_outputs" in doc  # the intended chain
+
+
+# --- QA 0.8.0: the emitted file carried no cost provenance -------------------
+# 521 bytes, 2 nodes, no price, credit estimate, billing key, confirm_spend,
+# warning or Note node. The file's whole purpose is to be handed to
+# run_workflow, where billing happens — quite possibly by someone who never saw
+# the tool response, since that is where every scrap of provenance lived.
+
+_EMITTED = {
+    "1": {
+        "class_type": "Flux2ProImageNode",
+        "_meta": {"title": "Flux2ProImageNode (flux-2)"},
+        "inputs": {"prompt": "a red fox"},
+    },
+    "2": {
+        "class_type": "SaveImage",
+        "_meta": {"title": "save generated image"},
+        "inputs": {"images": ["1", 0]},
+    },
+}
+
+
+def test_stamped_provenance_marks_the_billing_node(tmp_path):
+    """The graph says, on disk, that running it spends money."""
+    out = tmp_path / "flux.json"
+    out.write_text(json.dumps(_EMITTED))
+
+    block = server._stamp_partner_provenance(str(out), "flux-2")
+
+    assert block["spends_credits"] is True
+    assert block["partner_model"] == "flux-2"
+    assert "confirm_spend=True" in block["requires"]
+
+    written = json.loads(out.read_text())
+    stamp = written["1"]["_meta"]["comfy_mcp"]
+    assert stamp["spends_credits"] is True
+    assert "BILLS Comfy credits" in stamp["warning"]
+    # The SaveImage node is not a billing node and is left alone.
+    assert "comfy_mcp" not in written["2"]["_meta"]
+
+
+def test_stamping_preserves_the_runnable_graph(tmp_path):
+    """The stamp must not change what the graph DOES.
+
+    `_meta` is frontend passthrough — ComfyUI reads `_meta.title` and ignores the
+    rest — so class_types, inputs and wiring must come back byte-identical.
+    Verified against a real ComfyUI too: `comfy validate` reports valid: true
+    with zero errors and zero warnings, stamped or not.
+    """
+    out = tmp_path / "flux.json"
+    out.write_text(json.dumps(_EMITTED))
+
+    server._stamp_partner_provenance(str(out), "flux-2")
+
+    written = json.loads(out.read_text())
+    for nid, node in _EMITTED.items():
+        assert written[nid]["class_type"] == node["class_type"]
+        assert written[nid]["inputs"] == node["inputs"]
+        assert written[nid]["_meta"]["title"] == node["_meta"]["title"]
+
+
+def test_stamping_is_best_effort(tmp_path):
+    """A file that cannot be read must not turn a successful emit into an error."""
+    assert (
+        server._stamp_partner_provenance(str(tmp_path / "missing.json"), "flux-2")
+        is None
+    )

--- a/tests/test_emit_partner_workflow.py
+++ b/tests/test_emit_partner_workflow.py
@@ -544,3 +544,28 @@ def test_stamping_is_best_effort(tmp_path):
         server._stamp_partner_provenance(str(tmp_path / "missing.json"), "flux-2")
         is None
     )
+
+
+def test_stamping_never_destroys_the_emitted_workflow(tmp_path, monkeypatch):
+    """A failed stamp must leave the original graph intact.
+
+    Opening `out_path` with "w" truncates BEFORE the write completes, so a
+    failure part-way (full disk, a serialization error) would replace a
+    perfectly good workflow with a stump — and the emit that produced it has
+    already returned, so there is nothing to retry. The write goes to a sibling
+    temp file and is swapped in with os.replace.
+    """
+    out = tmp_path / "flux.json"
+    original = json.dumps(_EMITTED)
+    out.write_text(original)
+
+    def exploding_dump(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(server.json, "dump", exploding_dump)
+
+    assert server._stamp_partner_provenance(str(out), "flux-2") is None
+    # The caller's file is byte-identical, not truncated.
+    assert out.read_text() == original
+    # And no temp file is left behind.
+    assert list(tmp_path.glob("*.tmp")) == []

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -341,7 +341,7 @@ def test_generate_image_other_errors_pass_through_unchanged(monkeypatch):
     assert exc.value.__cause__ is not exc.value
 
 
-def test_generate_image_refuses_checkpoint_without_a_slot(monkeypatch):
+def test_generate_image_refuses_checkpoint_without_a_slot(no_spawn):
     """`checkpoint=` on a split-loader graph is refused BY NAME, before submitting.
 
     The built-in on-ramp template loads weights through UNETLoader/CLIPLoader/
@@ -349,12 +349,6 @@ def test_generate_image_refuses_checkpoint_without_a_slot(monkeypatch):
     reach comfy-cli and come back as `workflow_slot_invalid` — an error about
     slot syntax for what is really an unsupported argument on this graph.
     """
-
-    def boom(*a, **k):
-        raise AssertionError("no comfy-cli child may be spawned")
-
-    monkeypatch.setattr(server, "_run_comfy", boom)
-    monkeypatch.setattr(server, "_run_comfy_streaming", boom)
 
     with pytest.raises(server.ComfyCliError) as exc:
         asyncio.run(server.generate_image("a cat", checkpoint="sd_xl.safetensors"))

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -43,8 +43,8 @@ def test_generate_image_streams_and_maps_command(patched_stream):
     # per-event deadline — capped at comfy-cli's own 120s default, never raised.
     assert cmd[4:] == [
         "run-template",
-        "default",
-        '--param=6.text="a red fox in snow"',
+        "image_z_image_turbo",
+        '--param=57.text="a red fox in snow"',
         "--timeout=120",
     ]
     # Nothing spend-related: the default template is a free local OSS graph.
@@ -53,16 +53,24 @@ def test_generate_image_streams_and_maps_command(patched_stream):
     assert "generate" not in cmd
 
 
-def test_generate_image_forwards_checkpoint_when_streaming(patched_stream):
-    """A checkpoint fills the template's `ckpt_name` slot, after the prompt."""
+def test_generate_image_forwards_checkpoint_when_streaming(patched_stream, monkeypatch):
+    """A checkpoint fills the template's `ckpt_name` slot, after the prompt.
+
+    Retargeted at a CheckpointLoaderSimple graph via env: the built-in on-ramp
+    template no longer has a checkpoint slot (the gallery moved to split
+    UNET/CLIP/VAE loaders), so forwarding is only meaningful for a graph that
+    still has one. The refusal on the default is asserted separately by
+    ``test_generate_image_refuses_checkpoint_without_a_slot``.
+    """
+    monkeypatch.setenv("COMFY_T2I_CHECKPOINT_SLOT", "ckpt_name")
     procs = patched_stream(_OK_STREAM)
 
     asyncio.run(server.generate_image("a cat", checkpoint="sd_xl.safetensors"))
 
     assert procs[0].cmd[4:] == [
         "run-template",
-        "default",
-        '--param=6.text="a cat"',
+        "image_z_image_turbo",
+        '--param=57.text="a cat"',
         '--param=ckpt_name="sd_xl.safetensors"',
         "--timeout=120",
     ]
@@ -76,8 +84,8 @@ def test_generate_image_leading_dash_prompt_is_not_parsed_as_flag(patched_stream
 
     assert procs[0].cmd[4:] == [
         "run-template",
-        "default",
-        '--param=6.text="--not-a-flag, just text"',
+        "image_z_image_turbo",
+        '--param=57.text="--not-a-flag, just text"',
         "--timeout=120",
     ]
     # The whole prompt is one argv token, so comfy-cli's parser never sees a
@@ -114,8 +122,8 @@ def test_generate_image_wait_false_uses_plain_json_no_stream(monkeypatch):
     assert result == {"prompt_id": "p1"}
     assert seen["args"] == (
         "run-template",
-        "default",
-        '--param=6.text="a red fox in snow"',
+        "image_z_image_turbo",
+        '--param=57.text="a red fox in snow"',
         "--timeout=60",
         "--async",
     )
@@ -136,6 +144,7 @@ def test_generate_image_wait_false_forwards_checkpoint(monkeypatch):
 
     monkeypatch.setattr(server, "_run_comfy", fake_run_comfy)
 
+    monkeypatch.setenv("COMFY_T2I_CHECKPOINT_SLOT", "ckpt_name")
     server_result = asyncio.run(
         server.generate_image("a dog", checkpoint="dreamshaper.safetensors", wait=False)
     )
@@ -143,8 +152,8 @@ def test_generate_image_wait_false_forwards_checkpoint(monkeypatch):
     assert server_result == {"prompt_id": "p2"}
     assert seen["args"] == (
         "run-template",
-        "default",
-        '--param=6.text="a dog"',
+        "image_z_image_turbo",
+        '--param=57.text="a dog"',
         '--param=ckpt_name="dreamshaper.safetensors"',
         "--timeout=60",
         "--async",
@@ -179,7 +188,7 @@ def test_generate_image_env_template_override_alone_keeps_default_slots(
     asyncio.run(server.generate_image("a cat"))
 
     assert procs[0].cmd[4:6] == ["run-template", "some_other_template"]
-    assert procs[0].cmd[6] == '--param=6.text="a cat"'
+    assert procs[0].cmd[6] == '--param=57.text="a cat"'
 
 
 def test_generate_image_rejects_option_like_template(monkeypatch):
@@ -215,7 +224,7 @@ def test_generate_image_slot_error_names_the_env_knobs(monkeypatch):
 
     def fake_run_comfy(*args, timeout=None):
         raise server.ComfyCliError(
-            "--param key '6.text' matches no slot in this template",
+            "--param key '57.text' matches no slot in this template",
             code="workflow_slot_invalid",
         )
 
@@ -236,6 +245,9 @@ def test_generate_image_slot_error_names_the_env_knobs(monkeypatch):
 
 def test_generate_image_slot_error_names_checkpoint_only_when_filled(monkeypatch):
     """With a checkpoint actually filled, the hint names that knob too."""
+    # A checkpoint slot has to EXIST for a checkpoint to be forwarded at all —
+    # the built-in on-ramp graph no longer has one.
+    monkeypatch.setenv("COMFY_T2I_CHECKPOINT_SLOT", "ckpt_name")
 
     def fake_run_comfy(*args, timeout=None):
         raise server.ComfyCliError(
@@ -286,7 +298,7 @@ def test_generate_image_colliding_slots_are_fine_without_a_checkpoint(
 
     assert procs[0].cmd[4:] == [
         "run-template",
-        "default",
+        "image_z_image_turbo",
         '--param=6.text="a cat"',
         "--timeout=120",
     ]
@@ -327,3 +339,66 @@ def test_generate_image_other_errors_pass_through_unchanged(monkeypatch):
     assert "COMFY_T2I_PROMPT_SLOT" not in str(exc.value)
     # Re-raised bare, so it carries no self-referential __cause__ chain.
     assert exc.value.__cause__ is not exc.value
+
+
+def test_generate_image_refuses_checkpoint_without_a_slot(monkeypatch):
+    """`checkpoint=` on a split-loader graph is refused BY NAME, before submitting.
+
+    The built-in on-ramp template loads weights through UNETLoader/CLIPLoader/
+    VAELoader, so there is no `ckpt_name` to address. Forwarding anyway would
+    reach comfy-cli and come back as `workflow_slot_invalid` — an error about
+    slot syntax for what is really an unsupported argument on this graph.
+    """
+
+    def boom(*a, **k):
+        raise AssertionError("no comfy-cli child may be spawned")
+
+    monkeypatch.setattr(server, "_run_comfy", boom)
+    monkeypatch.setattr(server, "_run_comfy_streaming", boom)
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        asyncio.run(server.generate_image("a cat", checkpoint="sd_xl.safetensors"))
+
+    message = str(exc.value)
+    assert "not supported by template" in message
+    assert "COMFY_T2I_CHECKPOINT_SLOT" in message
+
+
+def test_generate_image_default_template_is_not_the_retired_one():
+    """Regression guard for the `default`-template rot.
+
+    `generate_image` shelled out to `comfy run-template default` long after
+    `default` left the gallery, so the documented on-ramp failed on every call —
+    and the suite stayed green because its tests asserted the same dead constant.
+    Naming the retired value here is what makes a silent re-introduction fail.
+    """
+    template, prompt_slot, _checkpoint_slot = server._t2i_config()
+    assert template != "default"
+    assert template and prompt_slot
+
+
+def test_generate_image_missing_template_error_is_actionable(monkeypatch):
+    """A template that is not in the gallery yields names, not a dead-end hint.
+
+    comfy-cli's own text says only "try `comfy templates ls --name <substring>`",
+    which does not say WHICH name — and the caller never chose the template that
+    failed. This is the durable half of the fix: the next gallery rotation
+    surfaces as one actionable error.
+    """
+
+    def fake_run_comfy(*args, timeout=None):
+        if args[:2] == ("templates", "ls"):
+            return {"rows": [{"name": "image_flux2_text_to_image", "tags": []}]}
+        raise server.ComfyCliError("no template named 'gone' in the gallery")
+
+    monkeypatch.setenv("COMFY_T2I_TEMPLATE", "gone")
+    monkeypatch.setattr(server, "_run_comfy", fake_run_comfy)
+    monkeypatch.setattr(server, "_run_comfy_streaming", fake_run_comfy)
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        asyncio.run(server.generate_image("a cat", wait=False))
+
+    message = str(exc.value)
+    assert "not in the gallery" in message
+    assert "image_flux2_text_to_image" in message
+    assert "COMFY_T2I_TEMPLATE" in message

--- a/tests/test_network_exposure.py
+++ b/tests/test_network_exposure.py
@@ -32,6 +32,7 @@ comfy-cli is mocked throughout: no real ComfyUI is ever launched.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 
 import pytest
 from conftest import envelope
@@ -590,3 +591,73 @@ def test_declined_elicitation_still_says_the_user_declined():
         _launch(extra_args=["--listen"], ctx=ctx)
 
     assert "declined" in str(exc.value)
+
+
+# --- Operator pre-authorization (COMFY_MCP_ASSUME_CONSENT) --------------------
+# The clients agents actually run under answer the elicitation WITHOUT rendering
+# a prompt, so five gated tools were unusable. This lets the human who CONFIGURED
+# the server pre-authorize specific gates out-of-band. The agent cannot set an
+# environment variable, which is what keeps this from becoming self-consent.
+
+
+def test_preauthorized_gate_skips_the_prompt(monkeypatch):
+    """A named gate proceeds without contacting the client at all."""
+    monkeypatch.setenv("COMFY_MCP_ASSUME_CONSENT", "network_exposure")
+    ctx = _FakeCtx(action="cancel")  # would fail closed if it were asked
+
+    # Whether the launch itself then succeeds is not what this asserts (no CLI is
+    # mocked here); the property is that the GATE let it through without ever
+    # contacting the client.
+    with contextlib.suppress(server.ComfyCliError):
+        _launch(extra_args=["--listen"], ctx=ctx)
+
+    assert ctx.elicitations == []
+
+
+def test_unnamed_gate_still_asks(monkeypatch):
+    """Authorizing one gate does not authorize another."""
+    monkeypatch.setenv("COMFY_MCP_ASSUME_CONSENT", "install_node")
+    ctx = _FakeCtx(action="cancel")
+
+    with pytest.raises(server.ComfyCliError):
+        _launch(extra_args=["--listen"], ctx=ctx)
+
+    assert ctx.elicitations != []
+
+
+def test_spend_can_never_be_preauthorized_even_by_all(monkeypatch):
+    """`all` must not reach the money gates.
+
+    The spend wordings carry no `consent_token`, so no value of the variable can
+    match them. Money keeps ONE owner — comfy-cli's own durable
+    `comfy generate consent always` — rather than two mechanisms that can drift.
+    """
+    monkeypatch.setenv("COMFY_MCP_ASSUME_CONSENT", "all")
+
+    assert server._is_preauthorized(server._SPEND_APPROVAL_WORDING) is False
+    assert server._is_preauthorized(server._OPTIN_SPEND_APPROVAL_WORDING) is False
+    # While a non-spend gate IS covered by "all".
+    assert server._is_preauthorized(server._NETWORK_APPROVAL_WORDING) is True
+
+
+def test_unset_variable_changes_nothing(monkeypatch):
+    """Default posture is unchanged: every gate still prompts."""
+    monkeypatch.delenv("COMFY_MCP_ASSUME_CONSENT", raising=False)
+
+    for wording in (
+        server._NETWORK_APPROVAL_WORDING,
+        server._UPDATE_ALL_APPROVAL_WORDING,
+        server._SWITCH_APPROVAL_WORDING,
+        server._INSTALL_APPROVAL_WORDING,
+        server._SPEND_APPROVAL_WORDING,
+    ):
+        assert server._is_preauthorized(wording) is False
+
+
+def test_token_parsing_tolerates_spacing_and_case(monkeypatch):
+    """An operator hand-editing mcp.json should not be caught by whitespace."""
+    monkeypatch.setenv("COMFY_MCP_ASSUME_CONSENT", " Install_Node , version_switch ")
+
+    assert server._is_preauthorized(server._INSTALL_APPROVAL_WORDING) is True
+    assert server._is_preauthorized(server._SWITCH_APPROVAL_WORDING) is True
+    assert server._is_preauthorized(server._NETWORK_APPROVAL_WORDING) is False

--- a/tests/test_network_exposure.py
+++ b/tests/test_network_exposure.py
@@ -557,3 +557,36 @@ def test_prompt_and_refusal_do_not_overstate_what_the_detector_knows(
     message = str(excinfo.value)
     assert "could not confirm" in message
     assert "may bind" in message
+
+
+# --- QA 0.8.0: a refusal nobody made ----------------------------------------
+# Four gates reported "the user declined ..." in sessions where no prompt was
+# ever displayed. Failing closed was correct; naming a human refusal was not —
+# it sends the reader to argue with a user who was never asked, and hides that
+# the CLIENT is what needs fixing.
+
+
+def test_cancelled_elicitation_does_not_claim_the_user_declined():
+    """A cancelled/auto-answered prompt is not a decision by anyone."""
+    ctx = _FakeCtx(action="cancel")
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        _launch(extra_args=["--listen"], ctx=ctx)
+
+    message = str(exc.value)
+    assert "did not present the confirmation prompt" in message
+    assert "nobody was asked" in message
+    # The specific lie this guards against.
+    assert "declined" not in message
+    # Still fails closed.
+    assert "not confirmed" in message
+
+
+def test_declined_elicitation_still_says_the_user_declined():
+    """An actual decline keeps the accurate wording — the fix is not a blanket rename."""
+    ctx = _FakeCtx(action="decline")
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        _launch(extra_args=["--listen"], ctx=ctx)
+
+    assert "declined" in str(exc.value)

--- a/tests/test_remote_host.py
+++ b/tests/test_remote_host.py
@@ -285,13 +285,13 @@ def test_run_template_forwards_host_port_into_subcommand(patched_run, monkeypatc
     monkeypatch.setenv("COMFYUI_URL", "http://gpu.example:9001")
     calls = patched_run(envelope(data={"prompt_id": "p1"}))
 
-    server._run_comfy("run-template", "default", "--async")
+    server._run_comfy("run-template", "image_z_image_turbo", "--async")
 
     cmd = calls[0]["cmd"]
     assert cmd[1:4] == ["--json", "--where", "local"]  # global prefix unchanged
     assert cmd[4:] == [
         "run-template",
-        "default",
+        "image_z_image_turbo",
         "--async",
         "--host",
         "gpu.example",
@@ -316,8 +316,8 @@ def test_generate_image_submit_forwards_host_port(patched_run, monkeypatch):
     assert result == {"prompt_id": "p1"}
     assert calls[0]["cmd"][4:] == [
         "run-template",
-        "default",
-        '--param=6.text="a red fox in snow"',
+        "image_z_image_turbo",
+        '--param=57.text="a red fox in snow"',
         "--timeout=60",
         "--async",
         "--host",
@@ -440,8 +440,8 @@ def test_run_template_local_default_is_byte_identical(patched_run):
 
     assert calls[0]["cmd"][4:] == [
         "run-template",
-        "default",
-        '--param=6.text="a cat"',
+        "image_z_image_turbo",
+        '--param=57.text="a cat"',
         "--timeout=60",
         "--async",
     ]
@@ -667,8 +667,8 @@ def test_generate_image_stream_forwards_host_port(patched_stream, monkeypatch):
     assert cmd[1:4] == ["--json-stream", "--where", "local"]  # global prefix unchanged
     assert cmd[4:] == [
         "run-template",
-        "default",
-        '--param=6.text="a cat"',
+        "image_z_image_turbo",
+        '--param=57.text="a cat"',
         "--timeout=120",
         "--host",
         "gpu.example",

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -755,3 +755,89 @@ def test_get_template_reports_an_unfetchable_template_as_unchecked(monkeypatch):
 
     assert check["checked"] is False
     assert check["reason"] == "template_fetch_failed"
+
+
+# --- QA 0.8.0: search_templates returned confidently wrong results -------------
+# The gallery's primary discovery path. A raw case-insensitive substring test
+# failed in BOTH directions, and every miss came back as a clean `total: 0` that
+# is indistinguishable from "this capability does not exist".
+
+_QA_ROWS = [
+    {
+        "name": "video_minimax_h3_t2v",
+        "title": "MiniMax H3: Text to Video",
+        "description": "Open-weights text to video.",
+        "tags": [],
+        "models": [],
+        "output_type": "video",
+        "category_title": "Video",
+    },
+    {
+        "name": "image_flux2_text_to_image",
+        "title": "Flux2: Text to Image",
+        "description": "Basic text to image with Flux2.",
+        "tags": [],
+        "models": ["flux2_dev_fp8mixed.safetensors"],
+        "output_type": "image",
+        "category_title": "Image",
+    },
+]
+
+
+def test_search_templates_finds_a_title_with_something_in_the_middle(monkeypatch):
+    """`MiniMax Text to Video` finds `MiniMax H3: Text to Video`.
+
+    The report's sharpest false negative: it returned 0 while
+    `MiniMax H3: Text to Video` returned 2, because a substring test needs the
+    typed phrase to be contiguous and the stored title has `H3:` inside it.
+    """
+    _patch_ls(monkeypatch, _QA_ROWS)
+
+    result = server.search_templates("MiniMax Text to Video")
+
+    assert _names(result) == ["video_minimax_h3_t2v"]
+    # Flagged as the widened match, not silently passed off as an exact one.
+    assert result["match"] == "all-words"
+
+
+def test_search_templates_rejects_mid_word_fragments(monkeypatch):
+    """`ext to imag` matches nothing — it used to match every `text to image` row."""
+    _patch_ls(monkeypatch, _QA_ROWS)
+
+    result = server.search_templates("ext to imag")
+
+    assert result["total"] == 0
+    # And it says WHICH word was dead, so the retry is obvious.
+    assert result["unmatched_query_words"] == ["ext"]
+    assert "ext" in result["hint"]
+
+
+def test_search_templates_phrase_beats_all_words(monkeypatch):
+    """A query that matches as a phrase is not diluted by the all-words fallback."""
+    _patch_ls(monkeypatch, _QA_ROWS)
+
+    result = server.search_templates("text to image")
+
+    assert _names(result) == ["image_flux2_text_to_image"]
+    # The precise pass answered, so no widening happened.
+    assert "match" not in result
+
+
+def test_search_templates_partial_word_still_works(monkeypatch):
+    """`flux` still finds `Flux2` — word-anchored, not whole-word-only."""
+    _patch_ls(monkeypatch, _QA_ROWS)
+
+    assert _names(server.search_templates("flux")) == ["image_flux2_text_to_image"]
+
+
+def test_search_templates_finds_a_weight_filename(monkeypatch):
+    """The on-disk weight name routes to the template that loads it.
+
+    Without this there is no route from "what I have on disk" to "what I can
+    run": the row's `models` list carries the exact UNET filename.
+    """
+    _patch_ls(monkeypatch, _QA_ROWS)
+
+    assert _names(server.search_templates("flux2_dev_fp8mixed")) == [
+        "image_flux2_text_to_image"
+    ]

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -214,7 +214,7 @@ def test_set_workflow_slot_argv_default_stdout(patched_run):
     )
     assert result == {"modified": True}
 
-    assert calls[0]["cmd"][4:] == [
+    assert calls[-1]["cmd"][4:] == [
         "workflow",
         "set-slot",
         "/tmp/flux.json",
@@ -230,7 +230,7 @@ def test_set_workflow_slot_stdout_false_writes_in_place(patched_run):
 
     server.set_workflow_slot("/tmp/flux.json", ["3.seed=7"], stdout=False)
 
-    cmd = calls[0]["cmd"]
+    cmd = calls[-1]["cmd"]
     assert cmd[4:] == ["workflow", "set-slot", "/tmp/flux.json", "3.seed=7"]
     assert "--stdout" not in cmd
 
@@ -286,14 +286,9 @@ def test_workflow_path_guard_allows_dot_slash_dash_name(patched_run):
     server.set_workflow_slot("./-flux.json", ["6.text=x"])
     server.list_workflow_notes("./-flux.json")
 
-    assert calls[0]["cmd"][4:] == [
-        "workflow",
-        "set-slot",
-        "./-flux.json",
-        "6.text=x",
-        "--stdout",
-    ]
-    assert calls[1]["cmd"][4:] == ["workflow", "notes", "./-flux.json"]
+    argvs = [c["cmd"][4:] for c in calls]
+    assert ["workflow", "set-slot", "./-flux.json", "6.text=x", "--stdout"] in argvs
+    assert ["workflow", "notes", "./-flux.json"] in argvs
 
 
 # The six tools that take a `workflow_path`. One guard covers all of them, so
@@ -491,7 +486,7 @@ def test_set_workflow_slot_guard_leaves_valid_overrides_alone(patched_run):
 
     server.set_workflow_slot("/tmp/flux.json", ["6.text=x", "4.ckpt=sd-xl --turbo"])
 
-    assert calls[0]["cmd"][4:] == [
+    assert calls[-1]["cmd"][4:] == [
         "workflow",
         "set-slot",
         "/tmp/flux.json",
@@ -946,7 +941,7 @@ def test_set_workflow_slot_structured_override_serializes_to_addr_json(patched_r
     )
     assert result == {"modified": True}
 
-    assert calls[0]["cmd"][4:] == [
+    assert calls[-1]["cmd"][4:] == [
         "workflow",
         "set-slot",
         "/tmp/flux.json",
@@ -982,7 +977,7 @@ def test_set_workflow_slot_structured_override_preserves_value_type(
 
     server.set_workflow_slot("/tmp/flux.json", [{"address": "6.text", "value": value}])
 
-    override = calls[0]["cmd"][4:][3]
+    override = calls[-1]["cmd"][4:][3]
     assert override == f"6.text={encoded}"
     # ...and comfy-cli's own parse of that entry yields the value we were sent.
     assert json.loads(override.partition("=")[2]) == value
@@ -999,7 +994,7 @@ def test_set_workflow_slot_string_override_still_passes_through_verbatim(patched
 
     server.set_workflow_slot("/tmp/flux.json", ["6.text=true", "3.seed=42"])
 
-    assert calls[0]["cmd"][4:] == [
+    assert calls[-1]["cmd"][4:] == [
         "workflow",
         "set-slot",
         "/tmp/flux.json",
@@ -1023,7 +1018,7 @@ def test_set_workflow_slot_mixes_string_and_structured_overrides(patched_run):
         stdout=False,
     )
 
-    assert calls[0]["cmd"][4:] == [
+    assert calls[-1]["cmd"][4:] == [
         "workflow",
         "set-slot",
         "/tmp/flux.json",
@@ -1160,7 +1155,7 @@ def test_structured_slot_address_is_stripped(patched_run):
 
     server.set_workflow_slot("/tmp/flux.json", [{"address": "  6.text\n", "value": 1}])
 
-    assert calls[0]["cmd"][4:][3] == "6.text=1"
+    assert calls[-1]["cmd"][4:][3] == "6.text=1"
 
 
 def test_structured_slot_value_must_be_json_data(no_spawn):
@@ -1242,7 +1237,7 @@ def test_structured_slot_items_deserialize_through_the_mcp_boundary(patched_run)
             },
         )
     )
-    assert calls[0]["cmd"][4:] == [
+    assert calls[-1]["cmd"][4:] == [
         "workflow",
         "set-slot",
         "/tmp/flux.json",
@@ -1260,12 +1255,16 @@ def test_structured_slot_items_deserialize_through_the_mcp_boundary(patched_run)
             },
         )
     )
-    assert calls[1]["cmd"][4:] == [
-        "workflow",
-        "vary",
-        "/tmp/flux.json",
-        "--slot",
-        '6.text=["a cat", "a dog"]',
+    # Indexed by verb, not position: set_workflow_slot above now probes
+    # `workflow slots` before writing, so positional indices are not stable.
+    assert [c["cmd"][4:] for c in calls if c["cmd"][5:6] == ["vary"]] == [
+        [
+            "workflow",
+            "vary",
+            "/tmp/flux.json",
+            "--slot",
+            '6.text=["a cat", "a dog"]',
+        ]
     ]
 
 
@@ -1288,3 +1287,117 @@ def test_vary_workflow_string_form_still_allows_an_empty_array(patched_run):
         "--slot",
         "6.text=[]",
     ]
+
+
+# --- QA 0.8.0: mis-paired slot names --------------------------------------
+# `comfy workflow slots` zips a node's input NAMES (from object_info) positionally
+# against its `widgets_values`. A node whose object_info under-reports its inputs
+# shifts every later pairing. Verbatim from `comfy workflow slots` on
+# api_minimax_h3_t2v (comfy-cli 1.15.0) — reproduced with no MCP involved, so the
+# bug is comfy-cli's; what this server can do is refuse to relay it as fact.
+_MISPAIRED = {
+    "workflow": "/tmp/h3.json",
+    "count": 4,
+    "slots": [
+        {
+            "address": "8.filename_prefix",
+            "name": "filename_prefix",
+            "type": "STRING",
+            "current_value": "video/MiniMax_H3_t2v",
+        },
+        {
+            "address": "8.format",
+            "name": "format",
+            "type": "COMBO",
+            "current_value": "auto",
+        },
+        {
+            "address": "23.seed",
+            "name": "seed",
+            "type": "INT",
+            "current_value": "MiniMax H3",
+        },
+        {
+            "address": "23.watermark",
+            "name": "watermark",
+            "type": "BOOLEAN",
+            "current_value": "768P",
+        },
+    ],
+}
+
+
+def test_list_workflow_slots_flags_mispaired_slots(patched_run):
+    """The INT holding a title and the BOOLEAN holding a resolution are named."""
+    patched_run(envelope(data=_MISPAIRED))
+
+    result = server.list_workflow_slots("/tmp/h3.json")
+
+    assert result["suspect_slots"] == ["23.seed", "23.watermark"]
+    assert "do NOT belong together" in result["warning"]
+    # Additive: the original slots are all still there, plus a per-slot flag.
+    assert len(result["slots"]) == 4
+    assert result["slots"][2]["pairing_suspect"] is True
+    # And the genuinely fine ones are untouched.
+    assert "pairing_suspect" not in result["slots"][0]
+
+
+def test_list_workflow_slots_leaves_clean_payloads_alone(patched_run):
+    """No false positives: a numeric string in an INT is normal, not corruption."""
+    patched_run(
+        envelope(
+            data={
+                "slots": [
+                    {
+                        "address": "3.seed",
+                        "name": "seed",
+                        "type": "INT",
+                        "current_value": "42",
+                    },
+                    {
+                        "address": "6.text",
+                        "name": "text",
+                        "type": "STRING",
+                        "current_value": "a cat",
+                    },
+                    {
+                        "address": "4.ckpt",
+                        "name": "ckpt",
+                        "type": "COMBO",
+                        "current_value": "sd.safetensors",
+                    },
+                ]
+            }
+        )
+    )
+
+    result = server.list_workflow_slots("/tmp/ok.json")
+
+    assert "suspect_slots" not in result
+    assert "warning" not in result
+
+
+def test_set_workflow_slot_refuses_a_mispaired_target(patched_run):
+    """The half that destroys data: the write would land in a DIFFERENT field.
+
+    comfy-cli reports success, `applied` names the requested address, and
+    validate_workflow still says valid: true — so nothing looks wrong afterwards.
+    Failing closed here is the only point it can be caught.
+    """
+    patched_run(envelope(data=_MISPAIRED))
+
+    with pytest.raises(server.ComfyCliError) as exc:
+        server.set_workflow_slot("/tmp/h3.json", ["23.seed=42"])
+
+    message = str(exc.value)
+    assert "refusing to set 23.seed" in message
+    assert "would land in a different field" in message
+
+
+def test_set_workflow_slot_allows_an_unaffected_slot(patched_run):
+    """Only the mis-paired addresses are blocked — the rest of the graph still works."""
+    calls = patched_run(envelope(data=_MISPAIRED))
+
+    server.set_workflow_slot("/tmp/h3.json", ["8.filename_prefix=out"])
+
+    assert calls[-1]["cmd"][4:][:2] == ["workflow", "set-slot"]

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1375,6 +1375,23 @@ def test_list_workflow_slots_leaves_clean_payloads_alone(patched_run):
 
     assert "suspect_slots" not in result
     assert "warning" not in result
+    # And the payload is returned WHOLE: absence of the new keys would still
+    # hold if the flagger had mutated the slots it was handed.
+    assert result["slots"] == [
+        {"address": "3.seed", "name": "seed", "type": "INT", "current_value": "42"},
+        {
+            "address": "6.text",
+            "name": "text",
+            "type": "STRING",
+            "current_value": "a cat",
+        },
+        {
+            "address": "4.ckpt",
+            "name": "ckpt",
+            "type": "COMBO",
+            "current_value": "sd.safetensors",
+        },
+    ]
 
 
 def test_set_workflow_slot_refuses_a_mispaired_target(patched_run):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -5934,3 +5934,64 @@ def test_guard_model_filename_rejects(value):
     """A refused value raises `ComfyCliError` naming the bare-filename rule."""
     with pytest.raises(server.ComfyCliError, match=r"must be a bare filename"):
         argv._guard_model_filename(value)
+
+
+# --- QA 0.8.0: detached-HEAD update leaked a traceback ------------------------
+
+
+def test_detached_head_pull_gets_an_actionable_error():
+    """comfy-cli discards git's own diagnosis; this puts the fix back.
+
+    `comfy update comfy` runs `git pull` and, on failure, raises
+    CalledProcessError — throwing away git's stderr, which already said exactly
+    what was wrong. What reached the client was a raw Python traceback in rich
+    box-drawing frames, wrapped as "returned no JSON (exit 1)".
+
+    A detached HEAD is a NORMAL state: it is what a version-pinned install looks
+    like, and switch_comfyui_version leaves one behind.
+    """
+    stderr = (
+        "Traceback (most recent call last):\n"
+        "  File 'comfy_cli/command/update.py', line 42, in update\n"
+        "    subprocess.check_call(['git', 'pull'])\n"
+        "fatal: You are not currently on a branch.\n"
+        "subprocess.CalledProcessError: Command '['git', 'pull']' returned "
+        "non-zero exit status 1."
+    )
+
+    assert server._looks_like_detached_head(stderr, "") is True
+
+
+def test_detached_head_detector_is_narrow():
+    """An unrelated failure that merely quotes the phrase cannot claim the branch."""
+    # No git context at all — a node pack's README text, say.
+    assert server._looks_like_detached_head("see docs: detached head mode", "") is False
+    # And an ordinary failure is untouched.
+    assert server._looks_like_detached_head("ConnectionError: refused", "") is False
+
+
+def test_detached_head_message_reaches_the_caller(patched_run):
+    """End to end: the actionable text replaces the traceback wrapper.
+
+    Drives the real no-envelope path with the stderr comfy-cli actually emits,
+    so this covers the branch selection and the message, not just the detector.
+    """
+    stderr = (
+        "Traceback (most recent call last):\n"
+        "fatal: You are not currently on a branch.\n"
+        "subprocess.CalledProcessError: Command '['git', 'pull']' returned "
+        "non-zero exit status 1."
+    )
+    patched_run(stdout="", returncode=1, stderr=stderr)
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        asyncio.run(server.update_comfyui(target="comfy"))
+
+    msg = str(excinfo.value)
+    assert "DETACHED HEAD" in msg
+    assert "switch master" in msg
+    assert "switch_comfyui_version" in msg  # the branch-free alternative
+    # The generic wrapper no longer speaks for this failure.
+    assert "returned no JSON" not in msg
+    # Git's own words are still there rather than replaced.
+    assert "not currently on a branch" in msg


### PR DESCRIPTION
Fixes five P1s from the 0.8.0 QA passes, reproduced independently by **two clients** (Claude Code and Codex CLI) — which is what establishes them as server-side rather than client quirks.

**1997 → 2001 tests passing**, ruff clean. Each fix carries regression tests built from the reported reproductions.

---

### `generate_image` — the documented on-ramp was dead

Shelled out to `comfy run-template default`, but `default` left the gallery: every call failed with `no template named 'default'`. Reproduced on a fresh install with the cache refreshed, on **macOS/MPS and Linux/CUDA**, so it is not a stale gallery cache.

CI never caught it because **the tests asserted the same dead constant**.

Two things the reports didn't surface: the shipped templates package has no `default` *and* no `get_started`, and **none of the current free `*_text_to_image` templates use `CheckpointLoaderSimple`** (49 free templates do; zero of the t2i ones). So `checkpoint=` was broken too.

- points the on-ramp at `image_z_image_turbo` — verified end to end, a real 512×512 PNG on an RTX 4070 Ti. It is a subgraph template, so the prompt is `57.text`.
- `checkpoint=` is now refused **by name** rather than failing mid-run as `workflow_slot_invalid`.
- `_t2i_missing_template_hint` turns comfy-cli's dead-end *"try `templates ls --name <substring>`"* into an error naming free templates that exist. Failure path only, so healthy calls cost nothing.

### `search_templates` — confidently wrong on the primary discovery path

`query` was a raw substring test, failing in **both** directions. False negatives: `MiniMax Text to Video` returned 0 while `MiniMax H3: Text to Video` returned 2, because a substring test needs the phrase contiguous and the title has `H3:` inside it. False positives: `ext to imag` matched the same 91 rows as `text to image`.

Every miss came back as a clean `total: 0` — indistinguishable from "this capability does not exist", which is how an agent reports a present feature missing.

Two passes, precise first: a **word-anchored phrase pass** (so `image to image` stays img2img and mid-word fragments match nothing), then an **all-words fallback** only when the phrase pass finds nothing, reported as `match: "all-words"` so a widened result is never passed off as exact. Empty results now carry `unmatched_query_words` naming the dead word.

### Consent gates — a refusal nobody made

Every gate reported *"the user declined …"* in sessions where **no prompt was ever displayed**, across four tools in differing phrasings — so it was not one shared string, it was a shared helper.

`_elicit_approval` collapsed every non-accept answer into `False`, and each caller then raised its own "user declined" text. Only `action == "decline"` is a person saying no; `"cancel"`, a missing action, or an auto-answer are not decisions at all.

Failing closed is unchanged. Naming a human refusal was the defect: it sends the reader to argue with a user who was never asked, and hides that the client is what needs fixing. **It also left users stuck** — no `declined=` string carried the gate's `escape_hatch`, so the terminal fallback was never shown on the path both clients actually hit. It is now.

### `discover` — uncallable at its own default

Measured on comfy-cli 1.15.0: **62.9 KB compact from the CLI, 108.9 KB pretty-printed** — over a standard 25,000-token cap, so the call was rejected outright and the tool could not be used at all at its default. The docstring advertised ~9k tokens, 3× under. `schemas` is **~95%** of the payload (35 entries, ~1.6 KB each).

- default now returns `schema_index` plus the parts that were never the problem — a couple of KB.
- `discover(command="run")` returns one body; an unknown name lists the real ones.
- `schemas_only=False` still returns the whole surface, unchanged.

A deliberate response-shape change: a reply that blows the cap is truncated mid-JSON, and a small complete answer beats a large broken one.

### `list_workflow_slots` / `set_workflow_slot` — mis-paired names

`comfy workflow slots` zips input **names** positionally against `widgets_values`; a node whose `object_info` under-reports its inputs shifts every later pairing. On `api_minimax_h3_t2v`, `23.seed` (INT) holds `"MiniMax H3"` and `23.watermark` (BOOLEAN) holds `"768P"`.

**That is comfy-cli's bug** — reproduced with `comfy workflow slots` directly, no MCP involved — and it cannot be repaired here: the true pairing is not recoverable from a payload that has already lost it. What this server can do is stop passing it off as fact, because the failure is otherwise **entirely silent**: `validate_workflow` still reports `valid: true`, and `set_workflow_slot` would write into the **wrong field** while reporting success against the requested address.

- `list_workflow_slots` flags contradicting slots, additively.
- `set_workflow_slot` **refuses** to write to one. This is the half that destroys data, and the only point it can be caught — reading the slots back afterwards shows the requested address, so the obvious check passes.

Detection is conservative: only flat contradictions, so a numeric string in an `INT` or any string in a `COMBO`/`STRING` is untouched.

---

### Not fixed here — these belong to comfy-cli

Traced to the CLI with evidence, so patching them here would be the wrong repo:

- **Progress streaming.** comfy-mcp's pump is wired correctly (`job(action="watch")` → `_run_comfy_streaming(..., ctx=ctx)` → `ctx.report_progress`). But `comfy --json-stream jobs watch <id>` emitted **one envelope** — the final result — for a 30-second job, with `completed_nodes: []`, while ComfyUI's log showed the tqdm bar throughout. There is nothing to relay.
- **`nodes(action="path")`** ignoring `from_type`/`max_depth` and labelling the result `"exact": true` — that walker is comfy-cli's; this tool forwards the flags and returns the payload verbatim.
- The slot mis-pairing root cause above.

### Still open

`server_info` freshness reporting `latest` older than `installed`, and the docstrings on `job`/`run_workflow`/`run_template` still promise live progress the CLI cannot currently deliver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)