### PR TITLE
chore: release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+Notable changes per release. Dates are UTC.
+
+The version is a **minor** bump whenever a tool's response shape or default
+behaviour changes, even though that would be a major bump after 1.0 — while the
+project is pre-1.0, minor is the strongest signal available, so read it as
+"check the notes before upgrading".
+
+## 0.9.0
+
+Seven P1 defects found by two independent QA passes (Claude Code and Codex CLI).
+Both clients hitting the same failures is what established them as server-side
+rather than client quirks.
+
+### Fixed
+
+- **`generate_image` was dead.** It shelled out to `comfy run-template default`,
+  but `default` had left the gallery, so every call failed with
+  `template_not_found`. Reproduced on a fresh install with the cache refreshed,
+  on macOS/MPS and Linux/CUDA alike. The on-ramp now runs
+  `image_z_image_turbo`, and a template that goes missing in future yields an
+  error naming templates that exist rather than a dead-end hint.
+- **`search_templates` answered the wrong rows.** `query` was a raw substring
+  test, wrong in both directions: `MiniMax Text to Video` returned nothing while
+  `MiniMax H3: Text to Video` existed, and the mid-word fragment `ext to imag`
+  matched 91 rows. It now runs a word-anchored phrase pass, falling back to
+  all-words only when the phrase matches nothing.
+- **Consent gates blamed the user for refusals nobody made.** Every non-accept
+  answer collapsed into "the user declined", including clients that resolve the
+  request without ever showing a prompt. Only an actual decline says so now.
+  Gates still fail closed.
+- **`discover` could not be called at its own default.** It returned every
+  schema body — ~63 KB, ~109 KB once a client pretty-prints it — over a typical
+  25,000-token cap, so the call was rejected outright.
+- **Mis-paired workflow slots were relayed as fact.** On dynamic-combo partner
+  templates, `list_workflow_slots` reported an `INT` slot holding a model title.
+  `set_workflow_slot` would have written into the wrong field while reporting
+  success, with `validate_workflow` still reporting valid.
+- **`update_comfyui` leaked a traceback on a detached HEAD** — a normal state for
+  a version-pinned install — instead of git's own "you are not currently on a
+  branch".
+- **Emitted partner workflows carried no cost provenance.** The file is the
+  thing handed to `run_workflow`, where billing happens, often by someone who
+  never saw the tool response that said it would bill.
+
+### Added
+
+- **`COMFY_MCP_ASSUME_CONSENT`** — pre-authorize specific confirmation gates from
+  the server's environment, for clients that cannot display a prompt. Set by
+  whoever configures the server, in a file the model cannot edit; an agent
+  cannot grant itself permission. Spending is excluded by construction: no
+  value, including `all`, reaches the credit gates. See the README.
+
+### Changed — check before upgrading
+
+- `discover()` now returns a `schema_index` of names instead of every schema
+  body. Pass `command="<name>"` for one body, or `schemas_only=False` for the
+  full surface.
+- `generate_image` runs a different template, and `checkpoint=` is refused on
+  graphs that load weights through split UNET/CLIP/VAE loaders — which is now
+  the gallery norm — rather than failing mid-run.
+- `search_templates` may return `match: "all-words"`, flagging a result widened
+  beyond the phrase that was typed.
+
+### Known issues — upstream in comfy-cli, not this server
+
+- **Progress streaming delivers nothing.** `job(action="watch")` relays what the
+  engine sends, and `comfy jobs watch` emits a single envelope at the end even
+  for a job whose ComfyUI log shows a live progress bar. Poll
+  `job(action="status")` meanwhile. Docstrings no longer promise otherwise.
+- **`nodes(action="path")` ignores `from_type` and `max_depth`** while labelling
+  its result `"exact": true`.
+- The slot mis-pairing above originates in `comfy workflow slots`; this release
+  detects and refuses it but cannot repair the pairing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfy-mcp"
-version = "0.8.0"
+version = "0.9.0"
 description = "MCP server for ComfyUI — a thin wrapper over comfy-cli."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/comfy_mcp/__init__.py
+++ b/src/comfy_mcp/__init__.py
@@ -1,3 +1,3 @@
 """comfy-mcp: a thin MCP wrapper over comfy-cli."""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"


### PR DESCRIPTION
Version bump for the release tag, plus the CHANGELOG the repo was missing.

## Why minor, not patch

The release is mostly bug fixes, but three change what a caller gets back:

- `discover()` returns a `schema_index` instead of every schema body
- `generate_image` runs a different template, and refuses `checkpoint=` on split-loader graphs
- `search_templates` may report `match: "all-words"`

It also adds `COMFY_MCP_ASSUME_CONSENT`, which is a minor bump on its own. Pre-1.0, minor is the strongest "read the notes before upgrading" signal available.

Both version sites move together — `pyproject.toml` and `src/comfy_mcp/__init__.py` — because `publish.yml` refuses to build when the tag and the two files disagree.

## CHANGELOG

New file. With publishing keyed to GitHub releases, this is where a user decides whether to upgrade, so behaviour changes get their own heading rather than being buried among the fixes. The three known comfy-cli issues (progress streaming, `nodes(action="path")` filtering, slot mis-pairing) are named as **upstream** so users do not rediscover them as comfy-mcp bugs.

## After merge

Publishing is trusted-publishing (OIDC) on GitHub release — no stored token. Cutting a `v0.9.0` release will build and publish to PyPI, making `pip install comfy-mcp` work for the first time; the name is not currently on the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)