### PR TITLE
docs: document the tokenized search matching semantics on nodes + search_models

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -8947,7 +8947,11 @@ def nodes(
     Wraps the `comfy nodes` family (`object_info`, incl. custom nodes).
     `action`:
     - "search" (default) -> `nodes search <query>`: find a class name by
-      keyword (e.g. "KSampler", "load image").
+      keyword. Case-insensitive, word-order-independent token match over
+      name/display/category/description ("ksampler advanced", "image
+      load"); zero hits fall back to close NAMES ("KSampeler" -> KSampler)
+      flagged `close_match: true` — guesses, not matches. Needs comfy-cli
+      1.14.0+, this server's floor; below it the query was one substring.
     - "get" -> `nodes show <name>`: one class's full input/output schema.
     - "list" -> `nodes ls [--produces/--accepts/--category/--pack/--label]`:
       filtered browse; bare call lists all.
@@ -9538,9 +9542,15 @@ def search_models(query: str = "", folder: str = "") -> Any:
     """Search / list model files available to the LOCAL ComfyUI install.
 
     Three modes: ``query`` -> ``comfy models search --text <query>``
-    (filename substring, all folders on v1.14.0+, ``checkpoints`` only below
-    the floor); else ``folder`` -> ``comfy models list-folder <folder>``;
-    else -> ``comfy models list-folders`` (folder names).
+    (filename match, all folders on v1.14.0+, ``checkpoints`` only below the
+    floor); else ``folder`` -> ``comfy models list-folder <folder>``; else ->
+    ``comfy models list-folders`` (folder names).
+
+    ``query`` tokens match word-order-independently and ignore ``-`` ``_``
+    ``.`` separators, so "sdxl base" finds ``sd_xl_base_1.0.safetensors``.
+    That needs a comfy-cli NEWER than v1.15.0 (Comfy-Org/comfy-cli#684,
+    merged after v1.15.0 was cut); on v1.15.0 and older the whole query is
+    one substring, so search a single word there.
 
     RESPONSE SHAPE DIFFERS BY MODE: ``query`` returns ``{rows: [...]}``,
     ``folder`` returns ``{files: [...]}``. Filenames only — no base-model/
@@ -9560,7 +9570,7 @@ def search_models(query: str = "", folder: str = "") -> Any:
     if query:
         # NUL only — deliberately NO `argv._reject_option_like` here, unlike the other
         # option values this module guards for hygiene. `--text` is a free-form
-        # substring match over model FILENAMES, and a leading dash is legitimate
+        # match over model FILENAMES, and a leading dash is legitimate
         # data in that position: the `-fp16` / `-fp8` / `-turbo` suffixes are
         # ordinary in model filenames, so `query="-fp16"` is a real search that
         # matches real rows. Click takes the token after a value-taking option

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -882,7 +882,18 @@ def test_nodes_reject_embedded_nul(monkeypatch):
             call()
 
 
-# --- tool docstring budget (<=300 est. tokens) ------------------------------
+# --- tool docstring budget (<=375 est. tokens) ------------------------------
+#
+# Raised 300 -> 375 when the "search" bullet gained `nodes search`'s matching
+# semantics (case-insensitive, word-order-independent token match; close-name
+# fallback). That is not decoration: the docstring IS the tool description an
+# agent reads, and without it an agent composes single-word queries and reads
+# a `close_match` guess as a real hit. Measured ~365 after the edit; the
+# ceiling sits just above so ordinary rewording never trips it while real
+# growth does. Ratchet DOWN if this bullet list is trimmed; never bump without
+# saying why in the same PR. The whole-server ceiling in
+# `test_payload_budget.py` is the other half of this guard and was NOT raised.
+_NODES_DOC_BUDGET_TOKENS = 375
 
 
 def test_nodes_tool_docstring_within_its_own_token_budget():
@@ -892,7 +903,9 @@ def test_nodes_tool_docstring_within_its_own_token_budget():
             doc = ast.get_docstring(node)
             assert doc is not None
             est_tokens = len(doc) // 4
-            assert est_tokens <= 300, f"nodes() docstring ~{est_tokens} est. tokens"
+            assert est_tokens <= _NODES_DOC_BUDGET_TOKENS, (
+                f"nodes() docstring ~{est_tokens} est. tokens"
+            )
             return
     pytest.fail("nodes() tool not found in server.py")
 


### PR DESCRIPTION
## ELI-5

If you ask this MCP server "find me a node called `ksampler advanced`", it hands the words straight to comfy-cli. comfy-cli used to look for that whole phrase as one chunk, so a two-word question found nothing; it now splits the question into words and finds a node that has all of them, in any order. Nothing in this repo does any of that matching — but the tool's docstring is the only description a calling agent ever sees, so if the docstring doesn't say "multi-word works", the agent keeps asking one word at a time. This PR says it. Same story for model filenames, where `sdxl base` now finds `sd_xl_base_1.0.safetensors`.

## Summary

Documentation only. comfy-cli's two search matchers changed and this repo's tool descriptions still described the old whole-string substring behavior. Per the thin-wrapper rule the fix here is the docstrings, nothing else — no filters, no flags, no matching logic, no new arguments.

## Changes

- **`nodes` (`action="search"`)** — the "search" bullet now states the matching semantics: case-insensitive, word-order-independent token match over class name, display name, category and description, with multi-word examples (`"ksampler advanced"`, `"image load"`), plus the zero-hit close-name fallback and the `close_match: true` flag that marks those rows as guesses rather than matches. One sentence pins the version: that matcher landed in **comfy-cli 1.14.0**, which is already this server's enforced floor (`_MIN_COMFY_CLI = (1, 14, 0)`), so no hedge beyond naming it is warranted.
- **`search_models`** — the `query` mode line now says tokens match order-independently and ignore `-` `_` `.` separators, with the `"sdxl base"` → `sd_xl_base_1.0.safetensors` example. This one **is** hedged, because the fix is merged in comfy-cli but not yet released (see Additional Notes).
- The adjacent leading-dash guard comment in `search_models` no longer calls `--text` a "substring match" — one word, so the comment does not contradict the docstring immediately above it.
- `tests/test_discovery.py::test_nodes_tool_docstring_within_its_own_token_budget` — the per-tool docstring tripwire moves **300 → 375** estimated tokens (measured ~365 after the edit), lifted into a named constant with the justification written next to it.

## Motivation

The upstream analysis concluded the text-query bug lived entirely in comfy-cli's matcher, not here — this repo passes the query verbatim. Once the matcher fix shipped, the only thing left for the wrapper to carry was documentation, because the docstring is the tool description agents actually consume.

## Testing

- [x] Existing tests pass (`pytest`) — 2015 passed, 1 skipped, 6 deselected
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — see the evidence below

`tests/test_discovery.py::test_nodes_search_argv` (the successor to the `test_search_nodes_argv` named in the original plan; the eight discovery tools were consolidated into `nodes(action=...)` in #215) asserts the exact argv `["nodes", "search", "sampler"]` and passes **unchanged** — this change is docstring-only.

Evidence for the version claims, read directly from a comfy-cli clone rather than assumed:

- `nodes search` matcher = comfy-cli `3c16a0b` ("tokenized, order-independent `nodes search` with category haystack and close-match fallback", Comfy-Org/comfy-cli#646). `git tag --contains 3c16a0b` → `v1.14.0`, `v1.15.0`. First release containing it: **v1.14.0**.
- `models search --text` matcher = comfy-cli `ed47611` (Comfy-Org/comfy-cli#684). `git tag --contains ed47611` → empty, and `git merge-base --is-ancestor ed47611 v1.15.0` → false. Merged to `main`, **not in any release** (latest is v1.15.0, cut 2026-08-05; the fix merged 2026-08-10).
- The `close_match` field name and its dual placement (top-level on `data` **and** on each row) were read off #646's diff, not inferred.

## Additional Notes

**Judgment calls, all of them flagged rather than made silently:**

1. **The plan named `search_nodes` at `src/comfy_local_mcp/server.py:630`.** That file and that tool no longer exist: the repo was renamed to `comfy-mcp`, and `search_nodes`/`get_node`/`list_nodes`/… were consolidated into the single grouped `nodes(action=...)` tool in #215. I applied the change to the equivalent surface — the `"search"` bullet of `nodes`.
2. **`search_models` was updated even though its fix is unreleased.** The gate in the plan was "has the second blocking ticket merged" — it has (comfy-cli#684, 2026-08-10). Since I could not name a released version, the docstring says "needs a comfy-cli NEWER than v1.15.0" and states what older releases do instead, mirroring the existing `v1.13.0`-era hedge this same docstring already used. If you would rather not document an unreleased behavior at all, that paragraph is the one to drop.
3. **The per-tool docstring budget was raised, not worked around.** The `nodes` docstring sat at ~295/300 tokens, so there was no room for the semantics the ticket asks for. These caps are ratchet tripwires from the payload-diet work in #213 ("makes growth a deliberate decision"), and sibling tools carry 350/400 caps — so 375 is in line rather than an outlier. The whole-server ceiling in `test_payload_budget.py` was **not** touched and still passes.
4. **README not updated.** Its `nodes` row describes what `"search"` does, not how it matches, so it is less detailed but not stale. Say the word if you want the semantics mirrored there.

**Not done:** nothing in the plan's scope was skipped. No filters, flags, or matching logic were added to this repo (thin-wrapper rule).
