### PR TITLE
docs(server): refresh the comfy-cli floor's cheap-to-raise precedent

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -286,10 +286,17 @@ _STREAM_LINE_LIMIT = 1024 * 1024
 # walk, the `templates` gallery cache TTL, and `comfy run`'s `--allow-spend`
 # interlock.
 #
-# Why that raise was cheap, as precedent for the next one: this server is
-# pre-launch (private repo, not published to PyPI), so ~nobody is pinned to the
-# previous release — a floor is only cheap to raise BEFORE you have users. And on
-# 1.13.0 enough of the tool surface is inert that the server reads as BROKEN
+# Why that raise was cheap — and why the next one is NOT. At the time this server
+# was pre-launch (private repo, nothing on PyPI), so ~nobody could be pinned to the
+# previous release, and a floor is only cheap to raise BEFORE you have users. That
+# window has CLOSED: comfy-mcp publishes to PyPI as of 0.9.0, so an installed base
+# exists and a raise is a BREAKING change for anyone below the new floor — this
+# guard refuses up front in `_run_comfy`, it does not degrade per verb. Raise it
+# only for a verb or option this tool surface actually CALLS and cannot degrade
+# around (the 1.14.0 rationale above), never because a newer comfy-cli merely
+# exists: 1.15.0 and 1.16.0 both shipped fixes to verbs called here — restored
+# cloud-job error text, live `jobs watch` progress — and neither moved this floor.
+# And on 1.13.0 enough of the tool surface is inert that the server reads as BROKEN
 # rather than as out-of-date, which is a worse first contact than a clear
 # "upgrade comfy-cli" refusal.
 #


### PR DESCRIPTION
## ELI-5

Next to the `_MIN_COMFY_CLI = (1, 14, 0)` floor there's a note explaining why bumping it was cheap last time: nobody was using this server yet, so nobody could be stranded on an older comfy-cli. That stopped being true — comfy-mcp is on PyPI now, so people *are* installing it, and the guard that enforces the floor refuses up front rather than degrading one verb at a time. Bumping it now strands real users. This updates the note so the next person to read it gets the current answer instead of last month's.

## What changed

Comment only, no behavior change. The block above `_MIN_COMFY_CLI` in `src/comfy_mcp/server.py`:

- **Marks the old premise expired.** It read "this server is pre-launch (private repo, not published to PyPI), so ~nobody is pinned to the previous release — a floor is only cheap to raise BEFORE you have users." comfy-mcp publishes to PyPI as of 0.9.0, so the installed base the argument depended on being empty is no longer empty.
- **Names the cost explicitly.** `_check_comfy_version` refuses in `_run_comfy`, once, up front — it does not degrade per verb — so a raise is a breaking change for anyone below the new floor, not a soft nudge.
- **Writes down the test the floor already follows in practice:** raise only for a verb or option this tool surface actually *calls* and cannot degrade around (the existing 1.14.0 rationale is exactly that), never because a newer comfy-cli merely exists.
- **Adds the supporting evidence:** comfy-cli 1.15.0 and 1.16.0 both shipped fixes to verbs called here — restored cloud-job error text, live `jobs watch` progress — and neither warranted moving the floor. Useful precedent precisely because those are real improvements that still didn't clear the bar.

The final point about 1.13.0 (an inert tool surface reads as BROKEN rather than out-of-date) is preserved verbatim — it justifies the *existing* floor and is unaffected.

## Why now

Noticed while cutting comfy-cli v1.16.0 and checking whether this server's floor needed to move with it. It didn't — but the comment argued the next raise would be cheap, on a premise that stopped holding when 0.9.0 was published. A stale rationale that advises the reader toward a breaking change is worth more than a comment-sized fix.

## Provenance

- `ruff check .` — all checks passed
- `ruff format --check .` — 56 files already formatted
- `pytest` — 2015 passed, 1 skipped, 6 deselected

Run against ruff 0.16.2 (inside the repo's pinned `>=0.16,<0.17`) on Python 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
