### PR TITLE
test(packaging): pin that the two version files agree, at PR time

### DIFF
--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,59 @@
+"""The packaged version lives in two files; pin that they agree.
+
+`publish.yml`'s `check-version` job already compares both against the release
+tag — but it runs on the `release: created` event, so it fires only AFTER the
+tag and the GitHub Release exist. A mismatch caught there costs a deleted
+release and tag, and a PyPI version number can never be reused. This pins the
+same invariant at PR time, where the fix is an edit instead.
+
+Read from the FILES rather than `importlib.metadata`: an editable install
+carries the version recorded when it was installed, so a stale local env would
+compare the wrong string in both directions. The files are the source of truth
+the release checks against.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import comfy_mcp
+
+_ROOT = Path(__file__).resolve().parent.parent
+_PYPROJECT = _ROOT / "pyproject.toml"
+_INIT = _ROOT / "src" / "comfy_mcp" / "__init__.py"
+
+
+def _pyproject_version() -> str:
+    text = _PYPROJECT.read_text(encoding="utf-8")
+    if sys.version_info >= (3, 11):
+        import tomllib
+
+        return tomllib.loads(text)["project"]["version"]
+    # 3.10 has no `tomllib`, and one field does not justify a TOML dependency.
+    # `^version` is anchored, so `target-version` under [tool.ruff] cannot match.
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    assert match is not None, 'no `version = "..."` line in pyproject.toml'
+    return match.group(1)
+
+
+def _dunder_version_literal() -> str:
+    """Read `__version__` as TEXT, mirroring what `check-version` parses."""
+    match = re.search(
+        r'^__version__\s*=\s*"([^"]+)"', _INIT.read_text(encoding="utf-8"), re.MULTILINE
+    )
+    assert match is not None, "no `__version__` assignment in src/comfy_mcp/__init__.py"
+    return match.group(1)
+
+
+def test_pyproject_and_dunder_version_agree():
+    """A release whose two versions disagree fails `check-version` after tagging."""
+    assert _pyproject_version() == _dunder_version_literal(), (
+        "pyproject.toml and src/comfy_mcp/__init__.py disagree on the version. "
+        "Both must equal the release tag or publish.yml's check-version job "
+        "fails after the release has already been created."
+    )
+
+
+def test_imported_dunder_matches_its_own_source():
+    """Guard the parse above: the literal read must match the imported value."""
+    assert comfy_mcp.__version__ == _dunder_version_literal()


### PR DESCRIPTION
## ELI-5

The version is written in two files here. If they ever disagree, the release breaks — but nothing notices until you've *already* cut the release, because the only check runs when a GitHub Release is created. By then the tag exists, the release exists, and a PyPI version number can never be reused, so cleaning up means deleting both and burning a number. This adds a test so the mismatch shows up on the PR that caused it, when the fix is a one-line edit.

## The gap

`pyproject.toml` and `src/comfy_mcp/__init__.py` each carry the version. `publish.yml`'s `check-version` job compares both against the release tag — deliberately, and it says why:

> The version lives in TWO places in this repo […] so a release can disagree with the package it would publish in two different ways. Check both against the tag BEFORE building, in a job that needs no credentials.

That guard is right, but it can only fire on `release: created`. Nothing in `ci.yml` looks at the version, and no test compared the two files, so the window between "the files drifted" and "we found out" was the entire release.

## What this adds

`tests/test_packaging.py`, two tests:

- **`test_pyproject_and_dunder_version_agree`** — the actual invariant.
- **`test_imported_dunder_matches_its_own_source`** — guards the parse, so a regex that silently stops matching can't turn the first test into a no-op.

Both read the **files**, not `importlib.metadata`. An editable install carries whatever version was recorded when it was installed, so a stale local env would compare the wrong string in either direction — and the files are what `check-version` reads.

`tomllib` on 3.11+, an anchored regex on 3.10 (which has no `tomllib`, and one field doesn't justify a TOML dependency). `^version` is anchored, so `target-version` under `[tool.ruff]` can't match it.

This does **not** replace `check-version`: that still catches a tag disagreeing with files that agree with each other, which a test can't see. Belt, meet braces.

## Verification

Confirmed the test actually detects drift rather than passing vacuously — set `__version__` to `0.10.1` against a `pyproject.toml` on `0.10.0`:

```
FAILED tests/test_packaging.py::test_pyproject_and_dunder_version_agree
1 failed, 1 passed
```

and passing again once reverted.

## Provenance

- `ruff check .` — all checks passed
- `ruff format --check .` — 57 files already formatted
- `pytest` — 2017 passed, 1 skipped, 6 deselected (2015 before, +2 here)

ruff 0.16.2 (inside the pinned `>=0.16,<0.17`) on Python 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
