### PR TITLE
build: add project URLs so the PyPI page links back to the repo and docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,24 @@ dependencies = [
 # schema major and, when COMFY_CLI_MIN_VERSION is set, a minimum version. See
 # src/comfy_mcp/server.py (ENVELOPE_SCHEMA_MAJOR / MIN_COMFY_CLI_VERSION).
 
+# The PyPI sidebar renders these, and it renders NOTHING without them: through
+# 0.10.0 the published metadata carried no `project_urls` and an empty
+# `Home-page`, so someone who found the package on PyPI had no route back to the
+# repository, the docs, or the issue tracker. `Homepage` also backfills the
+# legacy `Home-page` field that `pip show` prints.
+#
+# Keep every entry a page that is maintained OUTSIDE this file — the repo root,
+# the docs site, the issue tracker — rather than a deep link into a document
+# whose headings we would then have to keep in sync with a URL nobody here
+# tests. `Documentation` is the docs site's MCP page (its "Local Comfy MCP
+# Connection" section covers this package), which is the same page README.md
+# points readers at.
+[project.urls]
+Homepage = "https://github.com/Comfy-Org/comfy-mcp"
+Repository = "https://github.com/Comfy-Org/comfy-mcp"
+Documentation = "https://docs.comfy.org/agent-tools/mcp"
+Issues = "https://github.com/Comfy-Org/comfy-mcp/issues"
+
 [project.optional-dependencies]
 # The ruff floor is 0.16, not 0.15, because `[tool.ruff.lint] select` below now
 # enables RUF100 (unused-`noqa`) — and 0.16 narrowed BLE001 to stop flagging a

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,4 +1,6 @@
-"""The packaged version lives in two files; pin that they agree.
+"""Pin the packaging metadata that only PyPI, not this repo, ever renders.
+
+The version lives in two files; pin that they agree.
 
 `publish.yml`'s `check-version` job already compares both against the release
 tag — but it runs on the `release: created` event, so it fires only AFTER the
@@ -57,3 +59,45 @@ def test_pyproject_and_dunder_version_agree():
 def test_imported_dunder_matches_its_own_source():
     """Guard the parse above: the literal read must match the imported value."""
     assert comfy_mcp.__version__ == _dunder_version_literal()
+
+
+# The links PyPI renders in its sidebar. Nothing in this repo displays them, so
+# their absence is invisible here and only shows up on a published page — which
+# is how 0.10.0 shipped with `"project_urls": null` and a blank `Home-page`.
+_REQUIRED_URL_LABELS = ("Homepage", "Repository", "Documentation", "Issues")
+_REPO_URL = "https://github.com/Comfy-Org/comfy-mcp"
+
+
+def _project_urls() -> dict[str, str]:
+    text = _PYPROJECT.read_text(encoding="utf-8")
+    if sys.version_info >= (3, 11):
+        import tomllib
+
+        return tomllib.loads(text).get("project", {}).get("urls", {})
+    # 3.10 has no `tomllib` (see `_pyproject_version`). Slice the `[project.urls]`
+    # table out by hand: from its header to the next table header, so a `Key =
+    # "..."` line under some LATER table can never be read as a project URL.
+    match = re.search(
+        r"^\[project\.urls\]\s*$(.*?)(?=^\[|\Z)", text, re.MULTILINE | re.S
+    )
+    if match is None:
+        return {}
+    return dict(re.findall(r'^(\w+)\s*=\s*"([^"]+)"', match.group(1), re.MULTILINE))
+
+
+def test_pyproject_declares_the_pypi_sidebar_links():
+    """No `[project.urls]` means a PyPI page with no route back to the project."""
+    urls = _project_urls()
+    missing = [label for label in _REQUIRED_URL_LABELS if label not in urls]
+    assert not missing, (
+        f"pyproject.toml `[project.urls]` is missing {missing}. Without them the "
+        "PyPI page links nowhere: no repository, no docs, no issue tracker."
+    )
+    assert all(url.startswith("https://") for url in urls.values()), urls
+
+
+def test_project_urls_point_at_this_repository():
+    """A copy-paste from another project would publish someone else's links."""
+    urls = _project_urls()
+    assert urls["Repository"] == _REPO_URL
+    assert urls["Issues"].startswith(_REPO_URL + "/")

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -68,21 +68,88 @@ _REQUIRED_URL_LABELS = ("Homepage", "Repository", "Documentation", "Issues")
 _REPO_URL = "https://github.com/Comfy-Org/comfy-mcp"
 
 
+# The 3.10 leg's hand-rolled key/value line. Accepting a quoted key and a
+# single-quoted value costs one alternation each and buys agreement with the
+# 3.11+ `tomllib` leg: a TOML-legal `"Bug Tracker" = '...'` that tomllib parses
+# but a bare-word/double-quote-only pattern DROPS would leave the entry
+# unchecked on 3.10 while 3.11 checks it, and the two CI legs would disagree
+# about the same file.
+_URL_ENTRY_RE = re.compile(
+    r"""^[^\S\n]*(?:(?P<bare>\w[\w.-]*)|"(?P<dkey>[^"]*)"|'(?P<skey>[^']*)')"""
+    r"""[^\S\n]*=[^\S\n]*(?:"(?P<dval>[^"]*)"|'(?P<sval>[^']*)')""",
+    re.MULTILINE,
+)
+
+
+def _urls_from_toml_text(text: str) -> dict[str, str]:
+    """Read `[project.urls]` without `tomllib` — what the 3.10 leg must do.
+
+    Takes its TEXT rather than reading `_PYPROJECT` so the 3.11+ leg can pin it
+    against `tomllib` on a sample (below); otherwise this whole branch is dead
+    code on 3.14 and only the 3.10 job would ever notice it drifting.
+    """
+    # 3.10 has no `tomllib` (see `_pyproject_version`). Slice the `[project.urls]`
+    # table out by hand: from its header to the next table header, so a `Key =
+    # "..."` line under some LATER table can never be read as a project URL. The
+    # header tolerates a trailing comment — `[project.urls]  # PyPI sidebar` is
+    # legal TOML, and rejecting it would report every label missing on the 3.10
+    # leg while the table sat there correct, pointing the fix at the wrong file.
+    match = re.search(
+        r"^\[project\.urls\][^\S\n]*(?:#[^\n]*)?$(.*?)(?=^\[|\Z)",
+        text,
+        re.MULTILINE | re.S,
+    )
+    if match is None:
+        return {}
+    urls: dict[str, str] = {}
+    for entry in _URL_ENTRY_RE.finditer(match.group(1)):
+        key = next(
+            group
+            for group in (entry["bare"], entry["dkey"], entry["skey"])
+            if group is not None
+        )
+        urls[key] = entry["dval"] if entry["dval"] is not None else entry["sval"]
+    return urls
+
+
 def _project_urls() -> dict[str, str]:
     text = _PYPROJECT.read_text(encoding="utf-8")
     if sys.version_info >= (3, 11):
         import tomllib
 
         return tomllib.loads(text).get("project", {}).get("urls", {})
-    # 3.10 has no `tomllib` (see `_pyproject_version`). Slice the `[project.urls]`
-    # table out by hand: from its header to the next table header, so a `Key =
-    # "..."` line under some LATER table can never be read as a project URL.
-    match = re.search(
-        r"^\[project\.urls\]\s*$(.*?)(?=^\[|\Z)", text, re.MULTILINE | re.S
-    )
-    if match is None:
-        return {}
-    return dict(re.findall(r'^(\w+)\s*=\s*"([^"]+)"', match.group(1), re.MULTILINE))
+    return _urls_from_toml_text(text)
+
+
+# Everything TOML allows here that a bare-word/double-quote-only pattern drops:
+# a commented header, a quoted key, a single-quoted value, a hyphenated key —
+# plus a same-named key under a LATER table, which must not leak in.
+_SAMPLE_URLS_TOML = """\
+[project]
+name = "sample"
+
+[project.urls]  # PyPI sidebar
+Homepage = "https://example.invalid/home"
+"Bug Tracker" = 'https://example.invalid/bugs'
+Source-Code = "https://example.invalid/src"
+
+[tool.sample]
+Homepage = "https://example.invalid/not-a-project-url"
+"""
+
+
+def test_fallback_toml_parse_agrees_with_tomllib():
+    """The 3.10 leg parses by regex; pin that it reads what `tomllib` reads."""
+    parsed = _urls_from_toml_text(_SAMPLE_URLS_TOML)
+    assert parsed == {
+        "Homepage": "https://example.invalid/home",
+        "Bug Tracker": "https://example.invalid/bugs",
+        "Source-Code": "https://example.invalid/src",
+    }
+    if sys.version_info >= (3, 11):
+        import tomllib
+
+        assert parsed == tomllib.loads(_SAMPLE_URLS_TOML)["project"]["urls"]
 
 
 def test_pyproject_declares_the_pypi_sidebar_links():
@@ -99,5 +166,17 @@ def test_pyproject_declares_the_pypi_sidebar_links():
 def test_project_urls_point_at_this_repository():
     """A copy-paste from another project would publish someone else's links."""
     urls = _project_urls()
-    assert urls["Repository"] == _REPO_URL
-    assert urls["Issues"].startswith(_REPO_URL + "/")
+    # `Homepage` too, not just `Repository`: it is the field PyPI headlines and
+    # the one that backfills the legacy `Home-page` that `pip show` prints, so a
+    # stale copy-paste there is the most visible version of this bug. Read every
+    # label through `.get` — a parse that came back `{}` should fail saying WHICH
+    # label is wrong, not raise a bare `KeyError` naming no file.
+    for label in ("Homepage", "Repository"):
+        assert urls.get(label) == _REPO_URL, (
+            f"pyproject.toml `[project.urls]` has {label}={urls.get(label)!r}, "
+            f"expected {_REPO_URL}. PyPI would link at another project."
+        )
+    assert urls.get("Issues", "").startswith(_REPO_URL + "/"), (
+        f"pyproject.toml `[project.urls]` has Issues={urls.get('Issues')!r}, "
+        f"expected an issue tracker under {_REPO_URL}."
+    )


### PR DESCRIPTION
## ELI-5

If you found this package on PyPI, there was nothing to click. No link to the repo, no link to the docs, no link to file a bug. This adds those four links to the package metadata so PyPI can show them in its sidebar.

## Summary

`comfy-mcp` 0.10.0 published with `"project_urls": null` and a blank `Home-page`, so `pypi.org/project/comfy-mcp/` rendered no links back to the project. This declares a `[project.urls]` table and pins it with a test.

## Changes

- **`pyproject.toml`** — a `[project.urls]` table with `Homepage`, `Repository`, `Documentation`, and `Issues`. `Documentation` points at the docs site's MCP page (its "Local Comfy MCP Connection" section documents this package, including `pip install comfy-mcp`) — the same page README.md already sends readers to. Every entry is a page maintained outside this file rather than a deep link into a document whose headings would then have to stay in sync with a URL nothing here tests.
- **`tests/test_packaging.py`** — two tests: the four labels are present and every value is `https://`, and `Repository`/`Issues` point at this repository (a copy-paste from another project would otherwise publish someone else's links). They live alongside the existing version-agreement test for the same reason it exists: nothing in this repo renders this metadata, so a regression is invisible until it is already published, and a PyPI version number can never be reused.

## Motivation

Found while verifying a fresh `pip install comfy-mcp`: `pypi.org/pypi/comfy-mcp/json` returned `"project_urls": null` and `pip show` printed a blank `Home-page:`. A user who arrives from PyPI has no route to the repository, the docs, or the issue tracker.

## Testing

- [x] Existing tests pass (`pytest` — 2019 passed, 1 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually

Manual verification went past the test suite, because the suite only reads the same file the change edits — it cannot prove the *built* metadata carries the links:

- Built the wheel (`python -m build --wheel`) and read its `dist-info/METADATA`: it now carries `Project-URL: Homepage, …`, `Project-URL: Repository, …`, `Project-URL: Documentation, …`, `Project-URL: Issues, …`. That is the field PyPI populates `project_urls` from.
- Installed that wheel into a clean venv: `pip show comfy-mcp` now prints `Home-page: https://github.com/Comfy-Org/comfy-mcp`. Modern setuptools emits no `Home-page` field at all, but pip backfills it from the `Homepage` project URL, so the second symptom in the report clears too.
- Mutation-checked the new tests: deleting the `[project.urls]` table makes both of them fail, so they are live rather than self-satisfying.
- Every URL was fetched and returns 200.
- Exercised the Python 3.10 branch of the new TOML read directly (3.10 has no `tomllib`, matching the existing `_pyproject_version` helper), against both the real file and a file with the table removed. CI's `test (py3.10)` leg covers it for real.

## Additional Notes

**One criterion from the report is deliberately not in this PR: "cut it into the next release."** Releases here are their own `chore: release X.Y.Z` commit that bumps both version files and writes the CHANGELOG entry (`#225`, `#220` — CHANGELOG.md has been touched by nothing else). Bumping the version here would collide with that. The metadata takes effect on the next publish; the final acceptance check (`pypi.org/pypi/comfy-mcp/json` showing a populated `project_urls`) can only be run after it.

Judgment calls:

- **`Documentation` → the docs site, not the README anchor.** `https://github.com/Comfy-Org/comfy-mcp#readme` was the alternative. The docs page is the maintained, first-party home for setup instructions and is where the README itself points; if it ever stops covering the local server, this is a one-line change.
- **`Changelog` was left out.** CHANGELOG.md exists and PyPI renders that label nicely, but the report enumerated four links and this stays at four. Easy to add later.
- **`Homepage` and `Repository` are the same URL** — intentional. `Repository` is the semantically correct label, and `Homepage` is what pip backfills `Home-page` from, which was half the reported symptom.

Negative-claim falsification (regression case comfy-cloud-mcp-server#581): the trigger does not fire here. The diff is additive packaging metadata plus tests — it adds no deny path, no "not supported"/"unavailable" string, and denies no capability, so there is nothing to attempt and disprove.
