### PR TITLE
feat(cli): answer --help and --version instead of exiting silently

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ custom nodes included — not a static catalog.
 ## Module layout
 
 `server.py` holds the wrapper core (`_run_comfy`, the envelope parser, the `--json-stream`
-machinery, the spend-consent plumbing) and every `@mcp.tool()`. Nine **leaf** modules sit
+machinery, the spend-consent plumbing) and every `@mcp.tool()`. Ten **leaf** modules sit
 under it — none imports `server`, so the dependency edges only ever point one way:
 
 | Module | Owns |
@@ -114,6 +114,7 @@ under it — none imports `server`, so the dependency edges only ever point one 
 | `argv.py` | argument-injection and OS-limit guards for every tool-facing string headed for `subprocess`: shared primitives plus per-domain guards (workflow path, prompt id, download id, extra args, version, node names, log port, model path/filename, upload paths) |
 | `target.py` | remote-target resolution/redaction/provenance for run/job tools — `COMFYUI_URL`/`HOST`/`PORT` parsing, `--host`/`--port` forwarding, the local-only `download_model` refusal, and divergence notes on `system_stats`/`free_memory` so an agent doesn't gate a remote run on local numbers |
 | `params.py` | param/slot marshaling into comfy-cli argv for `generate`/`run-template`/`set-slot`/`vary`, incl. the structured slot machinery — `SlotOverride`/`SlotVariants` are this module's public TYPES (carve-out below) |
+| `cli.py` | the console script's own argv surface — the `--help` / `--version` text a HUMAN who types `comfy-mcp` in a terminal gets, and the installed-metadata version lookup behind it |
 
 `server` reaches them **module-qualified** (e.g. `failure_log._log_failure(...)`) and
 re-exports no BEHAVIOR: patching a moved name on `server` would silently patch nothing.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Four steps take you from a fresh install to your first generated image.
    `pip install .` puts a `comfy-mcp` console script on your `PATH`; that command is what you
    point your AI client at in step 3. (A dedicated venv is fine — MCP clients may not see that
    venv's `PATH`, which is exactly what `COMFY_BIN` is for; see [Prerequisites](#prerequisites).)
+   `comfy-mcp --version` confirms it landed — but don't run `comfy-mcp` itself to test it: it
+   is a **stdio** server that talks MCP over stdin/stdout, so in a terminal it just waits and
+   exits without printing anything. `comfy-mcp --help` says the same thing in one screen.
 
    > Installed this server back when it was called `comfy-local-mcp`? Do
    > [Upgrading from `comfy-local-mcp`](#upgrading-from-comfy-local-mcp) first — `pip install .`

--- a/src/comfy_mcp/cli.py
+++ b/src/comfy_mcp/cli.py
@@ -21,7 +21,8 @@ name in this module.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+import os
+import sys
 from importlib import metadata
 
 from . import __version__
@@ -31,6 +32,9 @@ _DISTRIBUTION = "comfy-mcp"
 
 _HELP_FLAGS = frozenset({"-h", "--help"})
 _VERSION_FLAGS = frozenset({"--version", "-V"})
+
+# POSIX end-of-options marker: everything after it is an operand, never a flag.
+_END_OF_OPTIONS = "--"
 
 
 def _version() -> str:
@@ -44,11 +48,42 @@ def _version() -> str:
     the release checks pin (``tests/test_packaging.py``). So try metadata, fall
     back to the literal — never the other way round, which would report the
     checkout's number for an install that shipped a different one.
+
+    The fallback is deliberately wider than "no ``.dist-info``": a
+    ``.dist-info`` that EXISTS but is corrupt, unreadable, or carries no
+    ``Version`` field fails as something other than
+    ``PackageNotFoundError`` (an ``OSError`` reading METADATA) or does not fail
+    at all and hands back ``None``. That broken install is precisely the case
+    the README sends users here to diagnose, so every one of those answers the
+    source literal rather than a traceback or ``comfy-mcp None``.
     """
     try:
-        return metadata.version(_DISTRIBUTION)
-    except metadata.PackageNotFoundError:
+        installed = metadata.version(_DISTRIBUTION)
+    except Exception:  # noqa: BLE001 - a broken install must still answer
         return __version__
+    return installed or __version__
+
+
+def _print(text: str) -> None:
+    """Write ``text`` to stdout, tolerating a reader that has already left.
+
+    The module docstring advertises piping ``--help`` into ``less``/``grep``,
+    and those readers close the pipe early as a matter of course (``| head``,
+    or ``q`` in a pager). The write — or the interpreter's own flush at
+    shutdown — then raises ``BrokenPipeError``, which is an ``OSError`` and so
+    is NOT the ``PermissionError`` :func:`server.main` translates: the user
+    gets a traceback plus an "Exception ignored" epilogue for the crime of
+    quitting a pager. Python's documented remedy is to redirect the fd at
+    ``devnull`` so that shutdown flush has somewhere harmless to go.
+    """
+    try:
+        sys.stdout.write(text)
+        sys.stdout.flush()
+    except BrokenPipeError:
+        try:
+            os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno())
+        except OSError:  # no real fd to salvage (a wrapped stdout); exit quietly
+            pass
 
 
 def _usage(min_comfy_cli: str) -> str:
@@ -59,9 +94,17 @@ def _usage(min_comfy_cli: str) -> str:
     runtime guard rejects an older comfy-cli with. Importing it here would
     point a leaf module at ``server``; duplicating it would let the advertised
     floor drift away from the enforced one.
+
+    The text is deliberately pure ASCII. It is printed through whatever
+    encoding the locale gives stdout once that stdout is a file or a pipe
+    rather than a terminal, so a single em dash is enough to turn
+    ``comfy-mcp --help > out.txt`` into a ``UnicodeEncodeError`` traceback with
+    half the message written — on a code page that cannot represent it (cp932)
+    or a strict-ASCII C locale. The one screen a confused user gets has to
+    render everywhere; ``test_usage_is_pure_ascii`` pins that.
     """
     return f"""\
-comfy-mcp {_version()} — MCP server for ComfyUI (stdio transport).
+comfy-mcp {_version()} - MCP server for ComfyUI (stdio transport).
 
 Not meant to be run interactively: it speaks MCP over stdin/stdout and is
 launched by an MCP client as a subprocess. Register it with your client
@@ -70,7 +113,7 @@ instead, for example:
   claude mcp add comfy-mcp -- comfy-mcp
 
 Run with no arguments (as a client does) it serves MCP on stdio and exits
-when stdin closes — so a bare `comfy-mcp` in a terminal looks like it did
+when stdin closes, so a bare `comfy-mcp` in a terminal looks like it did
 nothing. That is expected.
 
 Options:
@@ -84,22 +127,40 @@ Docs: https://github.com/Comfy-Org/comfy-mcp
 """
 
 
-def _handle_argv(argv: Sequence[str], min_comfy_cli: str) -> bool:
+def _handle_argv(argv: list[str], min_comfy_cli: str) -> bool:
     """Answer ``--help`` / ``--version`` if present; report whether we did.
 
     ``True`` means the caller has already been served and must NOT start the
     server. ``False`` means "carry on and serve" — including for arguments this
     does not recognise, which is deliberate: argv was ignored entirely before
     this existed, so rejecting an unknown flag would newly break any client
-    registration that passes one. A flag anywhere in ``argv`` counts (``-h`` is
-    the request even behind something else), and ``--help`` wins over
-    ``--version`` so a user asking for both gets the more useful answer.
+    registration that passes one. A flag anywhere in the OPTION section counts
+    (``-h`` is the request even behind something else), and ``--help`` wins
+    over ``--version`` so a user asking for both gets the more useful answer.
+
+    The option section ends at the first bare ``--``, the POSIX end-of-options
+    marker: past it a token is an operand, so ``comfy-mcp -- --help`` serves
+    rather than printing help. That matters because answering on stdout and
+    exiting 0 is the wrong reply to a *client*, which is listening for JSON-RPC
+    on that same stdout — it would see prose and a clean exit instead of a
+    diagnosable failure. Honouring ``--`` gives any caller that must pass such
+    a token an escape hatch; nothing else here is a flag that takes a value, so
+    there is no other way for one to arrive as somebody else's argument.
+
+    ``argv`` is a ``list``, not a ``Sequence``, and the guard below enforces it:
+    a bare ``str`` IS a ``Sequence[str]``, so ``_handle_argv("--help", …)``
+    would iterate CHARACTERS, match nothing, and silently start the server —
+    the exact silent-serve failure this module exists to remove. It fails loudly
+    instead.
     """
-    args = set(argv)
-    if args & _HELP_FLAGS:
-        print(_usage(min_comfy_cli), end="", flush=True)
+    if not isinstance(argv, list):
+        raise TypeError(f"argv must be a list of arguments, got {type(argv).__name__}")
+    end = argv.index(_END_OF_OPTIONS) if _END_OF_OPTIONS in argv else len(argv)
+    options = set(argv[:end])
+    if options & _HELP_FLAGS:
+        _print(_usage(min_comfy_cli))
         return True
-    if args & _VERSION_FLAGS:
-        print(f"comfy-mcp {_version()}", flush=True)
+    if options & _VERSION_FLAGS:
+        _print(f"comfy-mcp {_version()}\n")
         return True
     return False

--- a/src/comfy_mcp/cli.py
+++ b/src/comfy_mcp/cli.py
@@ -1,0 +1,105 @@
+"""The console script's own argv surface — ``--help`` and ``--version``.
+
+Leaf module over :mod:`comfy_mcp` (the package ``__init__`` alone, for the
+fallback version); nothing here imports ``server``. It exists because
+``comfy-mcp`` is a *stdio* server: a first-time user who types the command in a
+terminal gets no banner, no prompt and no error — the server starts, waits for
+JSON-RPC on stdin, and exits silently at EOF, which reads as "the install is
+broken". These two flags are the one place this program talks to a HUMAN, so
+they say what it is and how to launch it properly.
+
+Printing to **stdout** here is deliberate and is not a breach of the rule that
+stdout belongs to JSON-RPC (see :mod:`comfy_mcp.failure_log`): that rule holds
+while the server is serving, and the whole point of these flags is that they
+return before ``mcp.run()`` is ever reached, so no client is listening on the
+other end. ``--help`` on stdout is also what a pipe into ``less``/``grep``
+expects.
+
+Everything here is private and reached as ``cli._name`` — there is no public
+name in this module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from importlib import metadata
+
+from . import __version__
+
+# The installed distribution's name (``[project] name`` in pyproject.toml).
+_DISTRIBUTION = "comfy-mcp"
+
+_HELP_FLAGS = frozenset({"-h", "--help"})
+_VERSION_FLAGS = frozenset({"--version", "-V"})
+
+
+def _version() -> str:
+    """The running version, preferring installed package metadata.
+
+    Metadata is the authoritative answer for the thing the user actually
+    installed — it is what ``pip show comfy-mcp`` reports and what a
+    ``serverInfo.version`` should agree with. It is unavailable in exactly one
+    situation: running from a source tree that was never installed (no
+    ``.dist-info``), where :data:`comfy_mcp.__version__` is the source of truth
+    the release checks pin (``tests/test_packaging.py``). So try metadata, fall
+    back to the literal — never the other way round, which would report the
+    checkout's number for an install that shipped a different one.
+    """
+    try:
+        return metadata.version(_DISTRIBUTION)
+    except metadata.PackageNotFoundError:
+        return __version__
+
+
+def _usage(min_comfy_cli: str) -> str:
+    """The ``--help`` text.
+
+    ``min_comfy_cli`` is passed in rather than imported so the floor keeps a
+    single source of truth — ``server._MIN_COMFY_CLI_STR``, the same string the
+    runtime guard rejects an older comfy-cli with. Importing it here would
+    point a leaf module at ``server``; duplicating it would let the advertised
+    floor drift away from the enforced one.
+    """
+    return f"""\
+comfy-mcp {_version()} — MCP server for ComfyUI (stdio transport).
+
+Not meant to be run interactively: it speaks MCP over stdin/stdout and is
+launched by an MCP client as a subprocess. Register it with your client
+instead, for example:
+
+  claude mcp add comfy-mcp -- comfy-mcp
+
+Run with no arguments (as a client does) it serves MCP on stdio and exits
+when stdin closes — so a bare `comfy-mcp` in a terminal looks like it did
+nothing. That is expected.
+
+Options:
+  -h, --help     show this message and exit
+  -V, --version  show the version and exit
+
+Requires comfy-cli >= {min_comfy_cli} on PATH (`pip install "comfy-cli>={min_comfy_cli}"`);
+set COMFY_BIN to its absolute path if it is not on the PATH your client uses.
+
+Docs: https://github.com/Comfy-Org/comfy-mcp
+"""
+
+
+def _handle_argv(argv: Sequence[str], min_comfy_cli: str) -> bool:
+    """Answer ``--help`` / ``--version`` if present; report whether we did.
+
+    ``True`` means the caller has already been served and must NOT start the
+    server. ``False`` means "carry on and serve" — including for arguments this
+    does not recognise, which is deliberate: argv was ignored entirely before
+    this existed, so rejecting an unknown flag would newly break any client
+    registration that passes one. A flag anywhere in ``argv`` counts (``-h`` is
+    the request even behind something else), and ``--help`` wins over
+    ``--version`` so a user asking for both gets the more useful answer.
+    """
+    args = set(argv)
+    if args & _HELP_FLAGS:
+        print(_usage(min_comfy_cli), end="", flush=True)
+        return True
+    if args & _VERSION_FLAGS:
+        print(f"comfy-mcp {_version()}", flush=True)
+        return True
+    return False

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -76,7 +76,7 @@ import sys
 import tempfile
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, NamedTuple
 from urllib.parse import urlparse
@@ -86,7 +86,17 @@ from mcp import types
 from mcp.server.mcpserver import Context, Image, MCPServer
 from pydantic import BaseModel, Field
 
-from . import argv, clitext, errors, failure_log, instructions, params, target, tcc
+from . import (
+    argv,
+    cli,
+    clitext,
+    errors,
+    failure_log,
+    instructions,
+    params,
+    target,
+    tcc,
+)
 from .errors import ComfyCliError
 from .params import SlotOverride, SlotVariants
 
@@ -10950,8 +10960,14 @@ def _apply_startup_instructions() -> None:
     mcp._lowlevel_server.instructions = f"{instructions.INSTRUCTIONS}\n{block}\n"
 
 
-def main() -> None:
-    """Entry point: serve the MCP over stdio.
+def main(args: Sequence[str] | None = None) -> None:
+    """Entry point: answer ``--help`` / ``--version``, else serve over stdio.
+
+    ``args`` defaults to the process's arguments and exists so a test can drive
+    the entry point without rewriting ``sys.argv``; the console script calls
+    this with none. Only the two human-facing flags are intercepted (see
+    :func:`cli._handle_argv`) — every other argument still falls through to the
+    server exactly as it did when argv was ignored outright.
 
     A macOS protected-folder denial hit during startup (a config, log, or module
     the server itself reads from under ~/Documents, say) arrives as a bare
@@ -10967,6 +10983,17 @@ def main() -> None:
     :func:`_require_comfy_bin` do for the child process we spawn.
     """
     try:
+        # First thing in the body — before the startup probing below, which
+        # shells out and can be slow — because a human asking what this program
+        # is should get an answer that does not depend on the state of their
+        # install. Inside the `try` rather than above it because reading the
+        # version out of installed metadata walks `sys.path`, so it is one more
+        # startup read a protected-folder denial can land on, and it deserves
+        # the same translated guidance as the rest.
+        if cli._handle_argv(
+            list(sys.argv[1:] if args is None else args), _MIN_COMFY_CLI_STR
+        ):
+            return
         # Before serving: enrich the handshake instructions with the one-shot
         # machine snapshot. Runs inside this try on purpose — the
         # probe swallows its own failures (including a PermissionError, an

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -76,7 +76,7 @@ import sys
 import tempfile
 import threading
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, NamedTuple
 from urllib.parse import urlparse
@@ -10960,14 +10960,16 @@ def _apply_startup_instructions() -> None:
     mcp._lowlevel_server.instructions = f"{instructions.INSTRUCTIONS}\n{block}\n"
 
 
-def main(args: Sequence[str] | None = None) -> None:
+def main(args: list[str] | None = None) -> None:
     """Entry point: answer ``--help`` / ``--version``, else serve over stdio.
 
     ``args`` defaults to the process's arguments and exists so a test can drive
     the entry point without rewriting ``sys.argv``; the console script calls
-    this with none. Only the two human-facing flags are intercepted (see
-    :func:`cli._handle_argv`) — every other argument still falls through to the
-    server exactly as it did when argv was ignored outright.
+    this with none. It is a ``list``, not a ``Sequence``, because a bare ``str``
+    satisfies ``Sequence[str]`` and would be read character by character, which
+    :func:`cli._handle_argv` rejects outright. Only the two human-facing flags
+    are intercepted (see that function) — every other argument still falls
+    through to the server exactly as it did when argv was ignored outright.
 
     A macOS protected-folder denial hit during startup (a config, log, or module
     the server itself reads from under ~/Documents, say) arrives as a bare
@@ -10990,9 +10992,7 @@ def main(args: Sequence[str] | None = None) -> None:
         # version out of installed metadata walks `sys.path`, so it is one more
         # startup read a protected-folder denial can land on, and it deserves
         # the same translated guidance as the rest.
-        if cli._handle_argv(
-            list(sys.argv[1:] if args is None else args), _MIN_COMFY_CLI_STR
-        ):
+        if cli._handle_argv(sys.argv[1:] if args is None else args, _MIN_COMFY_CLI_STR):
             return
         # Before serving: enrich the handshake instructions with the one-shot
         # machine snapshot. Runs inside this try on purpose — the

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,131 @@
+"""The console script's `--help` / `--version` surface (`comfy_mcp.cli`).
+
+A stdio server that ignores argv gives a first-time user nothing: `comfy-mcp
+--help` starts the server, blocks on stdin, and exits silently at EOF, which is
+indistinguishable from a broken install. These pin the two flags that answer
+instead — and, just as importantly, that everything else still reaches the
+server, since argv was previously ignored outright and a client registration is
+free to pass arguments this program does not know about.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from importlib import metadata
+from pathlib import Path
+
+import pytest
+
+import comfy_mcp
+from comfy_mcp import cli, server
+
+_FLOOR = server._MIN_COMFY_CLI_STR
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_help_prints_usage_to_stdout(capsys):
+    handled = cli._handle_argv(["--help"], _FLOOR)
+    out = capsys.readouterr()
+    assert handled is True
+    assert out.err == ""
+    assert out.out.startswith("comfy-mcp ")
+    # The three things a confused user needs: what it is, that it is not an
+    # interactive program, and the one command that registers it properly.
+    assert "stdio" in out.out
+    assert "Not meant to be run interactively" in out.out
+    assert "claude mcp add comfy-mcp -- comfy-mcp" in out.out
+
+
+def test_help_advertises_the_enforced_comfy_cli_floor(capsys):
+    """The help text's floor is the runtime guard's, not a second copy of it."""
+    cli._handle_argv(["-h"], _FLOOR)
+    out = capsys.readouterr().out
+    assert f"comfy-cli >= {_FLOOR}" in out
+    assert f'pip install "comfy-cli>={_FLOOR}"' in out
+
+
+def test_version_prints_the_running_version(capsys):
+    handled = cli._handle_argv(["--version"], _FLOOR)
+    out = capsys.readouterr()
+    assert handled is True
+    assert out.err == ""
+    # Compared against `cli._version()` rather than `comfy_mcp.__version__`:
+    # an editable install carries the version recorded when it was installed,
+    # so a stale local env legitimately disagrees with the source literal (the
+    # same reason `test_packaging.py` reads the files instead of metadata).
+    assert out.out == f"comfy-mcp {cli._version()}\n"
+    assert re.fullmatch(r"comfy-mcp \d+\.\d+.*\n", out.out)
+
+
+def test_help_wins_over_version(capsys):
+    """Asking for both gets the answer that contains the other one."""
+    assert cli._handle_argv(["--version", "--help"], _FLOOR) is True
+    out = capsys.readouterr().out
+    assert "Options:" in out
+
+
+@pytest.mark.parametrize("argv", [[], ["--transport", "stdio"], ["-x"], ["help"]])
+def test_everything_else_falls_through_to_the_server(argv, capsys):
+    """Unrecognised argv must still serve — argv used to be ignored entirely."""
+    assert cli._handle_argv(argv, _FLOOR) is False
+    assert capsys.readouterr() == ("", "")
+
+
+def test_version_prefers_installed_metadata(monkeypatch):
+    monkeypatch.setattr(metadata, "version", lambda name: f"9.9.9-{name}")
+    assert cli._version() == "9.9.9-comfy-mcp"
+
+
+def test_version_falls_back_to_the_source_literal(monkeypatch):
+    """No `.dist-info` (a source tree that was never installed) still answers."""
+
+    def _missing(name):
+        raise metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(metadata, "version", _missing)
+    assert cli._version() == comfy_mcp.__version__
+
+
+def test_main_answers_help_without_starting_the_server(monkeypatch, capsys):
+    """`main()` returns before any startup probing or `mcp.run()`."""
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("the server must not start for --help")
+
+    monkeypatch.setattr(server, "_apply_startup_instructions", _boom)
+    monkeypatch.setattr(server.mcp, "run", _boom)
+    server.main(["--help"])
+    assert capsys.readouterr().out.startswith("comfy-mcp ")
+
+
+def test_main_serves_when_given_no_flags(monkeypatch):
+    """The default path is unchanged: no arguments still starts stdio."""
+    calls = []
+    monkeypatch.setattr(
+        server, "_apply_startup_instructions", lambda: calls.append("i")
+    )
+    monkeypatch.setattr(server.mcp, "run", lambda **kw: calls.append(kw))
+    monkeypatch.setattr(sys, "argv", ["comfy-mcp"])
+    server.main()
+    assert calls == ["i", {"transport": "stdio"}]
+
+
+@pytest.mark.parametrize("flag", ["--help", "--version"])
+def test_entry_point_exits_zero_with_output(flag):
+    """End-to-end through a real process: prints on stdout, exits 0.
+
+    `python -m comfy_mcp.server` reaches the same `main()` the `comfy-mcp`
+    console script does, so this covers the real `sys.argv` read and the exit
+    status a user sees — without needing the script on PATH.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-m", "comfy_mcp.server", flag],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=_ROOT,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.startswith("comfy-mcp ")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ free to pass arguments this program does not know about.
 
 from __future__ import annotations
 
+import io
 import re
 import subprocess
 import sys
@@ -73,6 +74,56 @@ def test_everything_else_falls_through_to_the_server(argv, capsys):
     assert capsys.readouterr() == ("", "")
 
 
+@pytest.mark.parametrize(
+    "argv",
+    [["--", "--help"], ["--", "-h"], ["--", "-V"], ["--transport", "--", "--version"]],
+)
+def test_end_of_options_marker_is_honoured(argv, capsys):
+    """Past a bare `--` a token is an operand, so it must not print to stdout.
+
+    Answering a *client* on stdout is worse than not answering: that stream is
+    the JSON-RPC channel, so prose plus exit 0 reads as protocol garbage rather
+    than a diagnosable failure. `--` is the escape hatch for a caller that has
+    to pass such a token along.
+    """
+    assert cli._handle_argv(argv, _FLOOR) is False
+    assert capsys.readouterr() == ("", "")
+
+
+def test_a_bare_string_is_rejected_rather_than_read_as_characters():
+    """`main("--help")` must not iterate letters and silently serve."""
+    with pytest.raises(TypeError, match="list of arguments"):
+        cli._handle_argv("--help", _FLOOR)  # type: ignore[arg-type]
+
+
+def test_usage_is_pure_ascii():
+    """Non-ASCII would make `comfy-mcp --help > out.txt` a UnicodeEncodeError.
+
+    Redirected or piped, stdout carries the locale's encoding, and a code page
+    that cannot represent an em dash raises after writing half the message.
+    """
+    usage = cli._usage(_FLOOR)
+    usage.encode("ascii")  # raises UnicodeEncodeError if a stray glyph creeps in
+
+
+@pytest.mark.parametrize("flag", ["--help", "--version"])
+def test_a_reader_that_left_early_does_not_traceback(flag, monkeypatch):
+    """`comfy-mcp --help | head -1`, or `q` in a pager, closes the pipe on us."""
+
+    class _ClosedPipe:
+        def write(self, text):
+            raise BrokenPipeError(32, "Broken pipe")
+
+        def flush(self):
+            raise BrokenPipeError(32, "Broken pipe")
+
+        def fileno(self):
+            raise io.UnsupportedOperation("fileno")
+
+    monkeypatch.setattr(sys, "stdout", _ClosedPipe())
+    assert cli._handle_argv([flag], _FLOOR) is True
+
+
 def test_version_prefers_installed_metadata(monkeypatch):
     monkeypatch.setattr(metadata, "version", lambda name: f"9.9.9-{name}")
     assert cli._version() == "9.9.9-comfy-mcp"
@@ -85,6 +136,39 @@ def test_version_falls_back_to_the_source_literal(monkeypatch):
         raise metadata.PackageNotFoundError(name)
 
     monkeypatch.setattr(metadata, "version", _missing)
+    assert cli._version() == comfy_mcp.__version__
+
+
+@pytest.mark.parametrize(
+    "broken",
+    [
+        pytest.param(OSError(13, "Permission denied"), id="unreadable-metadata"),
+        pytest.param(
+            UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid"), id="corrupt-metadata"
+        ),
+    ],
+)
+def test_version_falls_back_when_the_dist_info_is_broken(broken, monkeypatch):
+    """A `.dist-info` that exists but is unreadable fails as something else.
+
+    That is the broken install the README sends users here to diagnose, so it
+    must answer rather than traceback.
+    """
+
+    def _broken(name):
+        raise broken
+
+    monkeypatch.setattr(metadata, "version", _broken)
+    assert cli._version() == comfy_mcp.__version__
+
+
+def test_version_falls_back_when_metadata_has_no_version_field(monkeypatch):
+    """METADATA with no `Version:` hands back `None`, not an exception.
+
+    Printing `comfy-mcp None` would both mislead and violate the declared
+    `-> str`.
+    """
+    monkeypatch.setattr(metadata, "version", lambda name: None)
     assert cli._version() == comfy_mcp.__version__
 
 
@@ -119,6 +203,11 @@ def test_entry_point_exits_zero_with_output(flag):
     `python -m comfy_mcp.server` reaches the same `main()` the `comfy-mcp`
     console script does, so this covers the real `sys.argv` read and the exit
     status a user sees — without needing the script on PATH.
+
+    `stdin` is `DEVNULL` so a regression fails fast: if flag interception ever
+    stops firing, the child becomes a stdio MCP server, and on pytest's
+    inherited stdin it would block for the whole timeout — and pass or hang
+    depending on whether that handle happened to be at EOF.
     """
     proc = subprocess.run(
         [sys.executable, "-m", "comfy_mcp.server", flag],
@@ -126,6 +215,7 @@ def test_entry_point_exits_zero_with_output(flag):
         text=True,
         timeout=120,
         cwd=_ROOT,
+        stdin=subprocess.DEVNULL,
     )
     assert proc.returncode == 0, proc.stderr
     assert proc.stdout.startswith("comfy-mcp ")


### PR DESCRIPTION
## ELI-5

Typing `comfy-mcp --help` in a terminal used to print **nothing** and quit. That is because this program is not a normal command you run yourself — it is a server your AI client starts behind the scenes, and it talks in JSON over its input/output pipes. So it dutifully started up, heard nothing, and left. To a person installing it for the first time, that is indistinguishable from a broken install. Now `--help` prints a short screen saying what it is and how to register it with a client, and `--version` prints the installed version. Running it with no arguments still does exactly what it always did.

## Summary

Handle `--help` / `-h` and `--version` / `-V` on the `comfy-mcp` console script: print to stdout, exit 0. Everything else is unchanged — a bare `comfy-mcp` still serves MCP over stdio, and any argument this does not recognise still falls straight through to the server.

## Changes

- **New leaf module `src/comfy_mcp/cli.py`** — the usage text plus the version lookup. Nothing in it imports `server` (the module-layout rule), and it is reached module-qualified as `cli._handle_argv(...)` from `main()`.
- **`--version` reads installed package metadata** (`importlib.metadata.version("comfy-mcp")`), falling back to `comfy_mcp.__version__` only when there is no `.dist-info` — i.e. a source tree that was never installed. Never the other way round: a stale editable install would otherwise report the checkout's number for a build that shipped a different one. This is the same metadata source the empty-`serverInfo.version` follow-up will want.
- **The advertised comfy-cli floor is the enforced one.** `_usage()` takes the floor as an argument and `main()` passes `server._MIN_COMFY_CLI_STR`, so the help text cannot drift from the version guard that actually rejects an old comfy-cli. Importing it into the leaf module would have pointed `cli` at `server`; copying the string would have let the two diverge.
- **`main(args=None)`** — argv comes from `sys.argv` by default; the parameter exists so tests drive the entry point without rewriting `sys.argv`. The console script still calls `main()` with no arguments.
- `AGENTS.md` module-layout table gains the tenth leaf module (the keep-in-sync rule); README's install step now says `comfy-mcp --version` is the way to confirm the install and that running `comfy-mcp` bare prints nothing *on purpose*.
- `tests/test_cli.py` — 14 cases, including an end-to-end subprocess run of `python -m comfy_mcp.server --help|--version` asserting real stdout + exit 0.

## Motivation

Found while verifying a fresh `pip install comfy-mcp` in a clean venv: the first thing a new user types is the first thing that gives them nothing back. The fix is the smallest possible: two flags, a screen of text, no new dependency and no argument parser.

## Testing

- [x] Existing tests pass (`pytest`) — 2031 passed, 1 skipped, 6 deselected
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — in a fresh venv with `pip install -e '.[dev]'`, against the real installed console script:
  - `comfy-mcp --help` → the usage screen on stdout, exit 0
  - `comfy-mcp --version` → `comfy-mcp 0.10.0` on stdout, exit 0
  - `printf '' | comfy-mcp` → serves stdio, exits 0 at EOF with no output, exactly as before
  - `comfy-mcp --help | head -2` → no broken-pipe noise

## Additional Notes

**Judgment calls, all flagged rather than buried:**

1. **Unknown arguments still start the server; they are not rejected.** `comfy-mcp --nonsense` serves stdio rather than erroring. That is a deliberate Chesterton's-Fence call: argv was ignored *entirely* until this PR, so adding a "bad argument" exit would be a new refusal path that could break a client registration passing an argument we do not know about. The status quo for unrecognised input is preserved; only the two documented flags change behaviour. Happy to tighten this to a usage-on-stderr/exit-2 if reviewers prefer the stricter contract.
2. **`-V` and `-h` short forms added** alongside the `--version` / `--help` the ticket asked for — conventional, and neither collides with anything (nothing read argv before).
3. **`--help` beats `--version`** when both are passed, and a flag counts anywhere in argv rather than only in first position. No argument parser was added for this; a `set` membership test is the whole implementation.
4. **Printing on stdout is intentional** even though this repo's rule is that stdout belongs to JSON-RPC. That rule holds while *serving*; both flags return before `mcp.run()` is reached, so nothing is listening. The module docstring states this so a future reader does not "fix" it.
5. **The flag check sits inside `main()`'s existing `try`**, not above it: reading the version out of installed metadata walks `sys.path`, so it is one more startup read a macOS protected-folder (TCC) denial can land on, and it should get the same translated guidance as every other startup read rather than a raw traceback.

**Negative-claim falsification.** The diff adds the sentence "Not meant to be run interactively", which is capability-denying language, so it was checked empirically rather than assumed: `printf '' | comfy-mcp` on the real installed script exits 0 having printed nothing at all (captured stdout and stderr both empty) — there is genuinely no interactive output to be had, which is the bug being described. Critically, **no capability is removed and no dead-end path is added**: plain `comfy-mcp` still runs the server (`test_main_serves_when_given_no_flags` pins `mcp.run(transport="stdio")` is still reached), unrecognised arguments still serve, and the help text *redirects* the user to the path that works (`claude mcp add comfy-mcp -- comfy-mcp`) rather than telling them to stop.
