### PR TITLE
docs(packaging): install comfy-cli alongside comfy-mcp, and pin why it stays undeclared

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,8 @@ wrong copy of, so that risk doesn't apply.
 ## Toolchain
 
 Python ≥ 3.10; pip + setuptools (no `uv.lock` here — comfy-cli bundles `uv` and may write a
-stray one into the working directory; gitignored).
+stray one into the working directory; gitignored). **comfy-cli is deliberately NOT a declared
+dependency** — don't "fix" that by adding one; `pyproject.toml`'s comment says why.
 
 ```bash
 pip install -e '.[dev]'   # install with dev extras (pytest, ruff)
@@ -138,16 +139,6 @@ ruff format --check .     # format check (run `ruff format .` to fix)
 CI (`.github/workflows/ci.yml`) runs all three on Python 3.10 and 3.14 every PR; get them
 green locally. Never add a `paths`/`paths-ignore` filter to its `pull_request` trigger —
 `test (py3.10)`/`test (py3.14)` must report every PR; it no-ops on Markdown-only changes.
-
-**comfy-cli is deliberately NOT a declared dependency** — do not "fix" that by adding it.
-The engine that matters is whichever binary `PATH`/`COMFY_BIN` resolves to (usually a
-different environment from the one this server is installed into), so a pinned wheel here
-would install a second copy nothing calls; the `>= 1.14.0` floor is enforced at RUNTIME
-against the real binary instead (`_check_comfy_version`). The cost is that
-`pip install comfy-mcp` alone yields a server whose tools all error until comfy-cli is
-installed, so the docs carry that weight: the README quickstart installs both in one command
-and says why, and `tests/test_packaging.py` pins the pair (undeclared + documented) so
-neither half can drift without the other.
 
 ## Tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,16 @@ CI (`.github/workflows/ci.yml`) runs all three on Python 3.10 and 3.14 every PR;
 green locally. Never add a `paths`/`paths-ignore` filter to its `pull_request` trigger —
 `test (py3.10)`/`test (py3.14)` must report every PR; it no-ops on Markdown-only changes.
 
+**comfy-cli is deliberately NOT a declared dependency** — do not "fix" that by adding it.
+The engine that matters is whichever binary `PATH`/`COMFY_BIN` resolves to (usually a
+different environment from the one this server is installed into), so a pinned wheel here
+would install a second copy nothing calls; the `>= 1.14.0` floor is enforced at RUNTIME
+against the real binary instead (`_check_comfy_version`). The cost is that
+`pip install comfy-mcp` alone yields a server whose tools all error until comfy-cli is
+installed, so the docs carry that weight: the README quickstart installs both in one command
+and says why, and `tests/test_packaging.py` pins the pair (undeclared + documented) so
+neither half can drift without the other.
+
 ## Tests
 
 Tests live in `tests/` and mock comfy-cli — no real ComfyUI, no `comfy` binary. `_run_comfy`

--- a/README.md
+++ b/README.md
@@ -73,19 +73,28 @@ Four steps take you from a fresh install to your first generated image.
 1. **Install the pieces.**
 
    ```bash
-   pip install "comfy-cli>=1.14.0"  # the engine (>= 1.14.0 required)
-   comfy install                  # create a ComfyUI workspace (skip if you have one)
-   pip install .                  # this MCP server → the `comfy-mcp` command
+   pip install comfy-mcp "comfy-cli>=1.14.0"  # this server + the engine it wraps
+   comfy install                              # create a ComfyUI workspace (skip if you have one)
    ```
 
-   Run that last one from a checkout of this repo (`pip install -e .` for a working copy).
-   `pip install .` puts a `comfy-mcp` console script on your `PATH`; that command is what you
-   point your AI client at in step 3. (A dedicated venv is fine — MCP clients may not see that
+   **Both names, one command — on purpose.** Installing `comfy-mcp` does **not** install
+   comfy-cli: it is not a declared dependency of this package, because the server runs whichever
+   `comfy` binary your `PATH` (or [`COMFY_BIN`](#prerequisites)) resolves to, which is often not
+   the environment you installed the server into. Declaring it would put a second copy in this
+   venv that may not be the one your tools actually drive; the version that matters is checked at
+   **runtime** instead, against the binary really being called. Skip it and the server still
+   starts and completes the MCP handshake — every tool call then fails with "`comfy` not found on
+   PATH", which is a missing engine, not a broken install.
+
+   `pip install comfy-mcp` puts a `comfy-mcp` console script on your `PATH`; that command is what
+   you point your AI client at in step 3. (A dedicated venv is fine — MCP clients may not see that
    venv's `PATH`, which is exactly what `COMFY_BIN` is for; see [Prerequisites](#prerequisites).)
+   To install from a checkout of this repo instead, run `pip install .` there (`pip install -e .`
+   for a working copy) — the comfy-cli half is the same either way.
 
    > Installed this server back when it was called `comfy-local-mcp`? Do
-   > [Upgrading from `comfy-local-mcp`](#upgrading-from-comfy-local-mcp) first — `pip install .`
-   > alone will **not** clean up after the old name.
+   > [Upgrading from `comfy-local-mcp`](#upgrading-from-comfy-local-mcp) first — installing
+   > `comfy-mcp` alone will **not** clean up after the old name.
 
 2. **Launch ComfyUI** and leave it running:
 
@@ -135,7 +144,7 @@ the rename is **not** something `pip install .` finishes on its own, because `co
    `ModuleNotFoundError`:
 
    ```bash
-   pip uninstall comfy-local-mcp   # then: pip install .   (or `pip install -e .`)
+   pip uninstall comfy-local-mcp   # then: pip install comfy-mcp   (or `pip install -e .`)
    ```
 
 2. **Change `"command"` to `comfy-mcp`** in every MCP client config that starts this server
@@ -390,7 +399,12 @@ full cloud tool list, and the slash-command/prompt tables live.
   `download-status` / `downloads` / `download-cancel`), `models search`'s cross-folder walk, the
   templates gallery cache TTL, and `comfy run`'s `--allow-spend` interlock. On 1.13.0 enough of
   the surface is inert that the server reads as broken rather than as out-of-date, which is why
-  the floor moved rather than each tool degrading.
+  the floor moved rather than each tool degrading. **Installing this server does not install
+  comfy-cli** — it is deliberately *not* a declared dependency of the `comfy-mcp` package, because
+  the binary that matters is whichever one `PATH` / `COMFY_BIN` resolves to rather than one pinned
+  into this server's environment, so the floor above is enforced at runtime against that binary
+  (the rationale lives in `pyproject.toml`). Install the two together:
+  `pip install comfy-mcp "comfy-cli>=1.14.0"`.
 - **Every capability degrade is still in place**, because the floor and a degrade guard different
   failures: the floor catches a *wrong comfy-cli version*, a degrade catches a *correct version in
   a broken environment*. The version guard fails **open** on a `--version` it can't parse (a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,25 @@ dependencies = [
 # comfy-cli is intentionally NOT a declared dependency: this server shells out
 # to whatever `comfy` binary PATH/COMFY_BIN resolves to (which may differ from a
 # pip-installed one), and the envelope/discover contract it wraps is carried by a
-# specific comfy-cli build rather than a hard-pinnable PyPI release. Compatibility
-# is enforced at RUNTIME instead — `server_info` asserts the comfy-cli envelope
-# schema major and, when COMFY_CLI_MIN_VERSION is set, a minimum version. See
-# src/comfy_mcp/server.py (ENVELOPE_SCHEMA_MAJOR / MIN_COMFY_CLI_VERSION).
+# specific comfy-cli build rather than a hard-pinnable PyPI release. Declaring it
+# would install a second copy into THIS environment that the tools may never
+# call, while doing nothing about the one they do — and not a small one: pip
+# resolves comfy-cli into ~40 further distributions (GitPython, cookiecutter,
+# uv, analytics clients), all of which a declaration would force on every
+# install of this server, including the ones already driving a `comfy` on PATH.
+# Compatibility is enforced at
+# RUNTIME instead, against the binary actually invoked: `_check_comfy_version`
+# holds a hard `>= _MIN_COMFY_CLI` floor before the first call, `_unwrap_envelope`
+# asserts the envelope schema major, and `server_info` reports both plus the
+# optional COMFY_CLI_MIN_VERSION. See src/comfy_mcp/server.py.
+#
+# The cost is real and is paid in the DOCS, not here: `pip install comfy-mcp`
+# alone yields a server that completes the MCP handshake and then errors on every
+# tool call until comfy-cli is installed. So the README quickstart installs both
+# in one command (`pip install comfy-mcp "comfy-cli>=1.14.0"`) and says why, and
+# tests/test_packaging.py pins that pairing — undeclared HERE requires documented
+# THERE. Reverse this decision by all means, but reverse both halves together;
+# see AGENTS.md ("Toolchain").
 
 [project.optional-dependencies]
 # The ruff floor is 0.16, not 0.15, because `[tool.ruff.lint] select` below now

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,19 +55,20 @@ dependencies = [
 # resolves comfy-cli into ~40 further distributions (GitPython, cookiecutter,
 # uv, analytics clients), all of which a declaration would force on every
 # install of this server, including the ones already driving a `comfy` on PATH.
-# Compatibility is enforced at
-# RUNTIME instead, against the binary actually invoked: `_check_comfy_version`
-# holds a hard `>= _MIN_COMFY_CLI` floor before the first call, `_unwrap_envelope`
-# asserts the envelope schema major, and `server_info` reports both plus the
-# optional COMFY_CLI_MIN_VERSION. See src/comfy_mcp/server.py.
+# Compatibility is enforced at RUNTIME instead, against the binary actually
+# invoked: `_check_comfy_version` holds a hard `>= _MIN_COMFY_CLI` floor before
+# the first call, `_unwrap_envelope` asserts the envelope schema major, and
+# `server_info` reports both plus the optional COMFY_CLI_MIN_VERSION. See
+# src/comfy_mcp/server.py.
 #
 # The cost is real and is paid in the DOCS, not here: `pip install comfy-mcp`
 # alone yields a server that completes the MCP handshake and then errors on every
 # tool call until comfy-cli is installed. So the README quickstart installs both
 # in one command (`pip install comfy-mcp "comfy-cli>=1.14.0"`) and says why, and
 # tests/test_packaging.py pins that pairing — undeclared HERE requires documented
-# THERE. Reverse this decision by all means, but reverse both halves together;
-# see AGENTS.md ("Toolchain").
+# THERE. Reverse this decision by all means, but reverse all of it together:
+# this comment, that test, the README quickstart AND prerequisites, and the
+# one-liner in AGENTS.md ("Toolchain") that sends contributors back here.
 
 [project.optional-dependencies]
 # The ruff floor is 0.16, not 0.15, because `[tool.ruff.lint] select` below now

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -29,6 +29,8 @@ import re
 import sys
 from pathlib import Path
 
+import pytest
+
 import comfy_mcp
 from comfy_mcp import server
 
@@ -78,13 +80,54 @@ def _requirement_name(requirement: str) -> str:
     """The PEP 503-normalized distribution name in a PEP 508 requirement.
 
     Normalized rather than compared literally, so `comfy_cli` / `Comfy.CLI` —
-    the same distribution to pip — cannot slip past the assertion below. An
-    entry with no leading name (nothing valid produces one) returns `""` rather
-    than raising, so a malformed array fails on the assertion that reads it, not
-    inside this helper.
+    the same distribution to pip — cannot slip past the assertion below. The
+    strip comes first because pip accepts a padded requirement (`" comfy-cli"`)
+    and both parsers below hand it over verbatim: matched unstripped, that
+    entry would normalize to `""` and slip past the absence assertion. An entry
+    with no leading name at all returns `""` rather than raising, so a
+    malformed array fails on the assertion that reads it, not inside here.
     """
-    match = re.match(r"[A-Za-z0-9._-]+", requirement)
+    match = re.match(r"[A-Za-z0-9._-]+", requirement.strip())
     return re.sub(r"[-_.]+", "-", match.group(0)).lower() if match else ""
+
+
+def _dependencies_without_tomllib(text: str) -> list[str]:
+    """`[project] dependencies`, parsed the way the Python 3.10 leg must.
+
+    3.10 has no `tomllib`, and one field does not justify a TOML dependency
+    (same call as `_pyproject_version` above). Slice the array literal — its
+    terminator is anchored at column 0, which no line INSIDE the array is, so a
+    `]` inside one of its comments cannot end the slice early — then SCAN the
+    slice for quoted entries rather than matching one per line. TOML allows a
+    literal string (`'comfy-cli>=1.14.0'`), several entries on one line, and a
+    trailing `#` comment, none of which a line-anchored `^\\s*"..."` pattern
+    sees; and an entry this parser silently drops is an entry
+    `test_comfy_cli_is_not_a_declared_dependency` never gets to check.
+    `test_the_fallback_parse_matches_tomllib` pins it against the real parser.
+    """
+    match = re.search(
+        r"^dependencies\s*=\s*\[\n(.*?)^\]", text, re.MULTILINE | re.DOTALL
+    )
+    assert match is not None, "no `[project] dependencies` array in pyproject.toml"
+    body = match.group(1)
+    entries: list[str] = []
+    index = 0
+    while index < len(body):
+        char = body[index]
+        if char == "#":  # a comment runs to end of line
+            newline = body.find("\n", index)
+            index = len(body) if newline == -1 else newline + 1
+        elif char in "\"'":
+            end = index + 1
+            while end < len(body) and body[end] != char:
+                # Only a basic string can escape its own quote; `'…'` is literal.
+                end += 2 if char == '"' and body[end] == "\\" else 1
+            assert end < len(body), f"unterminated {char} string in dependencies"
+            entries.append(body[index + 1 : end])
+            index = end + 1
+        else:
+            index += 1
+    return entries
 
 
 def _runtime_dependencies() -> list[str]:
@@ -94,17 +137,7 @@ def _runtime_dependencies() -> list[str]:
         import tomllib
 
         return tomllib.loads(text)["project"]["dependencies"]
-    # 3.10 has no `tomllib`, and one field does not justify a TOML dependency
-    # (same call as `_pyproject_version` above). Slice the array literal: its
-    # terminator is anchored at column 0, which no line INSIDE the array is, so
-    # a `]` inside one of its comments cannot end the slice early.
-    match = re.search(
-        r"^dependencies\s*=\s*\[\n(.*?)^\]", text, re.MULTILINE | re.DOTALL
-    )
-    assert match is not None, "no `[project] dependencies` array in pyproject.toml"
-    # Requirements are the quoted, indented entries; a comment line starts with
-    # `#`, so requiring the quote at the start of the line skips them all.
-    return re.findall(r'^\s*"([^"]+)"', match.group(1), re.MULTILINE)
+    return _dependencies_without_tomllib(text)
 
 
 def test_runtime_dependencies_parse_as_expected():
@@ -116,6 +149,50 @@ def test_runtime_dependencies_parse_as_expected():
     """
     names = {_requirement_name(req) for req in _runtime_dependencies()}
     assert {"mcp", "pydantic", "anyio"} <= names, names
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="no tomllib to compare against")
+def test_the_fallback_parse_matches_tomllib():
+    """Pin the 3.10 fallback against a real TOML parser, on the legs that have one.
+
+    The check above only proves the fallback finds the three names it is told
+    to look for — it stays green if a fourth entry is dropped, which is exactly
+    how the absence assertion goes vacuous. Comparing the whole list catches a
+    dropped entry whatever form it takes; the 3.14 leg is where a mis-parse the
+    3.10 leg would swallow gets caught.
+    """
+    import tomllib
+
+    text = _PYPROJECT.read_text(encoding="utf-8")
+    assert (
+        _dependencies_without_tomllib(text)
+        == tomllib.loads(text)["project"]["dependencies"]
+    )
+
+
+@pytest.mark.parametrize(
+    "array",
+    [
+        pytest.param('    "mcp>=1.0",\n    "comfy-cli>=1.14.0",\n', id="basic-string"),
+        pytest.param("    'comfy-cli>=1.14.0',\n", id="literal-string"),
+        pytest.param('    "mcp>=1.0", "comfy-cli>=1.14.0",\n', id="two-on-one-line"),
+        pytest.param('    " comfy-cli>=1.14.0",\n', id="leading-whitespace"),
+        pytest.param('    "comfy-cli>=1.14.0",  # why\n', id="trailing-comment"),
+        pytest.param('    "comfy_cli>=1.14.0",\n', id="underscored-name"),
+    ],
+)
+def test_a_declared_comfy_cli_is_visible_in_every_toml_spelling(array):
+    """The absence assertion must SEE a comfy-cli however it is written.
+
+    A test that says "this name is absent" is only as good as the parser
+    underneath it: a spelling the parser skips reads as absent, and the
+    tripwire silently stops being one. Each form here is valid TOML that pip
+    accepts, and each was invisible to the line-anchored pattern this parser
+    replaced. Run against the helper (not the real file, which declares no
+    comfy-cli) — that is the only way to exercise the miss.
+    """
+    parsed = _dependencies_without_tomllib(f"dependencies = [\n{array}]\n")
+    assert "comfy-cli" in {_requirement_name(req) for req in parsed}, parsed
 
 
 def test_comfy_cli_is_not_a_declared_dependency():
@@ -149,11 +226,44 @@ def test_readme_quickstart_installs_the_engine_alongside():
     readme = _README.read_text(encoding="utf-8")
     command = f'pip install comfy-mcp "comfy-cli>={server._MIN_COMFY_CLI_STR}"'
     # Anchored to the Quickstart section (up to the next H2) — a mention buried
-    # further down is not what a new user follows.
-    start = readme.index("\n## Quickstart\n")
-    quickstart = readme[start : readme.index("\n## ", start + 1)]
+    # further down is not what a new user follows. `find`, not `index`: a
+    # renamed heading should fail as this test's own message, not as a bare
+    # `ValueError`, and Quickstart being the LAST H2 is a section to the end of
+    # the file, not an error.
+    start = readme.find("\n## Quickstart\n")
+    assert start != -1, "README has no `## Quickstart` section to anchor this test to"
+    end = readme.find("\n## ", start + 1)
+    quickstart = readme[start : end if end != -1 else len(readme)]
     assert command in quickstart, (
         f"the README quickstart must install the engine alongside the server "
         f"(`{command}`): comfy-cli is not a declared dependency, so nothing at "
         "install time tells the user they need it."
+    )
+
+
+def test_no_document_pins_a_stale_comfy_cli_floor():
+    """Every documented `comfy-cli >= …` names the CURRENT floor, not just the one above.
+
+    The quickstart is keyed to `_MIN_COMFY_CLI_STR`, but the same pin is
+    written out again in the README prerequisites and in `pyproject.toml`'s
+    rationale. Without this, raising the floor in `server.py` fails on the one
+    copy the test above reads and leaves the rest silently stale — telling a
+    user to install a comfy-cli the runtime gate will then reject.
+
+    Scoped to the DOCS. `server.py`'s own prose is left out on purpose: a
+    per-tool minimum there may legitimately sit above the global floor.
+    """
+    floor = server._MIN_COMFY_CLI_STR
+    pattern = r"comfy-cli\s*(?:>=|≥)\s*v?([0-9][0-9A-Za-z.+!-]*)"
+    stale = {}
+    for name in ("README.md", "AGENTS.md", "pyproject.toml"):
+        pinned = set(re.findall(pattern, (_ROOT / name).read_text(encoding="utf-8")))
+        if pinned - {floor}:
+            stale[name] = sorted(pinned - {floor})
+    assert not stale, (
+        f"these docs pin a comfy-cli floor other than `{floor}` (the value of "
+        f"`server._MIN_COMFY_CLI_STR`): {stale}. Raising the floor means "
+        "updating every copy — the README quickstart AND prerequisites, and "
+        "pyproject.toml's rationale — or the docs send users to a version the "
+        "runtime gate rejects."
     )

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,4 +1,6 @@
-"""The packaged version lives in two files; pin that they agree.
+"""Packaging invariants: the two version files, and the undeclared engine.
+
+The packaged version lives in two files; pin that they agree.
 
 `publish.yml`'s `check-version` job already compares both against the release
 tag — but it runs on the `release: created` event, so it fires only AFTER the
@@ -10,6 +12,17 @@ Read from the FILES rather than `importlib.metadata`: an editable install
 carries the version recorded when it was installed, so a stale local env would
 compare the wrong string in both directions. The files are the source of truth
 the release checks against.
+
+The second invariant is the deliberately UNDECLARED engine. comfy-cli is not a
+dependency of this distribution — the binary that matters is whichever one
+`PATH`/`COMFY_BIN` resolves to, so a pinned wheel would install a second copy
+the tools may never call — and the price is that a bare `pip install comfy-mcp`
+yields a server whose every tool errors until the user installs comfy-cli
+themselves. That price is paid in the README, which installs both in one
+command. The two halves are therefore one decision, and these tests pin them as
+a pair: undeclared HERE requires documented THERE, so a future "fix" to either
+half fails loudly instead of quietly leaving new users with a broken install (or
+leaving the docs telling them to install something pip already did).
 """
 
 import re
@@ -17,10 +30,12 @@ import sys
 from pathlib import Path
 
 import comfy_mcp
+from comfy_mcp import server
 
 _ROOT = Path(__file__).resolve().parent.parent
 _PYPROJECT = _ROOT / "pyproject.toml"
 _INIT = _ROOT / "src" / "comfy_mcp" / "__init__.py"
+_README = _ROOT / "README.md"
 
 
 def _pyproject_version() -> str:
@@ -57,3 +72,88 @@ def test_pyproject_and_dunder_version_agree():
 def test_imported_dunder_matches_its_own_source():
     """Guard the parse above: the literal read must match the imported value."""
     assert comfy_mcp.__version__ == _dunder_version_literal()
+
+
+def _requirement_name(requirement: str) -> str:
+    """The PEP 503-normalized distribution name in a PEP 508 requirement.
+
+    Normalized rather than compared literally, so `comfy_cli` / `Comfy.CLI` —
+    the same distribution to pip — cannot slip past the assertion below. An
+    entry with no leading name (nothing valid produces one) returns `""` rather
+    than raising, so a malformed array fails on the assertion that reads it, not
+    inside this helper.
+    """
+    match = re.match(r"[A-Za-z0-9._-]+", requirement)
+    return re.sub(r"[-_.]+", "-", match.group(0)).lower() if match else ""
+
+
+def _runtime_dependencies() -> list[str]:
+    """The requirement strings in `[project] dependencies`."""
+    text = _PYPROJECT.read_text(encoding="utf-8")
+    if sys.version_info >= (3, 11):
+        import tomllib
+
+        return tomllib.loads(text)["project"]["dependencies"]
+    # 3.10 has no `tomllib`, and one field does not justify a TOML dependency
+    # (same call as `_pyproject_version` above). Slice the array literal: its
+    # terminator is anchored at column 0, which no line INSIDE the array is, so
+    # a `]` inside one of its comments cannot end the slice early.
+    match = re.search(
+        r"^dependencies\s*=\s*\[\n(.*?)^\]", text, re.MULTILINE | re.DOTALL
+    )
+    assert match is not None, "no `[project] dependencies` array in pyproject.toml"
+    # Requirements are the quoted, indented entries; a comment line starts with
+    # `#`, so requiring the quote at the start of the line skips them all.
+    return re.findall(r'^\s*"([^"]+)"', match.group(1), re.MULTILINE)
+
+
+def test_runtime_dependencies_parse_as_expected():
+    """Guard the parse above: it must find the deps that ARE declared.
+
+    Without this, a regex that silently matched nothing (a reformatted array, a
+    trailing-comment style change) would make the negative assertion below pass
+    vacuously — the one failure mode a "this name is absent" test has.
+    """
+    names = {_requirement_name(req) for req in _runtime_dependencies()}
+    assert {"mcp", "pydantic", "anyio"} <= names, names
+
+
+def test_comfy_cli_is_not_a_declared_dependency():
+    """comfy-cli stays undeclared — see this module's docstring for why.
+
+    Not a style rule: the server invokes whatever `comfy` binary
+    `PATH`/`COMFY_BIN` names, and enforces its floor at runtime against THAT
+    binary. Declaring it here would install a copy into this environment that
+    the tools may never call. Reversing the decision is allowed — it just has
+    to be a decision, taken together with the README half below.
+    """
+    declared = [
+        req for req in _runtime_dependencies() if _requirement_name(req) == "comfy-cli"
+    ]
+    assert not declared, (
+        f"comfy-cli is declared as a runtime dependency ({declared}) — it is "
+        "deliberately NOT one (pyproject.toml's comment, AGENTS.md 'Toolchain'). "
+        "If that decision is being reversed on purpose, update this test, the "
+        "pyproject comment, AGENTS.md, and the README quickstart together."
+    )
+
+
+def test_readme_quickstart_installs_the_engine_alongside():
+    """The docs half of the decision above: install both, in one command.
+
+    Keyed on the exact command a user copies, with the floor read from
+    `_MIN_COMFY_CLI_STR` rather than hardcoded — so raising the floor in
+    `server.py` fails here until the README says the new number, the same way
+    the runtime error message does.
+    """
+    readme = _README.read_text(encoding="utf-8")
+    command = f'pip install comfy-mcp "comfy-cli>={server._MIN_COMFY_CLI_STR}"'
+    # Anchored to the Quickstart section (up to the next H2) — a mention buried
+    # further down is not what a new user follows.
+    start = readme.index("\n## Quickstart\n")
+    quickstart = readme[start : readme.index("\n## ", start + 1)]
+    assert command in quickstart, (
+        f"the README quickstart must install the engine alongside the server "
+        f"(`{command}`): comfy-cli is not a declared dependency, so nothing at "
+        "install time tells the user they need it."
+    )


### PR DESCRIPTION
## ELI-5

`pip install comfy-mcp` gives you a server that starts fine and then fails on every single tool call, because the engine it drives — `comfy-cli` — is not installed with it, and nothing told you that. This PR keeps the deliberate decision not to bundle comfy-cli, and instead makes the install docs say the true thing: install both, in one command.

## Summary

The wheel declares `mcp`, `pydantic`, `anyio` — not `comfy-cli`. That is on purpose (the server shells out to whichever `comfy` binary `PATH`/`COMFY_BIN` resolves to, and enforces its `>= 1.14.0` floor at runtime against *that* binary), but the reasoning lived only in a `pyproject.toml` comment, and the README's quickstart still described a source-checkout install (`pip install .`) rather than the published package. So a user following the natural PyPI path got the comfy-cli half nowhere. This is the docs-side fix, plus a test so the two halves cannot drift apart.

## Changes

- **README quickstart** now installs the published package and the engine in one command — `pip install comfy-mcp "comfy-cli>=1.14.0"` — and says explicitly that installing this server does *not* install comfy-cli, why, and what the symptom is if you skip it. The source-checkout install (`pip install .` / `-e .`) stays, as the alternative it now is.
- **Prerequisites** repeats the non-dependency statement where someone debugging looks for it, with the same co-install command.
- **AGENTS.md** ("Toolchain") records the decision for future contributors and agents, with a "do not 'fix' this by adding it" — `publish.yml`'s `verify-install` job already said "the USER's dependency and deliberately not bundled (see AGENTS.md)", pointing at a document that did not mention it. It does now.
- **pyproject.toml**'s rationale gains the other half of the tradeoff: what the decision costs, and where that cost is paid.
- **tests/test_packaging.py** pins the pair — comfy-cli absent from `[project] dependencies` (name-normalized, so `comfy_cli` is caught too) *and* the quickstart carrying the co-install command, with the floor read from `server._MIN_COMFY_CLI_STR` rather than hardcoded, so raising the floor fails here until the README says the new number. A third test guards the dependency parse itself, so the negative assertion cannot pass vacuously.

## Motivation

Reported from a fresh Python 3.12 venv against published 0.10.0. The report offered two fixes: declare `comfy-cli>=1.14.0` (Option A) or keep it undeclared and document it (Option B).

**Decision: Option B**, for three reasons.

1. It is a pre-existing, reviewed decision (#37 added both the runtime compatibility gate and the pyproject rationale), and the runtime gate is what actually protects the user: it checks the binary being *invoked*, which a declared dependency does not constrain.
2. A declaration installs a comfy-cli into the *server's* environment, which is frequently not the one whose `comfy` the tools drive — that is exactly what `COMFY_BIN` exists for. It would look fixed while the real binary stayed unchecked.
3. It is not a small dependency. Measured below: resolving `comfy-cli` adds ~40 further distributions (GitPython, cookiecutter, `uv`, `ruff`, analytics clients) that every `comfy-mcp` install would then carry.

The ticket also asked, if undeclared is intentional, that the rationale be recorded so it does not get "fixed" back and forth — that is the AGENTS.md + test half.

## Testing

- [x] Existing tests pass (`pytest` — 2020 passed, 1 skipped)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually (below)

**Empirical check of the claims this PR makes**, against the published 0.10.0 wheel in a fresh venv:

- `pip install --dry-run comfy-mcp` → `Would install … comfy-mcp-0.10.0 mcp-2.0.0 pydantic-2.13.4 anyio-4.14.2 …` — **no comfy-cli**. The report's premise reproduces.
- `pip install --dry-run comfy-mcp "comfy-cli>=1.14.0"` (the command this PR documents) → `Would install … comfy-cli-1.16.0 comfy-mcp-0.10.0 …` plus ~40 transitive distributions. The documented one-liner resolves, and the size of the dependency it would otherwise force is the third argument above.
- The symptom quoted in the README ("`comfy` not found on PATH") is the server's own `_require_comfy_bin` message, which already names the fix.

Negative-claim check: this diff denies no capability — it documents an install-time fact that was verified above by attempting the install both ways.

## Additional Notes

- **`pip show comfy-mcp` will still not list comfy-cli** — that is Option B, not an oversight. The report's first verification bullet (Requires includes comfy-cli) is the Option A alternative and is intentionally unmet; the second (docs updated) is what this PR delivers.
- The new `test_comfy_cli_is_not_a_declared_dependency` is a tripwire, not a veto: its failure message says how to reverse the decision properly (test + pyproject + AGENTS.md + README together).
- The 3.10 leg of CI exercises a regex fallback for reading the dependency array (no `tomllib` there). If the array is ever reformatted to a single line, that leg fails loudly with a named assertion rather than passing silently.
