### PR TITLE
fix(server): report the package version in the MCP initialize handshake

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -63,6 +63,7 @@ import asyncio
 import contextlib
 import errno
 import functools
+import importlib.metadata
 import ipaddress
 import json
 import logging
@@ -86,11 +87,65 @@ from mcp import types
 from mcp.server.mcpserver import Context, Image, MCPServer
 from pydantic import BaseModel, Field
 
+from . import __version__ as _SOURCE_VERSION
 from . import argv, clitext, errors, failure_log, instructions, params, target, tcc
 from .errors import ComfyCliError
 from .params import SlotOverride, SlotVariants
 
-mcp = MCPServer("comfy-mcp", instructions=instructions.INSTRUCTIONS)
+# The distribution name from `pyproject.toml` — what `pip install` records.
+# Spelled out rather than taken from `__package__`: that is the IMPORT name
+# (`comfy_mcp`), a different string that resolves here only because
+# `importlib.metadata` normalizes `_` to `-` before it looks a distribution up.
+_DISTRIBUTION = "comfy-mcp"
+
+
+def _server_version() -> str:
+    """The version this server reports in the ``initialize`` handshake.
+
+    Prefer the INSTALLED distribution's metadata: that is the release a user's
+    bug report has to be correlated with, and it is what ``pip install
+    comfy-mcp`` records. A source tree that was never installed (running
+    straight off ``PYTHONPATH=src``) has no distribution metadata at all, so
+    fall back to the package literal — ``tests/test_packaging.py`` pins that
+    literal to ``pyproject.toml``'s version, so the two only disagree when a
+    stale editable install lags the checkout, and there the *installed* string
+    is still the honest answer.
+
+    Fails OPEN in every direction, like the startup snapshot probe: this runs at
+    IMPORT time, so anything raising here would take the whole server down over
+    a display string.
+    """
+    try:
+        detected = importlib.metadata.version(_DISTRIBUTION)
+    except importlib.metadata.PackageNotFoundError:
+        # Not installed as a distribution at all — a source checkout on
+        # ``PYTHONPATH``. The normal dev case, not an error.
+        detected = None
+    except Exception:
+        # Anything else means the installed metadata exists but is unreadable
+        # (a truncated or half-written ``.dist-info``). The literal below is
+        # still a correct answer for the code that is actually running.
+        logging.getLogger(__name__).warning(
+            "could not read installed %s metadata; reporting the source version",
+            _DISTRIBUTION,
+            exc_info=True,
+        )
+        detected = None
+    # `or`, not a bare return: metadata with no `Version:` field yields None,
+    # which would reach the client as the very empty version this exists to fix.
+    return detected or _SOURCE_VERSION
+
+
+# `version` is passed explicitly because the SDK does not infer one: it defaults
+# to `""` and `Server.server_info` hands that straight to the client, so an
+# unversioned server answers `initialize` with `"serverInfo": {"name":
+# "comfy-mcp", "version": ""}` — nothing for a client to display, and nothing to
+# correlate a bug report against.
+mcp = MCPServer(
+    "comfy-mcp",
+    version=_server_version(),
+    instructions=instructions.INSTRUCTIONS,
+)
 
 # Allow overriding the binary (e.g. a venv path) without touching code. The
 # companion address override needs no constant here: a LOCAL ComfyUI on a

--- a/tests/test_server_version.py
+++ b/tests/test_server_version.py
@@ -1,0 +1,173 @@
+"""The `initialize` handshake must report this server's version, not `""`.
+
+The SDK does not infer a version: `MCPServer(...)` defaults `version` to the
+empty string and `Server.server_info` hands that straight to the client, so
+forgetting the argument is silent — every tool still works, and the only symptom
+is `"serverInfo": {"name": "comfy-mcp", "version": ""}` in a client's logs, with
+nothing to display and nothing to correlate a bug report against. Nothing else
+in the suite touches the handshake identity, so this file is the whole guard.
+
+It has three layers on purpose:
+
+* the WIRE check — a real `initialize` over a real stdio subprocess, the only
+  thing that proves the string reaches a CLIENT rather than merely reaching a
+  constructor;
+* the SOURCE check — where that string comes from, including the fallback the
+  wire check (which always runs installed) can never exercise;
+* the SDK check — that the constructor keyword is still spelled `version`, since
+  a rename would quietly restore the empty default.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import inspect
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+from mcp.server.mcpserver import MCPServer
+
+import comfy_mcp
+from comfy_mcp import server
+
+# Bounds the stdio handshake below. Generous because it covers interpreter
+# startup plus importing the SDK, not the handshake itself (milliseconds); a
+# cold CI runner is the slow case.
+_HANDSHAKE_TIMEOUT_S = 120.0
+
+_INITIALIZE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-06-18",
+        "capabilities": {},
+        "clientInfo": {"name": "comfy-mcp-tests", "version": "0"},
+    },
+}
+
+
+def _stdio_server_info() -> dict:
+    """Run the real stdio server, send `initialize`, return its `serverInfo`."""
+    proc = subprocess.Popen(
+        # Via the same entry point the console script uses, since that script is
+        # not guaranteed to be on PATH under every install layout.
+        [sys.executable, "-c", "from comfy_mcp.server import main; main()"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        # Point the startup machine-snapshot probe at a binary that cannot
+        # exist. The probe is best-effort and falls open either way, but letting
+        # it resolve a real `comfy` would make this test's runtime depend on
+        # whether the machine has comfy-cli installed and how fast it answers.
+        env={**os.environ, "COMFY_BIN": "/nonexistent/comfy-mcp-test-binary"},
+    )
+    try:
+        # Closing stdin after the one request is what ends the server: it reads
+        # EOF on its JSON-RPC channel and exits, so the success path never needs
+        # a kill.
+        stdout, stderr = proc.communicate(
+            json.dumps(_INITIALIZE) + "\n", timeout=_HANDSHAKE_TIMEOUT_S
+        )
+    except subprocess.TimeoutExpired:  # pragma: no cover - only on a wedged server
+        proc.kill()
+        _, stderr = proc.communicate()
+        pytest.fail(
+            f"stdio server did not answer initialize in {_HANDSHAKE_TIMEOUT_S}s. "
+            f"stderr: {stderr[-2000:]}"
+        )
+    for line in stdout.splitlines():
+        try:
+            message = json.loads(line)
+        except ValueError:
+            # stdout is the JSON-RPC channel, but be forgiving about anything
+            # else landing on it rather than turning noise into a confusing
+            # failure.
+            continue
+        if message.get("id") == 1 and "result" in message:
+            return message["result"]["serverInfo"]
+    pytest.fail(
+        f"no initialize response on stdout.\n"
+        f"stdout: {stdout[:2000]}\nstderr: {stderr[-2000:]}"
+    )
+
+
+def test_initialize_reports_a_real_version_over_stdio():
+    """The regression itself: a client saw `"version": ""`."""
+    info = _stdio_server_info()
+    assert info["name"] == "comfy-mcp"
+    assert info["version"], "serverInfo.version is empty — a client has nothing to show"
+    assert info["version"] == importlib.metadata.version("comfy-mcp")
+
+
+def test_the_configured_version_is_the_installed_distribution_version():
+    """Cheap, no-subprocess restatement of the above, for a fast failure."""
+    assert server.mcp.version == importlib.metadata.version("comfy-mcp")
+
+
+def test_version_falls_back_to_the_source_literal_without_distribution_metadata(
+    monkeypatch,
+):
+    """A checkout run straight off `PYTHONPATH=src` has no installed metadata.
+
+    Unreachable from the wire test, which always runs against an install — but
+    it is the branch that keeps `_server_version` from raising during import and
+    taking the whole server down, where a missing version used to merely look
+    untidy.
+    """
+
+    def _absent(name):
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", _absent)
+    assert server._server_version() == comfy_mcp.__version__
+
+
+def test_unreadable_distribution_metadata_falls_back_instead_of_raising(
+    monkeypatch, caplog
+):
+    """`_server_version` runs at import: raising would stop the server starting.
+
+    A half-written or truncated `.dist-info` is the realistic way
+    `importlib.metadata` fails with something other than
+    `PackageNotFoundError`, and a display string is not worth a dead server.
+    """
+
+    def _broken(name):
+        raise ValueError(f"unreadable metadata for {name}")
+
+    monkeypatch.setattr(importlib.metadata, "version", _broken)
+    with caplog.at_level("WARNING"):
+        assert server._server_version() == comfy_mcp.__version__
+    assert "could not read installed comfy-mcp metadata" in caplog.text
+
+
+def test_metadata_without_a_version_field_falls_back(monkeypatch):
+    """`Distribution.version` is `None` when the `Version:` field is missing.
+
+    Passing that through would reproduce the exact empty `serverInfo.version`
+    this whole file exists to prevent, one layer down.
+    """
+    monkeypatch.setattr(importlib.metadata, "version", lambda name: None)
+    assert server._server_version() == comfy_mcp.__version__
+
+
+def test_sdk_still_spells_the_handshake_version_argument_version():
+    """A renamed SDK keyword would silently restore the empty default.
+
+    Same reasoning as `test_sdk_conformance.py`. An outright rename would in
+    fact fail loudly at import (`TypeError: unexpected keyword argument`); what
+    this pins is the other half — that the DEFAULT is still the empty string
+    this fix exists to displace, so an SDK that starts deriving a version does
+    not leave the argument sitting here unexamined.
+    """
+    parameter = inspect.signature(MCPServer.__init__).parameters.get("version")
+    assert parameter is not None, "MCPServer no longer takes a `version` argument"
+    assert parameter.default == "", (
+        "MCPServer.version no longer defaults to the empty string — re-check "
+        "whether passing it explicitly is still what reaches serverInfo."
+    )


### PR DESCRIPTION
## ELI-5

When an MCP client connects, the server introduces itself: *"I'm comfy-mcp, version X."* Ours was saying *"I'm comfy-mcp, version ''"* — it never filled in the version. This fills it in from the installed package, so a client can show `0.10.0` and a bug report can be tied to a release.

## Summary

`initialize` was answering with `"serverInfo": {"name": "comfy-mcp", "version": ""}`. The MCP SDK does not derive a version: `MCPServer(...)` defaults `version` to `""` and `Server.server_info` hands that straight to the client ("An unversioned server reports an empty `version`; the SDK never substitutes its own" — the SDK's own docstring). We were never passing one.

## Changes

- `server.py`: pass `version=_server_version()` to `MCPServer(...)`.
- `_server_version()` resolves `importlib.metadata.version("comfy-mcp")` — the *installed* release, which is what a user's bug report has to be correlated with — and falls back to the `comfy_mcp.__version__` literal for a source tree that was never installed (`PYTHONPATH=src`). `tests/test_packaging.py` already pins that literal to `pyproject.toml`, so the two only diverge when a stale editable install lags the checkout, and there the installed string is the honest answer.
- It fails **open** in every direction, the way the startup machine-snapshot probe does: it runs at *import* time, so unreadable `.dist-info` metadata (or metadata with no `Version:` field, which yields `None`) falls back to the literal and logs a warning rather than raising and preventing the server from starting at all.
- `tests/test_server_version.py`: new, six tests in three layers — a real `initialize` over a real stdio subprocess (the wire), the resolution/fallback branches (the source), and a conformance pin that the SDK still spells the keyword `version` and still defaults it to `""`.

## Motivation

Clients that display or log the server version showed an empty string, and there was no way to tell which release a user was running from a handshake capture.

## Testing

- [x] Existing tests pass (`pytest` — 2023 passed, 1 skipped, 6 deselected)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually — stdio harness against the real entry point, exactly as the report describes:

```
# before
serverInfo: {"name": "comfy-mcp", "version": ""}
# after
serverInfo: {"name": "comfy-mcp", "version": "0.10.0"}
```

That harness is now the first test in the new file; it fails on the pre-fix tree (confirmed by stashing the `server.py` change and re-running) and passes after, so it is a real regression guard rather than a restatement of the implementation. It points the child's `COMFY_BIN` at a non-existent path so the best-effort startup snapshot probe cannot make the test's runtime depend on whether the machine has comfy-cli installed; the whole file runs in ~0.4s.

## Additional Notes

- **Thin-wrapper rule:** untouched. This is MCP protocol surface — the handshake identity block — which AGENTS.md names as the one thing that legitimately lives here rather than in comfy-cli. No new comfy-cli call, no derived verdict.
- **Judgment call — `importlib.metadata` first, literal second.** The reverse (literal first) is simpler and never touches metadata, but it reports what the *source tree* says, which is the wrong answer for the stated goal of correlating a bug report with an installed release. The literal is kept strictly as the not-installed fallback.
- **Judgment call — the broad `except`.** Beyond `PackageNotFoundError` this catches anything else `importlib.metadata` can raise, because the call sits at module import: a broken install would otherwise turn a cosmetic gap into a server that will not start. It logs with `exc_info` (so ruff's `BLE` is satisfied on its own terms, not with a `noqa`).
- **Deliberately out of scope:** `server_info`'s `compatibility` block still reports only comfy-cli's version, not this server's. Adding `server_version` there would change a tool's output shape for a benefit the handshake now covers; happy to do it as a follow-up if reviewers want it.
- **Negative-claim falsification (per the review checklist):** not applicable — the diff denies no capability. It adds a string to the handshake; there is no new deny/dead-end path, no "not supported" message, and no test flipped to assert one.
