### PR TITLE
ci: publish the server listing to the official MCP Registry on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -163,3 +163,109 @@ jobs:
           INSTALLED=$(python -c "import comfy_mcp; print(comfy_mcp.__version__)")
           echo "imported comfy_mcp ${INSTALLED}"
           test "${INSTALLED}" = "${VERSION}"
+
+  # The listing in the official MCP Registry (registry.modelcontextprotocol.io),
+  # which is the directory MCP clients search for installable servers. It is a
+  # separate publish from PyPI's and a separate identity: PyPI knows this project
+  # as the distribution `comfy-mcp`, the registry knows it as
+  # `io.github.Comfy-Org/comfy-mcp`, and the entry is what ties the two together.
+  #
+  # It runs after `verify-install` rather than after `build-and-publish` because
+  # the registry does not take the listing on trust: it fetches
+  # `https://pypi.org/pypi/comfy-mcp/<version>/json` and refuses to publish until
+  # that exact version exists AND its description carries the ownership token (see
+  # README.md's `mcp-name:` comment). `verify-install` is precisely the job that
+  # waits out PyPI's index lag, so hanging this off it turns a race into a
+  # dependency. `verify-install` needs `build-and-publish` needs `check-version`,
+  # so the tag has already been proven to match both packaged version files by the
+  # time this job reads it — that check is inherited, not repeated here.
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    needs: verify-install
+    runs-on: ubuntu-latest
+    permissions:
+      # Scoped to THIS job, not the workflow: `id-token: write` mints an OIDC
+      # token for this repository, and the only step that should be able to
+      # obtain one is the publisher login below. A job-level block zeroes what it
+      # does not name, so `contents: read` is restated for the checkout (the same
+      # reason `build-and-publish` restates it).
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Sync server.json to the release tag
+        env:
+          # The same input `check-version` reads, so both jobs derive the version
+          # from one source. `GITHUB_REF` would also work on this trigger, but a
+          # release can be created against a tag whose ref this job did not check
+          # out, and there is no reason for the two jobs to disagree about where
+          # the number comes from.
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          # The committed version in server.json is only a seed; the tag is the
+          # source of truth, so the listing always matches the release with no
+          # hand-editing. Guard it before it reaches a PUBLIC directory: an entry
+          # published under a garbage version cannot be quietly withdrawn, and
+          # `check-version` has only proven the tag equals the packaged version —
+          # not that either is canonical. Every release here is a plain vX.Y.Z, so
+          # reject leading zeros and any prerelease/build suffix (v01.2.3,
+          # v1.2.3-rc.1) rather than smuggle a non-canonical version into the
+          # registry.
+          if ! [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::Refusing to publish: '${TAG}' is not a canonical vX.Y.Z release tag"
+            exit 1
+          fi
+          # BOTH versions: the server version and the PyPI package version the
+          # registry resolves. Leaving `.packages[].version` at the committed seed
+          # would point a freshly published listing at whatever release happened
+          # to be current when the file was last touched.
+          jq --arg v "$VERSION" '.version = $v | .packages[].version = $v' \
+            server.json > server.tmp
+          mv server.tmp server.json
+          # `jq -e` so a rewrite that silently matched nothing (a renamed field, an
+          # emptied `packages` array) fails here rather than publishing the seed.
+          jq -e --arg v "$VERSION" \
+            '.version == $v and (.packages | length > 0) and all(.packages[]; .version == $v)' \
+            server.json > /dev/null
+          echo "server.json pinned to ${VERSION}"
+          cat server.json
+
+      # Pin mcp-publisher to an explicit release and verify the download against
+      # that release's published SHA256 before extracting or executing it. This
+      # job holds `id-token: write`, so an unpinned `releases/latest` binary would
+      # run — and receive an OIDC token for this repository — with no supply-chain
+      # guarantee whatsoever. Pin + verify closes that. Bump the version here
+      # deliberately; `checksums.txt` comes from the same pinned release, so the
+      # two can never drift apart.
+      - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.1
+        run: |
+          set -euo pipefail
+          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          case "$(uname -m)" in
+            x86_64) arch=amd64 ;;
+            aarch64 | arm64) arch=arm64 ;;
+            *) echo "::error::Unsupported architecture: $(uname -m)"; exit 1 ;;
+          esac
+          asset="mcp-publisher_${os}_${arch}.tar.gz"
+          base="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}"
+          curl -fsSL -o "$asset" "${base}/${asset}"
+          curl -fsSL -o checksums.txt "${base}/registry_${MCP_PUBLISHER_VERSION#v}_checksums.txt"
+          # Anchored to end-of-line so the sibling `<asset>.sbom.json` entry cannot
+          # be the line that gets checked. A grep that matches nothing exits 1 and
+          # `pipefail` fails the step, so a renamed asset cannot skip verification.
+          grep " ${asset}\$" checksums.txt | sha256sum -c -
+          tar xzf "$asset" mcp-publisher
+
+      # Exchanges the job's OIDC token for a registry credential. The namespace
+      # grant is CASE-SENSITIVE and scoped to `io.github.Comfy-Org/*`, which is why
+      # server.json spells the org exactly as GitHub does.
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+<!--
+mcp-name: io.github.Comfy-Org/comfy-mcp
+
+The line above is not decoration and not a comment for readers: it is the
+ownership token the official MCP Registry checks. Publishing the listing in
+`server.json` makes registry.modelcontextprotocol.io fetch this package's
+metadata from PyPI and look for `mcp-name: <the server.json name>` in the
+description — which for this project is this file, verbatim, as
+`[project] readme` in pyproject.toml. Finding it is how the registry proves
+that whoever owns the GitHub namespace also owns the PyPI package.
+
+So the string must stay byte-identical to `server.json`'s `name` (including
+its capitalisation), must stay in README.md rather than move to a file PyPI
+never sees, and must keep a space or a newline after it — a token glued to
+the following character is read as a prefix of some longer name and rejected.
+tests/test_packaging.py pins all three. Removing it does not break anything
+here; it breaks the next release's registry publish.
+-->
+
 <div align="center">
 
 <img src="assets/logo.svg" alt="Comfy" width="160"/>

--- a/server.json
+++ b/server.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Comfy-Org/comfy-mcp",
+  "description": "Drive the ComfyUI installed on your own machine: generate, monitor jobs, and build workflows.",
+  "version": "0.10.0",
+  "websiteUrl": "https://docs.comfy.org/agent-tools/mcp",
+  "repository": {
+    "url": "https://github.com/Comfy-Org/comfy-mcp",
+    "source": "github",
+    "id": "1286514652"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "comfy-mcp",
+      "version": "0.10.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -29,8 +29,17 @@ The third invariant is `[project.urls]`, the links PyPI renders in its
 sidebar. Nothing in this repo displays them, so their absence is invisible
 here and only shows up on a published page — which is how 0.10.0 shipped with
 `"project_urls": null` and a blank `Home-page`.
+
+The fourth is `server.json`, the listing published to the official MCP
+Registry. It is the same shape of problem one step further out: nothing in this
+repo reads that file, and its consumer is a PUBLIC directory reached only from
+`publish.yml`'s `publish-mcp-registry` job, on a `release: created` event, after
+PyPI has already been written to irreversibly. A mistake there is discovered at
+the worst possible moment, so the checks that can be made statically are made
+here instead.
 """
 
+import json
 import re
 import sys
 from pathlib import Path
@@ -44,6 +53,7 @@ _ROOT = Path(__file__).resolve().parent.parent
 _PYPROJECT = _ROOT / "pyproject.toml"
 _INIT = _ROOT / "src" / "comfy_mcp" / "__init__.py"
 _README = _ROOT / "README.md"
+_SERVER_JSON = _ROOT / "server.json"
 
 
 def _pyproject_version() -> str:
@@ -393,4 +403,183 @@ def test_project_urls_point_at_this_repository():
     assert urls.get("Issues", "").startswith(_REPO_URL + "/"), (
         f"pyproject.toml `[project.urls]` has Issues={urls.get('Issues')!r}, "
         f"expected an issue tracker under {_REPO_URL}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# server.json — the official MCP Registry listing.
+#
+# `publish.yml`'s `publish-mcp-registry` job rewrites the two version fields
+# from the release tag and hands the file to `mcp-publisher`. Everything ELSE in
+# it ships exactly as committed, to a public directory, under the org's
+# identity — and the failure modes are all silent here and loud there. So the
+# invariants below are the ones the registry itself enforces at publish time,
+# pinned at PR time where the fix is an edit.
+# ---------------------------------------------------------------------------
+
+# The namespace the org's registry grant covers is `io.github.Comfy-Org/*` and
+# it is CASE-SENSITIVE — a publish as `io.github.comfy-org/...` is rejected 403.
+_SERVER_NAME = "io.github.Comfy-Org/comfy-mcp"
+
+# https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json:
+# `description` is `maxLength: 100`, and the publisher rejects a longer one
+# rather than truncating it.
+_MAX_REGISTRY_DESCRIPTION = 100
+
+# The registry accepts exactly this base URL for `registryType: pypi`
+# (`model.RegistryURLPyPI`); anything else, including a trailing slash or the
+# JSON API path, fails validation as a registry/type mismatch.
+_PYPI_BASE_URL = "https://pypi.org"
+
+
+def _server_json() -> dict:
+    return json.loads(_SERVER_JSON.read_text(encoding="utf-8"))
+
+
+def test_server_json_is_valid_json_naming_this_org_namespace():
+    """The name is the identity the registry authorizes, and its case matters.
+
+    The sibling cloud server's first publish attempt died on exactly this:
+    `403 … You have permission to publish: io.github.Comfy-Org/*. Attempting to
+    publish: io.github.comfy-org/comfy-cloud-mcp-server`. A lowercased org here
+    would fail the same way — after the release is cut and PyPI is written.
+    """
+    assert _server_json().get("name") == _SERVER_NAME
+
+
+def test_server_json_declares_the_pypi_package_and_no_remotes():
+    """This is a LOCAL stdio server: a package to install, not a URL to call.
+
+    The cloud MCP's listing is the opposite shape — a `remotes` entry pointing
+    at its hosted endpoint — and it is the nearest file to copy from. A
+    `remotes` block here would advertise this project as something a client can
+    connect to over the network, which it is not.
+    """
+    server_json = _server_json()
+    assert "remotes" not in server_json, (
+        "server.json declares `remotes`. This server is stdio: the client "
+        "launches it as a subprocess from the installed PyPI package. A "
+        "`remotes` entry belongs to the cloud MCP, not to this one."
+    )
+    packages = server_json.get("packages")
+    assert isinstance(packages, list) and len(packages) == 1, packages
+    package = packages[0]
+    assert package.get("registryType") == "pypi", package
+    assert package.get("identifier") == "comfy-mcp", package
+    assert package.get("registryBaseUrl") == _PYPI_BASE_URL, package
+    assert package.get("transport") == {"type": "stdio"}, package
+
+
+def test_server_json_versions_seed_from_the_packaged_version():
+    """Both version fields, kept honest even though the job overwrites them.
+
+    `publish-mcp-registry` rewrites `.version` AND `.packages[].version` from
+    the tag, so a stale committed value never reaches the registry. It is still
+    wrong to leave one behind: the file is what a reader (and `mcp-publisher
+    validate`) sees, and a `packages[].version` that names a release which does
+    not exist on PyPI is indistinguishable from a real defect.
+    """
+    server_json = _server_json()
+    version = _pyproject_version()
+    assert server_json.get("version") == version, (
+        f"server.json version {server_json.get('version')!r} != packaged "
+        f"version {version!r}. Both version bumps happen in one commit."
+    )
+    assert [package.get("version") for package in server_json["packages"]] == [
+        version
+    ], server_json["packages"]
+
+
+def test_server_json_description_fits_the_registry_limit():
+    """`maxLength: 100` in the schema, enforced by the publisher, not trimmed."""
+    description = _server_json().get("description", "")
+    assert 0 < len(description) <= _MAX_REGISTRY_DESCRIPTION, (
+        f"server.json description is {len(description)} characters; the "
+        f"registry schema caps it at {_MAX_REGISTRY_DESCRIPTION}."
+    )
+
+
+def test_server_json_links_point_at_this_repository():
+    """A copy from the cloud server's listing would advertise the wrong project.
+
+    `repository.url` is checked against the same constant `[project.urls]` uses,
+    so the two cannot drift; `websiteUrl` is only required not to be the cloud
+    server's page, because which docs page is right is an editorial call this
+    test has no business making.
+    """
+    server_json = _server_json()
+    assert server_json.get("repository", {}).get("url") == _REPO_URL, server_json
+    assert server_json.get("repository", {}).get("source") == "github", server_json
+    website = server_json.get("websiteUrl", "")
+    assert website.startswith("https://"), website
+    assert "/agent-tools/cloud" not in website, (
+        f"server.json websiteUrl is {website!r}, the Comfy Cloud MCP's page. "
+        "This listing is for the local server."
+    )
+
+
+# The registry's own boundary rule for the ownership token, from
+# `internal/validators/registries/mcpname.go`: the matched name must be followed
+# by end-of-content, a character that cannot continue a server name, or an HTML
+# comment close. Anything else means the token was read as a PREFIX of some
+# longer name and the publish is rejected — which is a real trap here, because
+# the documented place to hide the token is an HTML comment.
+_SERVER_NAME_CHARS = re.compile(r"[A-Za-z0-9._/-]")
+
+
+def _token_has_boundary(rest: str) -> bool:
+    if not rest:
+        return True
+    if not _SERVER_NAME_CHARS.fullmatch(rest[0]):
+        return True
+    return rest.startswith("-->") or rest.startswith("--!>")
+
+
+@pytest.mark.parametrize(
+    ("rest", "expected"),
+    [
+        pytest.param("", True, id="end-of-content"),
+        pytest.param("\n", True, id="newline"),
+        pytest.param(" -->", True, id="spaced-comment-close"),
+        pytest.param("-->", True, id="glued-comment-close"),
+        pytest.param("--!>", True, id="glued-bogus-comment-close"),
+        pytest.param("<br>", True, id="html-tag"),
+        pytest.param("-pro", False, id="longer-name"),
+        pytest.param("/extra", False, id="longer-path"),
+        pytest.param(".dev", False, id="longer-dotted"),
+    ],
+)
+def test_the_boundary_helper_matches_the_registry_rule(rest, expected):
+    """Pin the helper against the cases the registry's own matcher distinguishes.
+
+    Without this, a helper that returned `True` unconditionally would make the
+    README check below pass on a token the registry rejects — the usual failure
+    mode of a test that asserts a string is "present and well-formed".
+    """
+    assert _token_has_boundary(rest) is expected
+
+
+def test_readme_carries_the_registry_ownership_token():
+    """The registry proves PyPI ownership by finding this string in the README.
+
+    It fetches `https://pypi.org/pypi/comfy-mcp/<version>/json` and scans
+    `info.description` — which IS this file, because `[project] readme` points
+    here — for `mcp-name: <the server.json name>`. No token, no publish. Nothing
+    else in the repo reads it, so deleting it as stray markup is easy and its
+    cost lands on the next release rather than on the PR that removed it.
+    """
+    readme = _README.read_text(encoding="utf-8")
+    name = _server_json()["name"]
+    token = f"mcp-name: {name}"
+    occurrences = [match.end() for match in re.finditer(re.escape(token), readme)]
+    assert occurrences, (
+        f"README.md does not contain the registry ownership token `{token}`. "
+        "The MCP Registry reads it out of the PUBLISHED PyPI description to "
+        "prove this repo owns the `comfy-mcp` distribution; without it "
+        "publish.yml's registry job fails after the release is already cut."
+    )
+    assert any(_token_has_boundary(readme[end:]) for end in occurrences), (
+        f"README.md contains `{token}` but every occurrence is glued to a "
+        "following name character, so the registry reads it as a prefix of a "
+        "longer name and rejects it. Put it on its own line."
     )


### PR DESCRIPTION
## ELI-5

The official MCP Registry is the phone book agents use to find MCP servers they can install. Comfy Org isn't in it at all — search "comfy" there today and you get three community projects and nothing official. This PR adds our entry for the local ComfyUI server, and wires it to publish itself from the same GitHub Release that already ships the PyPI package.

## Summary

Adds a root `server.json` — the MCP Registry listing for this server — and a `publish-mcp-registry` job to `.github/workflows/publish.yml` that publishes it on the existing `release: created` trigger, after the PyPI publish. Merging does not publish anything; the next GitHub Release does.

## Changes

- **`server.json`** — schema `2025-12-11`, named `io.github.Comfy-Org/comfy-mcp` (the org's registry grant is case-sensitive and scoped to `io.github.Comfy-Org/*`). Declares one `packages` entry: PyPI, `comfy-mcp`, `transport: {type: stdio}`. **No `remotes` entry** — this is a local subprocess server, not a hosted endpoint. `description` and `websiteUrl` (`https://docs.comfy.org/agent-tools/mcp`, whose "Local Comfy MCP Connection" section covers this package) describe the local server.
- **`.github/workflows/publish.yml`** — new `publish-mcp-registry` job: `id-token: write` scoped to that job only, `mcp-publisher` pinned to `v1.8.1` and verified against that release's published SHA256 before it is extracted or executed, and the tag-derived version guarded to canonical bare semver before it reaches the manifest.
- **`README.md`** — the registry's PyPI ownership token, `mcp-name: io.github.Comfy-Org/comfy-mcp`, in an HTML comment at the top, with a comment block explaining why it must not be removed or reworded.
- **`tests/test_packaging.py`** — pins the invariants that otherwise only fail at release time, in the module that already exists for exactly that (the two version files, the undeclared engine, `[project.urls]`).

## Motivation

The sibling `comfy-cloud-mcp-server` had the org's only registry-publish job, and it was pointed at an internal, non-installable server; that job is being removed separately. This repo is the one that should carry the listing, and it already publishes to PyPI on every release.

## Why the README change is load-bearing

The registry does not take a PyPI claim on trust. It fetches `https://pypi.org/pypi/comfy-mcp/<version>/json` and scans `info.description` for `mcp-name: <the server.json name>`; no token, no publish (`internal/validators/registries/pypi.go`). `info.description` is `[project] readme`, i.e. `README.md` verbatim — so the token has to live there. Verified against the built artifact rather than assumed:

```
$ python -m build --sdist
$ # PKG-INFO Description from the resulting sdist
token in PKG-INFO Description: True
following char: '\n\nT'
```

The trailing newline matters: the registry's matcher requires a boundary after the name, so a token glued to a following name character is read as a prefix of some longer name and rejected. The test mirrors that rule (and pins the mirror against the cases the real matcher distinguishes).

For completeness, the token is genuinely absent from what is on PyPI today, so this is not a no-op:

```
$ curl -s https://pypi.org/pypi/comfy-mcp/json | ...
latest on PyPI: 0.10.0
token present today: False
```

## Testing

- [x] Existing tests pass (`pytest`) — `2078 passed, 1 skipped, 6 deselected`
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually:
  - `server.json` validated with the **real publisher binary**, against the live registry: `./mcp-publisher validate` → `✅ server.json is valid` (mcp-publisher v1.8.1, downloaded and checksum-verified locally the same way the job does).
  - The version-sync step run locally against the committed `server.json` for `v1.2.3`, `v0.10.0`, `1.2.3` (accepted, both version fields rewritten) and `v01.2.3`, `v1.2.3-rc.1`, `not-a-tag`, `` (rejected). Every tag in this repo's history is a canonical `vX.Y.Z`, so the guard rejects no real release.
  - The `mcp-publisher` download path exercised end to end: the pinned release's `registry_1.8.1_checksums.txt` has a `<sha256>  mcp-publisher_<os>_<arch>.tar.gz` line, `grep " $asset$" | sha256sum -c -` verifies it, and `tar xzf "$asset" mcp-publisher` extracts a working binary (`mcp-publisher --help`).
  - The `jq -e` post-condition rejects an emptied `packages` array.

## Judgment calls

- **`needs: verify-install`, not `needs: build-and-publish`.** The acceptance criterion is "after the PyPI publish", and both satisfy it. `verify-install` is strictly better here: the registry refuses the listing until that exact version resolves on PyPI, and `verify-install` is already the job that retries out PyPI's index lag — so hanging the registry publish off it turns a race into a dependency. It transitively `needs` `build-and-publish` → `check-version`. Cost: if `verify-install` fails, the listing is not published for that release, and the job has to be re-run once PyPI settles.
- **Version derivation is inherited, not duplicated.** The job reads `github.event.release.tag_name` — the same input `check-version` reads — and adds only the canonical-semver guard. It does not re-compare `pyproject.toml` / `__init__.py`, because `check-version` already did and this job transitively depends on it.
- **Both version fields are rewritten**, `.version` and `.packages[].version`. The cloud template only had `.version` because its entry was a `remotes` block with no package version; a PyPI entry has one, and the registry requires it.
- **`actions/checkout@v6`, not a SHA pin.** Matches the three jobs already in this file. The template's SHA pins came from a repo that pins actions throughout; the three properties this ticket asked to port (pinned publisher, verified checksum, semver guard) are all here.
- **No `runtimeHint`.** The schema asks for it when `runtimeArguments` are present, and there are none; live `registryType: pypi` entries in the registry omit it. Left out rather than asserting a runtime this project has not tested.
- **The workflow job itself is not unit-tested.** There is no precedent in `tests/` for parsing workflow YAML and PyYAML is not a dev dependency; adding one for this seemed disproportionate. The job's shell logic was exercised by hand instead (above).

## Notes for the reviewer

- **Merging arms a public publish.** Nothing publishes on merge; the next GitHub Release does, under the org's identity, to a public directory. This PR is the review gate. No publish was triggered out of band to test it.
- The first publish creates the entry; later releases update it in place.
- Nothing about the PyPI publish, the dual-version scheme, or the `check-version` guard was changed — the diff is purely additive (`337 insertions, 0 deletions`).
