### PR TITLE
fix(lifecycle): report the pid holding the port, not comfy-cli's launch wrapper

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -2472,6 +2472,12 @@ def server_info() -> Any:
         - ``comfy_target`` (host/port), only when a remote ComfyUI is
           configured (``COMFYUI_URL``/``COMFYUI_HOST``) — the submit/poll
           tools follow it; this call never probes it.
+
+        ``config.background``, when a background server is recorded, reports
+        the pid comfy-cli verified is LISTENING on that port, with the pid it
+        recorded (the launch wrapper, which does not hold the port) kept as
+        ``recorded_pid``; ``pid_source``/``pid_note`` say which you got. Stop a
+        server with ``stop_comfyui``, never by killing a reported pid.
     """
     envelope, stdout, args, returncode, stderr = _run_comfy_raw("env", timeout=60.0)
     # `_run_comfy_raw` hands back `_last_json_object`'s answer unfiltered, so
@@ -2485,6 +2491,10 @@ def server_info() -> Any:
     compat["envelope_schema"] = _envelope_schema(envelope)
     freshness = _freshness_report()
     report = dict(data) if isinstance(data, dict) else {"env": data}
+    # Before anything is reported: the background record's pid is comfy-cli's
+    # LAUNCH WRAPPER, not the process holding the port. Only costs a subprocess
+    # when there is a record to reconcile.
+    report = _with_reconciled_background(report)
     report["compatibility"] = compat
     report["freshness"] = freshness
     # server_info is the "call first" diagnostic, so surface a malformed remote
@@ -6056,7 +6066,13 @@ def _launch_comfyui_sync(extra_args: list[str]) -> Any:
     if extra_args:
         args += ["--", *extra_args]
     with _lifecycle_slot("start"):
-        return _run_comfy(*args, timeout=180.0, plain_ok=True)
+        result = _run_comfy(*args, timeout=180.0, plain_ok=True)
+        # Still inside the slot: the pid this reports must describe the server
+        # this call just started, so a concurrent stop/restart must not land in
+        # between. The launch envelope's `pid` is the wrapper comfy-cli spawned,
+        # not the listener — see `_reconcile_reported_pid`. `restart_comfyui`
+        # composes this function, so it is corrected there too.
+        return _reconcile_reported_pid(result)
 
 
 # NOTE (temporary upstream caveat): `comfy launch --background` currently
@@ -6101,7 +6117,11 @@ async def launch_comfyui(
     needs no confirmation.
 
     Prints text with no JSON envelope; success returns a synthesized
-    ``{"ok": True, ...}``.
+    ``{"ok": True, ...}``. When the installed comfy-cli DOES report a pid, it
+    is the one verified to be listening on the port, not the launch wrapper
+    comfy-cli records (kept as ``recorded_pid``); ``pid_source``/``pid_note``
+    say which you got. Stop the server with ``stop_comfyui``, never by killing
+    a reported pid.
     """
     guarded = argv._guard_extra_args(extra_args)
     await _resolve_network_exposure_consent(
@@ -6421,6 +6441,145 @@ def _verified_untracked_listener(port: int) -> _UntrackedListener | None:
     raw = data.get("cmdline")
     cmdline = " ".join(part for part in raw if isinstance(part, str)) if raw else ""
     return _UntrackedListener(pid=pid, port=port, cmdline=cmdline)
+
+
+# --- reporting a pid that actually holds the port ---------------------------
+#
+# `comfy launch --background` records the pid of the WRAPPER it spawned — the
+# detached `comfy … launch` re-invocation — not the `python main.py` that
+# wrapper starts and that binds the port. Both the launch envelope's `pid` and
+# `comfy env`'s `config.background.pid` carry that recorded value, so anything
+# acting on the number this server hands out (killing it, matching it against
+# the port's listener, attributing a crash to it) acts on the parent: killing it
+# leaves ComfyUI running and still holding the port.
+#
+# The engine already answers the question correctly, so this asks it rather than
+# deriving anything: `_verified_untracked_listener` is the same single
+# `comfy stop --port <p> --dry-run` passthrough the kill gate above reads, and
+# its `verified` payload names the process comfy-cli itself identified on the
+# port. Nothing here consults the process table, and the recorded value is kept
+# alongside rather than discarded — it is still the pid `comfy stop` acts on.
+
+
+def _port_number(value: Any) -> int | None:
+    """``value`` as a TCP port, or ``None``.
+
+    comfy-cli's schemas type a port as ``integer`` OR ``string`` (the launch
+    envelope echoes what was parsed off the command line, and the background
+    record round-trips through the config file), so both spellings arrive here.
+
+    Not :func:`argv._guard_log_port`, whose contract is the opposite one: that
+    guards a port a TOOL CALLER supplied on its way into argv, so it refuses a
+    string and raises on anything invalid. This reads a port back OUT of
+    comfy-cli's own payload, where an unusable value means only that there is
+    nothing to reconcile — never an error to raise at the caller.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, str):
+        try:
+            value = int(value.strip())
+        except ValueError:
+            return None
+    if not isinstance(value, int):
+        return None
+    return value if 1 <= value <= 65535 else None
+
+
+def _reconcile_reported_pid(record: Any) -> Any:
+    """``record`` with its ``pid`` reconciled against the port's real listener.
+
+    Takes any mapping carrying comfy-cli's ``pid`` + ``port`` pair — the
+    ``launch`` envelope and ``comfy env``'s background record are the same shape
+    — and returns a copy in which:
+
+    * ``pid`` is the process comfy-cli verified is listening on that port,
+    * ``recorded_pid`` keeps the value comfy-cli recorded (the wrapper), and
+    * ``pid_source`` / ``pid_note`` say which is which.
+
+    Left EXACTLY as it came when there is no pid/port pair to reconcile, so the
+    plain-text ``launch`` synthesis (which carries neither) and a comfy-cli that
+    reports no background record are untouched.
+
+    Degrades rather than fails: :func:`_verified_untracked_listener` answers
+    ``None`` for every failure — nothing on the port, a listener comfy-cli will
+    not vouch for, or a comfy-cli predating ``comfy stop --port`` (it ships in
+    1.15.0) — and that case keeps the recorded pid and says it is unconfirmed.
+    Reporting an unverified pid while labelling it unverified is the honest
+    answer; silently reporting it as the listener is the bug.
+    """
+    if not isinstance(record, dict):
+        return record
+    recorded = record.get("pid")
+    if not isinstance(recorded, int) or isinstance(recorded, bool):
+        return record
+    port = _port_number(record.get("port"))
+    if port is None:
+        return record
+    listener = _verified_untracked_listener(port)
+    if listener is None:
+        return {
+            **record,
+            "pid_source": "cli-record",
+            "pid_note": (
+                "`pid` is the pid comfy-cli recorded and could NOT be confirmed "
+                f"against whatever is listening on port {port} (`comfy stop "
+                "--port <p> --dry-run` vouched for nothing: the port may be idle, "
+                "or this comfy-cli predates `comfy stop --port`, which ships in "
+                "1.15.0). For a server started by `comfy launch --background` the "
+                "recorded pid is the wrapper process, NOT the one holding the "
+                "port, so do not kill it or match it against a port listing — use "
+                "`stop_comfyui` to stop the server."
+            ),
+        }
+    if listener.pid == recorded:
+        return {
+            **record,
+            "recorded_pid": recorded,
+            "pid_source": "port-listener",
+            "pid_note": (
+                "`pid` is confirmed by comfy-cli (`comfy stop --port <p> "
+                f"--dry-run`) to be the process listening on port {port}."
+            ),
+        }
+    return {
+        **record,
+        "pid": listener.pid,
+        "recorded_pid": recorded,
+        "pid_source": "port-listener",
+        "pid_note": (
+            "`pid` is the process comfy-cli verified is listening on port "
+            f"{port} (`comfy stop --port <p> --dry-run`). `recorded_pid` is the "
+            "pid comfy-cli recorded for this port — normally the "
+            "`comfy launch --background` wrapper that spawned the listener, and "
+            "in any case NOT the process holding the port, so killing it leaves "
+            "ComfyUI running. Stop the server with `stop_comfyui`, which tears "
+            "down the whole tree."
+        ),
+    }
+
+
+def _with_reconciled_background(report: dict) -> dict:
+    """``comfy env``'s report with its background record's pid reconciled.
+
+    comfy-cli emits that record under ``config.background``; its ``env`` schema
+    also declares a top-level ``background`` of the same shape, which nothing
+    populates today. The top-level form is therefore only reconciled when the
+    ``config`` one is absent — reconciling both would spend a second subprocess
+    on the same port for one record spelled two ways.
+    """
+    config = report.get("config")
+    if isinstance(config, dict) and isinstance(config.get("background"), dict):
+        return {
+            **report,
+            "config": {
+                **config,
+                "background": _reconcile_reported_pid(config["background"]),
+            },
+        }
+    if isinstance(report.get("background"), dict):
+        return {**report, "background": _reconcile_reported_pid(report["background"])}
+    return report
 
 
 class KillUntrackedApproval(BaseModel):

--- a/tests/test_reported_pid.py
+++ b/tests/test_reported_pid.py
@@ -1,0 +1,339 @@
+"""Tests for the pid ``launch_comfyui`` / ``server_info`` report.
+
+``comfy launch --background`` records the pid of the WRAPPER it spawned — the
+detached ``comfy … launch`` re-invocation — not the ``python main.py`` that
+wrapper starts and that binds the port. That recorded value is what both the
+launch envelope's ``pid`` and ``comfy env``'s ``config.background.pid`` carry,
+so anything acting on the number this server hands out acts on the parent:
+killing it leaves ComfyUI running and still holding the port.
+
+What is under test is the reconciliation that fixes it, and it is still only a
+passthrough: ``comfy stop --port <p> --dry-run`` — the same probe the untracked
+kill gate reads — names the process comfy-cli itself verified is on the port,
+and that is the pid reported. The recorded value is kept beside it as
+``recorded_pid`` because it is still the pid ``comfy stop`` acts on. So:
+
+1. The correction: reported pid == the port holder comfy-cli vouched for, on
+   both tools, with the wrapper pid preserved and labelled.
+2. The degrade: an engine that will not vouch (nothing listening, a comfy-cli
+   predating ``comfy stop --port``) keeps the recorded pid and SAYS it is
+   unconfirmed, rather than reporting it as the listener.
+3. The cost: no pid/port pair to reconcile means no extra subprocess at all.
+
+comfy-cli is mocked throughout; no process is ever looked at or signalled.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from conftest import _FakeRunProc, _raises_at_spawn, envelope
+
+from comfy_mcp import server
+
+#: The pid comfy-cli records: the `comfy … launch` wrapper, reparented to init.
+WRAPPER_PID = 64063
+
+#: Its child — the `python main.py` that actually holds the port.
+LISTENER_PID = 64067
+
+PORT = 8188
+
+#: The listener's argv, as `comfy stop --port --dry-run` reports it.
+_CMDLINE = ["/ComfyUI/.venv/bin/python", "main.py", "--port", str(PORT)]
+
+
+def _dry_run(pid: int = LISTENER_PID, port: int = PORT, **overrides) -> dict:
+    """``comfy stop --port <p> --dry-run``'s payload for a verified ComfyUI.
+
+    Mirrors comfy-cli's ``stop.json`` schema (``stopped`` false because nothing
+    was stopped, ``dry_run``/``verified``/``untracked`` true, plus the identity),
+    so a test overriding one field is overriding a real one.
+    """
+    data = {
+        "stopped": False,
+        "dry_run": True,
+        "verified": True,
+        "untracked": True,
+        "pid": pid,
+        "port": port,
+        "cmdline": list(_CMDLINE),
+    }
+    data.update(overrides)
+    return data
+
+
+def _env_data(background: object = _dry_run, **overrides) -> dict:
+    """``comfy env``'s data payload, with a background record under ``config``.
+
+    ``comfy env`` reports the record comfy-cli wrote at launch, which is where
+    the wrapper pid surfaces to a caller. Pass ``background=None`` for an env
+    with no recorded server.
+    """
+    record = {"host": "127.0.0.1", "port": PORT, "pid": WRAPPER_PID}
+    if background is not _dry_run:
+        record = background  # type: ignore[assignment]
+    data = {
+        "python": {"version": "3.12.0", "executable": "/usr/bin/python3"},
+        "config": {"path": "/home/user/.config/comfy-cli/config.ini"},
+        "server": {"running": True, "url": "http://127.0.0.1:8188"},
+    }
+    data["config"]["background"] = record  # type: ignore[index]
+    data.update(overrides)
+    return data
+
+
+def _line(payload) -> str:
+    """One ``envelope/1`` stdout line carrying ``payload`` as its data."""
+    return json.dumps(envelope(data=payload))
+
+
+@pytest.fixture
+def sequenced(monkeypatch):
+    """Answer each spawn from a queue of ``(returncode, stdout, stderr)`` replies.
+
+    The reconciliation makes a SECOND comfy-cli call after the one the tool
+    itself made, so these paths shell out more than once and the shared
+    single-reply fakes cannot express them — the sequenced-replies carve-out
+    AGENTS.md allows for a local stub. It still mirrors the shared fake's spawn
+    signature and reuses its :class:`_FakeRunProc`, so a change to how ``server``
+    shells out breaks here loudly rather than drifting. A queue that runs out
+    fails the test, which is how "no extra subprocess" is asserted.
+    """
+
+    def setup(replies: list) -> list[dict]:
+        calls: list[dict] = []
+
+        def fake(
+            cmd, stdout, stderr, stdin, text, encoding, env, start_new_session, cwd
+        ):
+            record = {"cmd": cmd, "timeout": None, "cwd": cwd}
+            calls.append(record)
+            try:
+                reply = replies[len(calls) - 1]
+            except IndexError:
+                raise AssertionError(f"unexpected comfy-cli call: {cmd}") from None
+            failed = isinstance(reply, BaseException)
+            if failed and _raises_at_spawn(reply):
+                raise reply
+            returncode, out, err = (None, None, None) if failed else reply
+            return _FakeRunProc(
+                cmd,
+                record,
+                stdout=out,
+                stderr=err,
+                returncode=returncode,
+                raises=reply if failed else None,
+            )
+
+        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+        monkeypatch.setattr(server.subprocess, "Popen", fake)
+        monkeypatch.setattr(server, "_detect_comfy_cli_version", lambda: "1.15.0")
+        monkeypatch.setattr(server, "MIN_COMFY_CLI_VERSION", None)
+        # `server_info` also probes `comfy outdated`; these tests are about the
+        # pid, so keep that off the queue and out of the call assertions.
+        monkeypatch.setattr(server, "_freshness_report", lambda: {})
+        return calls
+
+    return setup
+
+
+# --- server_info: the recorded pid is reconciled before it is reported -------
+
+
+def test_server_info_reports_the_pid_that_holds_the_port(sequenced):
+    """The ticket's acceptance: reported pid == the verified port holder's pid."""
+    calls = sequenced([(0, _line(_env_data()), ""), (0, _line(_dry_run()), "")])
+
+    background = server.server_info()["config"]["background"]
+
+    assert background["pid"] == LISTENER_PID
+    assert background["pid"] != WRAPPER_PID
+    assert background["recorded_pid"] == WRAPPER_PID
+    assert background["pid_source"] == "port-listener"
+    # The rest of the record passes through untouched.
+    assert background["host"] == "127.0.0.1"
+    assert background["port"] == PORT
+    # Second spawn is the dry run, on the port the record names, and it is a
+    # DRY run: without `--dry-run` this reconciliation would stop the server.
+    assert calls[1]["cmd"][4:] == ["stop", "--port", str(PORT), "--dry-run"]
+
+
+def test_server_info_keeps_a_pid_the_engine_will_not_vouch_for_but_flags_it(
+    sequenced,
+):
+    """Nothing on the port -> the recorded pid stays, labelled unconfirmed.
+
+    The degrade must not silently promote the wrapper pid: `pid_source` says it
+    came from the CLI's record, and the note says not to act on it.
+    """
+    calls = sequenced(
+        [
+            (0, _line(_env_data()), ""),
+            (1, _line({}), "Nothing is listening on port 8188."),
+        ]
+    )
+
+    background = server.server_info()["config"]["background"]
+
+    assert background["pid"] == WRAPPER_PID
+    assert background["pid_source"] == "cli-record"
+    assert "recorded_pid" not in background
+    assert "could NOT be confirmed" in background["pid_note"]
+    assert len(calls) == 2
+
+
+def test_server_info_flags_the_pid_on_a_comfy_cli_without_stop_port(sequenced):
+    """A comfy-cli predating `comfy stop --port` degrades the same way.
+
+    Click rejects the unknown option while PARSING (exit 2, no envelope), so
+    nothing was ever dispatched and nothing could have been stopped.
+    """
+    sequenced(
+        [
+            (0, _line(_env_data()), ""),
+            (2, "", "Error: No such option: --port"),
+        ]
+    )
+
+    background = server.server_info()["config"]["background"]
+
+    assert background["pid"] == WRAPPER_PID
+    assert background["pid_source"] == "cli-record"
+    assert "1.15.0" in background["pid_note"]
+
+
+def test_server_info_does_not_probe_when_nothing_is_recorded(sequenced):
+    """No background record -> no reconciliation, and no second subprocess.
+
+    The queue holds ONE reply, so a second spawn fails the test rather than
+    quietly costing a `comfy stop --port` on every `server_info`.
+    """
+    calls = sequenced([(0, _line(_env_data(background=None)), "")])
+
+    result = server.server_info()
+
+    assert result["config"]["background"] is None
+    assert len(calls) == 1
+
+
+def test_server_info_reconciles_a_port_recorded_as_a_string(sequenced):
+    """The record round-trips through a config file, so its port can be text."""
+    data = _env_data()
+    data["config"]["background"]["port"] = str(PORT)
+    calls = sequenced([(0, _line(data), ""), (0, _line(_dry_run()), "")])
+
+    background = server.server_info()["config"]["background"]
+
+    assert background["pid"] == LISTENER_PID
+    assert calls[1]["cmd"][4:] == ["stop", "--port", str(PORT), "--dry-run"]
+
+
+def test_server_info_leaves_an_unreconcilable_record_alone(sequenced):
+    """A record with no usable port is passed through, unprobed and unlabelled."""
+    calls = sequenced(
+        [
+            (
+                0,
+                _line(_env_data(background={"host": "127.0.0.1", "pid": WRAPPER_PID})),
+                "",
+            )
+        ]
+    )
+
+    background = server.server_info()["config"]["background"]
+
+    assert background == {"host": "127.0.0.1", "pid": WRAPPER_PID}
+    assert len(calls) == 1
+
+
+def test_server_info_ignores_an_engine_that_reports_an_unverified_listener(sequenced):
+    """`verified` is comfy-cli's own judgment; without it there is no answer."""
+    sequenced(
+        [
+            (0, _line(_env_data()), ""),
+            (0, _line(_dry_run(verified=False)), ""),
+        ]
+    )
+
+    background = server.server_info()["config"]["background"]
+
+    assert background["pid"] == WRAPPER_PID
+    assert background["pid_source"] == "cli-record"
+
+
+def test_server_info_reports_an_already_correct_pid_as_verified(sequenced):
+    """An engine that records the listener itself needs no correction.
+
+    The fix is "report the port holder", not "always rewrite the pid": when the
+    two agree the pid stands and is simply reported as confirmed.
+    """
+    sequenced(
+        [
+            (0, _line(_env_data()), ""),
+            (0, _line(_dry_run(pid=WRAPPER_PID)), ""),
+        ]
+    )
+
+    background = server.server_info()["config"]["background"]
+
+    assert background["pid"] == WRAPPER_PID
+    assert background["recorded_pid"] == WRAPPER_PID
+    assert background["pid_source"] == "port-listener"
+
+
+# --- launch_comfyui: the same correction on the launch envelope --------------
+
+
+def test_launch_reports_the_pid_that_holds_the_port(sequenced):
+    """`comfy launch`'s own envelope carries the wrapper pid; correct it too."""
+    launch_data = {
+        "background": True,
+        "listen": "127.0.0.1",
+        "port": PORT,
+        "url": f"http://127.0.0.1:{PORT}",
+        "pid": WRAPPER_PID,
+    }
+    calls = sequenced([(0, _line(launch_data), ""), (0, _line(_dry_run()), "")])
+
+    result = server._launch_comfyui_sync([])
+
+    assert result["pid"] == LISTENER_PID
+    assert result["recorded_pid"] == WRAPPER_PID
+    assert result["pid_source"] == "port-listener"
+    assert result["url"] == f"http://127.0.0.1:{PORT}"
+    assert calls[1]["cmd"][4:] == ["stop", "--port", str(PORT), "--dry-run"]
+
+
+def test_launch_without_a_reported_pid_is_untouched(sequenced):
+    """The plain-text launch synthesis carries no pid, so there is none to fix.
+
+    A comfy-cli that prints human text and emits no envelope reports no pid at
+    all — nothing wrong is being handed out, and probing for one would be new
+    behavior rather than a correction. One queued reply, so a probe would fail.
+    """
+    calls = sequenced([(0, "", "ComfyUI is successfully launched in the background.")])
+
+    result = server._launch_comfyui_sync([])
+
+    assert result["ok"] is True
+    assert "pid" not in result
+    assert len(calls) == 1
+
+
+def test_restart_reports_the_corrected_pid_too(monkeypatch, sequenced):
+    """`restart_comfyui` composes the launch, so the correction rides along.
+
+    Asserted through `_restart_comfyui_locked` — the composition itself —
+    rather than by re-testing the launch half, so a future restart path that
+    stopped going through `_launch_comfyui_sync` would fail here.
+    """
+    monkeypatch.setattr(server, "stop_comfyui", lambda: {"ok": True})
+    launch_data = {"background": True, "port": PORT, "pid": WRAPPER_PID}
+    sequenced([(0, _line(launch_data), ""), (0, _line(_dry_run()), "")])
+
+    result = server._restart_comfyui_locked([])
+
+    assert result["pid"] == LISTENER_PID
+    assert result["recorded_pid"] == WRAPPER_PID


### PR DESCRIPTION
## ELI-5

When you start ComfyUI in the background, comfy-cli starts a little launcher process, and *that* launcher starts the real ComfyUI. Until now we told you the launcher's process id. So if you (or an agent) killed the pid we reported, the launcher died and ComfyUI kept running — still holding the port — and it looked like "stop didn't work". Now we ask the engine which process is actually holding the port and report that one instead, keeping the old number beside it and labelling both.

## The bug

`comfy launch --background` records the pid of the detached `comfy … launch` wrapper it spawns, not the `python main.py` that wrapper starts and that binds the port (comfy-cli's own `_tracked_wrapper_pid` documents this: *"`comfy launch --background` records the pid of the outer `comfy ... launch` wrapper, not the `python main.py` it spawns"*). That recorded value is what both the `launch` envelope's `pid` and `comfy env`'s `config.background.pid` carry, so anything acting on the pid this server hands out — killing it, matching it against a port listing, attributing a crash to it — acts on the parent. `stop_comfyui` itself was never affected: comfy-cli kills its own recorded pid through its own bookkeeping, which tears down the tree. Only the number we hand out was wrong.

## What changed

`_reconcile_reported_pid` reads the engine's own verdict before anything is reported. It calls `_verified_untracked_listener` — the existing single `comfy stop --port <p> --dry-run` passthrough that `restart_comfyui`'s kill gate already reads — and uses the process comfy-cli itself verified is listening on that port. Nothing here looks at the process table, so the thin-wrapper rule holds: the verdict is comfy-cli's, this is a second passthrough in a sequence.

On a reconciled record: `pid` is the verified listener, `recorded_pid` keeps comfy-cli's recorded value (still the pid `comfy stop` acts on), and `pid_source`/`pid_note` say which is which. Applied at two sites — `server_info`'s `config.background`, and `_launch_comfyui_sync`, which `restart_comfyui` composes, so the launch envelope's pid is corrected on both tools.

It degrades instead of failing. `_verified_untracked_listener` answers `None` for every failure — nothing listening, a listener comfy-cli will not vouch for, or a comfy-cli predating `comfy stop --port` — and then the recorded pid stays but is labelled `pid_source: "cli-record"` with a note saying it is unconfirmed and not to act on it. Reporting an unverified pid while saying so is honest; silently reporting it as the listener is the bug being fixed. There is no extra subprocess at all when there is no pid/port pair to reconcile (no background record, or the plain-text launch synthesis, which reports no pid) — asserted by a test whose reply queue would fail on a second spawn.

Safety of the probe: `--dry-run` is passed in the same argv as `--port`, and the exact argv is pinned by test. A comfy-cli that knows neither option rejects it while *parsing* (Click `NoSuchOption`, exit 2, nothing dispatched), so there is no version in which this reconciliation could stop a running server.

## Verification

`pytest -q` — 2090 passed, 6 deselected. `ruff check .` and `ruff format --check .` clean. 11 new tests in `tests/test_reported_pid.py`, including the regression the report asks for on both tools: reported pid == the pid the engine vouched for on the port, with the wrapper pid preserved as `recorded_pid`.

Falsification of the "unconfirmed" path, since this diff adds one: `comfy stop --port <p> --dry-run` genuinely exists rather than being assumed away — it is `comfy_cli/command/stop_port.py` + the `--port`/`--dry-run` options on `cmdline.py`'s `stop`, added in comfy-cli #675 (`505cf8a`), and `git tag --contains` puts that commit in **v1.15.0** and v1.16.0. Its payload shape (`verified`/`dry_run`/`pid`/`cmdline`) is comfy-cli's published `schemas/stop.json`, which is what the fixtures mirror. So the degrade branch is the genuinely-old-engine path, not a dead end shipped in place of a working one.

## What this does NOT cover

- **No live end-to-end run against a real listener.** This machine has no ComfyUI workspace and no `comfy` on `PATH`, so the correction was not confirmed against `lsof -nP -iTCP:<port> -sTCP:LISTEN` here; the report's own three reproductions plus comfy-cli's source are the evidence for the parentage, and the tests pin the wiring. Worth one live `server_info` on a machine with a background server before this is considered closed.
- **The duplicated `--enable-manager` in the child's argv is untouched and is still real.** It is a comfy-cli defect this repo cannot fix from here: `launch()` appends the manager flags, then re-invokes `comfy … launch` *with* them, and the re-invocation's `launch()` appends them again. Harmless today, but it is a defect on an artifact the report names, so it stays open.
- **The preferred fix is still upstream.** comfy-cli recording the child's pid would fix every consumer at once; this reconciles at the reporting edge instead, which is the option the report sanctions when the recording is not changed.
- A stale background record whose port has since been taken by a *different* ComfyUI reconciles to that process — `pid_source: "port-listener"` says the value was read off the port and `recorded_pid` preserves what comfy-cli recorded, so the two are never conflated, but the record is not proof of ownership.

Refs BE-6778
