### PR TITLE
fix(download): report whether a cancel actually stopped the transfer

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -10008,6 +10008,19 @@ def _download_cancel_note(
     NOT-cancelled ones name the way forward rather than dead-ending, because on
     every one of them the caller still has a decision to make (a file that
     landed anyway, a transfer that may still be running).
+
+    ``changed`` is REPORTED here, never interpreted. The engine's flag says only
+    THAT state moved on this call, not WHAT moved, so a note that named the
+    file's disposition from it — "comfy-cli kept the completed file at `dest`",
+    "comfy-cli reclaimed its partial file" — would be this wrapper guessing, and
+    guessing the same flag two contradictory ways on two adjacent branches.
+    Worse, it is the guess whose cost is asymmetric: comfy-cli downloads to the
+    final ``dest`` and a state-changing cancel may unlink it, so telling the
+    caller the file is there to delete can be exactly backwards. The three
+    values are kept distinct on the cancelled branch for the same reason
+    ``_run_comfy_with_changed`` refuses to coerce a missing flag to ``False``:
+    ``None`` is "the engine did not say", which cannot carry the ``True``
+    branch's claim that THIS call is what stopped the transfer.
     """
     if cancelled:
         if changed is False:
@@ -10015,25 +10028,44 @@ def _download_cancel_note(
                 "no-op: this download was ALREADY cancelled before this call, so "
                 "nothing was stopped now."
             )
+        if changed is None:
+            return (
+                "cancelled: comfy-cli reports this download cancelled, but "
+                "emitted no `changed` flag — so whether THIS call stopped it or "
+                "it was already cancelled is unknown."
+            )
         return "cancelled: comfy-cli stopped the transfer's worker."
+    moved = (
+        " comfy-cli reports this call changed state, but not what it changed."
+        if changed
+        else ""
+    )
     if status == "completed":
-        raced = " — it landed as the cancel arrived" if changed else ""
         return (
-            f"NOT cancelled: the transfer had already finished{raced}, so "
-            "comfy-cli kept the completed file at `dest`. Nothing was aborted; "
-            "delete the file yourself if the download was a mistake."
+            "NOT cancelled: the transfer had already finished, so there was no "
+            f"running transfer to stop.{moved} Nothing was aborted; check `dest` "
+            "and delete the file yourself if the download was a mistake."
         )
     if status in _DOWNLOAD_TERMINAL_STATUSES:
-        swept = "; comfy-cli reclaimed its partial file" if changed else ""
         return (
             f"NOT cancelled: this download was ALREADY {status} before this "
-            f"call{swept}. There was no running transfer to stop."
+            f"call, so there was no running transfer to stop.{moved}"
         )
-    where = f"status {status!r}" if status else "no status"
+    # SCRUBBED and capped like every other engine-derived string this server
+    # renders (`_unwrap_envelope`, `errors._render_error_details`): `status` is
+    # comfy-cli's, and a version-skewed engine or a tampered state file could
+    # put a credential-bearing URL or a blob where a one-word status belongs.
+    # The terminal branch above needs no such treatment — it only ever
+    # interpolates a member of `_DOWNLOAD_TERMINAL_STATUSES`.
+    where = (
+        f"status {failure_log._scrub_text(status)[: errors._MAX_ERROR_FIELD_CHARS]!r}"
+        if status
+        else "no status"
+    )
     return (
         f"NOT cancelled: comfy-cli returned {where}, so this transfer may still "
-        'be running. Re-check it with `download(action="status")` and re-issue '
-        "the cancel."
+        f'be running.{moved} Re-check it with `download(action="status")` and '
+        "re-issue the cancel if it is."
     )
 
 
@@ -10079,6 +10111,14 @@ def _with_cancel_verdict(payload: Any, changed: bool | None) -> Any:
         # the verdict anyway and keep the engine's own reply under `data`; the
         # note's last branch already says the status is missing.
         return {**verdict, "data": payload}
+    # The verdict wins a name clash deliberately, unlike `_with_download_id`,
+    # which keeps comfy-cli's `id` beside the spelling it adds. The asymmetry is
+    # the source: `id` and `download_id` are two spellings of a value the ENGINE
+    # owns, so dropping one would drop an engine answer, while `cancelled` /
+    # `changed` / `note` name no field of comfy-cli's `download-status` row —
+    # `changed` in particular is an ENVELOPE field, so the one here is already
+    # the engine's own, read one level up. A row that grew a `changed` of its
+    # own would therefore be shadowed by the same flag, not by an inference.
     return {**payload, **verdict}
 
 
@@ -10418,12 +10458,28 @@ def _download_verb_unsupported(
             f"{'check on' if verb == 'download-status' else 'cancel'}."
         ),
         "unsupported": True,
-        # The cancel half carries the verdict field too, set to the only honest
-        # value: this comfy-cli has no abort verb, so nothing was cancelled. An
-        # agent branching on `cancelled` must never have to read its ABSENCE as
-        # a cancel — which is the whole point of the field. `download-status`
+        # The cancel half carries the WHOLE verdict, set to the only honest
+        # values: this comfy-cli has no abort verb, so no cancel was attempted
+        # and nothing changed. All three keys, not just `cancelled` — the tool
+        # docstring promises callers that "`changed` and `note` say what
+        # happened instead", so shipping the degrade with `cancelled` alone
+        # would hand an agent that believed it a `KeyError`, which is the same
+        # read-the-absence failure the field exists to prevent. `download-status`
         # gets no such key: it is not a cancel and has no verdict to report.
-        **({"cancelled": False} if verb == "download-cancel" else {}),
+        **(
+            {
+                "cancelled": False,
+                "changed": False,
+                "note": (
+                    "NOT cancelled: this comfy-cli has no `model "
+                    "download-cancel`, so no cancel was attempted and nothing "
+                    "changed. There is no background transfer to stop here — "
+                    "`download_model` runs the download inline on this install."
+                ),
+            }
+            if verb == "download-cancel"
+            else {}
+        ),
     }
 
 

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -189,6 +189,17 @@ _MAX_DOWNLOAD_WAIT_TIMEOUT = 3600.0
 # worker owns and this call never waits on.
 _DOWNLOAD_SUBMIT_TIMEOUT = 120.0
 
+# Budget for `model download-cancel`. Deliberately its own constant, and
+# deliberately far below any transfer: cancelling is metadata plus a signal, and
+# comfy-cli's own worst case is bounded — `download_state.stop_worker` gives the
+# worker 5s to honour SIGTERM, then 2s to die on SIGKILL, around a few state
+# reads and an unlink. 30s is ~4x that, and it is what makes "the cancel blocked
+# for the rest of the download" structurally impossible here rather than merely
+# unobserved: whatever the engine does, this call is killed at the bound and
+# reports that it could not cancel (see `_download_cancel_sync`) instead of
+# holding the MCP request open for the transfer's remaining duration.
+_DOWNLOAD_CANCEL_TIMEOUT = 30.0
+
 # CEILING for the LEGACY foreground `model download` — the whole multi-GB
 # transfer happens inside that one call, hence the generous bound. It is a cap,
 # NOT the flat bound: a waiting caller is held only for what is left of their own
@@ -1116,6 +1127,36 @@ def _run_comfy(*args: str, timeout: float | None = None, plain_ok: bool = False)
     # like any other missing envelope. A real error envelope still has
     # `type==envelope`, so it flows through and raises with its code as usual.
     return _unwrap_envelope(real_envelope, args, returncode, stderr, stdout=stdout)
+
+
+def _run_comfy_with_changed(
+    *args: str, timeout: float | None = None
+) -> tuple[Any, bool | None]:
+    """:func:`_run_comfy`, plus the envelope's top-level ``changed`` flag.
+
+    ``changed`` is an envelope field, not a ``data`` field (``envelope.json``:
+    *"present on mutating commands; true iff state changed"*), so
+    :func:`_run_comfy` — which unwraps straight down to ``data`` — drops it. For
+    most verbs that is the right trade. For a MUTATING one whose ``data`` looks
+    identical whether or not anything happened, it is the whole answer: `model
+    download-cancel` returns the download's status row either way, and only
+    ``changed`` says whether this call is what stopped the transfer (see
+    :func:`_with_cancel_verdict`).
+
+    Same envelope contract as ``_run_comfy`` — the `_real_envelope` filter and
+    the raising `_unwrap_envelope` — following :func:`server_info`, the other
+    caller that needs the envelope itself rather than its payload. A missing or
+    non-boolean ``changed`` is reported as ``None`` (unknown), never coerced to
+    ``False``: an older comfy-cli that omits the flag has not told us the call
+    changed nothing.
+    """
+    envelope, stdout, args, returncode, stderr = _run_comfy_raw(*args, timeout=timeout)
+    envelope = _real_envelope(envelope)
+    # Raises when `envelope` is None, exactly as `_run_comfy` does, so it is
+    # non-None on the line below.
+    data = _unwrap_envelope(envelope, args, returncode, stderr, stdout=stdout)
+    changed = envelope.get("changed")
+    return data, changed if isinstance(changed, bool) else None
 
 
 # git's own wording, and the state it describes. Matched on BOTH streams because
@@ -9928,6 +9969,14 @@ _DOWNLOAD_TERMINAL_STATUSES = frozenset(
 # this work?".
 _DOWNLOAD_FAILURE_STATUSES = frozenset({"failed", "cancelled", "canceled"})
 
+# The subset that means a transfer was STOPPED, as opposed to having failed on
+# its own. Split out from `_DOWNLOAD_FAILURE_STATUSES` because `cancel` asks a
+# third question the other two sets do not answer — "is this download cancelled
+# *now*?" — and answering it off the failure set would read a `failed` transfer
+# as a successful cancel. Carries the US spelling for the same reason the
+# terminal set does.
+_DOWNLOAD_CANCELLED_STATUSES = frozenset({"cancelled", "canceled"})
+
 
 def _download_status_of(payload: Any) -> str | None:
     """The lower-cased ``status`` of a ``download-status`` payload, if it has one."""
@@ -9946,6 +9995,91 @@ def _is_download_terminal(payload: Any) -> bool:
 def _download_failed(payload: Any) -> bool:
     """True if a terminal ``download-status`` payload means the file did not land."""
     return _download_status_of(payload) in _DOWNLOAD_FAILURE_STATUSES
+
+
+def _download_cancel_note(
+    status: str | None, cancelled: bool, changed: bool | None
+) -> str:
+    """One line saying what the cancel actually did, and what is left to do.
+
+    The prose half of :func:`_with_cancel_verdict`; the booleans beside it are
+    what an agent branches on. Every branch is phrased from comfy-cli's own two
+    answers — the resulting ``status`` and the envelope's ``changed`` — and the
+    NOT-cancelled ones name the way forward rather than dead-ending, because on
+    every one of them the caller still has a decision to make (a file that
+    landed anyway, a transfer that may still be running).
+    """
+    if cancelled:
+        if changed is False:
+            return (
+                "no-op: this download was ALREADY cancelled before this call, so "
+                "nothing was stopped now."
+            )
+        return "cancelled: comfy-cli stopped the transfer's worker."
+    if status == "completed":
+        raced = " — it landed as the cancel arrived" if changed else ""
+        return (
+            f"NOT cancelled: the transfer had already finished{raced}, so "
+            "comfy-cli kept the completed file at `dest`. Nothing was aborted; "
+            "delete the file yourself if the download was a mistake."
+        )
+    if status in _DOWNLOAD_TERMINAL_STATUSES:
+        swept = "; comfy-cli reclaimed its partial file" if changed else ""
+        return (
+            f"NOT cancelled: this download was ALREADY {status} before this "
+            f"call{swept}. There was no running transfer to stop."
+        )
+    where = f"status {status!r}" if status else "no status"
+    return (
+        f"NOT cancelled: comfy-cli returned {where}, so this transfer may still "
+        'be running. Re-check it with `download(action="status")` and re-issue '
+        "the cancel."
+    )
+
+
+def _with_cancel_verdict(payload: Any, changed: bool | None) -> Any:
+    """Add the branchable cancel verdict to a ``model download-cancel`` payload.
+
+    comfy-cli answers a cancel with the download's ``download-status`` row —
+    which on its own is indistinguishable from the row a transfer nobody touched
+    would produce. A cancel that arrived too late comes back ``status:
+    "completed"``, ``percent: 100.0``, ``error: null``: a success payload for a
+    cancel that stopped nothing, with no field an agent could branch on to
+    discover that. Hence three fields, in the same shape ``job(action="cancel")``
+    already uses — independent facts reported separately rather than one
+    overloaded verdict:
+
+    - ``cancelled`` — comfy-cli's resulting ``status`` reads cancelled. This is
+      the field to branch on, NOT ``status``/``error``.
+    - ``changed`` — comfy-cli's OWN envelope flag for this call: did it change
+      any state (kill a worker, reclaim a partial file)? It is what separates a
+      cancel that did something from a no-op against an id that was already
+      terminal, including the already-``cancelled`` id whose ``status`` alone
+      would read as a fresh success. ``None`` when the engine emitted no flag,
+      which is honestly "unknown", not "no".
+    - ``note`` — :func:`_download_cancel_note`.
+
+    Nothing here is derived beyond reading those two engine answers: the verdict
+    is comfy-cli's, which is what keeps this inside the thin-wrapper rule. The
+    MCP surface being served is the same one ``_with_download_id`` serves — an
+    agent has one round trip and no terminal to read the CLI's printed
+    "already completed; nothing to cancel" line from.
+    """
+    status = _download_status_of(payload)
+    cancelled = status in _DOWNLOAD_CANCELLED_STATUSES
+    verdict = {
+        "cancelled": cancelled,
+        "changed": changed,
+        "note": _download_cancel_note(status, cancelled, changed),
+    }
+    if not isinstance(payload, dict):
+        # comfy-cli always emits a status row here, so a non-dict is a broken
+        # engine contract — but handing it back bare is the very failure this
+        # function exists to close (a reply with nothing to branch on). Report
+        # the verdict anyway and keep the engine's own reply under `data`; the
+        # note's last branch already says the status is missing.
+        return {**verdict, "data": payload}
+    return {**payload, **verdict}
 
 
 def _with_download_id(payload: Any, download_id: str) -> Any:
@@ -10284,6 +10418,12 @@ def _download_verb_unsupported(
             f"{'check on' if verb == 'download-status' else 'cancel'}."
         ),
         "unsupported": True,
+        # The cancel half carries the verdict field too, set to the only honest
+        # value: this comfy-cli has no abort verb, so nothing was cancelled. An
+        # agent branching on `cancelled` must never have to read its ABSENCE as
+        # a cancel — which is the whole point of the field. `download-status`
+        # gets no such key: it is not a cancel and has no verdict to report.
+        **({"cancelled": False} if verb == "download-cancel" else {}),
     }
 
 
@@ -10559,10 +10699,42 @@ def _download_wait_sync(download_id: str, timeout_seconds: float) -> Any:
 
 
 def _download_cancel_sync(download_id: str) -> Any:
-    """``download(action="cancel")``'s body — the exact ``cancel_download`` this replaced."""
-    return _with_download_id(
-        _run_comfy("model", "download-cancel", download_id, timeout=60.0), download_id
-    )
+    """``download(action="cancel")``'s body — one bounded ``model download-cancel``.
+
+    comfy-cli owns the abort itself and it is a real one: `download-cancel`
+    writes a cancel sentinel, then `killpg`s the detached worker's process group
+    (SIGTERM, then SIGKILL), then reclaims the partial file. This call never
+    waits on the transfer — it waits on that, under
+    :data:`_DOWNLOAD_CANCEL_TIMEOUT`.
+
+    Two things are added on the way out, and neither is a verdict of this
+    server's own. :func:`_with_cancel_verdict` surfaces comfy-cli's answers —
+    the resulting ``status`` and the envelope's ``changed`` — as fields an agent
+    can branch on, because the raw status row cannot tell an effective cancel
+    from a no-op. And the bound expiring is re-raised saying exactly that much:
+    the child's process group was killed at the deadline, so what happened to
+    the download is UNKNOWN from here — the one thing that must not be reported
+    is a cancel that may not have happened.
+    """
+    try:
+        payload, changed = _run_comfy_with_changed(
+            "model", "download-cancel", download_id, timeout=_DOWNLOAD_CANCEL_TIMEOUT
+        )
+    except ComfyCliError as exc:
+        if not exc.timed_out:
+            raise
+        raise ComfyCliError(
+            f"{exc} — nothing here claims the transfer stopped: comfy-cli did "
+            "not answer within the bound, so the download may still be running. "
+            f"Re-check it with `download(action='status', "
+            f"download_id={download_id!r})` and re-issue the cancel.",
+            code=exc.code,
+            no_envelope=exc.no_envelope,
+            returncode=exc.returncode,
+            timed_out=exc.timed_out,
+            data=exc.data,
+        ) from exc
+    return _with_download_id(_with_cancel_verdict(payload, changed), download_id)
 
 
 # The three actions `download` dispatches, in the order their old standalone
@@ -10606,6 +10778,8 @@ def download(
       the final payload, or `{"timed_out": True, "download_id": ...,
       "status": <last>}` on expiry -- a TIMEOUT, not a failure.
     - "cancel" -> stop a running transfer and its partial file.
+      `cancelled` (NOT `status`) says whether it did; `changed` and
+      `note` say what happened instead.
 
     `download_id` required for every action; `timeout_seconds` only for
     "wait" -- rejected elsewhere. Payloads key the handle `download_id`;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,7 +228,7 @@ NO_SUCH_OPTION_STDERR = (
 _UNSET = object()
 
 
-def envelope(*, ok: bool = True, data=_UNSET, error=None) -> dict:
+def envelope(*, ok: bool = True, data=_UNSET, error=None, changed=_UNSET) -> dict:
     """Build a comfy-cli ``envelope/1`` result body.
 
     Mirrors what the CLI emits on its ``--json`` path: an ``error`` object when
@@ -238,12 +238,20 @@ def envelope(*, ok: bool = True, data=_UNSET, error=None) -> dict:
     ``data`` defaults to ``{}`` only when it is OMITTED — an explicit
     ``data=None`` stays ``None``, which several tests rely on to exercise the
     non-dict-payload branches.
+
+    ``changed`` is the envelope's OPTIONAL top-level mutation flag (schema:
+    *"present on mutating commands; true iff state changed"*). Omitted by
+    default, exactly as comfy-cli omits it on a read-only verb — so a test that
+    does not pass it exercises the "engine said nothing" path rather than a
+    silent ``False``.
     """
     body: dict = {"schema": "envelope/1", "type": "envelope", "ok": ok}
     if error is not None:
         body["error"] = error
     else:
         body["data"] = {} if data is _UNSET else data
+    if changed is not _UNSET:
+        body["changed"] = changed
     return body
 
 

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import subprocess
 import time
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
@@ -907,6 +908,17 @@ def _sequenced(monkeypatch, replies: list, *, seconds_per_call: float = 0.0) -> 
             raise AssertionError(f"unexpected extra comfy-cli call: {args}") from None
 
     monkeypatch.setattr(server, "_run_comfy", fake_run)
+    # `download(action="cancel")` reads the envelope's `changed` flag as well as
+    # its data, so it spawns through `_run_comfy_with_changed`. Answer it from
+    # the SAME script — a sequenced reply is a `data` payload, and this stub
+    # reports `changed` as unknown, which is what an engine that omits the flag
+    # gives. Tests that care about the flag use `patched_run`, which fakes the
+    # subprocess and so carries a real envelope.
+    monkeypatch.setattr(
+        server,
+        "_run_comfy_with_changed",
+        lambda *args, **kwargs: (fake_run(*args, **kwargs), None),
+    )
     return calls
 
 
@@ -1400,13 +1412,17 @@ def test_download_status_is_the_default_action(patched_run):
 
 def test_cancel_download_maps_command_and_returns_data(patched_run):
     """download(action="cancel") wraps `comfy model download-cancel <id>`."""
-    calls = patched_run(envelope(data=_status("cancelled")))
+    calls = patched_run(envelope(data=_status("cancelled"), changed=True))
 
     assert server.download(action="cancel", download_id="a1b2c3d4e5f6")["status"] == (
         "cancelled"
     )
     assert calls[0]["cmd"][4:] == ["model", "download-cancel", "a1b2c3d4e5f6"]
-    assert calls[0]["timeout"] == 60.0
+    # The cancel's OWN budget, not the family's generic 60s: cancelling is
+    # metadata plus a signal, and the bound is what makes "the cancel blocked
+    # for the rest of the transfer" impossible rather than merely unobserved.
+    assert calls[0]["timeout"] == server._DOWNLOAD_CANCEL_TIMEOUT
+    assert server._DOWNLOAD_CANCEL_TIMEOUT <= 30.0
 
 
 def test_cancel_download_unknown_id_raises_error_envelope(patched_run):
@@ -1421,6 +1437,234 @@ def test_cancel_download_unknown_id_raises_error_envelope(patched_run):
 
     with pytest.raises(server.ComfyCliError, match="download_not_found"):
         server.download(action="cancel", download_id="nope")
+
+
+# --- the cancel verdict ------------------------------------------------------
+#
+# comfy-cli answers `model download-cancel` with the download's status ROW,
+# which is the same shape a transfer nobody touched would produce. A cancel that
+# arrived too late therefore came back `status: "completed"`, `percent: 100.0`,
+# `error: null` — a success payload for a cancel that stopped nothing, with no
+# field an agent could branch on to find that out. These pin the two engine
+# answers this now reports separately (the resulting `status`, and the
+# envelope's own `changed` flag), in the shape `job(action="cancel")` already
+# uses: independent facts, reported independently.
+
+
+def _cancelled_at(status: str, *, changed=None, **extra) -> dict:
+    """A `download-cancel` reply: comfy-cli's status row + its `changed` flag."""
+    return envelope(data=_status(status, **extra), changed=changed)
+
+
+def test_cancel_of_a_starting_transfer_reports_the_abort(patched_run):
+    """The reported repro: cancel issued while the transfer reads "starting".
+
+    comfy-cli's own abort is real — `download-cancel` writes a cancel sentinel,
+    `killpg`s the detached worker, then reclaims the partial file — so the row
+    that comes back reads `cancelled`, and it says it changed state. Both halves
+    reach the caller.
+    """
+    patched_run(_cancelled_at("cancelled", changed=True, completed_bytes=0))
+
+    result = server.download(action="cancel", download_id="a1b2c3d4e5f6")
+
+    assert result["cancelled"] is True
+    assert result["changed"] is True
+    assert result["note"].startswith("cancelled:")
+    # comfy-cli's own row is still there, unedited, beside the verdict.
+    assert result["status"] == "cancelled"
+    assert result["dest"] == "/models/x.safetensors"
+
+
+def test_a_cancel_that_stopped_nothing_is_never_a_success_payload(patched_run):
+    """The reported defect, verbatim: `completed` / 100% / `error: null`.
+
+    A transfer that finished before the cancel landed gives comfy-cli nothing
+    to stop, and its reply is indistinguishable from a healthy download's. That
+    payload must not read as a cancel: `cancelled` is the field to branch on,
+    and it is False here even though `status`/`error` say nothing is wrong.
+    """
+    patched_run(_cancelled_at("completed", changed=True, completed_bytes=4_000_000_000))
+
+    result = server.download(action="cancel", download_id="a1b2c3d4e5f6")
+
+    assert result["cancelled"] is False
+    assert result["status"] == "completed"
+    assert result["error"] is None
+    assert "NOT cancelled" in result["note"]
+    # Names what is left to decide rather than dead-ending on the refusal.
+    assert "delete the file yourself" in result["note"]
+
+
+def test_cancel_on_an_already_terminal_id_says_so_rather_than_succeeding(
+    patched_run,
+):
+    """An id that had already completed: a no-op, and it says which kind."""
+    patched_run(_cancelled_at("completed", changed=False))
+
+    result = server.download(action="cancel", download_id="a1b2c3d4e5f6")
+
+    assert result["cancelled"] is False
+    assert result["changed"] is False
+    assert "already finished" in result["note"]
+
+
+def test_cancel_on_an_already_failed_id_is_not_reported_as_a_cancel(patched_run):
+    """`failed` is terminal too — and it is not a transfer this call stopped."""
+    patched_run(_cancelled_at("failed", changed=True, error="connection reset"))
+
+    result = server.download(action="cancel", download_id="a1b2c3d4e5f6")
+
+    assert result["cancelled"] is False
+    assert "ALREADY failed" in result["note"]
+    # `changed` on a terminal row is comfy-cli reclaiming the partial file.
+    assert "reclaimed its partial file" in result["note"]
+
+
+def test_cancel_of_an_already_cancelled_id_reports_the_no_op(patched_run):
+    """The case `status` alone cannot tell from a fresh cancel.
+
+    A second cancel against the same id returns `cancelled` exactly as the
+    first did, so the status row is identical — only comfy-cli's `changed`
+    flag separates "this call stopped it" from "it was already stopped".
+    """
+    patched_run(_cancelled_at("cancelled", changed=False))
+
+    result = server.download(action="cancel", download_id="a1b2c3d4e5f6")
+
+    assert result["cancelled"] is True
+    assert result["changed"] is False
+    assert "ALREADY cancelled" in result["note"]
+
+
+def test_a_cancel_the_engine_did_not_honor_is_reported_as_still_running(
+    patched_run,
+):
+    """`ok` from comfy-cli with a live status is NOT a cancel.
+
+    The one shape that must never be waved through: the command succeeded, and
+    the transfer it was asked to stop is still moving bytes.
+    """
+    patched_run(_cancelled_at("downloading", changed=False))
+
+    result = server.download(action="cancel", download_id="a1b2c3d4e5f6")
+
+    assert result["cancelled"] is False
+    assert "may still be running" in result["note"]
+    assert 'download(action="status")' in result["note"]
+
+
+def test_a_missing_changed_flag_is_unknown_not_false(patched_run):
+    """An engine that omits the flag has not said the call changed nothing."""
+    patched_run(_cancelled_at("cancelled"))
+
+    result = server.download(action="cancel", download_id="a1b2c3d4e5f6")
+
+    assert result["changed"] is None
+    assert result["cancelled"] is True
+    # Not the "ALREADY cancelled" no-op wording, which `changed is False` owns.
+    assert "ALREADY" not in result["note"]
+
+
+def test_a_non_boolean_changed_flag_is_unknown_too(patched_run):
+    """`changed` is a boolean in the schema; anything else is not an answer."""
+    patched_run(_cancelled_at("cancelled", changed="yes"))
+
+    assert (
+        server.download(action="cancel", download_id="a1b2c3d4e5f6")["changed"] is None
+    )
+
+
+def test_the_verdict_survives_a_payload_that_is_not_a_status_row(patched_run):
+    """A broken engine contract still gets a field to branch on."""
+    patched_run(envelope(data=None, changed=True))
+
+    result = server.download(action="cancel", download_id="a1b2c3d4e5f6")
+
+    assert result["cancelled"] is False
+    assert result["data"] is None
+    assert "no status" in result["note"]
+
+
+def test_cancel_is_bounded_and_says_the_download_may_still_be_running(
+    patched_run,
+):
+    """The bound expiring is the one answer that must not claim anything.
+
+    The child's whole process group is killed at the deadline, so what happened
+    to the transfer is unknown from here — the error says that, and names the
+    way back to a real answer instead of reporting a cancel.
+    """
+    patched_run(
+        "",
+        raises=subprocess.TimeoutExpired(
+            cmd=[server.COMFY_BIN, "model", "download-cancel"],
+            timeout=server._DOWNLOAD_CANCEL_TIMEOUT,
+        ),
+    )
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.download(action="cancel", download_id="a1b2c3d4e5f6")
+
+    message = str(excinfo.value)
+    assert "nothing here claims the transfer stopped" in message
+    assert "may still be running" in message
+    assert "download(action='status'" in message
+    assert excinfo.value.timed_out is True
+
+
+def test_a_real_cancel_failure_is_not_swallowed_by_the_timeout_branch(patched_run):
+    """Only a TIMEOUT gets the re-worded raise; every other failure is raw."""
+    patched_run(
+        {
+            "type": "envelope",
+            "ok": False,
+            "error": {"code": "model_download_foreground_cancel", "message": "nope"},
+        }
+    )
+
+    with pytest.raises(server.ComfyCliError) as excinfo:
+        server.download(action="cancel", download_id="a1b2c3d4e5f6")
+
+    assert excinfo.value.code == "model_download_foreground_cancel"
+    assert "nothing here claims" not in str(excinfo.value)
+
+
+def test_the_unsupported_degrade_carries_the_cancel_verdict(patched_run):
+    """A comfy-cli with no `download-cancel` cancelled nothing, and says so.
+
+    The degrade's message already points at the inline `download_model` that
+    still works there; this pins the machine-readable half, so an agent
+    branching on `cancelled` never has to read its ABSENCE as a cancel.
+    """
+    returncode, stdout, stderr = _NO_DOWNLOAD_CANCEL
+    patched_run(stdout, returncode=returncode, stderr=stderr)
+
+    result = server.download(action="cancel", download_id="a1b2c3d4e5f6")
+
+    assert result["unsupported"] is True
+    assert result["cancelled"] is False
+
+
+def test_the_status_degrade_carries_no_cancel_verdict(patched_run):
+    """`download-status` is not a cancel and has no verdict to report."""
+    returncode, stdout, stderr = _NO_DOWNLOAD_STATUS
+    patched_run(stdout, returncode=returncode, stderr=stderr)
+
+    result = server.download(action="status", download_id="a1b2c3d4e5f6")
+
+    assert result["unsupported"] is True
+    assert "cancelled" not in result
+
+
+def test_only_cancel_grows_the_verdict_fields(patched_run):
+    """`status` is a READ — adding a cancel verdict there would be a lie."""
+    patched_run(envelope(data=_status("downloading"), changed=False))
+
+    result = server.download(action="status", download_id="a1b2c3d4e5f6")
+
+    assert "cancelled" not in result
+    assert "note" not in result
 
 
 # Click's usage error for a verb the installed comfy-cli does not have: exit 2,
@@ -2283,7 +2527,19 @@ def test_download_rejects_a_supplied_timeout_seconds_where_unused(no_spawn, acti
     assert "'wait'" in str(excinfo.value)
 
 
-# --- tool docstring budget (<=220 est. tokens) + R6 disambiguation ------------
+# --- tool docstring budget (<=245 est. tokens) + R6 disambiguation ------------
+
+# 220 -> 245 when the "cancel" bullet named the field a caller has to branch on.
+# The bullet used to end at "stop a running transfer and its partial file",
+# which is exactly the reading that made a no-op cancel look like a success: the
+# payload comfy-cli returns for a cancel that stopped nothing is a status row
+# reading `completed` / `error: null`, so an agent told only that the action
+# stops transfers has no reason to look past it. Naming `cancelled` (and
+# `changed` / `note`) is ~25 tokens, and it is the cheapest place to spend them
+# — this is the one text the model reads BEFORE it calls. Kept deliberately
+# tight, like the whole-payload ceiling in `test_payload_budget.py`: the next
+# growth is a decision too.
+_DOWNLOAD_DOC_BUDGET_TOKENS = 245
 
 
 def test_download_tool_docstring_within_its_own_token_budget():
@@ -2293,7 +2549,9 @@ def test_download_tool_docstring_within_its_own_token_budget():
             doc = ast.get_docstring(node)
             assert doc is not None
             est_tokens = len(doc) // 4
-            assert est_tokens <= 220, f"download() docstring ~{est_tokens} est. tokens"
+            assert est_tokens <= _DOWNLOAD_DOC_BUDGET_TOKENS, (
+                f"download() docstring ~{est_tokens} est. tokens"
+            )
             return
     pytest.fail("download() tool not found in server.py")
 

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1517,8 +1517,54 @@ def test_cancel_on_an_already_failed_id_is_not_reported_as_a_cancel(patched_run)
 
     assert result["cancelled"] is False
     assert "ALREADY failed" in result["note"]
-    # `changed` on a terminal row is comfy-cli reclaiming the partial file.
-    assert "reclaimed its partial file" in result["note"]
+    # `changed` is REPORTED, not interpreted: comfy-cli says that state moved,
+    # never what moved, so the note must not name a file disposition it would
+    # have had to guess (and would have guessed the opposite way one branch up).
+    assert "changed state, but not what it changed" in result["note"]
+    assert "partial file" not in result["note"]
+
+
+def test_the_changed_flag_is_never_read_as_a_file_disposition(patched_run):
+    """The same `changed: true` must not mean two opposite things.
+
+    A cancel that lost the race comes back `completed`; one against an id that
+    had already failed comes back `failed`. Both can carry `changed: true`, and
+    comfy-cli's flag says only THAT something moved. Naming the file's fate off
+    it told the caller the finished file was kept in one branch and the partial
+    reclaimed in the other — off one bit that distinguishes neither, while the
+    engine downloads to the final `dest` and a state-changing cancel may unlink
+    it. Neither branch claims a disposition now.
+    """
+    patched_run(_cancelled_at("completed", changed=True))
+
+    note = server.download(action="cancel", download_id="a1b2c3d4e5f6")["note"]
+
+    assert "changed state, but not what it changed" in note
+    assert "kept the completed file" not in note
+    # Still names the decision left to the caller, just without asserting the
+    # file is there: checking `dest` is the caller's step, not a claim of ours.
+    assert "check `dest`" in note
+
+
+def test_a_changed_cancel_with_a_live_status_does_not_contradict_the_engine(
+    patched_run,
+):
+    """The fallback branch reports `changed` instead of ignoring it.
+
+    A worker SIGKILLed before it could flip its state file leaves comfy-cli
+    saying it changed state while the status row still reads `downloading`.
+    Answering that with a bare "may still be running; re-issue the cancel"
+    contradicted the engine's own flag on the same call — so the flag is
+    relayed, and the re-issue is made conditional on the transfer still running.
+    """
+    patched_run(_cancelled_at("downloading", changed=True))
+
+    result = server.download(action="cancel", download_id="a1b2c3d4e5f6")
+
+    assert result["cancelled"] is False
+    assert result["changed"] is True
+    assert "changed state, but not what it changed" in result["note"]
+    assert "re-issue the cancel if it is" in result["note"]
 
 
 def test_cancel_of_an_already_cancelled_id_reports_the_no_op(patched_run):
@@ -1564,6 +1610,14 @@ def test_a_missing_changed_flag_is_unknown_not_false(patched_run):
     assert result["cancelled"] is True
     # Not the "ALREADY cancelled" no-op wording, which `changed is False` owns.
     assert "ALREADY" not in result["note"]
+    # ...and not the `changed is True` wording either. `None` is the case the
+    # flag was ADDED to name — an engine that omits it leaves a repeat cancel of
+    # an already-cancelled id indistinguishable from a fresh abort — so falling
+    # through to "comfy-cli stopped the transfer's worker" would reintroduce the
+    # exact ambiguity. It gets its own hedged branch.
+    assert "emitted no `changed` flag" in result["note"]
+    assert "unknown" in result["note"]
+    assert "stopped the transfer's worker" not in result["note"]
 
 
 def test_a_non_boolean_changed_flag_is_unknown_too(patched_run):
@@ -1584,6 +1638,24 @@ def test_the_verdict_survives_a_payload_that_is_not_a_status_row(patched_run):
     assert result["cancelled"] is False
     assert result["data"] is None
     assert "no status" in result["note"]
+
+
+def test_an_engine_supplied_status_is_scrubbed_and_capped_in_the_note(patched_run):
+    """`status` is comfy-cli's string, and it lands in client-facing prose.
+
+    Every other engine-derived field this server renders goes through
+    `failure_log._scrub_text` and `errors._MAX_ERROR_FIELD_CHARS`; the note's
+    fallback branch is the one place a raw `status` reached the caller. A
+    version-skewed engine or a tampered state file is all it takes to put a
+    credential-bearing URL or a blob where a one-word status belongs.
+    """
+    leaky = "https://<user>:<pass>@example.invalid/x " + "z" * 4_000
+    patched_run(_cancelled_at(leaky))
+
+    note = server.download(action="cancel", download_id="a1b2c3d4e5f6")["note"]
+
+    assert "<pass>" not in note
+    assert len(note) < 1_000
 
 
 def test_cancel_is_bounded_and_says_the_download_may_still_be_running(
@@ -1644,6 +1716,13 @@ def test_the_unsupported_degrade_carries_the_cancel_verdict(patched_run):
 
     assert result["unsupported"] is True
     assert result["cancelled"] is False
+    # The WHOLE verdict, not just `cancelled`: the tool docstring tells callers
+    # that `changed` and `note` say what happened instead, so an agent that
+    # believed it and subscripted `result["note"]` here would have hit a
+    # `KeyError` — the read-the-absence failure the verdict exists to close.
+    assert result["changed"] is False
+    assert "NOT cancelled" in result["note"]
+    assert "no `model download-cancel`" in result["note"]
 
 
 def test_the_status_degrade_carries_no_cancel_verdict(patched_run):


### PR DESCRIPTION
## ELI-5

If you started a big model download by mistake and told the server to cancel it, the answer you got back looked exactly like the answer you would get if the download had finished perfectly: `status: "completed"`, `percent: 100.0`, `error: null`. There was no way to tell "I stopped it" from "I was too late and it downloaded anyway" — so an agent reading that reply would happily report a successful cancel over a file it never stopped. The cancel itself was fine; the *reply* was missing the part that says what happened. It is there now: `cancelled` says whether the transfer is actually stopped, `changed` is comfy-cli's own "did this call do anything" flag, and `note` says in one line what to do next when the answer is no.

## The bug

`download(action="cancel")` returned comfy-cli's raw `download-status` row and nothing else. That row is the same shape a transfer nobody touched produces, so three genuinely different outcomes were indistinguishable at the wrapper boundary: a cancel that killed the worker, a cancel that arrived after the last byte landed, and a repeat cancel against an id that was already terminal. The last two are no-ops, and both of them come back `ok: true` with a healthy-looking row.

comfy-cli does answer the question — the wrapper was dropping the answer. `model download-cancel` sets the envelope's **top-level `changed`** flag (`envelope.json`: *"present on mutating commands; true iff state changed"*): true when it killed a worker or reclaimed a partial file, false on a no-op. `_run_comfy` unwraps straight down to `data`, so that flag never reached a caller.

Measured against comfy-cli `main` (see Verification), the two payloads are byte-identical in `data` and differ only in `changed`:

```
cancel of a LIVE transfer   -> data {... "status": "cancelled", "completed_bytes": 0 ...}  changed: true
repeat cancel, same id      -> data {... "status": "cancelled", "completed_bytes": 0 ...}  changed: false
cancel of a COMPLETED id    -> data {... "status": "completed", "percent": 100.0, "error": null ...}  changed: false
```

That third line is the reported payload, reproduced.

## Changes

- `_run_comfy_with_changed` — `_run_comfy` plus the envelope's `changed` flag, on the same `_run_comfy_raw` → `_real_envelope` → `_unwrap_envelope` contract `server_info` already uses for the envelope's `schema`. A missing or non-boolean flag is reported as `None` (unknown), never coerced to `False`.
- `_with_cancel_verdict` / `_download_cancel_note` — three fields beside comfy-cli's untouched row, in the shape `job(action="cancel")` uses (independent facts reported independently, not one overloaded verdict): `cancelled` (the field to branch on), `changed` (comfy-cli's own), and `note` (one line: what happened, and what is left to decide when nothing was stopped).
- `_download_verb_unsupported` carries `cancelled: false` on the cancel half, so an agent branching on the field never has to read its ABSENCE as a cancel. The `download-status` half deliberately gets no such key — it is a read, not a cancel.
- `_DOWNLOAD_CANCEL_TIMEOUT = 30.0` replaces the family's generic 60s for this one call. Cancelling is metadata plus a signal; comfy-cli's own worst case is bounded (`stop_worker`: 5s SIGTERM grace, then 2s for SIGKILL). The bound expiring re-raises saying the download **may still be running** and naming the way back to a real answer — a killed process group leaves that genuinely unknown, and the one thing that must not be reported there is a cancel that may not have happened.
- `conftest.envelope(..., changed=…)` gained the optional flag; omitting it still models an engine that emits none.

The thin-wrapper rule is intact: every value here is comfy-cli's own answer (the resulting `status`, the envelope's `changed`), and nothing is inferred from the filesystem or from a table kept in this repo. What is added is MCP surface — an agent has one round trip and no terminal to read comfy-cli's printed "already completed; nothing to cancel" line from — which is the same thing `_with_download_id` exists for.

## Verification

`pytest -q` — 2132 passed, 1 skipped, 6 deselected. `ruff check .` and `ruff format --check .` clean.

**Live, against a real comfy-cli** (this repo's tests mock the CLI, as its conventions require, so the engine-side claims were checked separately). comfy-cli `main` was installed into a throwaway venv and driven against a temp workspace and a throttled loopback HTTP server (~2 MB/s, 200 MiB, `127.0.0.1`) — no external network, no model host, nothing downloaded from anywhere real:

1. **The abort primitive exists** (this is the falsification of the "maybe there is no abort" branch in the report, and the reason no dead-end is shipped here): `comfy model --help` lists `download-cancel` — *"Kill a background download's worker and remove its partial file."* Its implementation writes a cancel sentinel, `killpg`s the detached worker (SIGTERM → SIGKILL), then sweeps the partial file.
2. **Cancel at `starting` / 0 bytes, the reported repro**: submit → status `downloading`, `completed_bytes: 0` → cancel returned in **1.3 s**, `status: "cancelled"`, `changed: true`. The ~200 MiB transfer had ~100 s left to run.
3. **Cancel of a live transfer mid-flight**: cancel returned in **1.9 s** at ~1% of 200 MiB; the partial file was gone from the models directory afterwards.
4. **Repeat cancel against that terminal id**: identical `data`, `changed: false`.
5. **Cancel of an already-completed id**: `status: "completed"`, `percent: 100.0`, `error: null`, `changed: false` — the reported payload, and now the one this wrapper labels `cancelled: false`.

New tests in `tests/test_downloads.py` cover each of those shapes plus the ones a live probe cannot produce on demand: a cancel the engine did not honour (`ok` with a still-`downloading` row → never reported as cancelled), a missing/non-boolean `changed`, a non-status payload, the bounded-timeout raise, and the two degrade halves. The cancel-at-`starting` regression test the report asks for is `test_cancel_of_a_starting_transfer_reports_the_abort`.

## What this does NOT cover

- **The reported blocking symptom was not reproduced, and this PR does not identify a mechanism for it.** The report has the cancel call blocking ~23 s and ~16 s — roughly each transfer's own duration. Nothing on the wrapper side waits on a transfer (the cancel is one bounded `subprocess` call), and the engine cannot hold the pipe either: `_spawn_download_worker` detaches the worker with `close_fds=True` and its own log file, so it inherits no pipe of the submitting process. Against comfy-cli `main` the cancel returned in 1.3–1.9 s in every probe above. So this PR **bounds** the symptom rather than curing a mechanism it found: `_DOWNLOAD_CANCEL_TIMEOUT` makes a transfer-length block impossible, and a bound that does expire is reported as "could not cancel", never as a cancel. If the block is real on the reporter's machine it is engine-side or environment-side, and reproducing it needs their comfy-cli version — which is why this stays worth a look rather than closed by this change.
- **Unexercised artifacts.** The report itself, the two download ids it names, and the machine it ran on (its ComfyUI, its comfy-cli build) are not reachable from here; the ids belong to transfers on someone else's disk. The evidence above is a fresh reproduction against comfy-cli `main`, not a replay of theirs.
- **`total_bytes: null` on submit is untouched** — the report's second, lower-severity finding, and out of scope for v1 by the ticket's own framing. It reproduced here: the submit envelope carries `"total_bytes": null` while the very next `download-status` poll reports `209715200`, because the worker only learns the length from the response headers after the submit has already returned. Fixing it means having the submit resolve the length (or the worker persist it before the submit replies), which is a comfy-cli change, not a wrapper one. **It stays open.**
- **Partial-file cleanup semantics after an abort** are unchanged and undocumented here — also out of scope for v1. Observed behaviour, for whoever picks it up: comfy-cli deletes the partial (`completed_bytes` went to 0 and the file was gone), so a cancelled download is not resumable.

## Judgment calls

- **No tracker reference in this body or the commit**, per `AGENTS.md`'s destined-public hygiene rule; the branch name carries the link instead. Given the two exclusions above — the unreproduced blocking symptom and the unfixed `total_bytes` finding — **this PR should not be treated as closing the source ticket**, and the reviewer should leave it open rather than let the merge sweep it.
- **The per-tool docstring ceiling moved 220 → 245 est. tokens**, with the reasoning in the test's own comment. The `download` docstring was at 219/220, and the "cancel" bullet used to end at *"stop a running transfer and its partial file"* — which is exactly the reading that made a no-op look like a success. Naming `cancelled` is ~25 tokens and it is the one text the model reads BEFORE it calls. The whole-payload ceiling in `test_payload_budget.py` was **not** touched (15,137 of 15,250).
- **`changed` is surfaced rather than inferred.** The alternative was deriving "was this already terminal?" from a pre-cancel status poll, which costs a second spawn and is racy by construction. comfy-cli already computes the answer; this reads it.
- **The timeout branch re-raises rather than returning a payload.** A `timed_out` return would be a success-shaped answer to "did the cancel work?" when the honest answer is that the process group was killed and nobody knows.

## Testing

- [x] Existing tests pass (`pytest`)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually (live comfy-cli probes, above)
