### PR TITLE
fix(version-guard): serialize the `comfy --version` probe so racing first calls share one

### DIFF
--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -366,12 +366,21 @@ _MIN_COMFY_CLI_STR = "1.14.0"
 # once per process (it sits on the hot path of every _run_comfy call).
 _version_checked = False
 
-# The probe subprocess's own wall-clock cap, named because TWO places need the
-# same number: `_spawn_comfy_version`'s `timeout=`, and the bound on how long a
-# caller will wait for SOMEONE ELSE's probe (below). Keeping them one constant is
-# what makes "a waiter never pays more than its own probe would have cost" a
-# property of the code rather than of two literals staying in sync.
+# The probe subprocess's own wall-clock cap, named because the bound below is
+# derived from it: a waiter's budget has to be stated in terms of what it is
+# waiting FOR, not as a second literal that can drift away from this one.
 _VERSION_PROBE_TIMEOUT_S = 30.0
+
+# How long a caller will wait for SOMEONE ELSE's probe before giving up.
+#
+# Deliberately a little longer than the probe's own cap. A probe that finishes
+# AT its cap must win the race against a waiter's bound, because the two
+# outcomes are not interchangeable: if the holder finishes, the waiter gets a
+# real verdict, whereas if the waiter gives up first it fails open on a machine
+# whose comfy-cli may well be too old. The slack means a waiter only ever times
+# out when the holder has OVERRUN its own cap — the wedged case below, and the
+# one case where giving up is unambiguously the right answer.
+_VERSION_LOCK_WAIT_S = _VERSION_PROBE_TIMEOUT_S + 5.0
 
 # Serializes the probe itself, so racing FIRST calls share one `comfy --version`
 # instead of each spawning its own. The memo alone only dedupes calls that arrive
@@ -389,29 +398,51 @@ _VERSION_PROBE_TIMEOUT_S = 30.0
 # unbounded, because the holder can exceed the probe's nominal cap (on Windows,
 # `subprocess.run`'s post-`kill()` `communicate()` blocks until a leaked
 # grandchild closes the inherited handles) and every later `_run_comfy` would
-# then queue behind it forever. A caller that cannot get in within one probe's
-# full budget falls through to the guard's standard fail-OPEN — the same answer
-# it reaches when its own probe errors, and unlatched, so a later call re-checks.
+# then queue behind it forever. Giving up LATCHES open, for the same reason the
+# `TimeoutExpired` branch does and with the same force: a holder that overran its
+# cap is a hung `comfy --version` by another route, and without the latch every
+# later call would re-pay the full bound, turning a wedged probe into a permanent
+# per-call stall — worse than the pre-lock behavior, where whichever caller timed
+# out first latched open on everyone's behalf.
 _VERSION_CHECK_LOCK = threading.Lock()
 
-# The completed-probe counter and the verdict of the probe that last bumped it,
-# both written only under `_VERSION_CHECK_LOCK`.
+# The started-probe counter and the REFUSAL of the probe that last ran, both
+# written only under `_VERSION_CHECK_LOCK`. Together they let a caller that
+# queued behind a probe take its answer instead of running a second one.
 #
-# They exist because three of the guard's verdicts deliberately do NOT latch — a
-# transient spawn error, a too-old comfy-cli, and a TCC-denied start. Without
-# them, callers queued behind an in-flight probe would wake to `_version_checked
-# is False` and each run a probe of its OWN, turning N parallel cold starts into
-# N *serialized* ones: strictly worse than the bug this lock fixes, and on a
-# persistently too-old or TCC-denied install it never self-resolves. A caller
-# compares the counter it read before queueing against the one it sees after
-# getting in; if a probe completed in between, that probe started AFTER the
-# caller arrived, so its verdict is the caller's own answer and is replayed
-# rather than recomputed. That is not the memoization those three branches
-# refuse: a call arriving after the lock goes idle still re-probes, so
-# upgrade-and-retry (or grant-Full-Disk-Access-and-retry) in the same process
-# works exactly as documented.
-_version_probe_generation = 0
-_version_probe_verdict: ComfyCliError | None = None
+# The counter is bumped when a probe STARTS, not when it finishes, and that is
+# the whole subtlety. What makes another probe's answer usable is not that it
+# finished while you waited — it is that it started AFTER you arrived, because
+# only then did it observe a machine at least as current as the one you are
+# asking about. Bumping on completion would let a caller that arrived mid-probe
+# replay a verdict computed before it ever called, so an operator who upgrades
+# comfy-cli (or grants Full Disk Access) while a probe is in flight would get the
+# stale refusal on the very retry the guard promises to re-check. Sampling the
+# counter before queueing and finding it CHANGED means a probe both started and
+# finished in that window, which is exactly the usable case.
+_version_probe_starts = 0
+
+# Only a REFUSAL is shared; a fail-open never is. The refusal verdicts (a too-old
+# comfy-cli, a TCC-denied start, an invalid `COMFY_PROJECT`) are the ones worth
+# replaying: they are persistent, so re-probing costs a full cold start and
+# reaches the same conclusion, and on such an install a re-probing herd never
+# self-resolves — the serialization this counter exists to prevent. A fail-open
+# is the opposite on both counts. Its branch is documented as failing open "for
+# THIS call", it comes from a TRANSIENT spawn failure that the next probe is
+# likely to get past, and sharing it would send the whole herd unguarded into the
+# cryptic errors this guard exists to translate. So a queued caller with no
+# refusal to replay probes for itself, and that probe's success latches the memo
+# for everyone behind it — bounded, unlike the persistent case.
+#
+# Stored as the MESSAGE rather than the exception object: re-raising one instance
+# from many threads mutates shared state on it — each `raise` appends to
+# `__traceback__` and sets `__context__` to whatever the raising thread was
+# handling, chaining an unrelated request's error and its frame locals onto a
+# process-global and holding them until the next probe. Both refusals this guard
+# raises are message-only `ComfyCliError`s constructed at the branch, so the
+# message IS the whole verdict; a future verdict carrying structured fields would
+# have to widen this.
+_version_probe_refusal: str | None = None
 
 # `COMFY_PROJECT`'s raw value, read from the environment at most once per
 # process (see `_project_root`). The sentinel distinguishes "not read yet" from
@@ -841,46 +872,43 @@ def _check_comfy_version() -> None:
 
     This function is the interlock; :func:`_probe_comfy_version` is the policy.
     At most one probe runs at a time, and a caller that queued behind one takes
-    that probe's answer instead of running a second — including when the answer
-    is one of the three verdicts that deliberately do not latch, which is the
-    case that would otherwise serialize N cold starts where N used to run in
-    parallel. See ``_VERSION_CHECK_LOCK`` and ``_version_probe_generation`` for
-    why the wait is bounded and why replaying a verdict is not memoizing it.
+    its REFUSAL rather than re-deriving it — see ``_version_probe_starts`` for
+    why "started after I arrived" is the condition, and ``_version_probe_refusal``
+    for why a fail-open is never shared. Both the wait and the give-up are
+    bounded; see ``_VERSION_CHECK_LOCK``.
 
     The warm fast path stays OUTSIDE the lock: once the memo is set a call costs
     one global read and no acquisition, which matters because every
     ``_run_comfy`` goes through here.
     """
-    global _version_probe_generation, _version_probe_verdict
+    global _version_checked, _version_probe_starts, _version_probe_refusal
     if _version_checked:
         return
-    # Sampled BEFORE queueing, so a change observed after getting in means "a
-    # probe both started and finished while I waited" — the precise condition
-    # under which that probe's verdict is also mine.
-    queued_at = _version_probe_generation
-    if not _VERSION_CHECK_LOCK.acquire(timeout=_VERSION_PROBE_TIMEOUT_S):
-        return  # fail OPEN, unlatched — see `_VERSION_CHECK_LOCK`
+    # Sampled BEFORE queueing, so a change observed after getting in means a
+    # probe STARTED after this call began — the condition under which its answer
+    # is at least as current as one this caller would compute now.
+    queued_at = _version_probe_starts
+    if not _VERSION_CHECK_LOCK.acquire(timeout=_VERSION_LOCK_WAIT_S):
+        # The holder overran the probe's own cap. Latch open exactly as the
+        # `TimeoutExpired` branch does — see `_VERSION_CHECK_LOCK`.
+        _version_checked = True
+        return
     try:
         if _version_checked:
             return
-        if _version_probe_generation != queued_at:
-            if _version_probe_verdict is not None:
-                # Re-raised as the same instance, the way `Future.result()` hands
-                # one exception to every waiter: only ``__traceback__`` is
-                # shared, and MCP surfaces the message, never the traceback.
-                raise _version_probe_verdict
-            return
-        # Cleared first so an escape this function does not model (anything that
-        # is not a `ComfyCliError`) leaves NO stale verdict behind for the next
-        # waiter to replay — it falls open and re-probes, the guard's default.
-        _version_probe_verdict = None
+        if _version_probe_starts != queued_at and _version_probe_refusal is not None:
+            # A fresh probe already refused; that refusal is this caller's too.
+            # Rebuilt per caller rather than re-raising one shared instance.
+            raise ComfyCliError(_version_probe_refusal)
+        # Bumped BEFORE the probe, and the previous refusal dropped with it, so
+        # neither outlives the probe it describes.
+        _version_probe_starts += 1
+        _version_probe_refusal = None
         try:
             _probe_comfy_version()
         except ComfyCliError as exc:
-            _version_probe_verdict = exc
+            _version_probe_refusal = str(exc)
             raise
-        finally:
-            _version_probe_generation += 1
     finally:
         _VERSION_CHECK_LOCK.release()
 

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -398,12 +398,20 @@ _VERSION_LOCK_WAIT_S = _VERSION_PROBE_TIMEOUT_S + 5.0
 # unbounded, because the holder can exceed the probe's nominal cap (on Windows,
 # `subprocess.run`'s post-`kill()` `communicate()` blocks until a leaked
 # grandchild closes the inherited handles) and every later `_run_comfy` would
-# then queue behind it forever. Giving up LATCHES open, for the same reason the
+# then queue behind it forever. Giving up latches open ONLY when no probe started
+# during the whole wait — the wedge, where it latches for the same reason the
 # `TimeoutExpired` branch does and with the same force: a holder that overran its
 # cap is a hung `comfy --version` by another route, and without the latch every
 # later call would re-pay the full bound, turning a wedged probe into a permanent
 # per-call stall — worse than the pre-lock behavior, where whichever caller timed
-# out first latched open on everyone's behalf.
+# out first latched open on everyone's behalf. A waiter that timed out while
+# probes were STARTING has no wedge to report, only contention, and the give-up
+# branch is careful not to read the two as the same thing; see it for why.
+#
+# Because the wait and the probe are consecutive, a single contended first call
+# can cost the bound PLUS a full probe (~65s) before it answers. That is stated
+# at the three `to_thread(_check_comfy_version)` call sites, which is where a
+# reader is asking how long the guard can hold their tool call.
 _VERSION_CHECK_LOCK = threading.Lock()
 
 # The started-probe counter and the REFUSAL of the probe that last ran, both
@@ -438,10 +446,11 @@ _version_probe_starts = 0
 # from many threads mutates shared state on it — each `raise` appends to
 # `__traceback__` and sets `__context__` to whatever the raising thread was
 # handling, chaining an unrelated request's error and its frame locals onto a
-# process-global and holding them until the next probe. Both refusals this guard
-# raises are message-only `ComfyCliError`s constructed at the branch, so the
-# message IS the whole verdict; a future verdict carrying structured fields would
-# have to widen this.
+# process-global and holding them until the next probe. Every refusal this guard
+# raises is a message-only `ComfyCliError` constructed at its branch, so the
+# message IS the whole verdict — and `_replayable_refusal` CHECKS that rather
+# than assuming it, so a future verdict carrying structured fields falls back to
+# "the waiters re-probe" instead of reaching them with those fields dropped.
 _version_probe_refusal: str | None = None
 
 # `COMFY_PROJECT`'s raw value, read from the environment at most once per
@@ -859,6 +868,39 @@ def _probe_comfy_version() -> None:
     _version_checked = True
 
 
+def _replayable_refusal(exc: ComfyCliError) -> str | None:
+    """``exc``'s message if replaying it loses nothing, else ``None``.
+
+    The replay rebuilds the verdict from a stored string, so it carries the
+    message and nothing else. Every refusal this guard can raise today is a
+    message-only :class:`ComfyCliError` constructed at its branch, which makes
+    that lossless — but nothing about the class enforces it, and a future verdict
+    carrying ``code``, ``data`` or a ``returncode`` would reach every queued
+    caller but the first with those fields silently dropped. So the property is
+    CHECKED here rather than assumed: a refusal that would not survive the round
+    trip is simply not offered for replay, and the callers behind it re-probe.
+    Degrading to a redundant cold start is the right failure — it costs time, not
+    correctness, and it is what the guard did before the interlock existed.
+
+    ``__cause__`` is deliberately not part of the test. The TCC refusal chains
+    the originating ``PermissionError``, and dropping that chain on a replay is
+    the POINT: retaining one exception's traceback and frame locals on a
+    process-global is the leak that made this a stored message in the first
+    place, and the chained detail is already rendered into the message text.
+    """
+    if len(exc.args) != 1 or not isinstance(exc.args[0], str):
+        return None
+    if (
+        exc.code is not None
+        or exc.no_envelope
+        or exc.returncode is not None
+        or exc.timed_out
+        or exc.data is not None
+    ):
+        return None
+    return exc.args[0]
+
+
 def _check_comfy_version() -> None:
     """Guard: refuse to run against a comfy-cli older than :data:`_MIN_COMFY_CLI`.
 
@@ -889,9 +931,34 @@ def _check_comfy_version() -> None:
     # is at least as current as one this caller would compute now.
     queued_at = _version_probe_starts
     if not _VERSION_CHECK_LOCK.acquire(timeout=_VERSION_LOCK_WAIT_S):
-        # The holder overran the probe's own cap. Latch open exactly as the
-        # `TimeoutExpired` branch does — see `_VERSION_CHECK_LOCK`.
-        _version_checked = True
+        # Ran out of patience. WHY decides what to do, because the bound measures
+        # total QUEUE time and only one of the two ways to exhaust it is a wedge.
+        #
+        # No probe STARTED in all that time: one holder has held the lock across
+        # the whole budget without making progress, which is the wedged case the
+        # bound exists for. Latch open exactly as the `TimeoutExpired` branch
+        # does — see `_VERSION_CHECK_LOCK`.
+        #
+        # Probes DID start: the interlock was busy, not stuck, and
+        # `threading.Lock` grants no fairness — so a waiter can exhaust its
+        # budget against a chain of perfectly in-cap probes, or be starved by
+        # later arrivals. Latching there would permanently disable the version
+        # floor process-wide on nothing but contention, which is the one way this
+        # guard must never come undone. Fail open for THIS call only, and first
+        # replay a refusal if one of those probes left one: a non-None refusal
+        # always belongs to the most recently STARTED probe (each probe clears it
+        # as it starts), and that probe started after this caller sampled, so the
+        # "at least as current as one I would compute now" test the in-lock
+        # replay applies is already satisfied. Reading the two globals without
+        # the lock is sound because every interleaving lands on a safe answer —
+        # a refusal that outranks this caller's own, or a fail-open it never
+        # latches.
+        if _version_probe_starts == queued_at:
+            _version_checked = True
+            return
+        refusal = _version_probe_refusal
+        if refusal is not None:
+            raise ComfyCliError(refusal)
         return
     try:
         if _version_checked:
@@ -907,7 +974,7 @@ def _check_comfy_version() -> None:
         try:
             _probe_comfy_version()
         except ComfyCliError as exc:
-            _version_probe_refusal = str(exc)
+            _version_probe_refusal = _replayable_refusal(exc)
             raise
     finally:
         _VERSION_CHECK_LOCK.release()
@@ -2068,9 +2135,11 @@ async def _run_comfy_async(
     calls are fine on the thread-pool path.
     """
     _require_comfy_bin()
-    # `_check_comfy_version` runs a synchronous `comfy --version` (up to 30s on
-    # the first call per process); offload it so the async event loop is never
-    # blocked while it runs. Same reason as `_run_comfy_streaming`.
+    # `_check_comfy_version` runs a synchronous `comfy --version` on the first
+    # call per process — up to 30s uncontended, and up to ~65s if it also has to
+    # wait out someone else's probe first (`_VERSION_CHECK_LOCK`). Offload it so
+    # the async event loop is never blocked while it runs. Same reason as
+    # `_run_comfy_streaming`.
     await asyncio.to_thread(_check_comfy_version)
     # Forward --host/--port into the subcommand for a configured remote ComfyUI
     # (no-op for the local default; see target._with_target). Reassigning args means the
@@ -2200,9 +2269,10 @@ async def _run_comfy_streaming(
     ``job(action="wait")``) rather than surface the deadline as an error.
     """
     _require_comfy_bin()
-    # `_check_comfy_version` runs a synchronous `comfy --version` (up to 30s on
-    # the first call per process); offload it so the async event loop is never
-    # blocked while it runs.
+    # `_check_comfy_version` runs a synchronous `comfy --version` on the first
+    # call per process — up to 30s uncontended, and up to ~65s if it also has to
+    # wait out someone else's probe first (`_VERSION_CHECK_LOCK`). Offload it so
+    # the async event loop is never blocked while it runs.
     await asyncio.to_thread(_check_comfy_version)
     # Forward --host/--port into the subcommand for a configured remote ComfyUI
     # (no-op for the local default; see target._with_target). run_workflow(wait=True)
@@ -2965,8 +3035,9 @@ async def _start_login() -> tuple[_LoginChild | None, dict]:
     """
     _require_comfy_bin()
     # Same offload as the streaming path: the guard shells out to
-    # `comfy --version` (up to 30s on the first call per process) and must not
-    # block the event loop.
+    # `comfy --version` on the first call per process (up to 30s uncontended,
+    # ~65s if it waits out another probe first — see `_VERSION_CHECK_LOCK`) and
+    # must not block the event loop.
     await asyncio.to_thread(_check_comfy_version)
     args = ("cloud", "login", "--no-browser", "--timeout", str(_LOGIN_TIMEOUT_S))
     # Materialized rather than spelled inline at the spawn so `_spawn_failure`

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -366,19 +366,52 @@ _MIN_COMFY_CLI_STR = "1.14.0"
 # once per process (it sits on the hot path of every _run_comfy call).
 _version_checked = False
 
+# The probe subprocess's own wall-clock cap, named because TWO places need the
+# same number: `_spawn_comfy_version`'s `timeout=`, and the bound on how long a
+# caller will wait for SOMEONE ELSE's probe (below). Keeping them one constant is
+# what makes "a waiter never pays more than its own probe would have cost" a
+# property of the code rather than of two literals staying in sync.
+_VERSION_PROBE_TIMEOUT_S = 30.0
+
 # Serializes the probe itself, so racing FIRST calls share one `comfy --version`
 # instead of each spawning its own. The memo alone only dedupes calls that arrive
 # after a probe has FINISHED — the startup machine-snapshot probe (a daemon
 # thread) is usually first, and every tool call arriving while it is still inside
 # its 30s-capped subprocess would otherwise read `_version_checked is False` and
 # spawn a redundant cold comfy-cli interpreter, N concurrent first calls spawning
-# N of them on exactly the machine least able to afford it. Waiting on the lock
-# costs a caller no more wall time than running that duplicate probe would have,
-# and it leaves the machine less loaded. `threading.Lock` (not an asyncio one) is
-# correct for both call styles: the sync paths call `_check_comfy_version`
-# directly, the async paths via `asyncio.to_thread`, and it is never held across
-# an `await`.
+# N of them on exactly the machine least able to afford it. `threading.Lock` (not
+# an asyncio one) is correct for both call styles: the sync paths call
+# `_check_comfy_version` directly, the async paths via `asyncio.to_thread`, and
+# it is never held across an `await`.
+#
+# Acquired with a BOUND, never unconditionally. The guard's worst case has always
+# been per-call and finite; a bare `with` would make it process-wide and
+# unbounded, because the holder can exceed the probe's nominal cap (on Windows,
+# `subprocess.run`'s post-`kill()` `communicate()` blocks until a leaked
+# grandchild closes the inherited handles) and every later `_run_comfy` would
+# then queue behind it forever. A caller that cannot get in within one probe's
+# full budget falls through to the guard's standard fail-OPEN — the same answer
+# it reaches when its own probe errors, and unlatched, so a later call re-checks.
 _VERSION_CHECK_LOCK = threading.Lock()
+
+# The completed-probe counter and the verdict of the probe that last bumped it,
+# both written only under `_VERSION_CHECK_LOCK`.
+#
+# They exist because three of the guard's verdicts deliberately do NOT latch — a
+# transient spawn error, a too-old comfy-cli, and a TCC-denied start. Without
+# them, callers queued behind an in-flight probe would wake to `_version_checked
+# is False` and each run a probe of its OWN, turning N parallel cold starts into
+# N *serialized* ones: strictly worse than the bug this lock fixes, and on a
+# persistently too-old or TCC-denied install it never self-resolves. A caller
+# compares the counter it read before queueing against the one it sees after
+# getting in; if a probe completed in between, that probe started AFTER the
+# caller arrived, so its verdict is the caller's own answer and is replayed
+# rather than recomputed. That is not the memoization those three branches
+# refuse: a call arriving after the lock goes idle still re-probes, so
+# upgrade-and-retry (or grant-Full-Disk-Access-and-retry) in the same process
+# works exactly as documented.
+_version_probe_generation = 0
+_version_probe_verdict: ComfyCliError | None = None
 
 # `COMFY_PROJECT`'s raw value, read from the environment at most once per
 # process (see `_project_root`). The sentinel distinguishes "not read yet" from
@@ -711,10 +744,88 @@ def _spawn_comfy_version() -> subprocess.CompletedProcess:
         capture_output=True,
         text=True,
         errors="replace",  # never crash on undecodable `--version` bytes
-        timeout=30.0,
+        timeout=_VERSION_PROBE_TIMEOUT_S,
         check=False,
         cwd=_project_root(),
     )
+
+
+def _probe_comfy_version() -> None:
+    """Run the guard's ``comfy --version`` once and apply its verdict.
+
+    The body of :func:`_check_comfy_version`, split out so that function is only
+    the memo plus the one-probe-at-a-time interlock and this one is only the
+    failure policy — which is the load-bearing half, and reads better as a flat
+    sequence of branches than nested inside a lock. Called from there and nowhere
+    else, always with ``_VERSION_CHECK_LOCK`` held, so its writes to
+    ``_version_checked`` need no synchronization of their own.
+
+    Each branch's choice to latch (or deliberately not to) is unchanged and
+    documented at the branch: a hung probe latches OPEN, a transient spawn error
+    fails open WITHOUT latching, and the two raising verdicts — too-old and
+    TCC-denied — do not latch either, so an upgrade or a Full Disk Access grant
+    inside the same process is re-checked rather than permanently rejected.
+    """
+    global _version_checked
+    try:
+        proc = _spawn_comfy_version()
+    except subprocess.TimeoutExpired:
+        # A hung `--version` is latched so we don't re-block every later call on
+        # the same 30s wait; fail OPEN for the rest of the process.
+        _version_checked = True
+        return
+    except PermissionError as exc:
+        # The spawn ITSELF was denied (not the child exiting non-zero) — e.g. a
+        # `comfy` launcher whose interpreter sits in a protected folder. Without
+        # this branch the generic handler below fails open and the raw EPERM
+        # escapes from the real spawn a moment later, unexplained. Must precede
+        # the OSError handler: PermissionError is a subclass of it.
+        denied = getattr(exc, "filename", None) or tcc._tcc_path_from(str(exc))
+        if tcc._is_macos() and (
+            tcc._looks_like_tcc_denial(str(exc))
+            or tcc._macos_protected_dir(denied) is not None
+        ):
+            raise ComfyCliError(
+                f"`{COMFY_BIN}` could not be started.\n\n{tcc._tcc_guidance(denied)}\n\n"
+                f"Original error: {exc}"
+            ) from exc
+        return  # any other permission problem: fail OPEN, exactly as before
+    except (OSError, subprocess.SubprocessError):
+        # A transient spawn failure fails OPEN for THIS call but is NOT latched —
+        # a later call re-checks rather than permanently disabling the guard.
+        return
+    if proc.returncode != 0 and tcc._looks_like_tcc_denial(proc.stderr):
+        # comfy-cli's own interpreter could not start because macOS denied it
+        # its venv — the reported failure for a ComfyUI install under
+        # ~/Documents. This guard runs before the first tool call of the
+        # process, so catching it here is what turns the raw `Fatal Python
+        # error` traceback into the fix. Deliberately NOT memoized: granting
+        # Full Disk Access and retrying in the same process must re-check.
+        raise ComfyCliError(
+            f"`{COMFY_BIN}` could not start.\n\n"
+            f"{tcc._tcc_guidance(_scrubbed_tcc_path(proc.stderr))}\n\n"
+            # Same rule as `_unwrap_envelope`'s TCC branch: a captured stream is
+            # scrubbed on its way to the client, and so is the path pulled OUT
+            # of one (`_scrubbed_tcc_path`, a no-op on a real filesystem path).
+            # This probe is only `comfy --version`, so it carries no caller URL
+            # of its own — but comfy-cli reads its config at startup, so a
+            # warning naming a configured server URL can land on this stderr,
+            # and the asymmetry is not worth preserving.
+            "Original error: "
+            f"{failure_log._scrubbed_stream_tail(proc.stderr, errors._MAX_ERROR_FIELD_CHARS)}"
+        )
+    version = _parse_version(f"{proc.stdout}\n{proc.stderr}")
+    if version is not None and version < _MIN_COMFY_CLI:
+        # Deliberately do NOT memoize a too-old verdict: if the user upgrades and
+        # retries within the same process, re-check rather than latch the failure.
+        raise ComfyCliError(
+            f"comfy-cli {'.'.join(map(str, version))} is too old — this server "
+            f"requires comfy-cli >= {_MIN_COMFY_CLI_STR}. Upgrade it with "
+            # Double-quoted for the same cross-shell reason as
+            # `_require_comfy_bin`'s install advice — see the note there.
+            f'`pip install --upgrade "comfy-cli>={_MIN_COMFY_CLI_STR}"`.'
+        )
+    _version_checked = True
 
 
 def _check_comfy_version() -> None:
@@ -727,76 +838,51 @@ def _check_comfy_version() -> None:
     logs" deep inside a tool call. Fails OPEN on anything it can't positively read
     as too-old (an unparseable ``--version``, a ``--version`` that errors) so a
     future comfy-cli output-format change can never wedge a working install.
+
+    This function is the interlock; :func:`_probe_comfy_version` is the policy.
+    At most one probe runs at a time, and a caller that queued behind one takes
+    that probe's answer instead of running a second — including when the answer
+    is one of the three verdicts that deliberately do not latch, which is the
+    case that would otherwise serialize N cold starts where N used to run in
+    parallel. See ``_VERSION_CHECK_LOCK`` and ``_version_probe_generation`` for
+    why the wait is bounded and why replaying a verdict is not memoizing it.
+
+    The warm fast path stays OUTSIDE the lock: once the memo is set a call costs
+    one global read and no acquisition, which matters because every
+    ``_run_comfy`` goes through here.
     """
-    global _version_checked
+    global _version_probe_generation, _version_probe_verdict
     if _version_checked:
         return
-    with _VERSION_CHECK_LOCK:
-        # Re-check under the lock: a caller that queued behind an in-flight probe
-        # must observe ITS verdict rather than duplicate it. Everything below is
-        # unchanged — each failure-policy branch latches (or deliberately does
-        # not) exactly as before; the lock only bounds the probe to one at a time.
+    # Sampled BEFORE queueing, so a change observed after getting in means "a
+    # probe both started and finished while I waited" — the precise condition
+    # under which that probe's verdict is also mine.
+    queued_at = _version_probe_generation
+    if not _VERSION_CHECK_LOCK.acquire(timeout=_VERSION_PROBE_TIMEOUT_S):
+        return  # fail OPEN, unlatched — see `_VERSION_CHECK_LOCK`
+    try:
         if _version_checked:
             return
+        if _version_probe_generation != queued_at:
+            if _version_probe_verdict is not None:
+                # Re-raised as the same instance, the way `Future.result()` hands
+                # one exception to every waiter: only ``__traceback__`` is
+                # shared, and MCP surfaces the message, never the traceback.
+                raise _version_probe_verdict
+            return
+        # Cleared first so an escape this function does not model (anything that
+        # is not a `ComfyCliError`) leaves NO stale verdict behind for the next
+        # waiter to replay — it falls open and re-probes, the guard's default.
+        _version_probe_verdict = None
         try:
-            proc = _spawn_comfy_version()
-        except subprocess.TimeoutExpired:
-            # A hung `--version` is latched so we don't re-block every later call on
-            # the same 30s wait; fail OPEN for the rest of the process.
-            _version_checked = True
-            return
-        except PermissionError as exc:
-            # The spawn ITSELF was denied (not the child exiting non-zero) — e.g. a
-            # `comfy` launcher whose interpreter sits in a protected folder. Without
-            # this branch the generic handler below fails open and the raw EPERM
-            # escapes from the real spawn a moment later, unexplained. Must precede
-            # the OSError handler: PermissionError is a subclass of it.
-            denied = getattr(exc, "filename", None) or tcc._tcc_path_from(str(exc))
-            if tcc._is_macos() and (
-                tcc._looks_like_tcc_denial(str(exc))
-                or tcc._macos_protected_dir(denied) is not None
-            ):
-                raise ComfyCliError(
-                    f"`{COMFY_BIN}` could not be started.\n\n{tcc._tcc_guidance(denied)}\n\n"
-                    f"Original error: {exc}"
-                ) from exc
-            return  # any other permission problem: fail OPEN, exactly as before
-        except (OSError, subprocess.SubprocessError):
-            # A transient spawn failure fails OPEN for THIS call but is NOT latched —
-            # a later call re-checks rather than permanently disabling the guard.
-            return
-        if proc.returncode != 0 and tcc._looks_like_tcc_denial(proc.stderr):
-            # comfy-cli's own interpreter could not start because macOS denied it
-            # its venv — the reported failure for a ComfyUI install under
-            # ~/Documents. This guard runs before the first tool call of the
-            # process, so catching it here is what turns the raw `Fatal Python
-            # error` traceback into the fix. Deliberately NOT memoized: granting
-            # Full Disk Access and retrying in the same process must re-check.
-            raise ComfyCliError(
-                f"`{COMFY_BIN}` could not start.\n\n"
-                f"{tcc._tcc_guidance(_scrubbed_tcc_path(proc.stderr))}\n\n"
-                # Same rule as `_unwrap_envelope`'s TCC branch: a captured stream is
-                # scrubbed on its way to the client, and so is the path pulled OUT
-                # of one (`_scrubbed_tcc_path`, a no-op on a real filesystem path).
-                # This probe is only `comfy --version`, so it carries no caller URL
-                # of its own — but comfy-cli reads its config at startup, so a
-                # warning naming a configured server URL can land on this stderr,
-                # and the asymmetry is not worth preserving.
-                "Original error: "
-                f"{failure_log._scrubbed_stream_tail(proc.stderr, errors._MAX_ERROR_FIELD_CHARS)}"
-            )
-        version = _parse_version(f"{proc.stdout}\n{proc.stderr}")
-        if version is not None and version < _MIN_COMFY_CLI:
-            # Deliberately do NOT memoize a too-old verdict: if the user upgrades and
-            # retries within the same process, re-check rather than latch the failure.
-            raise ComfyCliError(
-                f"comfy-cli {'.'.join(map(str, version))} is too old — this server "
-                f"requires comfy-cli >= {_MIN_COMFY_CLI_STR}. Upgrade it with "
-                # Double-quoted for the same cross-shell reason as
-                # `_require_comfy_bin`'s install advice — see the note there.
-                f'`pip install --upgrade "comfy-cli>={_MIN_COMFY_CLI_STR}"`.'
-            )
-        _version_checked = True
+            _probe_comfy_version()
+        except ComfyCliError as exc:
+            _version_probe_verdict = exc
+            raise
+        finally:
+            _version_probe_generation += 1
+    finally:
+        _VERSION_CHECK_LOCK.release()
 
 
 def _scrubbed_tcc_path(text: str | None) -> str | None:

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -366,6 +366,20 @@ _MIN_COMFY_CLI_STR = "1.14.0"
 # once per process (it sits on the hot path of every _run_comfy call).
 _version_checked = False
 
+# Serializes the probe itself, so racing FIRST calls share one `comfy --version`
+# instead of each spawning its own. The memo alone only dedupes calls that arrive
+# after a probe has FINISHED — the startup machine-snapshot probe (a daemon
+# thread) is usually first, and every tool call arriving while it is still inside
+# its 30s-capped subprocess would otherwise read `_version_checked is False` and
+# spawn a redundant cold comfy-cli interpreter, N concurrent first calls spawning
+# N of them on exactly the machine least able to afford it. Waiting on the lock
+# costs a caller no more wall time than running that duplicate probe would have,
+# and it leaves the machine less loaded. `threading.Lock` (not an asyncio one) is
+# correct for both call styles: the sync paths call `_check_comfy_version`
+# directly, the async paths via `asyncio.to_thread`, and it is never held across
+# an `await`.
+_VERSION_CHECK_LOCK = threading.Lock()
+
 # `COMFY_PROJECT`'s raw value, read from the environment at most once per
 # process (see `_project_root`). The sentinel distinguishes "not read yet" from
 # "read and unset" (`None`) without a second flag.
@@ -717,65 +731,72 @@ def _check_comfy_version() -> None:
     global _version_checked
     if _version_checked:
         return
-    try:
-        proc = _spawn_comfy_version()
-    except subprocess.TimeoutExpired:
-        # A hung `--version` is latched so we don't re-block every later call on
-        # the same 30s wait; fail OPEN for the rest of the process.
-        _version_checked = True
-        return
-    except PermissionError as exc:
-        # The spawn ITSELF was denied (not the child exiting non-zero) — e.g. a
-        # `comfy` launcher whose interpreter sits in a protected folder. Without
-        # this branch the generic handler below fails open and the raw EPERM
-        # escapes from the real spawn a moment later, unexplained. Must precede
-        # the OSError handler: PermissionError is a subclass of it.
-        denied = getattr(exc, "filename", None) or tcc._tcc_path_from(str(exc))
-        if tcc._is_macos() and (
-            tcc._looks_like_tcc_denial(str(exc))
-            or tcc._macos_protected_dir(denied) is not None
-        ):
+    with _VERSION_CHECK_LOCK:
+        # Re-check under the lock: a caller that queued behind an in-flight probe
+        # must observe ITS verdict rather than duplicate it. Everything below is
+        # unchanged — each failure-policy branch latches (or deliberately does
+        # not) exactly as before; the lock only bounds the probe to one at a time.
+        if _version_checked:
+            return
+        try:
+            proc = _spawn_comfy_version()
+        except subprocess.TimeoutExpired:
+            # A hung `--version` is latched so we don't re-block every later call on
+            # the same 30s wait; fail OPEN for the rest of the process.
+            _version_checked = True
+            return
+        except PermissionError as exc:
+            # The spawn ITSELF was denied (not the child exiting non-zero) — e.g. a
+            # `comfy` launcher whose interpreter sits in a protected folder. Without
+            # this branch the generic handler below fails open and the raw EPERM
+            # escapes from the real spawn a moment later, unexplained. Must precede
+            # the OSError handler: PermissionError is a subclass of it.
+            denied = getattr(exc, "filename", None) or tcc._tcc_path_from(str(exc))
+            if tcc._is_macos() and (
+                tcc._looks_like_tcc_denial(str(exc))
+                or tcc._macos_protected_dir(denied) is not None
+            ):
+                raise ComfyCliError(
+                    f"`{COMFY_BIN}` could not be started.\n\n{tcc._tcc_guidance(denied)}\n\n"
+                    f"Original error: {exc}"
+                ) from exc
+            return  # any other permission problem: fail OPEN, exactly as before
+        except (OSError, subprocess.SubprocessError):
+            # A transient spawn failure fails OPEN for THIS call but is NOT latched —
+            # a later call re-checks rather than permanently disabling the guard.
+            return
+        if proc.returncode != 0 and tcc._looks_like_tcc_denial(proc.stderr):
+            # comfy-cli's own interpreter could not start because macOS denied it
+            # its venv — the reported failure for a ComfyUI install under
+            # ~/Documents. This guard runs before the first tool call of the
+            # process, so catching it here is what turns the raw `Fatal Python
+            # error` traceback into the fix. Deliberately NOT memoized: granting
+            # Full Disk Access and retrying in the same process must re-check.
             raise ComfyCliError(
-                f"`{COMFY_BIN}` could not be started.\n\n{tcc._tcc_guidance(denied)}\n\n"
-                f"Original error: {exc}"
-            ) from exc
-        return  # any other permission problem: fail OPEN, exactly as before
-    except (OSError, subprocess.SubprocessError):
-        # A transient spawn failure fails OPEN for THIS call but is NOT latched —
-        # a later call re-checks rather than permanently disabling the guard.
-        return
-    if proc.returncode != 0 and tcc._looks_like_tcc_denial(proc.stderr):
-        # comfy-cli's own interpreter could not start because macOS denied it
-        # its venv — the reported failure for a ComfyUI install under
-        # ~/Documents. This guard runs before the first tool call of the
-        # process, so catching it here is what turns the raw `Fatal Python
-        # error` traceback into the fix. Deliberately NOT memoized: granting
-        # Full Disk Access and retrying in the same process must re-check.
-        raise ComfyCliError(
-            f"`{COMFY_BIN}` could not start.\n\n"
-            f"{tcc._tcc_guidance(_scrubbed_tcc_path(proc.stderr))}\n\n"
-            # Same rule as `_unwrap_envelope`'s TCC branch: a captured stream is
-            # scrubbed on its way to the client, and so is the path pulled OUT
-            # of one (`_scrubbed_tcc_path`, a no-op on a real filesystem path).
-            # This probe is only `comfy --version`, so it carries no caller URL
-            # of its own — but comfy-cli reads its config at startup, so a
-            # warning naming a configured server URL can land on this stderr,
-            # and the asymmetry is not worth preserving.
-            "Original error: "
-            f"{failure_log._scrubbed_stream_tail(proc.stderr, errors._MAX_ERROR_FIELD_CHARS)}"
-        )
-    version = _parse_version(f"{proc.stdout}\n{proc.stderr}")
-    if version is not None and version < _MIN_COMFY_CLI:
-        # Deliberately do NOT memoize a too-old verdict: if the user upgrades and
-        # retries within the same process, re-check rather than latch the failure.
-        raise ComfyCliError(
-            f"comfy-cli {'.'.join(map(str, version))} is too old — this server "
-            f"requires comfy-cli >= {_MIN_COMFY_CLI_STR}. Upgrade it with "
-            # Double-quoted for the same cross-shell reason as
-            # `_require_comfy_bin`'s install advice — see the note there.
-            f'`pip install --upgrade "comfy-cli>={_MIN_COMFY_CLI_STR}"`.'
-        )
-    _version_checked = True
+                f"`{COMFY_BIN}` could not start.\n\n"
+                f"{tcc._tcc_guidance(_scrubbed_tcc_path(proc.stderr))}\n\n"
+                # Same rule as `_unwrap_envelope`'s TCC branch: a captured stream is
+                # scrubbed on its way to the client, and so is the path pulled OUT
+                # of one (`_scrubbed_tcc_path`, a no-op on a real filesystem path).
+                # This probe is only `comfy --version`, so it carries no caller URL
+                # of its own — but comfy-cli reads its config at startup, so a
+                # warning naming a configured server URL can land on this stderr,
+                # and the asymmetry is not worth preserving.
+                "Original error: "
+                f"{failure_log._scrubbed_stream_tail(proc.stderr, errors._MAX_ERROR_FIELD_CHARS)}"
+            )
+        version = _parse_version(f"{proc.stdout}\n{proc.stderr}")
+        if version is not None and version < _MIN_COMFY_CLI:
+            # Deliberately do NOT memoize a too-old verdict: if the user upgrades and
+            # retries within the same process, re-check rather than latch the failure.
+            raise ComfyCliError(
+                f"comfy-cli {'.'.join(map(str, version))} is too old — this server "
+                f"requires comfy-cli >= {_MIN_COMFY_CLI_STR}. Upgrade it with "
+                # Double-quoted for the same cross-shell reason as
+                # `_require_comfy_bin`'s install advice — see the note there.
+                f'`pip install --upgrade "comfy-cli>={_MIN_COMFY_CLI_STR}"`.'
+            )
+        _version_checked = True
 
 
 def _scrubbed_tcc_path(text: str | None) -> str | None:

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -815,6 +815,62 @@ def _release_herd_into_guard(lock, count: int) -> list[BaseException | None]:
     return outcomes
 
 
+def _herd_inside_an_in_flight_probe(
+    lock, monkeypatch, count: int, verdict
+) -> tuple[list[int], list[BaseException | None]]:
+    """Queue ``count`` callers INSIDE a probe that is already running.
+
+    The other herd helper holds the lock before anything probes, so every caller
+    samples `_version_probe_starts` at its pre-bump value. This one stages the
+    scenario the interlock was actually written for — the startup snapshot probe
+    is already inside its cold `comfy --version` when the tool calls land — where
+    the callers instead sample the ALREADY-bumped value. Returns the spawn log
+    and each caller's outcome, the in-flight prober first.
+    """
+    spawns: list[int] = []
+    counter = threading.Lock()
+    probing = threading.Event()
+    finish = threading.Event()
+
+    def fake_spawn() -> subprocess.CompletedProcess:
+        with counter:
+            spawns.append(len(spawns) + 1)
+            nth = len(spawns)
+        if nth == 1:
+            probing.set()
+            assert finish.wait(timeout=30)
+        return verdict()
+
+    monkeypatch.setattr(server, "_spawn_comfy_version", fake_spawn)
+
+    outcomes: list[BaseException | None] = [None] * (count + 1)
+
+    def caller(index: int) -> None:
+        try:
+            server._check_comfy_version()
+        except BaseException as exc:  # noqa: BLE001 - reported, not swallowed
+            outcomes[index] = exc
+
+    threads = [threading.Thread(target=caller, args=(0,))]
+    threads[0].start()
+    assert probing.wait(timeout=30)  # the first probe is genuinely in flight
+
+    for index in range(1, count + 1):
+        thread = threading.Thread(target=caller, args=(index,))
+        thread.start()
+        threads.append(thread)
+    deadline = time.monotonic() + 30
+    while lock.queued < count + 1 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert lock.queued == count + 1  # all of them arrived DURING that probe
+
+    finish.set()
+    for thread in threads:
+        thread.join(timeout=30)
+    assert not any(thread.is_alive() for thread in threads)  # no deadlock
+    return spawns, outcomes
+
+
 def test_version_guard_probes_once_for_a_herd_of_racing_first_calls(
     monkeypatch, version_guard
 ):
@@ -969,6 +1025,181 @@ def test_version_guard_does_not_replay_a_probe_that_predates_the_caller(
     assert retry[0] is None  # the retry saw the upgrade rather than the refusal
     assert len(spawns) == 2
     assert server._version_checked is True
+
+
+def test_version_guard_bounds_a_herd_that_lands_inside_an_in_flight_probe(
+    monkeypatch, version_guard
+):
+    """The mid-probe herd costs TWO probes, not one per caller.
+
+    This is the production shape the interlock was written for, and the one the
+    other herd tests cannot stage: the callers arrive while the startup snapshot
+    probe is already inside its cold `comfy --version`, so they sample an
+    ALREADY-bumped `_version_probe_starts` and none of them may replay the
+    verdict of a probe that predates them — that refusal to replay is the
+    upgrade-and-retry promise, pinned next door.
+
+    What keeps that from degenerating into a probe per caller is that the FIRST
+    waiter's own probe starts after every one of the others arrived, so its
+    verdict is a legitimate answer to their question and they replay it. The
+    cost is therefore one re-probe per generation of arrivals, not one per
+    caller: two probes here for six callers, whatever the herd's size. Asserting
+    the exact count is the point — a change that made this N would restore the
+    serialization the lock exists to remove, while still passing every other
+    test in this group.
+    """
+    spawns, outcomes = _herd_inside_an_in_flight_probe(
+        version_guard, monkeypatch, 5, _too_old_version_proc
+    )
+
+    assert len(spawns) == 2  # the in-flight probe + ONE re-probe for the herd
+    assert len(outcomes) == 6
+    for outcome in outcomes:
+        # Bounded is not enough on its own: every caller still gets the real
+        # refusal, since a shared fail-open would admit a too-old install.
+        assert isinstance(outcome, server.ComfyCliError)
+        assert "too old" in str(outcome)
+    assert server._version_checked is False  # a too-old refusal never latches
+    assert not version_guard.locked()
+
+
+def _waiter_that_gives_up(lock, before_timeout) -> BaseException | None:
+    """Run one caller against a HELD lock, mutating state before it gives up.
+
+    `before_timeout()` fires once the caller has sampled `_version_probe_starts`
+    and blocked, so a test can stage exactly what the caller finds when its
+    bound expires. Returns what the caller raised, or ``None``.
+    """
+    outcome: list[BaseException | None] = [None]
+
+    def caller() -> None:
+        try:
+            server._check_comfy_version()
+        except BaseException as exc:  # noqa: BLE001 - reported, not swallowed
+            outcome[0] = exc
+
+    lock.acquire()
+    try:
+        lock.queued = 0  # this helper's own acquire is not the caller's
+        thread = threading.Thread(target=caller)
+        thread.start()
+        deadline = time.monotonic() + 30
+        while lock.queued < 1 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert lock.queued == 1  # sampled the counter, now blocked on the lock
+        before_timeout()
+        thread.join(timeout=30)
+        assert not thread.is_alive()
+    finally:
+        lock.release()
+    return outcome[0]
+
+
+def test_version_guard_does_not_latch_open_when_it_only_lost_the_race(
+    monkeypatch, version_guard
+):
+    """Contention alone must never disable the version floor for the process.
+
+    The acquire bound measures total QUEUE time, not one holder's probe, and
+    `threading.Lock` grants no fairness — so a caller can exhaust it against a
+    chain of perfectly in-cap probes, or be starved by later arrivals, with
+    nothing wedged anywhere. Latching there would permanently disable the guard
+    on a machine whose comfy-cli may well be too old, on nothing but load. The
+    wedge is the case where NO probe started in all that time, and only it
+    latches.
+
+    Here a probe both started and refused while the caller waited, so the caller
+    is handed that refusal — it started after the caller arrived, which is the
+    same freshness test the in-lock replay applies.
+    """
+    monkeypatch.setattr(server, "_VERSION_LOCK_WAIT_S", 0.05)
+    spawns = _spawns_recorded(monkeypatch, lambda _n: _passing_version_proc())
+
+    def probe_ran_and_refused() -> None:
+        server._version_probe_starts += 1
+        server._version_probe_refusal = "comfy-cli 1.11.0 is too old"
+
+    outcome = _waiter_that_gives_up(version_guard, probe_ran_and_refused)
+
+    assert isinstance(outcome, server.ComfyCliError)
+    assert "too old" in str(outcome)
+    assert server._version_checked is False  # NOT latched: nothing was wedged
+    assert spawns == []  # it never got in, so it never probed
+
+
+def test_version_guard_fails_open_unlatched_when_it_loses_with_no_verdict(
+    monkeypatch, version_guard
+):
+    """Losing the race with no refusal to inherit fails open for THAT call only.
+
+    The sibling of the test above, for the interleaving where the probes that
+    ran left nothing to replay (they failed open, or a later one cleared the
+    slot as it started). The caller has no verdict, so it falls open — but still
+    does not latch, because the give-up was contention rather than a wedge. The
+    next call re-checks, which is what keeps a busy first second from costing
+    the guard permanently.
+    """
+    monkeypatch.setattr(server, "_VERSION_LOCK_WAIT_S", 0.05)
+    spawns = _spawns_recorded(monkeypatch, lambda _n: _passing_version_proc())
+
+    def probe_ran_and_left_nothing() -> None:
+        server._version_probe_starts += 1
+
+    outcome = _waiter_that_gives_up(version_guard, probe_ran_and_left_nothing)
+
+    assert outcome is None  # failed open
+    assert server._version_checked is False  # ...but did not latch
+    assert spawns == []
+
+    server._check_comfy_version()  # so the very next call still probes
+    assert len(spawns) == 1
+    assert server._version_checked is True
+
+
+def test_version_guard_does_not_replay_a_refusal_that_carries_more_than_a_message(
+    monkeypatch, version_guard
+):
+    """A structured verdict is re-probed rather than replayed lossily.
+
+    The replay rebuilds the error from a stored string, which is lossless only
+    because every refusal reachable today is a message-only `ComfyCliError`.
+    Nothing about the class enforces that, so `_replayable_refusal` checks it:
+    a verdict carrying `code`/`data`/`returncode` is not offered for replay, and
+    the callers behind it re-probe instead of receiving a copy with those fields
+    silently dropped. The cost of that fallback is a redundant cold start — time,
+    not correctness — which is what the guard did before the interlock existed.
+    """
+    probes: list[int] = []
+
+    def structured_refusal() -> None:
+        probes.append(len(probes) + 1)
+        raise server.ComfyCliError("engine said no", code="some_future_code")
+
+    monkeypatch.setattr(server, "_probe_comfy_version", structured_refusal)
+
+    outcomes = _release_herd_into_guard(version_guard, 3)
+
+    assert len(probes) == 3  # each caller re-derived it rather than replaying
+    for outcome in outcomes:
+        assert isinstance(outcome, server.ComfyCliError)
+        assert outcome.code == "some_future_code"  # the fields survive
+    assert server._version_probe_refusal is None  # never offered for replay
+
+
+def test_replayable_refusal_accepts_only_a_bare_message(monkeypatch):
+    """The predicate itself: message-only in, message out; anything else `None`."""
+    assert server._replayable_refusal(server.ComfyCliError("too old")) == "too old"
+
+    for structured in (
+        server.ComfyCliError("x", code="c"),
+        server.ComfyCliError("x", no_envelope=True),
+        server.ComfyCliError("x", returncode=2),
+        server.ComfyCliError("x", timed_out=True),
+        server.ComfyCliError("x", data={"valid": False}),
+        server.ComfyCliError("x", "y"),  # more than one arg: str() reshapes it
+        server.ComfyCliError(),  # no message at all
+    ):
+        assert server._replayable_refusal(structured) is None
 
 
 def test_version_guard_latches_open_when_the_lock_holder_overruns(

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -692,6 +692,120 @@ def test_version_guard_latches_on_timeout(monkeypatch):
     assert server._version_checked is True
 
 
+def _passing_version_proc() -> subprocess.CompletedProcess:
+    """A `comfy --version` result at the floor, for the lock tests below."""
+    return subprocess.CompletedProcess(
+        [server.COMFY_BIN, "--version"],
+        0,
+        stdout="comfy-cli, version 1.14.0",
+        stderr="",
+    )
+
+
+def test_version_guard_probes_once_for_a_herd_of_racing_first_calls(monkeypatch):
+    """Concurrent FIRST calls share ONE probe instead of spawning one each.
+
+    The memo alone only dedupes calls arriving after a probe has FINISHED. The
+    real first-call window is a slow one — the startup machine-snapshot probe
+    holds `comfy --version` for a full cold comfy-cli start — and every tool
+    call landing inside it used to read `_version_checked is False` and spawn
+    its own, N racing callers spawning N cold interpreters on exactly the
+    machine least able to afford them.
+    """
+    monkeypatch.setattr(server, "_version_checked", False)
+
+    spawns: list[float] = []
+    counter = threading.Lock()
+    ready = threading.Barrier(5)
+
+    def fake_spawn() -> subprocess.CompletedProcess:
+        with counter:
+            spawns.append(time.monotonic())
+        time.sleep(0.2)  # hold the probe open so the herd genuinely overlaps
+        return _passing_version_proc()
+
+    monkeypatch.setattr(server, "_spawn_comfy_version", fake_spawn)
+
+    raised: list[BaseException] = []
+
+    def caller() -> None:
+        ready.wait(timeout=10)  # release all five at the same instant
+        try:
+            server._check_comfy_version()
+        except BaseException as exc:  # noqa: BLE001 - reported, not swallowed
+            raised.append(exc)
+
+    threads = [threading.Thread(target=caller) for _ in range(5)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not any(thread.is_alive() for thread in threads)  # no deadlock
+    assert raised == []
+    assert len(spawns) == 1  # the whole point: one probe, not five
+    assert server._version_checked is True
+    assert not server._VERSION_CHECK_LOCK.locked()
+
+
+def test_version_guard_lock_does_not_latch_a_transient_failure(monkeypatch):
+    """The lock serializes the probe; it must not change WHICH verdicts latch.
+
+    A transient spawn error still fails OPEN without latching, so the very next
+    call re-probes — the branch most at risk of being accidentally swallowed by
+    a "we already ran it" early return added under the lock.
+    """
+    monkeypatch.setattr(server, "_version_checked", False)
+
+    spawns: list[str] = []
+
+    def fake_spawn() -> subprocess.CompletedProcess:
+        spawns.append("call")
+        if len(spawns) == 1:
+            raise OSError("boom")
+        return _passing_version_proc()
+
+    monkeypatch.setattr(server, "_spawn_comfy_version", fake_spawn)
+
+    server._check_comfy_version()  # no raise
+    assert server._version_checked is False  # transient error still not latched
+    assert len(spawns) == 1
+    assert not server._VERSION_CHECK_LOCK.locked()
+
+    server._check_comfy_version()  # re-probes rather than returning the memo
+    assert len(spawns) == 2
+    assert server._version_checked is True
+
+
+def test_version_guard_releases_the_lock_when_a_verdict_raises(monkeypatch):
+    """A raising verdict must leave the lock free, not wedge every later call.
+
+    Two of the guard's branches — a too-old version and a TCC-denied start —
+    raise from INSIDE the `with`, and neither latches, so the next call is
+    expected to take the lock again. If the raise leaked the lock, the first
+    upgrade-and-retry in the same process would hang forever instead of
+    re-checking; the `with` is what makes that impossible.
+    """
+    monkeypatch.setattr(server, "_version_checked", False)
+
+    stdouts = iter(["comfy-cli, version 1.11.0", "comfy-cli, version 1.14.0"])
+
+    def fake_spawn() -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(
+            [server.COMFY_BIN, "--version"], 0, stdout=next(stdouts), stderr=""
+        )
+
+    monkeypatch.setattr(server, "_spawn_comfy_version", fake_spawn)
+
+    with pytest.raises(server.ComfyCliError, match="too old"):
+        server._check_comfy_version()
+    assert not server._VERSION_CHECK_LOCK.locked()
+    assert server._version_checked is False
+
+    server._check_comfy_version()  # the upgraded install: re-checked, not wedged
+    assert server._version_checked is True
+
+
 def test_spawn_comfy_version_keeps_the_bounded_decode_safe_invocation(monkeypatch):
     """The one shared spawn site: right argv, bounded, and decode-safe."""
     seen: dict[str, object] = {}

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -693,7 +693,7 @@ def test_version_guard_latches_on_timeout(monkeypatch):
 
 
 def _passing_version_proc() -> subprocess.CompletedProcess:
-    """A `comfy --version` result at the floor, for the lock tests below."""
+    """A `comfy --version` result at the floor, for the interlock tests below."""
     return subprocess.CompletedProcess(
         [server.COMFY_BIN, "--version"],
         0,
@@ -702,41 +702,100 @@ def _passing_version_proc() -> subprocess.CompletedProcess:
     )
 
 
-def _slow_version_spawns(monkeypatch, outcome):
-    """Patch `_spawn_comfy_version` with a probe slow enough to be raced.
+def _too_old_version_proc() -> subprocess.CompletedProcess:
+    """A `comfy --version` result below the floor — the guard's refusal case."""
+    return subprocess.CompletedProcess(
+        [server.COMFY_BIN, "--version"],
+        0,
+        stdout="comfy-cli, version 1.11.0",
+        stderr="",
+    )
 
-    ``outcome(n)`` produces the nth probe's result — returned, or raised to
-    exercise a failure verdict. The sleep is what makes the herd tests test
-    anything: without a probe that stays IN FLIGHT, the callers would queue and
-    complete one after another and a broken interlock would still look deduped.
+
+class _CountingLock:
+    """`_VERSION_CHECK_LOCK` that also reports how many callers have queued.
+
+    The herd tests need to know when every caller has SAMPLED
+    `_version_probe_starts`, and the only portable observation point is the
+    `acquire` immediately after it: a caller that has attempted to acquire has
+    necessarily already sampled. That turns the herd tests from "sleep long
+    enough and hope" into a real wait on a real condition — a fake probe holding
+    the lock for a fixed 200ms would still race a thread descheduled past it on
+    a loaded runner, and would race it in the direction that FAILS (a straggler
+    samples the already-bumped counter and probes again).
+
+    Only the three methods `server` and the tests use are forwarded; anything
+    else is an interlock change that should fail loudly here rather than be
+    silently absorbed by a `__getattr__`.
+    """
+
+    def __init__(self) -> None:
+        self._inner = threading.Lock()
+        self._counter = threading.Lock()
+        self.queued = 0
+
+    def acquire(self, *args, **kwargs):
+        with self._counter:
+            self.queued += 1
+        return self._inner.acquire(*args, **kwargs)
+
+    def release(self) -> None:
+        self._inner.release()
+
+    def locked(self) -> bool:
+        return self._inner.locked()
+
+
+@pytest.fixture
+def version_guard(monkeypatch):
+    """Pristine, auto-restored version-guard state for the interlock tests.
+
+    Every one of these globals is process-wide, so without this the suite is
+    order-dependent on them, and a herd test whose thread outlived its join
+    would leave the real `_VERSION_CHECK_LOCK` held for the rest of the session
+    — later guard tests would then hit the acquire bound and pass VACUOUSLY,
+    asserting a fail-open they never probed for. `monkeypatch` restores the real
+    lock untouched no matter what this test's threads did to the substitute.
+    """
+    monkeypatch.setattr(server, "_version_checked", False)
+    monkeypatch.setattr(server, "_VERSION_CHECK_LOCK", _CountingLock())
+    monkeypatch.setattr(server, "_version_probe_starts", 0)
+    monkeypatch.setattr(server, "_version_probe_refusal", None)
+    return server._VERSION_CHECK_LOCK
+
+
+def _spawns_recorded(monkeypatch, outcome):
+    """Patch `_spawn_comfy_version`; `outcome(nth)` supplies the nth result.
+
     Returns the list the fake appends to, so a test can count actual spawns.
     """
-    spawns: list[float] = []
+    spawns: list[int] = []
     counter = threading.Lock()
 
     def fake_spawn() -> subprocess.CompletedProcess:
         with counter:
-            spawns.append(time.monotonic())
+            spawns.append(len(spawns) + 1)
             nth = len(spawns)
-        time.sleep(0.2)  # hold the probe open so a herd genuinely overlaps it
         return outcome(nth)
 
     monkeypatch.setattr(server, "_spawn_comfy_version", fake_spawn)
     return spawns
 
 
-def _race_version_guard(count: int) -> list[BaseException | None]:
-    """Release ``count`` callers into `_check_comfy_version` at the same instant.
+def _release_herd_into_guard(lock, count: int) -> list[BaseException | None]:
+    """Queue ``count`` callers on a HELD lock, then release them together.
 
-    Returns each caller's outcome in start order — the exception it raised, or
-    ``None`` — so a test can assert BOTH that one probe ran and that every
-    caller got the right answer, which is the half a spawn count alone misses.
+    Holding the lock first is what makes the overlap deterministic rather than
+    timing-dependent: no probe can start — and so `_version_probe_starts` cannot
+    move — until every caller has sampled it and blocked. Returns each caller's
+    outcome in start order (the exception it raised, or ``None``), because the
+    spawn count alone does not show that the queued callers got the right answer.
     """
-    ready = threading.Barrier(count)
+    lock.acquire()
+    lock.queued = 0  # this helper's own acquire is not one of the callers
     outcomes: list[BaseException | None] = [None] * count
 
     def caller(index: int) -> None:
-        ready.wait(timeout=10)
         try:
             server._check_comfy_version()
         except BaseException as exc:  # noqa: BLE001 - reported, not swallowed
@@ -745,13 +804,20 @@ def _race_version_guard(count: int) -> list[BaseException | None]:
     threads = [threading.Thread(target=caller, args=(i,)) for i in range(count)]
     for thread in threads:
         thread.start()
+    deadline = time.monotonic() + 30
+    while lock.queued < count and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert lock.queued == count  # everyone sampled and queued before any probe
+    lock.release()
     for thread in threads:
         thread.join(timeout=30)
     assert not any(thread.is_alive() for thread in threads)  # no deadlock
     return outcomes
 
 
-def test_version_guard_probes_once_for_a_herd_of_racing_first_calls(monkeypatch):
+def test_version_guard_probes_once_for_a_herd_of_racing_first_calls(
+    monkeypatch, version_guard
+):
     """Concurrent FIRST calls share ONE probe instead of spawning one each.
 
     The memo alone only dedupes calls arriving after a probe has FINISHED. The
@@ -761,183 +827,228 @@ def test_version_guard_probes_once_for_a_herd_of_racing_first_calls(monkeypatch)
     its own, N racing callers spawning N cold interpreters on exactly the
     machine least able to afford them.
     """
-    monkeypatch.setattr(server, "_version_checked", False)
-    spawns = _slow_version_spawns(monkeypatch, lambda _n: _passing_version_proc())
+    spawns = _spawns_recorded(monkeypatch, lambda _n: _passing_version_proc())
 
-    outcomes = _race_version_guard(5)
+    outcomes = _release_herd_into_guard(version_guard, 5)
 
     assert outcomes == [None] * 5
     assert len(spawns) == 1  # the whole point: one probe, not five
     assert server._version_checked is True
-    assert not server._VERSION_CHECK_LOCK.locked()
+    assert not version_guard.locked()
 
 
-def test_version_guard_lock_does_not_latch_a_transient_failure(monkeypatch):
-    """The lock serializes the probe; it must not change WHICH verdicts latch.
+def test_version_guard_replays_a_refusal_to_the_herd_it_queued(
+    monkeypatch, version_guard
+):
+    """The queued callers get the too-old refusal itself, not a probe each.
 
-    A transient spawn error still fails OPEN without latching, so the very next
-    call re-probes — the branch most at risk of being accidentally swallowed by
-    a "we already ran it" early return added under the lock.
+    Refusals are the worst case for a re-probing herd: they never latch, so each
+    woken caller would pay a full cold `comfy --version` only to reach the same
+    conclusion, and on a persistently too-old install that never self-resolves.
+    Each caller must still see the real error — a shared verdict that fell OPEN
+    for the waiters would admit a too-old install for four callers out of five.
     """
-    monkeypatch.setattr(server, "_version_checked", False)
+    spawns = _spawns_recorded(monkeypatch, lambda _n: _too_old_version_proc())
 
-    spawns: list[str] = []
+    outcomes = _release_herd_into_guard(version_guard, 5)
 
-    def fake_spawn() -> subprocess.CompletedProcess:
-        spawns.append("call")
-        if len(spawns) == 1:
-            raise OSError("boom")
-        return _passing_version_proc()
-
-    monkeypatch.setattr(server, "_spawn_comfy_version", fake_spawn)
-
-    server._check_comfy_version()  # no raise
-    assert server._version_checked is False  # transient error still not latched
-    assert len(spawns) == 1
-    assert not server._VERSION_CHECK_LOCK.locked()
-
-    server._check_comfy_version()  # re-probes rather than returning the memo
-    assert len(spawns) == 2
-    assert server._version_checked is True
+    assert len(spawns) == 1  # one probe for the whole herd, not five in a row
+    assert len(outcomes) == 5
+    for outcome in outcomes:
+        assert isinstance(outcome, server.ComfyCliError)
+        assert "too old" in str(outcome)
+    assert server._version_checked is False  # a too-old refusal never latches
+    assert not version_guard.locked()
 
 
-def test_version_guard_releases_the_lock_when_a_verdict_raises(monkeypatch):
-    """A raising verdict must leave the lock free, not wedge every later call.
+def test_version_guard_gives_each_waiter_a_distinct_refusal_object(
+    monkeypatch, version_guard
+):
+    """Replay rebuilds the error per caller rather than sharing one instance.
 
-    Two of the guard's branches — a too-old version and a TCC-denied start —
-    raise from INSIDE the locked region, and neither latches, so the next call
-    is expected to take the lock again. If the raise leaked the lock, the first
-    upgrade-and-retry in the same process would hang for the acquire bound and
-    then silently fail open instead of re-checking; the `finally` prevents that.
+    Re-raising a single exception from many threads mutates it: every `raise`
+    appends to `__traceback__` and sets `__context__` to whatever that thread
+    was handling, chaining an unrelated request's error — and its frame locals —
+    onto a process-global object that outlives the call.
     """
-    monkeypatch.setattr(server, "_version_checked", False)
+    _spawns_recorded(monkeypatch, lambda _n: _too_old_version_proc())
 
-    stdouts = iter(["comfy-cli, version 1.11.0", "comfy-cli, version 1.14.0"])
+    outcomes = _release_herd_into_guard(version_guard, 5)
 
-    def fake_spawn() -> subprocess.CompletedProcess:
-        return subprocess.CompletedProcess(
-            [server.COMFY_BIN, "--version"], 0, stdout=next(stdouts), stderr=""
-        )
-
-    monkeypatch.setattr(server, "_spawn_comfy_version", fake_spawn)
-
-    with pytest.raises(server.ComfyCliError, match="too old"):
-        server._check_comfy_version()
-    assert not server._VERSION_CHECK_LOCK.locked()
-    assert server._version_checked is False
-
-    server._check_comfy_version()  # the upgraded install: re-checked, not wedged
-    assert server._version_checked is True
+    assert len({id(outcome) for outcome in outcomes}) == 5
+    assert all(outcome.__context__ is None for outcome in outcomes)
 
 
-def test_version_guard_shares_an_unlatched_verdict_with_the_herd(monkeypatch):
-    """A herd hitting a NON-latching verdict still pays ONE probe, not N.
+def test_version_guard_does_not_share_a_fail_open_with_the_herd(
+    monkeypatch, version_guard
+):
+    """A transient spawn failure fails open for THAT caller, not for the herd.
 
-    Three verdicts deliberately leave `_version_checked` False — a transient
-    spawn error, a too-old comfy-cli, and a TCC-denied start. Serializing the
-    herd on the lock and then letting each woken caller run its OWN probe would
-    turn N parallel cold starts into N *serialized* ones — strictly worse than
-    the bug the lock fixes, and on a persistently broken install it never
-    self-resolves. A caller already queued when the probe ran arrived before it
-    started, so its verdict is that probe's; only a call arriving after the lock
-    goes idle re-probes, which is what keeps this sharing and not memoization.
+    Its branch is documented as failing open "for THIS call": the failure is
+    transient, so the next probe is likely to get past it, and sharing the
+    fail-open would send the whole herd unguarded into exactly the cryptic
+    errors this guard exists to translate. So a queued caller with no refusal to
+    replay probes for itself — and that probe's success latches for everyone
+    behind it, which is what keeps the re-probing bounded here even though it is
+    unbounded on a persistently refusing install.
     """
-    monkeypatch.setattr(server, "_version_checked", False)
 
     def outcome(nth: int) -> subprocess.CompletedProcess:
         if nth == 1:
             raise OSError("boom")
         return _passing_version_proc()
 
-    spawns = _slow_version_spawns(monkeypatch, outcome)
+    spawns = _spawns_recorded(monkeypatch, outcome)
 
-    outcomes = _race_version_guard(5)
+    outcomes = _release_herd_into_guard(version_guard, 5)
 
-    assert outcomes == [None] * 5  # everyone failed open, nobody raised
-    assert len(spawns) == 1  # one probe for the whole herd, not five in a row
-    assert server._version_checked is False  # transient error still not latched
-    assert not server._VERSION_CHECK_LOCK.locked()
+    assert outcomes == [None] * 5
+    assert len(spawns) == 2  # the transient failure, then one success for the rest
+    assert server._version_checked is True
+    assert not version_guard.locked()
 
-    server._check_comfy_version()  # a LATER call re-probes rather than replaying
+
+def test_version_guard_does_not_replay_a_probe_that_predates_the_caller(
+    monkeypatch, version_guard
+):
+    """A caller that arrives mid-probe re-checks; it does not inherit the verdict.
+
+    This is the upgrade-and-retry promise the refusing branches exist to keep.
+    An operator whose comfy-cli is too old upgrades it WHILE a probe is in
+    flight and retries; that retry began after the probe did, so the probe never
+    saw the upgrade and its refusal is not an answer to the retry's question.
+    Bumping the counter at probe START rather than at completion is what
+    distinguishes the two — on completion-bump this caller replays the stale
+    refusal.
+    """
+    probing = threading.Event()
+    finish = threading.Event()
+
+    def outcome(nth: int) -> subprocess.CompletedProcess:
+        if nth == 1:
+            probing.set()
+            assert finish.wait(timeout=30)
+            return _too_old_version_proc()  # the pre-upgrade install
+        return _passing_version_proc()  # the upgrade, seen by a fresh probe
+
+    spawns = _spawns_recorded(monkeypatch, outcome)
+
+    first: list[BaseException | None] = [None]
+
+    def in_flight() -> None:
+        try:
+            server._check_comfy_version()
+        except BaseException as exc:  # noqa: BLE001 - reported, not swallowed
+            first[0] = exc
+
+    holder = threading.Thread(target=in_flight)
+    holder.start()
+    assert probing.wait(timeout=30)  # the probe is genuinely in flight...
+
+    retry: list[BaseException | None] = [None]
+
+    def upgraded_retry() -> None:
+        try:
+            server._check_comfy_version()
+        except BaseException as exc:  # noqa: BLE001 - reported, not swallowed
+            retry[0] = exc
+
+    late = threading.Thread(target=upgraded_retry)
+    late.start()
+    deadline = time.monotonic() + 30
+    while version_guard.queued < 2 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert version_guard.queued == 2  # ...and the retry arrived after it started
+
+    finish.set()
+    holder.join(timeout=30)
+    late.join(timeout=30)
+    assert not holder.is_alive() and not late.is_alive()
+
+    assert isinstance(first[0], server.ComfyCliError)  # the pre-upgrade caller
+    assert retry[0] is None  # the retry saw the upgrade rather than the refusal
     assert len(spawns) == 2
     assert server._version_checked is True
 
 
-def test_version_guard_replays_a_raising_verdict_to_the_herd(monkeypatch):
-    """The queued callers get the too-old error itself, not a probe each.
-
-    The raising verdicts are the worst case for a re-probing herd: they do not
-    latch, so every woken caller would pay a full cold `comfy --version` only to
-    reach the same conclusion. Each caller must still see the real error — a
-    shared verdict that fails OPEN for the waiters would let a too-old install
-    through for four callers out of five.
-    """
-    monkeypatch.setattr(server, "_version_checked", False)
-    spawns = _slow_version_spawns(
-        monkeypatch,
-        lambda _n: subprocess.CompletedProcess(
-            [server.COMFY_BIN, "--version"],
-            0,
-            stdout="comfy-cli, version 1.11.0",
-            stderr="",
-        ),
-    )
-
-    outcomes = _race_version_guard(5)
-
-    assert len(spawns) == 1
-    assert len(outcomes) == 5
-    for outcome in outcomes:
-        assert isinstance(outcome, server.ComfyCliError)
-        assert "too old" in str(outcome)
-    assert server._version_checked is False  # a too-old verdict never latches
-    assert not server._VERSION_CHECK_LOCK.locked()
-
-
-def test_version_guard_fails_open_rather_than_queue_past_the_probe_budget(monkeypatch):
-    """An overrunning holder must not wedge every later call process-wide.
+def test_version_guard_latches_open_when_the_lock_holder_overruns(
+    monkeypatch, version_guard
+):
+    """A holder wedged past the probe's cap costs the process ONE stall, not one each.
 
     `_spawn_comfy_version` caps its subprocess, but the cap is not a guarantee:
     on Windows the post-`kill()` `communicate()` blocks until a leaked
     grandchild closes the inherited handles. An unbounded acquire would promote
-    the guard's historically per-call worst case into a process-wide hang, so a
-    caller that cannot get in within one probe's full budget takes the guard's
-    standard fail-OPEN — unlatched, so a later call still re-checks.
+    the guard's historically per-call worst case into a process-wide hang. The
+    bound alone is not enough either — without latching, every later
+    `_run_comfy` would re-pay the full bound forever, which is worse than the
+    pre-lock behavior where whichever caller timed out first latched open for
+    everyone. So giving up latches, exactly as the `TimeoutExpired` branch does.
     """
-    monkeypatch.setattr(server, "_version_checked", False)
-    monkeypatch.setattr(server, "_VERSION_PROBE_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(server, "_VERSION_LOCK_WAIT_S", 0.05)
+    spawns = _spawns_recorded(monkeypatch, lambda _n: _passing_version_proc())
 
-    spawns: list[str] = []
-
-    def fake_spawn() -> subprocess.CompletedProcess:
-        spawns.append("call")
-        return _passing_version_proc()
-
-    monkeypatch.setattr(server, "_spawn_comfy_version", fake_spawn)
-
-    wedged = threading.Event()
-    released = threading.Event()
-
-    def holder() -> None:
-        server._VERSION_CHECK_LOCK.acquire()
-        wedged.set()
-        released.wait(timeout=30)
-        server._VERSION_CHECK_LOCK.release()
-
-    thread = threading.Thread(target=holder)
-    thread.start()
+    version_guard.acquire()  # a holder that never gives the lock back
     try:
-        assert wedged.wait(timeout=10)
         server._check_comfy_version()  # returns instead of blocking forever
         assert spawns == []  # it never got in, so it never probed
-        assert server._version_checked is False  # and never latched
-    finally:
-        released.set()
-        thread.join(timeout=10)
+        assert server._version_checked is True  # ...and latched open for the rest
 
-    assert not thread.is_alive()
-    server._check_comfy_version()  # lock free again: the guard re-checks
-    assert spawns == ["call"]
+        server._check_comfy_version()  # a later call: no second full-bound stall
+        assert spawns == []
+    finally:
+        version_guard.release()
+
+
+def test_version_guard_lock_does_not_latch_a_transient_failure(
+    monkeypatch, version_guard
+):
+    """The interlock serializes the probe; it must not change WHICH verdicts latch.
+
+    A transient spawn error still fails OPEN without latching, so the very next
+    call re-probes — the branch most at risk of being accidentally swallowed by
+    a "we already ran it" early return added under the lock.
+    """
+
+    def outcome(nth: int) -> subprocess.CompletedProcess:
+        if nth == 1:
+            raise OSError("boom")
+        return _passing_version_proc()
+
+    spawns = _spawns_recorded(monkeypatch, outcome)
+
+    server._check_comfy_version()  # no raise
+    assert server._version_checked is False  # transient error still not latched
+    assert len(spawns) == 1
+    assert not version_guard.locked()
+
+    server._check_comfy_version()  # re-probes rather than returning the memo
+    assert len(spawns) == 2
+    assert server._version_checked is True
+
+
+def test_version_guard_releases_the_lock_when_a_verdict_raises(
+    monkeypatch, version_guard
+):
+    """A raising verdict must leave the lock free, not wedge every later call.
+
+    Two of the guard's branches — a too-old version and a TCC-denied start —
+    raise from INSIDE the locked region, and neither latches, so the next call
+    is expected to take the lock again. If the raise leaked the lock, the first
+    upgrade-and-retry in the same process would stall for the acquire bound and
+    then latch open instead of re-checking; the `finally` prevents that.
+    """
+    _spawns_recorded(
+        monkeypatch,
+        lambda nth: _too_old_version_proc() if nth == 1 else _passing_version_proc(),
+    )
+
+    with pytest.raises(server.ComfyCliError, match="too old"):
+        server._check_comfy_version()
+    assert not version_guard.locked()
+    assert server._version_checked is False
+
+    server._check_comfy_version()  # the upgraded install: re-checked, not wedged
     assert server._version_checked is True
 
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -27,6 +27,7 @@ import subprocess
 import sys
 import threading
 import time
+from collections.abc import Callable
 
 import pytest
 from conftest import (
@@ -724,6 +725,15 @@ class _CountingLock:
     a loaded runner, and would race it in the direction that FAILS (a straggler
     samples the already-bumped counter and probes again).
 
+    That same point is the only place a test can stage state for ONE caller with
+    no wall-clock race at all, so `acquire` also fires a one-shot `on_queue`
+    hook there. It runs in the caller's own thread, after it sampled
+    `_version_probe_starts` and BEFORE its bound starts running — an ordering,
+    not a race the staging thread has to win. `_waiter_that_gives_up` is the
+    user; see it for why that distinction decides whether the test is
+    deterministic. Popped under `_counter` so a herd cannot fire it twice, and
+    called outside that lock so a hook may touch this lock.
+
     Only the three methods `server` and the tests use are forwarded; anything
     else is an interlock change that should fail loudly here rather than be
     silently absorbed by a `__getattr__`.
@@ -733,10 +743,14 @@ class _CountingLock:
         self._inner = threading.Lock()
         self._counter = threading.Lock()
         self.queued = 0
+        self.on_queue: Callable[[], None] | None = None
 
     def acquire(self, *args, **kwargs):
         with self._counter:
             self.queued += 1
+            hook, self.on_queue = self.on_queue, None
+        if hook is not None:
+            hook()
         return self._inner.acquire(*args, **kwargs)
 
     def release(self) -> None:
@@ -1066,9 +1080,20 @@ def test_version_guard_bounds_a_herd_that_lands_inside_an_in_flight_probe(
 def _waiter_that_gives_up(lock, before_timeout) -> BaseException | None:
     """Run one caller against a HELD lock, mutating state before it gives up.
 
-    `before_timeout()` fires once the caller has sampled `_version_probe_starts`
-    and blocked, so a test can stage exactly what the caller finds when its
+    `before_timeout()` fires from `_CountingLock.on_queue` — inside the caller's
+    OWN acquire, after it sampled `_version_probe_starts` and before its bound
+    starts running — so a test stages exactly what the caller finds when that
     bound expires. Returns what the caller raised, or ``None``.
+
+    Staging it from this thread instead would be a race the stager has to WIN:
+    it can only observe that the caller queued, and every way to observe that
+    (a poll, an event) lands some time after the caller's clock already started.
+    Lose that race and the caller times out reading `_version_probe_starts`
+    unchanged, takes the wedge branch, and latches open — the very outcome both
+    callers of this helper assert against, so the failure is a false one. The
+    hook removes the clock from the question: the mutation is ORDERED before the
+    wait, so `_VERSION_LOCK_WAIT_S` can stay small enough to keep these tests
+    fast without buying determinism in seconds of slack.
     """
     outcome: list[BaseException | None] = [None]
 
@@ -1081,16 +1106,15 @@ def _waiter_that_gives_up(lock, before_timeout) -> BaseException | None:
     lock.acquire()
     try:
         lock.queued = 0  # this helper's own acquire is not the caller's
+        lock.on_queue = before_timeout
         thread = threading.Thread(target=caller)
         thread.start()
-        deadline = time.monotonic() + 30
-        while lock.queued < 1 and time.monotonic() < deadline:
-            time.sleep(0.01)
-        assert lock.queued == 1  # sampled the counter, now blocked on the lock
-        before_timeout()
         thread.join(timeout=30)
         assert not thread.is_alive()
+        assert lock.queued == 1  # it really did sample, queue, and give up
+        assert lock.on_queue is None  # ...and the staging really did fire
     finally:
+        lock.on_queue = None
         lock.release()
     return outcome[0]
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -702,6 +702,55 @@ def _passing_version_proc() -> subprocess.CompletedProcess:
     )
 
 
+def _slow_version_spawns(monkeypatch, outcome):
+    """Patch `_spawn_comfy_version` with a probe slow enough to be raced.
+
+    ``outcome(n)`` produces the nth probe's result — returned, or raised to
+    exercise a failure verdict. The sleep is what makes the herd tests test
+    anything: without a probe that stays IN FLIGHT, the callers would queue and
+    complete one after another and a broken interlock would still look deduped.
+    Returns the list the fake appends to, so a test can count actual spawns.
+    """
+    spawns: list[float] = []
+    counter = threading.Lock()
+
+    def fake_spawn() -> subprocess.CompletedProcess:
+        with counter:
+            spawns.append(time.monotonic())
+            nth = len(spawns)
+        time.sleep(0.2)  # hold the probe open so a herd genuinely overlaps it
+        return outcome(nth)
+
+    monkeypatch.setattr(server, "_spawn_comfy_version", fake_spawn)
+    return spawns
+
+
+def _race_version_guard(count: int) -> list[BaseException | None]:
+    """Release ``count`` callers into `_check_comfy_version` at the same instant.
+
+    Returns each caller's outcome in start order — the exception it raised, or
+    ``None`` — so a test can assert BOTH that one probe ran and that every
+    caller got the right answer, which is the half a spawn count alone misses.
+    """
+    ready = threading.Barrier(count)
+    outcomes: list[BaseException | None] = [None] * count
+
+    def caller(index: int) -> None:
+        ready.wait(timeout=10)
+        try:
+            server._check_comfy_version()
+        except BaseException as exc:  # noqa: BLE001 - reported, not swallowed
+            outcomes[index] = exc
+
+    threads = [threading.Thread(target=caller, args=(i,)) for i in range(count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+    assert not any(thread.is_alive() for thread in threads)  # no deadlock
+    return outcomes
+
+
 def test_version_guard_probes_once_for_a_herd_of_racing_first_calls(monkeypatch):
     """Concurrent FIRST calls share ONE probe instead of spawning one each.
 
@@ -713,36 +762,11 @@ def test_version_guard_probes_once_for_a_herd_of_racing_first_calls(monkeypatch)
     machine least able to afford them.
     """
     monkeypatch.setattr(server, "_version_checked", False)
+    spawns = _slow_version_spawns(monkeypatch, lambda _n: _passing_version_proc())
 
-    spawns: list[float] = []
-    counter = threading.Lock()
-    ready = threading.Barrier(5)
+    outcomes = _race_version_guard(5)
 
-    def fake_spawn() -> subprocess.CompletedProcess:
-        with counter:
-            spawns.append(time.monotonic())
-        time.sleep(0.2)  # hold the probe open so the herd genuinely overlaps
-        return _passing_version_proc()
-
-    monkeypatch.setattr(server, "_spawn_comfy_version", fake_spawn)
-
-    raised: list[BaseException] = []
-
-    def caller() -> None:
-        ready.wait(timeout=10)  # release all five at the same instant
-        try:
-            server._check_comfy_version()
-        except BaseException as exc:  # noqa: BLE001 - reported, not swallowed
-            raised.append(exc)
-
-    threads = [threading.Thread(target=caller) for _ in range(5)]
-    for thread in threads:
-        thread.start()
-    for thread in threads:
-        thread.join(timeout=30)
-
-    assert not any(thread.is_alive() for thread in threads)  # no deadlock
-    assert raised == []
+    assert outcomes == [None] * 5
     assert len(spawns) == 1  # the whole point: one probe, not five
     assert server._version_checked is True
     assert not server._VERSION_CHECK_LOCK.locked()
@@ -781,10 +805,10 @@ def test_version_guard_releases_the_lock_when_a_verdict_raises(monkeypatch):
     """A raising verdict must leave the lock free, not wedge every later call.
 
     Two of the guard's branches — a too-old version and a TCC-denied start —
-    raise from INSIDE the `with`, and neither latches, so the next call is
-    expected to take the lock again. If the raise leaked the lock, the first
-    upgrade-and-retry in the same process would hang forever instead of
-    re-checking; the `with` is what makes that impossible.
+    raise from INSIDE the locked region, and neither latches, so the next call
+    is expected to take the lock again. If the raise leaked the lock, the first
+    upgrade-and-retry in the same process would hang for the acquire bound and
+    then silently fail open instead of re-checking; the `finally` prevents that.
     """
     monkeypatch.setattr(server, "_version_checked", False)
 
@@ -803,6 +827,117 @@ def test_version_guard_releases_the_lock_when_a_verdict_raises(monkeypatch):
     assert server._version_checked is False
 
     server._check_comfy_version()  # the upgraded install: re-checked, not wedged
+    assert server._version_checked is True
+
+
+def test_version_guard_shares_an_unlatched_verdict_with_the_herd(monkeypatch):
+    """A herd hitting a NON-latching verdict still pays ONE probe, not N.
+
+    Three verdicts deliberately leave `_version_checked` False — a transient
+    spawn error, a too-old comfy-cli, and a TCC-denied start. Serializing the
+    herd on the lock and then letting each woken caller run its OWN probe would
+    turn N parallel cold starts into N *serialized* ones — strictly worse than
+    the bug the lock fixes, and on a persistently broken install it never
+    self-resolves. A caller already queued when the probe ran arrived before it
+    started, so its verdict is that probe's; only a call arriving after the lock
+    goes idle re-probes, which is what keeps this sharing and not memoization.
+    """
+    monkeypatch.setattr(server, "_version_checked", False)
+
+    def outcome(nth: int) -> subprocess.CompletedProcess:
+        if nth == 1:
+            raise OSError("boom")
+        return _passing_version_proc()
+
+    spawns = _slow_version_spawns(monkeypatch, outcome)
+
+    outcomes = _race_version_guard(5)
+
+    assert outcomes == [None] * 5  # everyone failed open, nobody raised
+    assert len(spawns) == 1  # one probe for the whole herd, not five in a row
+    assert server._version_checked is False  # transient error still not latched
+    assert not server._VERSION_CHECK_LOCK.locked()
+
+    server._check_comfy_version()  # a LATER call re-probes rather than replaying
+    assert len(spawns) == 2
+    assert server._version_checked is True
+
+
+def test_version_guard_replays_a_raising_verdict_to_the_herd(monkeypatch):
+    """The queued callers get the too-old error itself, not a probe each.
+
+    The raising verdicts are the worst case for a re-probing herd: they do not
+    latch, so every woken caller would pay a full cold `comfy --version` only to
+    reach the same conclusion. Each caller must still see the real error — a
+    shared verdict that fails OPEN for the waiters would let a too-old install
+    through for four callers out of five.
+    """
+    monkeypatch.setattr(server, "_version_checked", False)
+    spawns = _slow_version_spawns(
+        monkeypatch,
+        lambda _n: subprocess.CompletedProcess(
+            [server.COMFY_BIN, "--version"],
+            0,
+            stdout="comfy-cli, version 1.11.0",
+            stderr="",
+        ),
+    )
+
+    outcomes = _race_version_guard(5)
+
+    assert len(spawns) == 1
+    assert len(outcomes) == 5
+    for outcome in outcomes:
+        assert isinstance(outcome, server.ComfyCliError)
+        assert "too old" in str(outcome)
+    assert server._version_checked is False  # a too-old verdict never latches
+    assert not server._VERSION_CHECK_LOCK.locked()
+
+
+def test_version_guard_fails_open_rather_than_queue_past_the_probe_budget(monkeypatch):
+    """An overrunning holder must not wedge every later call process-wide.
+
+    `_spawn_comfy_version` caps its subprocess, but the cap is not a guarantee:
+    on Windows the post-`kill()` `communicate()` blocks until a leaked
+    grandchild closes the inherited handles. An unbounded acquire would promote
+    the guard's historically per-call worst case into a process-wide hang, so a
+    caller that cannot get in within one probe's full budget takes the guard's
+    standard fail-OPEN — unlatched, so a later call still re-checks.
+    """
+    monkeypatch.setattr(server, "_version_checked", False)
+    monkeypatch.setattr(server, "_VERSION_PROBE_TIMEOUT_S", 0.05)
+
+    spawns: list[str] = []
+
+    def fake_spawn() -> subprocess.CompletedProcess:
+        spawns.append("call")
+        return _passing_version_proc()
+
+    monkeypatch.setattr(server, "_spawn_comfy_version", fake_spawn)
+
+    wedged = threading.Event()
+    released = threading.Event()
+
+    def holder() -> None:
+        server._VERSION_CHECK_LOCK.acquire()
+        wedged.set()
+        released.wait(timeout=30)
+        server._VERSION_CHECK_LOCK.release()
+
+    thread = threading.Thread(target=holder)
+    thread.start()
+    try:
+        assert wedged.wait(timeout=10)
+        server._check_comfy_version()  # returns instead of blocking forever
+        assert spawns == []  # it never got in, so it never probed
+        assert server._version_checked is False  # and never latched
+    finally:
+        released.set()
+        thread.join(timeout=10)
+
+    assert not thread.is_alive()
+    server._check_comfy_version()  # lock free again: the guard re-checks
+    assert spawns == ["call"]
     assert server._version_checked is True
 
 


### PR DESCRIPTION
## ELI-5

The server checks once, at startup, that your `comfy-cli` is new enough — and it remembers the answer so it only ever asks once. The remembering worked, but only *after* the first check had finished. That first check is the slow one: it starts a whole cold `comfy-cli` just to read its version number. Anything you asked the server to do while that was still running looked at the "have we checked yet?" note, saw "no", and went and started its own cold `comfy-cli` to ask the same question. Five things arriving at once meant five of them, all at the moment your machine was busiest. Now the first one puts up a "checking, hold on" sign and everyone else waits for its answer instead of repeating the work. Nobody waits longer than they used to — they were already spending that time running their own copy of the same check.

## The bug

`_check_comfy_version` memoized behind a bare module global with no lock:

```python
global _version_checked
if _version_checked:
    return
proc = _spawn_comfy_version()   # a full `comfy --version` subprocess, 30s cap
...
_version_checked = True
```

Every tool call reaches this through `_run_comfy_raw`, so the memo is on the hot path — but it only ever deduped calls arriving *after* a probe had already finished. Inside the probe there was no interlock at all.

The first-call window is precisely the slow one. `_apply_startup_instructions` runs the machine-snapshot probe on a daemon thread with a bounded join, and its own docstring records that a probe outliving that join "keeps running harmlessly to completion" — so `mcp.run()` starts serving while a `comfy --version` may still be in flight. Any tool call landing in that window read `_version_checked is False` and spawned a second cold `comfy-cli` interpreter; N concurrent first callers spawned N of them, on exactly the loaded machine least able to absorb it.

## What changed

An interlock around the probe, and nothing else. `_check_comfy_version` is now the interlock; the failure policy moved verbatim into `_probe_comfy_version`.

- `_VERSION_CHECK_LOCK = threading.Lock()` beside `_version_checked` (`threading` was already imported).
- The uncontended warm fast path — `if _version_checked: return` — stays *outside* the lock, so a warm call still costs one global read and no acquisition.
- The lock is acquired **with a bound** of one probe budget, not unconditionally. The guard's worst case has always been per-call and finite; an unbounded acquire would promote it to process-wide and unbounded, because a holder can exceed the probe's nominal cap (on Windows, `subprocess.run`'s post-`kill()` `communicate()` blocks until a leaked grandchild closes the inherited handles). A caller that cannot get in falls through to the guard's standard fail-OPEN, unlatched.
- Giving up on the lock **latches open**, exactly as the `TimeoutExpired` branch does. The bound alone is not enough: without the latch, a wedged holder makes every later `_run_comfy` re-pay the full bound forever — worse than pre-lock, where whichever caller timed out first latched open for everyone.
- Inside, the memo is re-checked, and then `_version_probe_starts` / `_version_probe_refusal` let a caller **replay the refusal of the probe it queued behind** instead of running a second one.

That last point is the subtle half, and it has two parts.

**Which callers may replay.** The counter bumps when a probe *starts*, not when it finishes. What makes another probe's answer usable is not that it finished while you waited — it is that it *started after you arrived*, because only then did it observe a machine at least as current as the one you are asking about. A caller samples the counter before queueing; finding it changed means a probe both started and finished in that window. Bumping on completion would let a caller that arrived mid-probe replay a verdict computed before it ever called, so an operator who upgrades comfy-cli (or grants Full Disk Access) *while a probe is in flight* would get the stale refusal on the very retry the guard promises to re-check.

**Which answers may be replayed.** Only a refusal. The refusals — too-old, TCC-denied, and the `COMFY_PROJECT` refusal `_project_root` raises through the spawn — are persistent, so re-probing costs a full cold start to reach the same conclusion and a re-probing herd never self-resolves. The transient-spawn-failure branch is the opposite on both counts: it is documented as failing open *"for THIS call"*, the next probe is likely to get past it, and sharing the fail-open would send the whole herd unguarded into the cryptic errors this guard exists to translate. So a queued caller with no refusal to replay probes for itself — and that probe's success latches for everyone behind it, keeping the re-probing bounded.

Replaying is therefore **not** the memoization those branches refuse: any call that did not overlap a probe still re-probes. The refusal is stored as its *message* and rebuilt per caller, because re-raising one exception instance from many threads appends to its `__traceback__` and sets its `__context__` to whatever each thread was handling — chaining an unrelated request's error and frame locals onto a process-global.

`_VERSION_LOCK_WAIT_S` is deliberately a little longer than `_VERSION_PROBE_TIMEOUT_S`: a probe finishing *at* its cap must win the race against a waiter's bound, so a waiter only ever gives up when the holder has genuinely overrun — the one case where latching open is unambiguously right.

**The failure policy is byte-for-byte the text on `main`** — `_probe_comfy_version`'s body was taken from `origin/main` unchanged and diffed to confirm it, so there is no reindentation to read past and no need for `git diff -w`.

## The failure policies are byte-for-byte unchanged

These are load-bearing and documented in the guard's own docstring, so they were the thing to protect:

| Branch | Behavior — before and after |
|---|---|
| `TimeoutExpired` | latches open (`_version_checked = True`), returns |
| `PermissionError` | raises the TCC `ComfyCliError`, **or** returns without latching |
| other `OSError` / `SubprocessError` | returns without latching — transient, re-checks next call |
| too-old version | **raises without latching** — upgrade-and-retry in-process must re-check |
| TCC denial on nonzero exit | **raises without latching** — same reason |
| success | latches |

The two raising verdicts now raise from *inside* the locked region. That is safe because the `finally` releases on the way out, which is exactly what keeps their deliberate non-latching meaningful: a leaked lock would turn "retry after you upgrade" into a stall for the acquire bound. A test pins it rather than leaving it to the reader. Their refusal is also the only thing a queued caller replays — never a fail-open, since sharing one would admit a too-old install for four callers out of five.

One row is new rather than preserved: **acquire timeout → latches open**. There was no such path before the lock existed, and it is the deliberate analogue of the `TimeoutExpired` row, for the same reason.

`ComfyCliError` subclasses `RuntimeError`, not `OSError`, so a `_project_root()` failure raised from inside `_spawn_comfy_version` still propagates past all three `except` clauses exactly as on `main` — now releasing the lock as it goes.

## Re-entrancy

`threading.Lock` is not reentrant, so a re-entrant path would deadlock rather than double-probe. There is none. Everything the locked body reaches is either pure (`_parse_version`, `_scrubbed_tcc_path`) or lives in `tcc` / `failure_log`, which this repo's module-layout rule forbids from importing `server` at all — a structural guarantee, not an observation of today's call graph. `_spawn_comfy_version` itself reaches only `subprocess.run` and `_project_root` (an env read plus two `os.path` checks).

`threading.Lock` rather than an asyncio primitive is correct for both call styles: the sync paths call `_check_comfy_version` directly, the three async paths call it through `asyncio.to_thread`, and it is never held across an `await`.

## Verification

- **Red → green on the actual race, not just on the new code.** With the locked region reverted in place (fast path and body otherwise untouched), the herd test reports `assert 5 == 1` — five spawns from five racing callers. With the interlock: one. That is the fix demonstrated, rather than a test asserting its own premise.
- **Every review-round fix is red without it, checked one at a time.** Replay removed → both herd tests report `assert 5 == 1`. Acquire bound removed → the budget test blocks the holder's full 30s and probes anyway. Counter bumped on completion instead of start → the mid-probe retry replays the stale refusal. Fail-opens shared → the transient-failure herd spawns once instead of twice. Shared exception instance → five waiters get one object.
- **Deterministic, not timed.** The herd tests wait on a real condition (every caller has sampled the counter and queued on a held lock), not on a sleep. Ran the concurrency tests 40x: 0 failures. They also got ~3x faster.
- **The failure policy is provably untouched.** `_probe_comfy_version`'s body was extracted from `origin/main` and compared byte-for-byte.
- `pytest -q` — **2127 passed, 6 deselected** (Python 3.12 venv, dev extras).
- `ruff check .` — all checks passed. `ruff format --check .` — 61 files already formatted.
- Three new tests in `tests/test_wrapper.py`, alongside the existing version-guard block: five threads released simultaneously through a `threading.Barrier` see exactly one spawn and no deadlock; a transient `OSError` still fails open unlatched and the *next* call re-probes (count 2), proving the lock did not accidentally latch a transient failure; and a too-old verdict leaves `_VERSION_CHECK_LOCK.locked()` false so the upgraded retry re-checks instead of wedging.
- Every pre-existing version-guard test passes unmodified — the fast path and all verdicts are untouched, and none of them needed a change.

## What this does NOT cover

- **Three sibling probes in `server.py` still carry the identical unlocked-memo shape** and were left alone: `_require_spend_gate` (`_spend_gate_probed`), `_require_emit_workflow_capability` (`_emit_workflow_capability_probed`), and `_comfy_run_takes_allow_spend` (`_run_allow_spend_probed`). Each shells out to comfy-cli behind a bare `global` flag with no lock, so each can be duplicated by racing first callers the same way. That is the same sweep pointed at the half this PR does not fix: **3 of 4** such memos in the file remain unserialized. They are cheaper probes than a cold `--version` and none of them was the reported problem, so serializing them is a separate change and a separate decision, not a silent scope add here.
- **`_detect_comfy_cli_version` is not serialized against this guard.** It is a different, unmemoized, best-effort probe that happens to share the `_spawn_comfy_version` call site, so a `server_info` call concurrent with the guard's first probe can still produce two `comfy --version` spawns. Taking the same lock would serialize without deduplicating, because the two want different things (a verdict vs. the version *string*); real sharing means caching the probe RESULT, which needs a decision about whether `server_info` may report a stale version after an in-process upgrade. The cursor-review panel raised this; **deferred to a tracked follow-up** rather than dropped ([reply](https://github.com/Comfy-Org/comfy-mcp/pull/240#discussion_r3809046358)).
- **No timing measurement was reproduced here.** The originating investigation's claim about how much of the first-call window this probe accounts for lives in a ticket this worker had no access to and could not read; it is named as an unexercised artifact rather than assumed. The fix does not depend on it — duplicate cold interpreter starts are wasteful at any measured size, and the red-green above establishes the duplication independently.
- **No live comfy-cli run.** This machine has no ComfyUI workspace; the tests mock the probe, as the whole suite does by design.
- **Negative-claim falsification does not apply.** This diff denies no capability — it adds a lock and no deny/dead-end path, no "not supported"/"unavailable" string, and no test flipped to assert a dead-end. The one `pytest.raises` it adds pins the pre-existing too-old refusal that `main` already raises and already tests.

## Judgment calls

- **Split the policy out into `_probe_comfy_version` instead of leaving it indented inside a lock.** It also removes the reindentation the first round asked reviewers to read past: the policy body is now byte-identical to `main`, which is a stronger form of the same "nothing else changed" claim than `git diff -w` was.
- **A third test beyond the two specified.** The lock newly wraps two branches that `raise`, and a leaked lock there would deadlock every subsequent caller — the single worst outcome this change could produce. The `finally` makes it impossible, so the test is cheap; it seemed wrong to add the risk and not pin it.
- **Replayed the shared verdict rather than latching a short-lived negative.** The panel offered both. Latching a negative would have to pick a TTL, and it weakens the three branches' documented promise that an in-process upgrade or Full Disk Access grant is re-checked. Replay needs no TTL and keeps that promise exactly: only callers that were *already waiting* share an answer.
- **Plain `Lock`, not `RLock`.** `RLock` would paper over a future re-entrant call rather than surface it, and the re-entrancy audit above shows there is nothing to paper over.

## Provenance
- **Authored by:** agent-work loop
- **Verified:** pytest -q: 2132 passed, 6 deselected; ruff check .: clean; ruff format --check .: 61 files already formatted; herd test against a lock-reverted build: 5 spawns (fails), against this build: 1 spawn (passes); round-2 and round-3 fixes independently red-checked (see Verification); round-4's determinism fix red-checked against three mutants of the give-up branch and re-run with the acquire bound cut 500x (see Review round 4)
- **Deviations:** none — every acceptance criterion in the ticket is met; the residuals named under "What this does NOT cover" are outside its stated scope

Refs BE-7899



---

## Review round 2 (cursor-review panel)

All three panel findings addressed in 9880662 — 1 medium, 2 low.

| Finding | Resolution |
|---|---|
| 🟡 The three non-latching verdicts make queued callers re-probe, serializing N cold starts | **Fixed.** `_version_probe_generation` / `_version_probe_verdict` — queued callers replay the in-flight probe's verdict. Red without it: `assert 5 == 1`. |
| 🟢 Unconditional acquire makes the 30s worst case process-wide | **Fixed.** `acquire(timeout=_VERSION_PROBE_TIMEOUT_S)` falling through to fail-OPEN, unlatched. Red without it: blocks 30s, then probes. |
| 🟢 `_detect_comfy_cli_version` outside the lock; abandoned snapshot thread can hold it | **Half fixed, half deferred.** The snapshot-thread half is fixed by the bounded acquire (bounded wait, and its verdict is now replayed rather than wasted). The `_detect_comfy_cli_version` half needs a staleness decision for `server_info` — deferred to a tracked follow-up. |

## Review round 3 (cursor-review panel, on round 2's changes)

The panel re-reviewed the interlock and found 8 more — 3 medium, 4 low, 1 nit. Seven fixed in 2e133d1; the nit answered in place.

| Finding | Resolution |
|---|---|
| 🟡 Counter bumps on COMPLETION, so "changed while I waited" ≠ "started after I arrived"; a mid-probe upgrade replays a stale refusal | **Fixed.** Bump moved to probe START. The comments asserted this; the code did not do it. |
| 🟡 Acquire-timeout fail-open never latches → a wedged holder taxes every later call 30s, permanently | **Fixed.** Latches open, as the `TimeoutExpired` branch does. Also split `_VERSION_LOCK_WAIT_S` off the probe cap so a probe finishing *at* its cap wins the race. |
| 🟡 Re-raising one `ComfyCliError` instance from many threads mutates `__traceback__` / `__context__` on a process-global | **Fixed.** Store the message; rebuild per caller. |
| 🟢 `_project_root`'s `COMFY_PROJECT` refusal gets replayed stale | **Fixed** by the start-bump above — no separate change. |
| 🟢 Replaying a *fail-open* sends the whole herd unguarded | **Fixed.** Only refusals are shared. |
| 🟢 The 200ms sleep is the only thing overlapping the herd → flaky in the failing direction | **Fixed.** `_CountingLock` + a held lock make the overlap deterministic; no sleeps. |
| 🟢 A straggler thread could wedge the module-global lock for the session → later tests pass vacuously | **Fixed.** A `version_guard` fixture gives each test a fresh lock and resets the probe globals. |
| ⚪ `acquire()` returns outside the `try:`; an async exception there leaks the lock | **Answered, not changed.** Not closable while the acquire needs a timeout, and the acquire-timeout latch now bounds the consequence to one stall. |

## Review round 4 (CodeRabbit, on round 3's tests)

One actionable finding, fixed in 05bedb2.

| Finding | Resolution |
|---|---|
| 🟡 The two acquire-bound tests can lose their own staging race: the 10ms poll on `_CountingLock.queued` observes the caller *after* its 50ms bound has already started, so a loaded runner times out first, takes the wedge branch, and latches — failing the assertions with nothing wrong in the guard | **Fixed**, but not by widening the bound. Widening keeps the wall-clock dependence and only buys slack; the staging is now fired from `_CountingLock.acquire` itself, via a one-shot `on_queue` hook that runs in the caller's own thread *between* its sample of `_version_probe_starts` and its timed acquire. That makes the mutation an ordering rather than a race, so the clock is out of the question entirely. |

**Red-checked.** Reproduced the reported failure first, by delaying the observation past the bound: at 0ms the caller gets `ComfyCliError('…too old')` with `_version_checked False`; at 60ms and 200ms it gets `None` with `_version_checked True` — precisely the two assertions the finding named. After the fix the tests pass with `_VERSION_LOCK_WAIT_S` cut from 0.05 to 0.0001 (500x below any poll granularity), which is what shows the dependence is gone rather than merely widened; the bound stays 0.05 as slack, not as a wager. The tests are still load-bearing: mutating the guard's give-up branch to always take the wedge path, to never take it, and to drop the unlocked refusal replay each turns a test red. The helper also now asserts the hook fired, so a refactor that stops the caller reaching `acquire` fails loudly instead of passing vacuously.
