### PR TITLE
test: hoist the blocking-child stub into a shared conftest fixture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,10 @@ sweep:
   (`asyncio.create_subprocess_exec`). Its fake pipes are real `asyncio.StreamReader`s from
   conftest's `stream_reader(text, limit)` helper — reuse it rather than hand-roll an
   awaitable, so fakes exercise the buffer-limit behavior too.
+- `blocking_stream(first_lines, stderr_text=…) -> procs` — the `--json-stream` path when
+  the child emits `first_lines` and then BLOCKS past the caller's deadline (timeout
+  paths): stdout is a real `stream_reader(…, eof=False)`; `procs[i].killed` records the
+  timeout kill.
 - `patched_async_run(stdout=…, returncode=…, stderr=…, hang=…, on_spawn=…) -> procs` — the
   plain-JSON *async* path (`_run_comfy_async`): same spawn and real `StreamReader` pipes as
   `patched_stream`, but parses the capture once at the end, not line-by-line. `hang=True`
@@ -182,7 +186,9 @@ carries the legacy foreground `model download`, `workflow_deps`' 300s resolve, a
 capture. `auth_login` (`_start_login`) is a third spawn site with its own browser flow.
 
 A local stub is justified only where the call genuinely differs — the `comfy --version`
-probe (its own kwargs) and multi-call sequenced replies.
+probe (its own kwargs), multi-call sequenced replies, and `test_wrapper.py`'s
+`_StderrBlockingProc` (stdout EOFs fast while `stderr.read()` blocks, which neither
+streaming fixture models).
 
 ## Destined-public hygiene
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,7 @@ They mirror how `server` spawns the CLI: a spawn-signature change is one edit, n
   conftest's `stream_reader(text, limit)` — reuse it, never hand-roll an awaitable, so
   buffer limits stay exercised.
 - `blocking_stream(first_lines, stderr_text=…) -> procs` — its TIMEOUT counterpart: a child
-  that BLOCKS with both pipes open and `wait()` parked until `kill()` EOFs and reaps it.
+  that BLOCKS with both pipes open, `wait()` parked until `kill()` — or a 30s net — EOFs them.
 - `patched_async_run(stdout=…, returncode=…, stderr=…, hang=…, on_spawn=…) -> procs` — the
   plain-JSON *async* path (`_run_comfy_async`): same spawn and real `StreamReader` pipes as
   `patched_stream`, but parses the capture once at the end, not line-by-line. `hang=True`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,8 +148,7 @@ and the parser are exercised directly (`test_wrapper.py`, `test_parser.py`); eac
 has its own file. Add a tool's test with it.
 
 **Mock comfy-cli via the shared fixtures in `tests/conftest.py`, never a hand-rolled stub.**
-They mirror how `server` spawns the CLI, so a spawn-signature change is one edit, not a
-sweep:
+They mirror how `server` spawns the CLI: a spawn-signature change is one edit, not a sweep:
 
 - `envelope(ok=…, data=…, error=…)` — build an `envelope/1` body.
 - `patched_run(stdout=…, returncode=…, stderr=…, raises=…, on_spawn=…) -> calls` — the plain
@@ -159,36 +158,31 @@ sweep:
 - `patched_plain_run(returncode, stdout, stderr) -> calls` — same, for verbs that print
   human text with no envelope (`launch`/`stop`/`generate`).
 - `patched_stream(stdout_text) -> procs` — the `--json-stream` NDJSON path
-  (`asyncio.create_subprocess_exec`). Its fake pipes are real `asyncio.StreamReader`s from
-  conftest's `stream_reader(text, limit)` helper — reuse it rather than hand-roll an
-  awaitable, so fakes exercise the buffer-limit behavior too.
-- `blocking_stream(first_lines, stderr_text=…) -> procs` — the `--json-stream` path when
-  the child emits `first_lines` and then BLOCKS past the caller's deadline (timeout
-  paths): stdout is a real `stream_reader(…, eof=False)`; `procs[i].killed` records the
-  timeout kill.
+  (`asyncio.create_subprocess_exec`); fake pipes are real `asyncio.StreamReader`s from
+  conftest's `stream_reader(text, limit)` — reuse it, never hand-roll an awaitable, so
+  buffer limits stay exercised.
+- `blocking_stream(first_lines, stderr_text=…) -> procs` — its TIMEOUT counterpart: a child
+  that BLOCKS with both pipes open and `wait()` parked until `kill()` EOFs and reaps it.
 - `patched_async_run(stdout=…, returncode=…, stderr=…, hang=…, on_spawn=…) -> procs` — the
   plain-JSON *async* path (`_run_comfy_async`): same spawn and real `StreamReader` pipes as
   `patched_stream`, but parses the capture once at the end, not line-by-line. `hang=True`
-  leaves the pipes OPEN so the fake child never finishes (timeout/cancellation cases);
-  `kill()` closes them (mirroring the process-group kill so a post-kill drain reaches EOF),
-  records `killed`, and fires `on_spawn(cmd)` like `patched_run`'s.
+  leaves the pipes OPEN so the child never finishes; `kill()` closes them (the process-group
+  kill, so a post-kill drain reaches EOF), records `killed`, and fires `on_spawn(cmd)`.
 
 The two spawn paths differ deliberately: the plain `--json` path is synchronous
 (`subprocess.Popen` + a bounded `communicate`, off-loaded to a thread pool for async
-callers); anything STREAMING or long-lived spawns via `asyncio.create_subprocess_exec`
-instead — nothing blocking runs on the event loop, enforced by ruff's `ASYNC` select. Two
-async runners live there: `_run_comfy_streaming` (NDJSON + progress) and `_run_comfy_async`,
-a plain-JSON twin of `_run_comfy` for CANCELLATION — `asyncio.to_thread` is non-blocking,
-but cancellation never reaches the thread, so a client giving up left the child running. It
-carries the legacy foreground `model download`, `workflow_deps`' 300s resolve, and
-`upload_file`'s 300s transfer. Each stream keeps only a `_STDERR_MAX_CHARS` tail
-(`_drain_capped_into`; callers widen stdout via `stdout_cap=`), never `communicate()`'s full
-capture. `auth_login` (`_start_login`) is a third spawn site with its own browser flow.
+callers); anything STREAMING or long-lived spawns via `asyncio.create_subprocess_exec` —
+nothing blocking runs on the event loop, enforced by ruff's `ASYNC` select. Two async
+runners live there: `_run_comfy_streaming` (NDJSON + progress) and `_run_comfy_async`, a
+plain-JSON twin of `_run_comfy` for CANCELLATION — cancellation never reaches a `to_thread`
+worker, so a client giving up left the child running; it carries the longest-lived children
+(foreground `model download`, `workflow_deps`, `upload_file`). Each stream keeps only a
+`_STDERR_MAX_CHARS` tail (`_drain_capped_into`; callers widen stdout via `stdout_cap=`),
+never `communicate()`'s full capture. `auth_login` (`_start_login`) is a third spawn site.
 
-A local stub is justified only where the call genuinely differs — the `comfy --version`
-probe (its own kwargs), multi-call sequenced replies, and `test_wrapper.py`'s
-`_StderrBlockingProc` (stdout EOFs fast while `stderr.read()` blocks, which neither
-streaming fixture models).
+A local stub is justified only where the call genuinely differs — the `comfy --version` probe
+(its own kwargs), multi-call sequenced replies, and `test_wrapper.py`'s `_StderrBlockingProc`
+(stdout EOFs fast while `stderr.read()` blocks, which neither streaming fixture models).
 
 ## Destined-public hygiene
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,10 @@ copy per test file:
   ``communicate``) — ``envelope`` + ``patched_run`` / ``patched_plain_run``;
 * the streaming ``--json-stream`` path
   (``asyncio.create_subprocess_exec`` + incremental stream reads) —
-  ``patched_stream``. ``run_workflow``, ``job(action="watch")`` and
-  ``generate_image`` all drive the same NDJSON stream.
+  ``patched_stream``, plus ``blocking_stream`` for the timeout paths (a child
+  that emits some lines and then blocks past the caller's deadline).
+  ``run_workflow``, ``job(action="watch")`` and ``generate_image`` all drive the
+  same NDJSON stream.
 * the plain-JSON ASYNC path (``asyncio.create_subprocess_exec`` + bounded drains
   of both pipes) — ``patched_async_run``, for ``server._run_comfy_async``. Same
   spawn and same real ``StreamReader`` pipes as the streaming fake, but the output
@@ -587,6 +589,58 @@ def patched_stream(monkeypatch):
             proc = _FakeProc(
                 list(cmd), stdout_text, env=env, stdin=stdin, limit=limit, cwd=cwd
             )
+            procs.append(proc)
+            return proc
+
+        monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
+        monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
+        return procs
+
+    return setup
+
+
+class _BlockingStreamProc:
+    """A fake streaming child that emits ``first_lines`` and then never yields.
+
+    The one case ``patched_stream`` cannot model: its ``_FakeProc`` drains a
+    canned stream to EOF instantly and reports itself already exited, so it can
+    never hold a read past a deadline. ``returncode`` starts None so the timeout
+    handler's kill fires; no ``pid``, so ``server._kill_proc_tree_async`` takes
+    the ``proc.kill()`` fallback instead of signalling a made-up process group.
+    """
+
+    def __init__(self, cmd, first_lines, stderr_text=""):
+        self.cmd = cmd
+        # Real reader left OPEN: the lines are readable, then the next read
+        # blocks until the caller's deadline cancels it (see stream_reader).
+        self.stdout = stream_reader("".join(first_lines), eof=False)
+        self.stderr = stream_reader(stderr_text)
+        self.returncode = None
+        self.killed = False
+
+    async def wait(self):
+        self.returncode = 0
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+
+
+@pytest.fixture
+def blocking_stream(monkeypatch):
+    """Patch the streaming spawn with a child that emits lines then blocks.
+
+    Returns ``setup(first_lines, stderr_text=…) -> procs`` — the list capturing
+    each spawned :class:`_BlockingStreamProc`, so a test can assert
+    ``procs[0].killed`` (the timeout handler reaped the child) or the argv it
+    was spawned with. The timeout-path counterpart of :func:`patched_stream`.
+    """
+
+    def setup(first_lines, *, stderr_text: str = "") -> list[_BlockingStreamProc]:
+        procs: list[_BlockingStreamProc] = []
+
+        async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
+            proc = _BlockingStreamProc(list(cmd), first_lines, stderr_text)
             procs.append(proc)
             return proc
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -599,31 +599,88 @@ def patched_stream(monkeypatch):
     return setup
 
 
+# Last-resort net, NOT a modelling choice: both pipes EOF on their own after
+# this long and ``wait()`` returns, so a regression that stops APPLYING the
+# deadline (a ``timeout`` that no longer reaches ``_run_comfy_streaming``) FAILS
+# instead of hanging the suite forever — there is no per-test timeout in
+# ``pyproject.toml`` to fall back on, and the hand-rolled fakes this fixture
+# replaced got the same bound from their ``asyncio.sleep(1.0)``. Deliberately
+# longer than every bound in the code under test (``_reap_async``'s 5s, the
+# timeout path's 2s stderr re-await): the net must never be what satisfies one
+# of those waits, or it would paper over the very ordering these tests pin.
+_BLOCKED_CHILD_EOF = 30.0
+
+
 class _BlockingStreamProc:
-    """A fake streaming child that emits ``first_lines`` and then never yields.
+    """A fake streaming child that emits ``first_lines`` and then blocks, ALIVE.
 
     The one case ``patched_stream`` cannot model: its ``_FakeProc`` drains a
     canned stream to EOF instantly and reports itself already exited, so it can
-    never hold a read past a deadline. ``returncode`` starts None so the timeout
-    handler's kill fires; no ``pid``, so ``server._kill_proc_tree_async`` takes
-    the ``proc.kill()`` fallback instead of signalling a made-up process group.
+    never hold a read past a deadline. Here BOTH pipes are left open, because a
+    child that is still running has EOF'd neither, and ``returncode`` starts
+    None so the timeout handler's kill actually fires. No ``pid``, so
+    ``server._kill_proc_tree_async`` takes the ``proc.kill()`` fallback instead
+    of signalling a made-up process group — same reasoning as :class:`_FakeProc`.
+
+    ``wait()`` does NOT return until the child terminates, and ``kill()`` is what
+    terminates it: it closes both pipes and sets ``returncode``, exactly as
+    :class:`_FakeAsyncRunProc` does and for the same reason — killing the process
+    GROUP drops every inherited copy of the write fd, which is the only thing
+    that lets a post-kill drain reach EOF instead of blocking. That fidelity is
+    what holds ``_run_comfy_streaming``'s ordering under test: it kills the tree
+    FIRST and only then re-awaits the bounded stderr drain, so a fake whose
+    stderr had already EOF'd would stay green with the kill removed, and one
+    whose ``wait()`` returned early would stay green with the wait moved ahead of
+    the kill — while a real child wedged on both counts.
     """
 
-    def __init__(self, cmd, first_lines, stderr_text=""):
+    def __init__(
+        self,
+        cmd,
+        first_lines,
+        stderr_text="",
+        env=None,
+        stdin=None,
+        limit=None,
+        cwd=None,
+        start_new_session=None,
+    ):
         self.cmd = cmd
-        # Real reader left OPEN: the lines are readable, then the next read
-        # blocks until the caller's deadline cancels it (see stream_reader).
-        self.stdout = stream_reader("".join(first_lines), eof=False)
-        self.stderr = stream_reader(stderr_text)
+        self.env = env
+        self.limit = limit  # what `server` asked for, for the argv assertions
+        self.stdin_arg = stdin  # what `server` asked for, not a writable pipe
+        self.cwd = cwd  # the COMFY_PROJECT anchor `server` resolved, if any
+        self.start_new_session = start_new_session
+        # Real readers left OPEN: the canned output is readable, then the next
+        # read blocks — the caller's deadline is what ends it (see stream_reader).
+        self.stdout = stream_reader("".join(first_lines), limit, eof=False)
+        self.stderr = stream_reader(stderr_text, limit, eof=False)
         self.returncode = None
         self.killed = False
+        self._exited = asyncio.Event()
+        self._expiry = asyncio.get_running_loop().call_later(
+            _BLOCKED_CHILD_EOF, self._expire, 0
+        )
+
+    def _expire(self, returncode: int) -> None:
+        """End the block: EOF both pipes and let ``wait()`` return."""
+        if self.returncode is not None:
+            return
+        self.returncode = returncode
+        self.stdout.feed_eof()
+        self.stderr.feed_eof()
+        self._exited.set()
 
     async def wait(self):
-        self.returncode = 0
+        # A live child does not reap: block until something terminates it, so a
+        # cleanup path that waits BEFORE it kills wedges here rather than passing.
+        await self._exited.wait()
         return self.returncode
 
     def kill(self):
         self.killed = True
+        self._expiry.cancel()
+        self._expire(-9)
 
 
 @pytest.fixture
@@ -632,15 +689,49 @@ def blocking_stream(monkeypatch):
 
     Returns ``setup(first_lines, stderr_text=…) -> procs`` — the list capturing
     each spawned :class:`_BlockingStreamProc`, so a test can assert
-    ``procs[0].killed`` (the timeout handler reaped the child) or the argv it
-    was spawned with. The timeout-path counterpart of :func:`patched_stream`.
+    ``procs[0].killed`` (the timeout handler reaped the child), the argv it was
+    spawned with, or the spawn kwargs. The timeout-path counterpart of
+    :func:`patched_stream`, and like it as strict as a real POSIX spawn about the
+    argv it is handed (see :func:`_encode_argv_like_posix`).
+
+    ``first_lines`` is a list of NEWLINE-TERMINATED lines, checked rather than
+    assumed: an unterminated tail sits in the reader's buffer forever, so the
+    event it holds never reaches the progress tracker, and a bare string would
+    otherwise be accepted silently by the ``"".join`` below.
     """
 
     def setup(first_lines, *, stderr_text: str = "") -> list[_BlockingStreamProc]:
+        assert not isinstance(first_lines, str), (
+            "first_lines is a LIST of lines, not a single string"
+        )
+        first_lines = list(first_lines)  # so the check below can't drain a generator
+        assert all(line.endswith("\n") for line in first_lines), (
+            "every line must be newline-terminated or it never leaves the buffer"
+        )
         procs: list[_BlockingStreamProc] = []
 
-        async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
-            proc = _BlockingStreamProc(list(cmd), first_lines, stderr_text)
+        async def fake_exec(
+            *cmd,
+            stdout,
+            stderr,
+            env,
+            stdin=None,
+            limit=None,
+            cwd=None,
+            start_new_session=None,
+            **kwargs,
+        ):
+            _encode_argv_like_posix(cmd)
+            proc = _BlockingStreamProc(
+                list(cmd),
+                first_lines,
+                stderr_text,
+                env=env,
+                stdin=stdin,
+                limit=limit,
+                cwd=cwd,
+                start_new_session=start_new_session,
+            )
             procs.append(proc)
             return proc
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -32,7 +32,7 @@ import threading
 from pathlib import Path
 
 import pytest
-from conftest import _OK_STREAM, _RecordingCtx, envelope, stream_reader
+from conftest import _OK_STREAM, _RecordingCtx, envelope
 
 from comfy_mcp import server
 
@@ -884,49 +884,14 @@ def test_job_watch_stream_error_envelope_raises_with_code(patched_stream):
         asyncio.run(server.job(action="watch", prompt_id="pid"))
 
 
-class _BlockingProc:
-    """A fake child whose stdout yields ``first_lines`` then blocks (forces a
-    timeout). Copied from the former ``test_watch_job`` coverage — see
-    ``conftest._FakeProc`` for the sibling used by the non-timeout paths."""
-
-    def __init__(self, cmd, first_lines):
-        self.cmd = cmd
-        self._lines = [line.encode("utf-8") for line in first_lines]
-        self.stdout = self
-        self.stderr = stream_reader("")
-        self.returncode = None
-        self.killed = False
-
-    async def readuntil(self, separator=b"\n"):
-        if self._lines:
-            return self._lines.pop(0)
-        await asyncio.sleep(1.0)
-        raise asyncio.IncompleteReadError(b"", None)
-
-    async def wait(self):
-        self.returncode = 0
-        return self.returncode
-
-    def kill(self):
-        self.killed = True
-
-
-def test_job_watch_times_out_returns_payload(monkeypatch):
+def test_job_watch_times_out_returns_payload(blocking_stream):
     """R8: a genuine watch expiry is a `timed_out` payload, never a raise —
     proof that `job`'s "watch" branch passes `raise_on_timeout=False` through
     to `_run_comfy_streaming`, exactly as `watch_job` did."""
     queued = json.dumps(
         {"type": "queued", "nodes": [{"node_id": "1"}, {"node_id": "2"}]}
     )
-    procs: list[_BlockingProc] = []
-
-    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
-        proc = _BlockingProc(cmd, [queued + "\n"])
-        procs.append(proc)
-        return proc
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
+    procs = blocking_stream([queued + "\n"])
 
     result = asyncio.run(
         server.job(
@@ -955,20 +920,12 @@ def test_job_watch_raise_on_timeout_is_false(monkeypatch):
     assert seen["raise_on_timeout"] is False
 
 
-def test_job_watch_times_out_reports_progress_without_ctx(monkeypatch):
+def test_job_watch_times_out_reports_progress_without_ctx(blocking_stream):
     queued = json.dumps(
         {"type": "queued", "nodes": [{"node_id": "1"}, {"node_id": "2"}]}
     )
     executed = json.dumps({"type": "executed", "node": "1"})
-    procs: list[_BlockingProc] = []
-
-    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
-        proc = _BlockingProc(cmd, [queued + "\n", executed + "\n"])
-        procs.append(proc)
-        return proc
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
+    procs = blocking_stream([queued + "\n", executed + "\n"])
 
     result = asyncio.run(
         server.job(action="watch", prompt_id="pid", timeout_seconds=0.25)

--- a/tests/test_run_template.py
+++ b/tests/test_run_template.py
@@ -30,7 +30,7 @@ import asyncio
 import json
 
 import pytest
-from conftest import _OK_STREAM, _RecordingCtx, envelope, stream_reader
+from conftest import _OK_STREAM, _RecordingCtx, envelope
 from mcp.server.elicitation import (
     AcceptedElicitation,
     CancelledElicitation,
@@ -503,44 +503,7 @@ def test_run_template_wait_false_still_forwards_consent(patched_run):
     ]
 
 
-class _BlockingProc:
-    """A child fake that emits ``first_lines`` and then never yields an envelope.
-
-    Local rather than in ``conftest`` because this is the one case where the call
-    genuinely differs (see AGENTS.md): the shared ``patched_stream`` fake drains a
-    canned stream to EOF instantly and reports itself already exited, so it can
-    never hold the read past a deadline — which is precisely the state this test
-    is about.
-
-    ``returncode`` starts None so the timeout handler's kill fires; no ``pid``, so
-    that kill takes ``server._kill_proc_tree_async``'s ``proc.kill()`` fallback
-    instead of signalling a made-up process group.
-    """
-
-    def __init__(self, cmd, first_lines):
-        self.cmd = cmd
-        self._lines = [line.encode("utf-8") for line in first_lines]
-        self.stdout = self  # the reader protocol lives on the proc itself
-        self.stderr = stream_reader("")
-        self.returncode = None
-        self.killed = False
-
-    async def readuntil(self, separator=b"\n"):
-        if self._lines:
-            return self._lines.pop(0)
-        # Outlives the test's tiny deadline; no envelope ever comes.
-        await asyncio.sleep(1.0)
-        raise asyncio.IncompleteReadError(b"", None)
-
-    async def wait(self):
-        self.returncode = 0
-        return self.returncode
-
-    def kill(self):
-        self.killed = True
-
-
-def test_run_template_timeout_raises_the_streaming_shape(monkeypatch):
+def test_run_template_timeout_raises_the_streaming_shape(monkeypatch, blocking_stream):
     """An expired `wait=True` run raises the STREAMING timeout error, with progress.
 
     The dialect change moves this failure off `_run_comfy`'s
@@ -552,15 +515,7 @@ def test_run_template_timeout_raises_the_streaming_shape(monkeypatch):
     test: the real one is 30s of deliberate slack past the caller's budget.
     """
     queued = json.dumps({"schema": "event/1", "type": "queued", "nodes": [{"id": "1"}]})
-    procs: list[_BlockingProc] = []
-
-    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
-        proc = _BlockingProc(cmd, [queued + "\n"])
-        procs.append(proc)
-        return proc
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
+    procs = blocking_stream([queued + "\n"])
     monkeypatch.setattr(server, "_RUN_TEMPLATE_TIMEOUT_GRACE", 0.0)
 
     with pytest.raises(server.ComfyCliError) as exc:

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -3387,40 +3387,7 @@ def test_run_workflow_stream_works_without_ctx(patched_stream):
 # The `watch_job`-specific tests (streams-progress, stream-error-envelope,
 # times-out-returns-payload, times-out-without-ctx, rejects-unusable-id,
 # rejects-embedded-nul, clamps-oversized-timeout, rejects-bad-timeout) moved
-# to tests/test_jobs.py as `job(action="watch")`. `_BlockingProc` below stays
-# — it is still used by `test_run_workflow_timeout_error_includes_snapshot_and_hint`
-# and `_BlockingProcWithStderr`.
-
-
-class _BlockingProc:
-    """A fake child whose stdout yields ``first_lines`` then blocks (forces a timeout).
-
-    ``returncode`` starts None (the child is running) so the timeout handler's
-    kill actually fires; carries no ``pid`` so the kill takes the ``proc.kill()``
-    fallback rather than signalling a made-up group. See conftest's ``_FakeProc``.
-    """
-
-    def __init__(self, cmd, first_lines):
-        self.cmd = cmd
-        self._lines = [line.encode("utf-8") for line in first_lines]
-        self.stdout = self  # the reader protocol lives on the proc itself
-        self.stderr = stream_reader("")
-        self.returncode = None
-        self.killed = False
-
-    async def readuntil(self, separator=b"\n"):
-        if self._lines:
-            return self._lines.pop(0)
-        # Outlives the test's tiny timeout, so the envelope never arrives.
-        await asyncio.sleep(1.0)
-        raise asyncio.IncompleteReadError(b"", None)
-
-    async def wait(self):
-        self.returncode = 0
-        return self.returncode
-
-    def kill(self):
-        self.killed = True
+# to tests/test_jobs.py as `job(action="watch")`.
 
 
 def test_run_workflow_wait_false_uses_plain_json_no_stream(monkeypatch):
@@ -4068,28 +4035,12 @@ def test_sync_non_timeout_failure_still_reaps_the_child(patched_run):
     assert calls[0]["proc"].killed is True
 
 
-class _BlockingProcWithStderr(_BlockingProc):
-    """A blocking child fake that also carries buffered stderr (a crashed traceback)."""
-
-    def __init__(self, cmd, first_lines, stderr_text):
-        super().__init__(cmd, first_lines)
-        self.stderr = stream_reader(stderr_text)
-
-
-def test_streaming_timeout_surfaces_stdout_and_stderr_tails(monkeypatch):
+def test_streaming_timeout_surfaces_stdout_and_stderr_tails(blocking_stream):
     """A raising streaming timeout appends the NDJSON stdout tail and the child's stderr tail."""
     queued = json.dumps({"type": "queued", "nodes": [{"node_id": "1"}]})
-    procs: list[_BlockingProcWithStderr] = []
-
-    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
-        proc = _BlockingProcWithStderr(
-            cmd, [queued + "\n"], "Traceback ...\nUnicodeEncodeError: boom"
-        )
-        procs.append(proc)
-        return proc
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
+    procs = blocking_stream(
+        [queued + "\n"], stderr_text="Traceback ...\nUnicodeEncodeError: boom"
+    )
 
     with pytest.raises(server.ComfyCliError) as exc:
         asyncio.run(
@@ -4104,18 +4055,10 @@ def test_streaming_timeout_surfaces_stdout_and_stderr_tails(monkeypatch):
     assert procs[0].killed  # child cleaned up
 
 
-def test_streaming_timeout_stdout_tail_is_bounded(monkeypatch):
+def test_streaming_timeout_stdout_tail_is_bounded(blocking_stream):
     """Even a chatty streaming child cannot inflate the raised message past the tail bound."""
     noisy = [("x" * 100 + "\n") for _ in range(50)]  # 5000+ chars of NDJSON
-    procs: list[_BlockingProcWithStderr] = []
-
-    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
-        proc = _BlockingProcWithStderr(cmd, noisy, "")
-        procs.append(proc)
-        return proc
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
+    blocking_stream(noisy)
 
     with pytest.raises(server.ComfyCliError) as exc:
         asyncio.run(
@@ -5413,20 +5356,12 @@ def test_two_overlapping_run_workflow_calls_complete_independently(monkeypatch):
     assert all(p.killed for p in procs)  # both cleaned up
 
 
-def test_run_workflow_timeout_error_includes_snapshot_and_hint(monkeypatch):
+def test_run_workflow_timeout_error_includes_snapshot_and_hint(blocking_stream):
     """A genuine timeout surfaces the progress snapshot + a job/wait=False hint."""
     queued = json.dumps(
         {"type": "queued", "nodes": [{"node_id": "1"}, {"node_id": "2"}]}
     )
-    procs: list[_BlockingProc] = []
-
-    async def fake_exec(*cmd, stdout, stderr, env, **kwargs):
-        proc = _BlockingProc(cmd, [queued + "\n"])
-        procs.append(proc)
-        return proc
-
-    monkeypatch.setattr(server.shutil, "which", lambda _: "/fake/comfy")
-    monkeypatch.setattr(server.asyncio, "create_subprocess_exec", fake_exec)
+    procs = blocking_stream([queued + "\n"])
 
     with pytest.raises(server.ComfyCliError) as excinfo:
         asyncio.run(


### PR DESCRIPTION
## ELI-5

Three test files each kept their own private copy of the same pretend `comfy` process: one that prints a couple of lines and then goes quiet forever, so the code under test hits its deadline. This PR moves that pretend process into the shared fixtures file as `blocking_stream` and deletes all three copies. Nothing about the product changes and no test changes what it checks — there is just one fake now instead of three.

## Summary

Hoists the duplicated "fake comfy-cli child that emits some lines then blocks past the deadline" stub into ONE shared `tests/conftest.py` fixture, `blocking_stream`, and deletes every per-file copy. Test-only; the suite's behaviour is unchanged.

This is the case AGENTS.md's shared-fixture rule ("mock comfy-cli via the shared fixtures in `tests/conftest.py`, never a hand-rolled stub") was written for, and it was the one streaming state that had no shared fixture: `patched_stream`'s `_FakeProc` drains a canned stream to EOF instantly and reports itself already exited, so it can never hold a read past a deadline.

## Changes

- `tests/conftest.py`: adds `_BlockingStreamProc` + the `blocking_stream(first_lines, stderr_text=…) -> procs` fixture, placed immediately after `patched_stream`. stdout is a real `stream_reader(…, eof=False)` — the same "child still running" shape `_FakeAsyncRunProc` already uses — rather than the copies' hand-rolled `readuntil` that slept 1s and then raised `IncompleteReadError`. `returncode` starts `None` so the timeout handler's kill fires, and there is no `pid`, so `server._kill_proc_tree_async` takes its `proc.kill()` fallback instead of signalling a made-up process group.
- `tests/test_jobs.py`: deletes `_BlockingProc`; `test_job_watch_times_out_returns_payload` and `test_job_watch_times_out_reports_progress_without_ctx` take `blocking_stream`; drops the now-unused `stream_reader` import.
- `tests/test_run_template.py`: deletes `_BlockingProc`; `test_run_template_timeout_raises_the_streaming_shape` keeps `monkeypatch` only for its per-test `_RUN_TEMPLATE_TIMEOUT_GRACE = 0.0` (verb-specific — deliberately NOT folded into the shared fixture); drops the `stream_reader` import.
- `tests/test_wrapper.py`: deletes `_BlockingProc`, `_BlockingProcWithStderr`, and the stale comment block claiming `_BlockingProc` had to stay; rewrites its three users onto `blocking_stream`. `stream_reader` stays imported (other users remain).
- `tests/test_wrapper.py`: **`_StderrBlockingProc` is deliberately left local** — its behaviour genuinely differs (stdout EOFs fast while `stderr.read()` blocks), which is the AGENTS.md exemption case.
- `AGENTS.md`: adds the `blocking_stream` bullet to the shared-fixture list, and names `_StderrBlockingProc` in the "a local stub is justified only where the call genuinely differs" sentence so a future reader can tell which remaining stub is intentional.

Net −93 lines.

### Latent quirk removed

The deleted copies EOF'd one second after their lines ran out (`await asyncio.sleep(1.0)` then `IncompleteReadError`). Every current caller uses a 0.25s deadline, so they all took the intended timeout path — but a future test with a deadline over 1s would silently have taken the EOF path instead of the timeout path the stub exists to exercise. `eof=False` never EOFs, so that footgun is gone.

## Motivation

Deferred CodeRabbit feedback on #238, then validated by a read-only spike before this was written.

## Testing

- [x] Existing tests pass (`pytest`)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually (below)

Pass count pinned against a **pristine `main` worktree at the same base commit (610a4a3)**, run with the same interpreter, so "unchanged" is measured rather than asserted:

| | result |
|---|---|
| `main` @ 610a4a3 (pristine worktree) | 2119 passed, 6 deselected |
| this branch | 2119 passed, 6 deselected |

`ruff check .` → `All checks passed!`; `ruff format --check .` → `61 files already formatted`.

**Mutation check — the new fixture's blocking semantics are load-bearing, not decorative.** Flipping the fixture's `eof=False` to `eof=True` (locally, reverted) fails 5 of the 6 migrated tests, so they genuinely still exercise the timeout path rather than passing vacuously on an EOF path.

`git grep -n "class _BlockingProc\|_blocking_stream(\|_blocking_streaming_child" tests/` returns nothing.

## Additional Notes

**Judgment calls**

- The fixture's docstring is four lines longer than the spike's prototype text, describing the return value in `patched_stream`'s own style. Behaviour is identical.
- Adding `_StderrBlockingProc` to AGENTS.md's local-stub sentence was not strictly required (that sentence never listed the blocking child, so it needed no correction) — it is included because after this PR that is the only blocking-shaped local stub left, and the sentence is where a reader looks to find out whether it is intentional. Its code is untouched.

**Deliberately out of scope, and still outstanding after this merges**

Two more copies of the same stub live on an open branch, not on `main`, so they could not be folded in here without depending on unmerged work: `tests/test_generate.py`'s `_BlockingProc` / `_blocking_stream` helper and `tests/test_wrapper.py`'s `_blocking_streaming_child`, both introduced by **#238** (`fix(generate_image): return the prompt_id when the wait expires`), which was still OPEN when this branch was cut. They should migrate onto `blocking_stream` once #238 lands — note that `test_generate.py`'s helper also set `_RUN_TEMPLATE_TIMEOUT_GRACE = 0.0`, which belongs at the call site (as it does in `test_run_template.py` here), not in the shared fixture. This PR therefore does **not** finish de-duplicating the stub repo-wide; it de-duplicates every copy that exists on `main`.

**Conflicts** — checked, none: #237 touches `tests/conftest.py` at lines 228–258 (the `envelope()` region) while this inserts at 599+; #240 touches `tests/test_wrapper.py` at line 692 (the version-guard region) while this edits 3387+.

**Unexercised artifact** — the driving spike's findings write-up (an internal tracker item) is not reachable from the environment this was built in, so this PR is verified against the repository itself rather than against that write-up: the three stub copies were read in place, the shared-fixture rule was read in `AGENTS.md`, and `server._run_comfy_streaming` was read to confirm it never drains stdout after the timeout kill (so leaving the fake's stdout reader open is safe). The pass-count and mutation evidence above stands on its own.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** `pytest -q` on this branch: 2119 passed, 6 deselected, 0 failed — identical to a pristine `main` worktree at the same base commit (610a4a3); `ruff check .`: all checks passed; `ruff format --check .`: 61 files already formatted; mutation check (`eof=False` → `eof=True`): 5 of 6 migrated tests fail, confirming the blocking behaviour is exercised
- **Deviations:** the two stub copies that arrive with open PR #238 are not migrated here (they are not on `main`); see "Deliberately out of scope" above
