### PR TITLE
feat: add inline media previews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,8 @@ registry slugs, refusing a URL, since the prompt promises a REGISTRY pack.
 `restart_comfyui`'s kill gate is STATE-scoped instead, firing mid-sequence once a launch
 loses the port. Mirror the engine's contract per tool; never generalize one gate to another.
 
-The local differentiator: discovery (`nodes`, `search_models`) reads the **live install** —
-custom nodes included — not a static catalog.
+Local differentiators: discovery (`nodes`, `search_models`) reads the **live install**, custom
+nodes included, while `preview_media` returns comfy-cli's rendered PNG as MCP image content.
 
 ## Module layout
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ here; it breaks the next release's registry publish.
 **What it does:**
 
 - 🖼️ **Generate** — run a workflow JSON (API-format or UI export), or go text-prompt → image in one call.
-- ⏱️ **Monitor jobs** — submit async, then wait / watch / cancel, read the failure verdict, and collect the output PNGs.
+- ⏱️ **Monitor jobs** — submit async, then wait / watch / cancel, read the failure verdict, and collect the output files.
+- 🎞️ **Preview media** — turn video into a contact sheet and audio into a waveform the agent can inspect.
 - 🔍 **Introspect your live install** — search the nodes, models, and templates your ComfyUI *actually* has (custom nodes included), not a static catalog.
 - 🧩 **Build workflows** — validate a graph, edit a template's slots, and fan one workflow into variants.
 - ♻️ **Manage ComfyUI** — launch / stop / restart the server, tail its logs, and stage input assets.
@@ -81,7 +82,7 @@ server has no path to is Comfy Cloud itself: no cloud-hosted execution, no cloud
 cross-session cloud batches. Every tool here shells out to `comfy --where local`. Pick by where you
 want the work to run, or [install the cloud server too](#comfy-cloud-mcp).
 
-> **Status:** beta. 40 tools; core loop validated end-to-end against a live local ComfyUI
+> **Status:** beta. 41 tools; core loop validated end-to-end against a live local ComfyUI
 > (`server_info → run_workflow → fetch_outputs` → PNG on disk). CI runs pytest + ruff on
 > Python 3.10 and 3.14.
 
@@ -146,6 +147,10 @@ Four steps take you from a fresh install to your first generated image.
 `fetch_outputs(prompt_id, out_dir)` **copies** a finished job's outputs into any directory you
 name — so telling the agent "save them to `./outputs`" puts a copy right where you asked while
 the originals stay in the ComfyUI workspace.
+
+For video or audio output, pass the downloaded file to `preview_media`. It asks comfy-cli to
+render a PNG contact sheet or waveform and returns that image inline, so the agent can inspect
+the result without trying to embed the original media file in the MCP response.
 
 ## Upgrading from `comfy-local-mcp`
 
@@ -954,13 +959,13 @@ Set it in the client registration `env` block, same as `COMFY_BIN`:
 
 ## Tools
 
-40 tools, grouped below by what they do. Every tool runs `comfy` with the global
+41 tools, grouped below by what they do. Every tool runs `comfy` with the global
 `--json --where local` flags, unwraps comfy-cli's `envelope/1`, and returns its `data`.
 
 **Argument naming** is uniform, so an agent never has to guess it (the server's handshake
 instructions say the same thing): an input workflow file is always `workflow_path`, an output
-file is `out_path`, an output directory is `out_dir`, a registry lookup key is `name`, and a job
-handle is `prompt_id`.
+file is `out_path`, an input media file is `media_path`, an output directory is `out_dir`, a
+registry lookup key is `name`, and a job handle is `prompt_id`.
 
 ### Run and monitor
 
@@ -973,6 +978,7 @@ handle is `prompt_id`.
 | `run_template(name, params=None, confirm_spend=False, wait=True, timeout_seconds=600.0, ctx=None)` | `comfy run-template <name> [--param=KEY=VALUE…] [--timeout=<s>] [--allow-spend] [--async]` | One-command template run — fetch the gallery template, fill its parameterized slots, and run it on whichever ComfyUI the server targets, so it follows `COMFYUI_URL`/`COMFYUI_HOST` like `run_workflow` does ([Driving a remote ComfyUI](#driving-a-remote-comfyui)) (the one-shot alternative to `fetch_template` → `run_workflow`). `params` are `{slot: value}` (slot address `6.text` or name `prompt`), JSON-encoded so types round-trip. Most templates are free OSS graphs; one embedding partner (paid) nodes spends credits and fails closed unless `confirm_spend=True` unlocks it — and on an elicitation-capable client that asks **you** per call before anything runs (same posture as `partner_generate`; a default, free run is never prompted, and `comfy generate consent always` does not apply to this verb). No capability probe is needed here (unlike `partner_generate`): this verb's gate ships inside the verb itself, so a comfy-cli that has `run-template` has the gate. `wait=True` (the default) streams the run's live progress as MCP progress notifications, the same way `run_workflow` / `job(action="watch")` do, so a long template run is not a silent block; `wait=False` submits `--async` and returns a `prompt_id`. comfy-cli's `--timeout` for this verb is *per-event*, not a whole-run deadline, so `timeout_seconds` is forwarded only to tighten it below the engine's 120s default — prefer `wait=False` over a large `timeout_seconds` for long runs. |
 | `job(action="status", prompt_id="", timeout_seconds=None)` | `comfy jobs status/watch/cancel/ls <prompt_id>` | One grouped tool over the six former `job_status`/`wait_for_job`/`watch_job`/`get_execution_error`/`cancel_job`/`get_queue` tools — pick a behavior with `action`. `"status"` (default) polls status + outputs. `"error"` returns a compact failure verdict — the failing node, `exception_type`/`exception_message`, and a bounded traceback tail — so an agent can self-repair; `error: None` on a healthy prompt. Failures comfy-cli diagnosed itself rather than ComfyUI (a `server_died` crash mid-run) carry no node-level fields, so the verdict also reports `error_code` — comfy-cli's own code, `None` on an ordinary node failure — with its message backfilling `exception_message`. `"wait"` polls (bounded, default 25.0s) until a job reaches a terminal status, returning a `{"timed_out": True, …}` payload on expiry — chain several rather than one long call. `"watch"` streams live progress (bounded, default 600.0s) as MCP progress notifications, same `timed_out` shape except `status` is a live `{progress, total, nodes_done}` snapshot. `"cancel"` stops a queued/running job. `"queue"` lists known jobs (Comfy Cloud-tracked rows filtered out, since this server never drives them; follows a configured remote like the other job actions). `prompt_id` is required for every action but `"queue"`; `timeout_seconds` only for `"wait"`/`"watch"` — passing either where the action does not use it is rejected rather than silently ignored. |
 | `fetch_outputs(prompt_id, out_dir, url_only=False, inline_images=False)` | `comfy download <prompt_id> --where local -o <out_dir> [--url-only]` | Write a finished job's outputs into `out_dir` — including a job that ran on a configured remote, which comfy-cli resolves from the local `prompt_id` state file rather than from a server (see [Driving a remote ComfyUI](#driving-a-remote-comfyui)); `url_only=True` emits the output URLs without copying bytes; `inline_images=True` also returns the copied images as inline MCP image content so the agent can see them without a second read. |
+| `preview_media(media_path, out_path="", grid="4x3", width=480, inline_image=True)` | `comfy preview <media_path> [--out <out_path>] --grid <COLSxROWS> --width <pixels>` | Render a local image thumbnail, video contact sheet, or audio waveform as PNG. comfy-cli owns media classification and rendering; this server does not parse media or call ffmpeg. By default the result contains comfy-cli's metadata followed by the generated PNG as inline MCP image content; `inline_image=False` returns metadata only. `grid` controls video frame sampling, and `out_path` is optional because comfy-cli otherwise writes `<media>.preview.png`. The input must exist on the MCP host, so for a remote job call `fetch_outputs` first and pass one of its downloaded paths here. Relative paths follow `COMFY_PROJECT`. |
 
 ### Resource management
 

--- a/src/comfy_mcp/argv.py
+++ b/src/comfy_mcp/argv.py
@@ -164,8 +164,9 @@ def _reject_option_like(label: str, value: str, expected: str = "") -> str:
 # ``run_workflow`` / ``validate_workflow`` / the four other ``workflow_path``
 # tools, ``download_model``'s ``relative_path`` and ``filename``,
 # ``fetch_template``'s / ``emit_partner_workflow``'s / ``partner_generate``'s
-# ``out_path``, ``fetch_outputs``'s and ``vary_workflow``'s ``out_dir``, each
-# entry of ``upload_file``'s ``paths``, and ``search_models``' ``folder``.
+# ``out_path``, ``preview_media``'s ``media_path`` / ``out_path``,
+# ``fetch_outputs``'s and ``vary_workflow``'s ``out_dir``, each entry of
+# ``upload_file``'s ``paths``, and ``search_models``' ``folder``.
 # ``download_model``'s ``url`` is the one path-adjacent value with a ceiling of
 # its own (:data:`_MAX_URL_LEN`), passed to the same helper as an explicit
 # ``limit``. Keep this list in sync — the SCOPE note at :data:`_MAX_URL_LEN`

--- a/src/comfy_mcp/instructions.py
+++ b/src/comfy_mcp/instructions.py
@@ -22,7 +22,8 @@ flows:
   `fetch_outputs`. Prefer this over `run_workflow(wait=True)` so a slow run
   does not block; same for `generate_image` / `run_template` on slow hardware,
   where YOUR transport cap bounds a `wait=True` call too. A run that outlives
-  a wait keeps going — poll its `prompt_id`, never re-run it.
+  a wait keeps going — poll its `prompt_id`, never re-run it. For video/audio,
+  call `preview_media` on a path returned by `fetch_outputs`.
 - Large model downloads: `download_model` submits to a background worker and
   returns a `download_id`; poll `download(action="wait")` /
   `download(action="status")`, or `download(action="cancel")` to stop one.
@@ -158,8 +159,9 @@ flows:
 Argument naming is uniform across the tool surface — do not guess it: input
 workflow files use `workflow_path` (`run_workflow`, `validate_workflow`,
 `list_workflow_slots`, `list_workflow_notes`, `set_workflow_slot`,
-`vary_workflow`); output files use `out_path` (`fetch_template`,
-`partner_generate`, `emit_partner_workflow`); output directories use
+`vary_workflow`); input media uses `media_path` (`preview_media`); output files
+use `out_path` (`fetch_template`, `partner_generate`, `emit_partner_workflow`,
+`preview_media`); output directories use
 `out_dir` (`fetch_outputs`, `vary_workflow`); registry lookup keys use `name`
 (`get_template`, `nodes`, `run_template`); job handles use `prompt_id`
 (`job`, `fetch_outputs`); and

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -6306,7 +6306,7 @@ def _select_inline_images(paths: list[str]) -> list[str]:
             size = os.path.getsize(path)
         except OSError:
             continue
-        if selected and total + size > _INLINE_IMAGE_MAX_BYTES:
+        if total + size > _INLINE_IMAGE_MAX_BYTES:
             break
         selected.append(path)
         total += size

--- a/src/comfy_mcp/server.py
+++ b/src/comfy_mcp/server.py
@@ -6329,20 +6329,14 @@ def fetch_outputs(
     """Download a completed job's output files into ``out_dir``.
 
     Wraps ``comfy download <prompt_id> --where local -o <out_dir>``.
-    ``url_only=True`` adds ``--url-only`` — emits URLs without downloading.
+    ``url_only=True`` emits URLs without downloading.
 
-    Works for a job that ran on a configured REMOTE too, even though this verb
-    forwards no ``--host``/``--port`` (not in ``_TARGET_AWARE_SUBCOMMANDS``):
-    the run that submitted the job wrote a state file on THIS machine keyed by
-    ``prompt_id``, and against a remote that file records each output as an
-    absolute URL comfy-cli streams from there. Only a ``prompt_id`` this
-    machine never submitted has no such state file (``download_job_not_found``).
+    Remote jobs work although ``download`` is not in
+    ``_TARGET_AWARE_SUBCOMMANDS``: the submitting run's local state file maps
+    ``prompt_id`` to output URLs. An unknown local id has no record.
 
-    ``inline_images=True`` ALSO returns copied images as inline MCP content
-    (base64); the on-disk copy is unchanged either way. Returns a list:
-    comfy-cli's metadata first, then the image files (capped at
-    ``_INLINE_IMAGE_MAX_COUNT`` files / ``_INLINE_IMAGE_MAX_BYTES`` aggregate;
-    on-disk copies are never capped).
+    ``inline_images=True`` appends bounded MCP images to the metadata. Disk
+    copies remain uncapped.
     """
     prompt_id = argv._guard_prompt_id(prompt_id)
     # `out_dir` is the sibling client-supplied positional and rides the same argv
@@ -6366,6 +6360,54 @@ def fetch_outputs(
     paths = _select_inline_images(_collect_output_images(data, out_dir))
     images = [Image(path=path) for path in paths]
     return [data, *images]
+
+
+def _preview_image_path(data: Any) -> str | None:
+    """Resolve comfy-cli's generated preview path against its spawn directory."""
+    if not isinstance(data, dict):
+        return None
+    preview = data.get("preview")
+    if not isinstance(preview, str) or not preview.lower().endswith(".png"):
+        return None
+    if not os.path.isabs(preview):
+        preview = os.path.join(_project_root() or os.getcwd(), preview)
+    resolved = os.path.realpath(preview)
+    return resolved if os.path.isfile(resolved) else None
+
+
+@mcp.tool()
+def preview_media(
+    media_path: str,
+    out_path: str = "",
+    grid: str = "4x3",
+    width: int = 480,
+    inline_image: bool = True,
+) -> Any:
+    """Render local media as a PNG through ``comfy preview``.
+
+    comfy-cli owns classification and creates a thumbnail, video contact sheet,
+    or audio waveform. ``inline_image=True`` appends the bounded PNG to its
+    metadata; false returns metadata only. Relative paths follow
+    ``COMFY_PROJECT``.
+    """
+    argv._guard_arg_len("media_path", media_path)
+    media_path = argv._reject_option_like("media_path", media_path)
+    media_path = argv._reject_nul("media_path", media_path)
+    grid = argv._reject_nul("grid", grid)
+
+    args = ["preview", media_path]
+    if out_path:
+        argv._guard_arg_len("out_path", out_path)
+        out_path = argv._reject_nul("out_path", out_path)
+        args.extend(["--out", out_path])
+    args.extend(["--grid", grid, "--width", str(width)])
+
+    data = _run_comfy(*args, timeout=180.0)
+    if not inline_image:
+        return data
+    path = _preview_image_path(data)
+    paths = _select_inline_images([path]) if path is not None else []
+    return [data, *(Image(path=path) for path in paths)]
 
 
 # ComfyUI's two network-EXPOSING flags. Both are declared `nargs="?"` in

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -100,6 +100,18 @@ def test_preview_media_does_not_inline_a_non_png_engine_path(patched_run, tmp_pa
     assert server.preview_media("clip.mp4") == [metadata]
 
 
+def test_preview_media_does_not_inline_an_oversized_preview(
+    patched_run, tmp_path, monkeypatch
+):
+    rendered = tmp_path / "clip.preview.png"
+    rendered.write_bytes(b"x" * 11)
+    metadata = {"kind": "video", "preview": str(rendered)}
+    monkeypatch.setattr(server, "_INLINE_IMAGE_MAX_BYTES", 10)
+    patched_run(envelope(data=metadata))
+
+    assert server.preview_media("clip.mp4") == [metadata]
+
+
 @pytest.mark.parametrize(
     "media_path",
     ["--help", "clip\x00.mp4", "x" * (argv._MAX_PATH_ARG_LEN + 1)],

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,140 @@
+"""Tests for the ``preview_media`` thin wrapper over ``comfy preview``."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from conftest import envelope
+
+from comfy_mcp import argv, server
+
+_FAKE_PNG = b"\x89PNG\r\n\x1a\npreview-pixels"
+
+
+def test_preview_media_wraps_cli_and_inlines_the_generated_png(patched_run, tmp_path):
+    media = tmp_path / "clip.mp4"
+    out = tmp_path / "clip-contact-sheet.png"
+    metadata = {
+        "input": str(media),
+        "kind": "video",
+        "preview": str(out),
+        "duration": 12.5,
+        "fps": 24.0,
+        "has_audio": True,
+    }
+
+    def render_preview(_cmd):
+        out.write_bytes(_FAKE_PNG)
+
+    calls = patched_run(envelope(data=metadata), on_spawn=render_preview)
+
+    result = server.preview_media(str(media), str(out))
+
+    assert calls[0]["cmd"][4:] == [
+        "preview",
+        str(media),
+        "--out",
+        str(out),
+        "--grid",
+        "4x3",
+        "--width",
+        "480",
+    ]
+    assert calls[0]["timeout"] == pytest.approx(180.0)
+    assert result[0] == metadata
+    assert isinstance(result[1], server.Image)
+    content = result[1].to_image_content()
+    assert content.mime_type == "image/png"
+    assert base64.b64decode(content.data) == _FAKE_PNG
+
+
+def test_preview_media_forwards_grid_width_and_omits_optional_out_path(patched_run):
+    metadata = {"kind": "audio", "preview": "track.preview.png"}
+    calls = patched_run(envelope(data=metadata))
+
+    assert (
+        server.preview_media("track.wav", grid="3x2", width=720, inline_image=False)
+        == metadata
+    )
+    assert calls[0]["cmd"][4:] == [
+        "preview",
+        "track.wav",
+        "--grid",
+        "3x2",
+        "--width",
+        "720",
+    ]
+
+
+def test_preview_media_resolves_relative_output_from_comfy_project(
+    patched_run, tmp_path, monkeypatch
+):
+    preview = tmp_path / "clip.preview.png"
+    preview.write_bytes(_FAKE_PNG)
+    monkeypatch.setenv("COMFY_PROJECT", str(tmp_path))
+    calls = patched_run(envelope(data={"kind": "video", "preview": "clip.preview.png"}))
+
+    result = server.preview_media("clip.mp4")
+
+    assert calls[0]["cwd"] == str(tmp_path)
+    assert isinstance(result[1], server.Image)
+    assert base64.b64decode(result[1].to_image_content().data) == _FAKE_PNG
+
+
+def test_preview_media_keeps_metadata_when_inline_file_is_missing(
+    patched_run, tmp_path
+):
+    metadata = {"kind": "video", "preview": str(tmp_path / "missing.preview.png")}
+    patched_run(envelope(data=metadata))
+
+    assert server.preview_media("clip.mp4") == [metadata]
+
+
+def test_preview_media_does_not_inline_a_non_png_engine_path(patched_run, tmp_path):
+    rendered = tmp_path / "clip.webp"
+    rendered.write_bytes(b"webp")
+    metadata = {"kind": "video", "preview": str(rendered)}
+    patched_run(envelope(data=metadata))
+
+    assert server.preview_media("clip.mp4") == [metadata]
+
+
+@pytest.mark.parametrize(
+    "media_path",
+    ["--help", "clip\x00.mp4", "x" * (argv._MAX_PATH_ARG_LEN + 1)],
+)
+def test_preview_media_rejects_invalid_input_path_before_spawn(no_spawn, media_path):
+    with pytest.raises(server.ComfyCliError):
+        server.preview_media(media_path)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"out_path": "preview\x00.png"},
+        {"out_path": "x" * (argv._MAX_PATH_ARG_LEN + 1)},
+        {"grid": "4x3\x00"},
+    ],
+)
+def test_preview_media_rejects_invalid_options_before_spawn(no_spawn, kwargs):
+    with pytest.raises(server.ComfyCliError):
+        server.preview_media("clip.mp4", **kwargs)
+
+
+def test_preview_media_inline_false_does_not_read_the_reported_path(
+    patched_run, tmp_path
+):
+    reported = tmp_path / "missing.preview.png"
+    metadata = {"kind": "image", "preview": str(reported)}
+    patched_run(envelope(data=metadata))
+
+    assert server.preview_media("image.png", inline_image=False) == metadata
+
+
+def test_preview_media_is_taught_in_the_handshake():
+    instructions = server.mcp.instructions
+
+    assert "preview_media" in instructions
+    assert "video/audio" in instructions
+    assert "fetch_outputs" in instructions

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -2955,6 +2955,7 @@ def test_server_instructions_document_the_argument_naming_convention():
 
     for argument in (
         "workflow_path",
+        "media_path",
         "out_path",
         "out_dir",
         "name",
@@ -2989,7 +2990,7 @@ def test_tool_arguments_follow_the_naming_convention():
         assert "workflow_path" in schemas[name]
 
     # Output file -> `out_path`; output directory -> `out_dir`.
-    for name in ("fetch_template", "partner_generate"):
+    for name in ("fetch_template", "partner_generate", "preview_media"):
         assert "out_path" in schemas[name]
     for name in ("fetch_outputs", "vary_workflow"):
         assert "out_dir" in schemas[name]


### PR DESCRIPTION
## Summary

Add a `preview_media` tool that wraps `comfy preview` and returns the generated PNG as inline MCP image content.

## Changes

- Wrap image thumbnails, video contact sheets, and audio waveforms through comfy-cli
- Return comfy-cli metadata first, with optional bounded inline PNG content
- Document the `fetch_outputs` to `preview_media` flow and add shared-fixture tests

## Motivation

`fetch_outputs` can download video and audio files, but agents cannot inspect those formats through the current MCP image return path. This closes that feedback loop without adding media parsing or direct ffmpeg calls to this server.

Closes #255

## Testing

- [x] Existing tests pass (`pytest`)
- [x] Lint passes (`ruff check .`)
- [x] Format check passes (`ruff format --check .`)
- [x] Tested manually (describe below)

The published PyPI `comfy-cli==1.14.0` was tested through `uvx`. Its `preview` command accepted `--out`, `--grid`, and `--width`, rendered `assets/comfy-demo.mp4`, and returned a successful `envelope/1` preview payload.

A wrapper integration test used comfy-cli 1.16.0. `preview_media(..., grid="3x2", width=360)` returned video metadata and an inline `image/png` contact sheet.

Full suite: `2228 passed, 7 deselected`.

## Additional Notes

`preview_media` reads local files. For a remote ComfyUI job, call `fetch_outputs` first and pass one of the downloaded paths.
