### PR TITLE
feat(groom): turn on the review-gated auto-builder

### DIFF
--- a/.github/workflows/groom.yml
+++ b/.github/workflows/groom.yml
@@ -96,6 +96,26 @@ jobs:
       # File as cloud-code-bot so groom's issues are a distinct, queryable actor
       # rather than github-actions[bot]. Unset -> reusable falls back gracefully.
       bot_app_id: ${{ vars.APP_ID }}
+      # Turn the top `max_prs` CONFIRMED, non-security findings into REVIEW-GATED
+      # PRs instead of issues, which is what `vars.GROOM_CONFIG`'s `max_findings: 0`
+      # here already assumes: that value PARKS issue filing (a literal `[:0]`
+      # slice, not "unlimited"), so without the builder this repo runs the full
+      # finder + verifier and emits nothing at all.
+      #
+      # `max_prs` is NOT set here on purpose: `vars.GROOM_CONFIG` already carries
+      # it (currently 2) and the variable outranks this `with:` block, so a value
+      # here would be dead config that reads as authoritative. Retune the variable.
+      #
+      # HARD PREREQUISITE — do not merge before it is met. `build_pr` reads
+      # `steps.bot_token.outputs.token` with NO github.token fallback (the issue
+      # sink degrades to github-actions[bot]; the PR sink cannot), and callers
+      # grant only `contents: read`, so there is no other way to push a branch.
+      # This repo has NEITHER `vars.APP_ID` NOR `secrets.CLOUD_CODE_BOT_PRIVATE_KEY`
+      # today, so builder mode would kill every finding at the PR sink AFTER the
+      # agents have billed. Provision the PRIVATE KEY FIRST and the APP_ID SECOND:
+      # the reusable mints whenever bot_app_id is non-empty and hard-fails on an
+      # empty key, so the reverse order breaks the runs that currently work.
+      builder: true
       # Manual dispatch may dry-run; the schedule always files live
       # (github.event.inputs is null on a schedule -> '' != 'true' -> false).
       dry_run: ${{ github.event.inputs.dry_run == 'true' }}


### PR DESCRIPTION
## ELI-5

This repo's groom robot was set up to hand its findings over as pull requests, but nobody ever told it it was allowed to write code — so it has been reading the whole repo on a schedule, finding real problems, and throwing them away. This gives it permission. It still can't merge anything; it opens PRs a human reviews.

**Draft on purpose** — one credential has to land in this repo first (below).

## What was broken

`vars.GROOM_CONFIG` here sets `max_findings: 0`. That is a literal slice (`to_file[:0]`), not "unlimited" — it **parks issue filing**, which is correct only when the builder is on and findings arrive as PRs instead. `Comfy-Org/cloud` and `comfy-infra` run that same variable and both set `builder: true` in the caller. This caller never did, so it has had neither sink.

Visible in the record: the variable was set **2026-07-31**, and the last `groom`-labeled issue here is from **2026-07-31**. Every scheduled run since has been green and produced nothing. `max_prs` in the variable was inert the whole time — it only governs the builder path, and `builder` is in the reusable's `_LOCKED_KEYS`, so a variable can never switch it on.

## The fix

`builder: true` in the caller — the reviewed diff the lock is designed to force. Nothing else changes:

- **`max_prs` deliberately not added here.** The variable already carries it (2) and outranks `with:`; a duplicate would be dead config that reads as authoritative.
- **`max_findings: 0` stays.** With the builder on it means "PRs, not issues", which is the intent. Bail issues are unaffected — `build_pr` still files one for a confirmed finding whose patch was too large or CI-privileged, so nothing is silently dropped.
- Findings skipped while the cap was 0 were deferred, not lost; the dedup ledger holds them.

## BLOCKER — merge only after this is done

`build_pr` reads `steps.bot_token.outputs.token` with **no `github.token` fallback** (the issue sink degrades to `github-actions[bot]`; the PR sink cannot), and callers grant only `contents: read`, so there is no other way to push a branch. This repo has **neither `vars.APP_ID` nor `secrets.CLOUD_CODE_BOT_PRIVATE_KEY`** today. Merging as-is would kill every finding at the PR sink *after* the agents have billed.

- [ ] cloud-code-bot (App 2016716) installed on `Comfy-Org/comfy-mcp` with contents + pull-requests write
- [ ] `secrets.CLOUD_CODE_BOT_PRIVATE_KEY` set — **first**
- [ ] `vars.APP_ID` = `2016716` — **second**
- [ ] `gh workflow run groom.yml --repo Comfy-Org/comfy-mcp -f dry_run=true` green, with "Mint bot-identity token" succeeding

**Order matters.** The reusable mints whenever `bot_app_id` is non-empty and hard-fails on an empty key, so setting `APP_ID` before the key breaks the runs that work today. Verify the `op read` returns bytes before piping it into `gh secret set` — a failed read stores an *empty* secret, which passes Actions startup validation and then hard-fails inside the job.

## Security posture

Unchanged, and worth stating since this grants an agent the ability to author code:

- The agent jobs (`audit_find`, `audit_verify`, `build`) run `contents: read` and mint no GitHub token — the process that reads untrusted code never holds write credentials.
- `build_pr` is the only job in the path with a write token. It runs **no agent and no repo code**: it applies the patch artifact on a fresh branch, commits, pushes, opens the PR.
- PRs are review-gated. Groom never merges. Security-adjacent findings are excluded from the builder and stay as issues to investigate.

## Provenance

Found by sweeping every repo with a groom caller after `Comfy-Org/evals` turned up the same misconfiguration ([evals#487](https://github.com/Comfy-Org/evals/pull/487)): the `max_findings: 0` variable was copied from repos that run `builder: true` to three that don't. Semantics verified against `github-workflows/.github/groom/config.py` (`_LOCKED_KEYS`, and the comment scoping `max_findings` to the `file` job) and `build_pr`'s credential handling at the pinned SHA.

## Testing

- `yaml.safe_load` parses; `jobs.groom.with.builder` resolves to `true`.
- Credential state checked live via the Actions variables/secrets API for this repo (both absent) — hence the draft.
- Not verifiable pre-merge: the builder path only runs from the default branch. The dry run in the checklist above is the gate.