### PR TITLE
ci: allowlist ECMA-48 in the public-repo-hygiene caller

### DIFF
--- a/.github/workflows/public-repo-hygiene.yml
+++ b/.github/workflows/public-repo-hygiene.yml
@@ -4,10 +4,18 @@
 #
 # Why the checker is not in this repo any more: the old job ran
 # the checker straight out of the PR's own checkout, so a PR could widen the
-# allowlist — or disable the scan — and go green. The reusable loads the
-# checker from the pinned `workflows_ref` commit instead, so a PR here cannot
-# reach it through this workflow's inputs. The allowlist is deliberately NOT
-# an input, for the same reason.
+# known-public repo allowlist — or disable the scan — and go green. The
+# reusable loads the checker from the pinned `workflows_ref` commit instead,
+# so a PR here cannot reach it through this workflow's inputs. The known-public
+# repo/team allowlist is deliberately NOT an input, for the same reason.
+#
+# One allowlist IS an input: `ticket_allowlist` in the `with:` block below. It
+# reaches only the generic ticket-shape check (LETTERS-DIGITS tokens), never
+# the repo allowlist; it is additive (the checker unions it with its built-in
+# entries, so a caller can add a token but never drop one); and every entry
+# sits in this file's diff. That diff is the control, so review this block the
+# way the reusable's own header asks: a PR that introduces a ticket-shaped
+# token AND its allowlist entry in the same change is the bypass to look for.
 #
 # The pin is kept fresh by bump-public-repo-hygiene-callers.yml once this repo
 # is enrolled in the PUBLIC_REPO_HYGIENE_CALLERS roster.
@@ -29,8 +37,11 @@ jobs:
       workflows_ref: a02bb3e4803556eebb945b62a8b00bbc06294798
       # `ECMA-48` is the ANSI escape-sequence standard that clitext.py and
       # test_compat.py cite when parsing CSI parameter bytes. It has the
-      # LETTERS-DIGITS shape the checker reads as an internal ticket id, and the
-      # built-in allowlist covers RFC/ISO/PEP/CVE prefixes but not ECMA, so
-      # every scan here reported it. This input is additive: the built-in list
-      # still applies, and a caller can only widen it, never shrink it.
+      # LETTERS-DIGITS shape the checker reads as an internal ticket id, and
+      # the checker's built-in prefix carve-outs (CVE/CWE/PEP/RFC/ISO/UTF) do
+      # not include ECMA, so every scan here reported it. Entries here are
+      # matched as EXACT tokens, case-insensitively, and only the built-in
+      # prefixes clear by prefix — a bare `ECMA` entry suppresses nothing
+      # (checked against the checker at the pinned SHA), so a citation of a
+      # different ECMA standard would need its own entry.
       ticket_allowlist: ECMA-48

--- a/.github/workflows/public-repo-hygiene.yml
+++ b/.github/workflows/public-repo-hygiene.yml
@@ -22,8 +22,15 @@ jobs:
   hygiene:
     permissions:
       contents: read
-    uses: Comfy-Org/github-workflows/.github/workflows/public-repo-hygiene.yml@4df9bf684ee45d5baf2a49d2068685ce780a8609 # github-workflows main (4df9bf6)
+    uses: Comfy-Org/github-workflows/.github/workflows/public-repo-hygiene.yml@a02bb3e4803556eebb945b62a8b00bbc06294798 # github-workflows main (a02bb3e)
     with:
       # REQUIRED, and must equal the `uses:` SHA above — the reusable asserts
       # they match, which is what pins the checker to the reviewed commit.
-      workflows_ref: 4df9bf684ee45d5baf2a49d2068685ce780a8609
+      workflows_ref: a02bb3e4803556eebb945b62a8b00bbc06294798
+      # `ECMA-48` is the ANSI escape-sequence standard that clitext.py and
+      # test_compat.py cite when parsing CSI parameter bytes. It has the
+      # LETTERS-DIGITS shape the checker reads as an internal ticket id, and the
+      # built-in allowlist covers RFC/ISO/PEP/CVE prefixes but not ECMA, so
+      # every scan here reported it. This input is additive: the built-in list
+      # still applies, and a caller can only widen it, never shrink it.
+      ticket_allowlist: ECMA-48


### PR DESCRIPTION
## ELI5
This repo runs a shared "did anything internal leak into this public repo" scanner. It reads `ECMA-48` (the terminal escape-code standard our ANSI parser cites in two comments) as an internal ticket number, because it has the same LETTERS-DIGITS shape. This tells the scanner that one token is a standards number, not a ticket. It is the last thing keeping the check red on `main`.

## Motivation
`hygiene / public-repo-hygiene` has been red on `main` and on every PR since [#254 — ci: adopt the shared public-repo-hygiene workflow](https://github.com/Comfy-Org/comfy-mcp/pull/254) merged on 2026-08-22. Seven findings: five were references to `comfy-skills` and `workflow_templates` that the checker's known-public allowlist gained the next day ([Comfy-Org/github-workflows#212 — fix(public-repo-hygiene): allowlist six verified-public Comfy-Org repos](https://github.com/Comfy-Org/github-workflows/pull/212)), cleared by the pin bump in [#260 — ci: bump public-repo-hygiene to github-workflows@a02bb3e](https://github.com/Comfy-Org/comfy-mcp/pull/260). The remaining two are the `ECMA-48` citations in `src/comfy_mcp/clitext.py` and `tests/test_compat.py`, which no built-in prefix (RFC/ISO/PEP/CVE) covers. Until they are allowlisted, every PR here, such as [#253 — ci: bump cursor-review to github-workflows@27e23ac](https://github.com/Comfy-Org/comfy-mcp/pull/253), carries a failing required-looking check that has to be overridden by hand.

## Provenance
- **Authored by:** interactive session
- **Verified:** ran the checker script from `Comfy-Org/github-workflows` `main` against this branch with `--ticket-allow ECMA-48`: 0 findings. Control run without the flag: 4 findings, all `ECMA-48` (the two source comments plus the two new lines in this caller). `yaml.safe_load` parses the caller and `jobs.hygiene.with.workflows_ref` equals the `uses:` SHA. This PR's own `hygiene / public-repo-hygiene` run passed before #260 merged, when the branch also carried the pin bump. Not run: `pytest` and `ruff`, no Python changed.
- **Deviations:** originally carried the pin bump as well; #260 landed that half first, so `origin/main` was merged in and this PR now adds only the allowlist entry.

## Reviewer context
- **Type:** hygiene, CI configuration only
- **Slots into:** this repo's adoption of the shared hygiene check (#254), completing what #260 started. Turns the check green on `main` and on every open PR once they pick up `main`.
- **Not in scope:** the `ECMA-48` comments themselves. Rewording them to dodge the pattern would trade an accurate citation for a checker quirk; the reusable exposes `ticket_allowlist` for exactly this case.

## Summary
- Add `ticket_allowlist: ECMA-48` to the caller's `with:` block, with a comment explaining why; the input is additive on top of the built-in allowlist and can only widen it

## Test plan
- [ ] `hygiene / public-repo-hygiene` is green on this PR
- [ ] After merge, the scheduled/push run on `main` is green
